### PR TITLE
Fix gallery lightbox and zoom: pass $w() elements instead of string s…

### DIFF
--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -659,10 +659,10 @@ function initImageGallery() {
     } catch (e) {}
 
     // Fullscreen lightbox on main image click
-    initImageLightbox('#productGallery', '#productMainImage');
+    initImageLightbox($w('#productGallery'), $w('#productMainImage'));
 
     // Hover zoom on main product image
-    initImageZoom('#productMainImage');
+    initImageZoom($w('#productMainImage'));
 
     // Preload gallery thumbnail images for smoother browsing
     preloadGalleryThumbnails();


### PR DESCRIPTION
…electors

initImageLightbox() and initImageZoom() expect Wix element objects but were receiving string selectors ('#productGallery', '#productMainImage'). Strings lack .items, .onItemClicked(), .src, .onClick(), .onMouseIn(), .onMouseOut() methods, silently breaking both lightbox overlay and hover zoom on Product Page.

Gallery hookup audit (cf-qxo) findings:
- Product Page: #productGallery ✓, #productMainImage ✓, thumbnail click ✓
- Product Page: lightbox overlay FIXED (was receiving string, now $w element)
- Product Page: zoom overlay FIXED (was receiving string, now $w element)
- Category Page: #gridImage ✓, quick view modal ✓, hero section ✓
- Home Page: #heroBg ✓, #featuredRepeater ✓, #categoryRepeater ✓
- Fullscreen Page: #videoPlayer ✓, #videosRepeater ✓, filters ✓
- All 738 tests pass