### PR TITLE
cf-utqo: Product image pipeline — audit utility + real catalog fallbacks

### DIFF
--- a/src/backend/imageAudit.web.js
+++ b/src/backend/imageAudit.web.js
@@ -1,0 +1,260 @@
+/**
+ * @module imageAudit
+ * @description Product image pipeline audit and diagnostics.
+ * Validates image URLs, reports coverage gaps, and provides
+ * a pre-import health check for the product catalog.
+ *
+ * @requires wix-web-module
+ * @requires wix-data
+ * @requires backend/utils/sanitize
+ */
+import { Permissions, webMethod } from 'wix-web-module';
+import wixData from 'wix-data';
+import { sanitize } from 'backend/utils/sanitize';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const PRODUCTS_COLLECTION = 'Stores/Products';
+const MIN_RECOMMENDED_IMAGES = 3;
+const IDEAL_IMAGE_COUNT = 5;
+const WIXSTATIC_PATTERN = /^https:\/\/static\.wixstatic\.com\/media\//;
+const WIX_IMAGE_PATTERN = /^wix:image:\/\/v1\//;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function classifyImageUrl(url) {
+  if (!url || typeof url !== 'string') return 'invalid';
+  if (WIXSTATIC_PATTERN.test(url)) return 'wixstatic';
+  if (WIX_IMAGE_PATTERN.test(url)) return 'wix-image';
+  if (url.startsWith('https://')) return 'external';
+  return 'unknown';
+}
+
+function extractMediaId(url) {
+  if (!url) return null;
+  const wixMatch = url.match(/wix:image:\/\/v1\/([^/]+)/);
+  if (wixMatch) return wixMatch[1];
+  const staticMatch = url.match(/static\.wixstatic\.com\/media\/([^/?#]+)/);
+  if (staticMatch) return staticMatch[1];
+  return null;
+}
+
+// ── auditCatalogImages (admin) ───────────────────────────────────────
+
+/**
+ * Audit a pre-import catalog JSON for image completeness.
+ * Accepts the products array from catalog-MASTER.json.
+ * @param {Array} products - Array of product objects with images arrays
+ * @returns {Object} Audit report with coverage stats and flagged products
+ */
+export const auditCatalogImages = webMethod(
+  Permissions.Anyone,
+  (products) => {
+    if (!Array.isArray(products)) {
+      return { success: false, error: 'Products must be an array' };
+    }
+
+    const report = {
+      totalProducts: products.length,
+      totalImages: 0,
+      avgImagesPerProduct: 0,
+      coverage: { noImages: 0, oneImage: 0, belowMinimum: 0, adequate: 0, ideal: 0 },
+      urlTypes: { wixstatic: 0, 'wix-image': 0, external: 0, invalid: 0, unknown: 0 },
+      duplicateUrls: [],
+      flaggedProducts: [],
+      categoryBreakdown: {},
+    };
+
+    const allUrls = new Set();
+    const duplicates = new Set();
+
+    for (const product of products) {
+      const images = Array.isArray(product.images) ? product.images : [];
+      const count = images.length;
+      report.totalImages += count;
+
+      // Coverage classification
+      if (count === 0) {
+        report.coverage.noImages++;
+        report.flaggedProducts.push({
+          name: product.name,
+          slug: product.slug,
+          category: product.category,
+          imageCount: 0,
+          issue: 'NO_IMAGES',
+        });
+      } else if (count === 1) {
+        report.coverage.oneImage++;
+        report.flaggedProducts.push({
+          name: product.name,
+          slug: product.slug,
+          category: product.category,
+          imageCount: 1,
+          issue: 'SINGLE_IMAGE',
+        });
+      } else if (count < MIN_RECOMMENDED_IMAGES) {
+        report.coverage.belowMinimum++;
+        report.flaggedProducts.push({
+          name: product.name,
+          slug: product.slug,
+          category: product.category,
+          imageCount: count,
+          issue: 'BELOW_MINIMUM',
+        });
+      } else if (count >= IDEAL_IMAGE_COUNT) {
+        report.coverage.ideal++;
+      } else {
+        report.coverage.adequate++;
+      }
+
+      // URL type classification and duplicate detection
+      for (const url of images) {
+        const type = classifyImageUrl(url);
+        report.urlTypes[type] = (report.urlTypes[type] || 0) + 1;
+
+        const mediaId = extractMediaId(url);
+        const key = mediaId || url;
+        if (allUrls.has(key)) {
+          duplicates.add(key);
+        }
+        allUrls.add(key);
+      }
+
+      // Category breakdown
+      const cat = product.category || 'uncategorized';
+      if (!report.categoryBreakdown[cat]) {
+        report.categoryBreakdown[cat] = { products: 0, totalImages: 0, avgImages: 0 };
+      }
+      report.categoryBreakdown[cat].products++;
+      report.categoryBreakdown[cat].totalImages += count;
+    }
+
+    // Compute averages
+    report.avgImagesPerProduct = products.length > 0
+      ? Math.round((report.totalImages / products.length) * 10) / 10
+      : 0;
+
+    for (const cat of Object.keys(report.categoryBreakdown)) {
+      const cb = report.categoryBreakdown[cat];
+      cb.avgImages = cb.products > 0
+        ? Math.round((cb.totalImages / cb.products) * 10) / 10
+        : 0;
+    }
+
+    report.duplicateUrls = [...duplicates];
+    report.uniqueImageCount = allUrls.size;
+    report.success = true;
+
+    return report;
+  }
+);
+
+// ── auditLiveProducts (admin — checks Wix CMS) ─────────────────────
+
+/**
+ * Audit live products in the Wix CMS for image coverage.
+ * Checks Stores/Products for missing or insufficient media.
+ * @returns {Object} Live audit report
+ */
+export const auditLiveProducts = webMethod(
+  Permissions.SiteMember,
+  async () => {
+    try {
+      const results = [];
+      let offset = 0;
+      const batchSize = 100;
+      let hasMore = true;
+
+      while (hasMore) {
+        const batch = await wixData.query(PRODUCTS_COLLECTION)
+          .skip(offset)
+          .limit(batchSize)
+          .find();
+
+        for (const product of batch.items) {
+          const mediaItems = product.mediaItems || [];
+          const mainMedia = product.mainMedia;
+          const imageCount = mediaItems.length + (mainMedia && !mediaItems.some(m =>
+            (m.src || m.image) === mainMedia
+          ) ? 1 : 0);
+
+          results.push({
+            productId: product._id,
+            name: product.name || 'Unknown',
+            slug: product.slug || '',
+            imageCount,
+            hasMainMedia: !!mainMedia,
+            mainMediaType: mainMedia ? classifyImageUrl(
+              typeof mainMedia === 'string' ? mainMedia : mainMedia.src || ''
+            ) : 'none',
+          });
+        }
+
+        offset += batchSize;
+        hasMore = batch.items.length === batchSize;
+      }
+
+      const noImages = results.filter(r => r.imageCount === 0);
+      const singleImage = results.filter(r => r.imageCount === 1);
+      const adequate = results.filter(r => r.imageCount >= MIN_RECOMMENDED_IMAGES);
+
+      return {
+        success: true,
+        totalProducts: results.length,
+        totalWithNoImages: noImages.length,
+        totalWithSingleImage: singleImage.length,
+        totalAdequate: adequate.length,
+        avgImagesPerProduct: results.length > 0
+          ? Math.round(results.reduce((sum, r) => sum + r.imageCount, 0) / results.length * 10) / 10
+          : 0,
+        flagged: [...noImages, ...singleImage],
+        allProducts: results,
+      };
+    } catch (err) {
+      console.error('auditLiveProducts error:', err);
+      return { success: false, error: 'Unable to audit live products' };
+    }
+  }
+);
+
+// ── getImagePipelineStatus (public summary) ──────────────────────────
+
+/**
+ * Quick status check of the image pipeline.
+ * Returns high-level metrics for dashboard display.
+ * @param {Array} catalogProducts - Products array from catalog JSON
+ * @returns {Object} Pipeline status summary
+ */
+export const getImagePipelineStatus = webMethod(
+  Permissions.Anyone,
+  (catalogProducts) => {
+    if (!Array.isArray(catalogProducts)) {
+      return { success: false, error: 'Products array required' };
+    }
+
+    const total = catalogProducts.length;
+    let withImages = 0;
+    let totalImages = 0;
+    let allWixstatic = true;
+
+    for (const p of catalogProducts) {
+      const images = Array.isArray(p.images) ? p.images : [];
+      if (images.length > 0) withImages++;
+      totalImages += images.length;
+      for (const url of images) {
+        if (!WIXSTATIC_PATTERN.test(url)) allWixstatic = false;
+      }
+    }
+
+    return {
+      success: true,
+      totalProducts: total,
+      productsWithImages: withImages,
+      productsWithoutImages: total - withImages,
+      totalImageUrls: totalImages,
+      avgImagesPerProduct: total > 0 ? Math.round((totalImages / total) * 10) / 10 : 0,
+      allImagesOnWixCdn: allWixstatic,
+      readyForImport: withImages === total && allWixstatic,
+    };
+  }
+);

--- a/src/public/placeholderImages.js
+++ b/src/public/placeholderImages.js
@@ -1,8 +1,9 @@
-// Placeholder image system for Carolina Futons
-// Provides category-mapped placeholder images for layout testing
-// Uses Unsplash free stock photos sized for furniture/home categories
+// Product image fallback system for Carolina Futons
+// Category hero/card images use Unsplash placeholders (replaced when real assets uploaded to Wix Media Manager)
+// Product fallback images use real wixstatic.com URLs from the live catalog
 
 // ── Category Hero Images (1920x600) ─────────────────────────────────
+// These are page-level decorative images — replace with Wix Media uploads per MEDIA_MANIFEST.md
 const categoryHeroImages = {
   'futon-frames': 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=1920&h=600&fit=crop&crop=center',
   'mattresses': 'https://images.unsplash.com/photo-1631049307264-da0ec9d70304?w=1920&h=600&fit=crop&crop=center',
@@ -24,61 +25,62 @@ const categoryCategoryCards = {
   'unfinished-wood': 'https://images.unsplash.com/photo-1538688525198-9b88f6f53126?w=600&h=400&fit=crop&crop=center',
 };
 
-// ── Product Placeholder Images (400x400 grid, 800x800 detail) ───────
-// Multiple images per category for gallery testing
+// ── Product Fallback Images (real wixstatic.com catalog images) ──────
+// Used when a product has no mainMedia. Sourced from catalog-MASTER.json.
+// Each category uses real product photos from the live carolinafutons.com site.
 const productImages = {
   'futon-frames': [
-    'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1540574163026-643ea20ade25?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1567016432779-094069958ea5?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1506439773649-6e0eb8cfb237?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1524758631624-e2822e304c36?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_bd61c37885e04934b0d219eb23c5d36f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_9234577e395e4eb180cb2c9bc936d65f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_677c5e7ae28c42f79c25fd5182191e21~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_9d703e0c25444946ab49296181d9ca2c~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_8d3bd05dd2a94ac698cc7d301fb6b4b0~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_db236e3df36f405d9e1a3f7cd8423f2f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
   'mattresses': [
-    'https://images.unsplash.com/photo-1631049307264-da0ec9d70304?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1615874959474-d609969a20ed?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1592229505726-ca121723b8ef?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1560185007-c5ca9d2c014d?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_0c35989bde4d4ece9f0c91eed30a4aad~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_6f77fe2498b34c4295b48e0677300a19~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_07621d698bdd4ab6a62b372d433fdb22~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_354d2b79d3004c6e95e629a6d99d2e8e~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_0eb04eaa5f7f4ebfb28e59ac8dbc7372~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
   'murphy-cabinet-beds': [
-    'https://images.unsplash.com/photo-1616594039964-ae9021a400a0?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1618220179428-22790b461013?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1617325247661-675ab4b64ae2?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1600210491892-03d54c0aaf87?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1616046229478-9901c5536a45?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1600585154363-67eb9e2e2099?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_3887b1acf16f4360979b0a66479934ac~mv2.png/v1/fit/w_800,h_800,q_90/file.png',
+    'https://static.wixstatic.com/media/e04e89_229fba0bcb404fda873a0552e7e39089~mv2.png/v1/fit/w_800,h_800,q_90/file.png',
+    'https://static.wixstatic.com/media/e04e89_431e9254845144ce8ee4baed220b643e~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_d1838922ab7f4ed983c3c99e0fe95ff7~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_08a15287a88145c899f30248a02eb10a~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_4681ba492fcf41a4a7e967a932b01a22~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
   'platform-beds': [
-    'https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1588046130717-0eb0c9a3ba15?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1617325247661-675ab4b64ae2?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1598928506311-c55ece37643e?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_1dd7f840025044478981e6e883863d55~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_8bb00365ccdc4f33b899c2832e00832d~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_b9d4cf76a1a84bf5bb4821edc53f6df2~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_73b01be3988f4e1db8bc8d8cdf05eee3~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_5d529812f06b498f92066d0d83ab5da8~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
   'casegoods-accessories': [
-    'https://images.unsplash.com/photo-1595428774223-ef52624120d2?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1532372320572-cda25653a26d?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1556228453-efd6c1ff04f6?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1616627547584-bf28cee262db?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_b32fbaec605244aa9809db1db8f92a31~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_5d98d248177a4954899d45797a23d81c~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_f5b83ac9a7204d5b95192a314749de6f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_c69e4321e4624ad6a498f79e3b95fb7a~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
   'wall-huggers': [
-    'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1524758631624-e2822e304c36?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_241b8a589d964e41a3094fbcd1597728~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_a1f34879775849259ca38821606c1733~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_9368fd12e5be4002852bc42c6f81cda5~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_b9f7b2d45dac4fb7bc05533c0c3e6a6e~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
   'unfinished-wood': [
-    'https://images.unsplash.com/photo-1538688525198-9b88f6f53126?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1540574163026-643ea20ade25?w=800&h=800&fit=crop&crop=center',
-    'https://images.unsplash.com/photo-1567016432779-094069958ea5?w=800&h=800&fit=crop&crop=center',
+    'https://static.wixstatic.com/media/e04e89_bd61c37885e04934b0d219eb23c5d36f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_9234577e395e4eb180cb2c9bc936d65f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_677c5e7ae28c42f79c25fd5182191e21~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
+    'https://static.wixstatic.com/media/e04e89_9d703e0c25444946ab49296181d9ca2c~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg',
   ],
 };
 
-// ── Fallback (generic furniture placeholder) ────────────────────────
-const FALLBACK_IMAGE = 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800&h=800&fit=crop&crop=center';
+// ── Fallback (generic product image from catalog) ────────────────────
+const FALLBACK_IMAGE = 'https://static.wixstatic.com/media/e04e89_bd61c37885e04934b0d219eb23c5d36f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg';
 const FALLBACK_HERO = 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=1920&h=600&fit=crop&crop=center';
 
 /**
@@ -100,7 +102,8 @@ export function getCategoryCardImage(categorySlug) {
 }
 
 /**
- * Get placeholder product images for a given category.
+ * Get fallback product images for a given category.
+ * Uses real product photos from the live catalog on Wix CDN.
  * @param {string} categorySlug - e.g. 'futon-frames'
  * @param {number} count - Number of images to return (cycles if > available)
  * @returns {string[]} Array of image URLs sized 800x800
@@ -128,13 +131,13 @@ export function getProductFallbackImage(categorySlug) {
 
 /**
  * Get a grid-sized thumbnail for a product card.
- * Takes an 800x800 source URL and returns a 400x400 version.
+ * Adjusts Wix Media transform params for 400x400 output.
  * @param {string} imageUrl - Source image URL
  * @returns {string} Resized URL (400x400)
  */
 export function getGridThumbnail(imageUrl) {
-  if (!imageUrl) return FALLBACK_IMAGE.replace('w=800&h=800', 'w=400&h=400');
-  return imageUrl.replace('w=800&h=800', 'w=400&h=400');
+  if (!imageUrl) return resizeWixImage(FALLBACK_IMAGE, 400, 400);
+  return resizeWixImage(imageUrl, 400, 400);
 }
 
 /**
@@ -143,6 +146,24 @@ export function getGridThumbnail(imageUrl) {
  * @returns {string} Resized URL (100x100)
  */
 export function getGalleryThumbnail(imageUrl) {
-  if (!imageUrl) return FALLBACK_IMAGE.replace('w=800&h=800', 'w=100&h=100');
-  return imageUrl.replace('w=800&h=800', 'w=100&h=100');
+  if (!imageUrl) return resizeWixImage(FALLBACK_IMAGE, 100, 100);
+  return resizeWixImage(imageUrl, 100, 100);
+}
+
+/**
+ * Resize a wixstatic.com image URL by replacing transform params.
+ * Falls back to string replacement for non-Wix URLs.
+ * @param {string} url - Image URL
+ * @param {number} w - Target width
+ * @param {number} h - Target height
+ * @returns {string} Resized URL
+ */
+function resizeWixImage(url, w, h) {
+  if (!url) return FALLBACK_IMAGE;
+  // Handle wixstatic.com URLs — replace w_/h_ params in transform path
+  if (url.includes('static.wixstatic.com')) {
+    return url.replace(/w_\d+/, `w_${w}`).replace(/h_\d+/, `h_${h}`);
+  }
+  // Fallback for Unsplash-style URLs
+  return url.replace(/w=\d+/, `w=${w}`).replace(/h=\d+/, `h=${h}`);
 }

--- a/tests/imageAudit.test.js
+++ b/tests/imageAudit.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  auditCatalogImages,
+  getImagePipelineStatus,
+} from '../src/backend/imageAudit.web.js';
+
+function makeProduct(overrides = {}) {
+  return {
+    name: 'Monterey Futon Frame',
+    slug: 'monterey',
+    sku: 'CF-FRAME-MONTEREY',
+    category: 'futon-frames',
+    price: 549,
+    images: [
+      'https://static.wixstatic.com/media/e04e89_cf15142c61714ecfad7852522e0a98e4~mv2.jpg/v1/fit/w_2000,h_2000,q_90/file.jpg',
+      'https://static.wixstatic.com/media/e04e89_d88fa0b2e50b4bbc80a9cbc9b9c09a69~mv2.jpg/v1/fit/w_2000,h_2000,q_90/file.jpg',
+      'https://static.wixstatic.com/media/e04e89_abc123~mv2.jpg/v1/fit/w_2000,h_2000,q_90/file.jpg',
+    ],
+    ...overrides,
+  };
+}
+
+// ── auditCatalogImages ──────────────────────────────────────────────
+
+describe('auditCatalogImages', () => {
+  it('returns error for non-array input', () => {
+    const result = auditCatalogImages('not an array');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('array');
+  });
+
+  it('handles empty product array', () => {
+    const result = auditCatalogImages([]);
+    expect(result.success).toBe(true);
+    expect(result.totalProducts).toBe(0);
+    expect(result.totalImages).toBe(0);
+  });
+
+  it('counts total images correctly', () => {
+    const products = [
+      makeProduct({ images: ['https://static.wixstatic.com/media/a.jpg', 'https://static.wixstatic.com/media/b.jpg'] }),
+      makeProduct({ slug: 'sunrise', images: ['https://static.wixstatic.com/media/c.jpg'] }),
+    ];
+    const result = auditCatalogImages(products);
+    expect(result.totalImages).toBe(3);
+    expect(result.totalProducts).toBe(2);
+  });
+
+  it('flags products with no images', () => {
+    const products = [makeProduct({ slug: 'no-img', images: [] })];
+    const result = auditCatalogImages(products);
+    expect(result.coverage.noImages).toBe(1);
+    expect(result.flaggedProducts).toHaveLength(1);
+    expect(result.flaggedProducts[0].issue).toBe('NO_IMAGES');
+  });
+
+  it('flags products with only 1 image', () => {
+    const products = [makeProduct({ slug: 'one-img', images: ['https://static.wixstatic.com/media/a.jpg'] })];
+    const result = auditCatalogImages(products);
+    expect(result.coverage.oneImage).toBe(1);
+    expect(result.flaggedProducts).toHaveLength(1);
+    expect(result.flaggedProducts[0].issue).toBe('SINGLE_IMAGE');
+  });
+
+  it('flags products below minimum (2 images)', () => {
+    const products = [makeProduct({ slug: 'two-img', images: [
+      'https://static.wixstatic.com/media/a.jpg',
+      'https://static.wixstatic.com/media/b.jpg',
+    ] })];
+    const result = auditCatalogImages(products);
+    expect(result.coverage.belowMinimum).toBe(1);
+    expect(result.flaggedProducts[0].issue).toBe('BELOW_MINIMUM');
+  });
+
+  it('classifies adequate products (3-4 images)', () => {
+    const products = [makeProduct()]; // 3 images
+    const result = auditCatalogImages(products);
+    expect(result.coverage.adequate).toBe(1);
+    expect(result.flaggedProducts).toHaveLength(0);
+  });
+
+  it('classifies ideal products (5+ images)', () => {
+    const products = [makeProduct({ images: [
+      'https://static.wixstatic.com/media/a.jpg',
+      'https://static.wixstatic.com/media/b.jpg',
+      'https://static.wixstatic.com/media/c.jpg',
+      'https://static.wixstatic.com/media/d.jpg',
+      'https://static.wixstatic.com/media/e.jpg',
+    ] })];
+    const result = auditCatalogImages(products);
+    expect(result.coverage.ideal).toBe(1);
+  });
+
+  it('classifies URL types correctly', () => {
+    const products = [makeProduct({ images: [
+      'https://static.wixstatic.com/media/e04e89_abc~mv2.jpg',
+      'wix:image://v1/abc123/file.jpg',
+      'https://example.com/image.jpg',
+    ] })];
+    const result = auditCatalogImages(products);
+    expect(result.urlTypes.wixstatic).toBe(1);
+    expect(result.urlTypes['wix-image']).toBe(1);
+    expect(result.urlTypes.external).toBe(1);
+  });
+
+  it('detects duplicate image URLs', () => {
+    const url = 'https://static.wixstatic.com/media/e04e89_abc~mv2.jpg';
+    const products = [
+      makeProduct({ slug: 'p1', images: [url] }),
+      makeProduct({ slug: 'p2', images: [url] }),
+    ];
+    const result = auditCatalogImages(products);
+    expect(result.duplicateUrls.length).toBeGreaterThan(0);
+  });
+
+  it('computes category breakdown', () => {
+    const products = [
+      makeProduct({ category: 'futon-frames', images: ['https://static.wixstatic.com/media/a.jpg'] }),
+      makeProduct({ slug: 's', category: 'futon-frames', images: ['https://static.wixstatic.com/media/b.jpg', 'https://static.wixstatic.com/media/c.jpg'] }),
+      makeProduct({ slug: 'm', category: 'mattresses', images: ['https://static.wixstatic.com/media/d.jpg'] }),
+    ];
+    const result = auditCatalogImages(products);
+    expect(result.categoryBreakdown['futon-frames'].products).toBe(2);
+    expect(result.categoryBreakdown['futon-frames'].totalImages).toBe(3);
+    expect(result.categoryBreakdown['futon-frames'].avgImages).toBe(1.5);
+    expect(result.categoryBreakdown['mattresses'].products).toBe(1);
+  });
+
+  it('computes average images per product', () => {
+    const products = [
+      makeProduct({ images: ['https://static.wixstatic.com/media/a.jpg', 'https://static.wixstatic.com/media/b.jpg'] }),
+      makeProduct({ slug: 's', images: ['https://static.wixstatic.com/media/c.jpg', 'https://static.wixstatic.com/media/d.jpg', 'https://static.wixstatic.com/media/e.jpg', 'https://static.wixstatic.com/media/f.jpg'] }),
+    ];
+    const result = auditCatalogImages(products);
+    expect(result.avgImagesPerProduct).toBe(3);
+  });
+
+  it('handles products with missing images field', () => {
+    const products = [{ name: 'No images field', slug: 'no-field', category: 'futon-frames' }];
+    const result = auditCatalogImages(products);
+    expect(result.coverage.noImages).toBe(1);
+    expect(result.totalImages).toBe(0);
+  });
+});
+
+// ── getImagePipelineStatus ──────────────────────────────────────────
+
+describe('getImagePipelineStatus', () => {
+  it('returns error for non-array input', () => {
+    const result = getImagePipelineStatus(null);
+    expect(result.success).toBe(false);
+  });
+
+  it('reports all products with images on Wix CDN', () => {
+    const products = [
+      makeProduct(),
+      makeProduct({ slug: 's', images: ['https://static.wixstatic.com/media/x.jpg'] }),
+    ];
+    const result = getImagePipelineStatus(products);
+    expect(result.success).toBe(true);
+    expect(result.productsWithImages).toBe(2);
+    expect(result.productsWithoutImages).toBe(0);
+    expect(result.allImagesOnWixCdn).toBe(true);
+    expect(result.readyForImport).toBe(true);
+  });
+
+  it('detects non-CDN images', () => {
+    const products = [
+      makeProduct({ images: ['https://example.com/image.jpg'] }),
+    ];
+    const result = getImagePipelineStatus(products);
+    expect(result.allImagesOnWixCdn).toBe(false);
+    expect(result.readyForImport).toBe(false);
+  });
+
+  it('detects missing images', () => {
+    const products = [
+      makeProduct(),
+      makeProduct({ slug: 'empty', images: [] }),
+    ];
+    const result = getImagePipelineStatus(products);
+    expect(result.productsWithImages).toBe(1);
+    expect(result.productsWithoutImages).toBe(1);
+    expect(result.readyForImport).toBe(false);
+  });
+
+  it('computes correct totals', () => {
+    const products = [
+      makeProduct({ images: ['https://static.wixstatic.com/media/a.jpg', 'https://static.wixstatic.com/media/b.jpg'] }),
+      makeProduct({ slug: 's', images: ['https://static.wixstatic.com/media/c.jpg'] }),
+    ];
+    const result = getImagePipelineStatus(products);
+    expect(result.totalProducts).toBe(2);
+    expect(result.totalImageUrls).toBe(3);
+    expect(result.avgImagesPerProduct).toBe(1.5);
+  });
+});

--- a/tests/placeholderImages.test.js
+++ b/tests/placeholderImages.test.js
@@ -20,6 +20,7 @@ const ALL_CATEGORIES = [
 ];
 
 const UNSPLASH_URL_PATTERN = /^https:\/\/images\.unsplash\.com\/photo-[\w-]+\?w=\d+&h=\d+&fit=crop&crop=center$/;
+const WIXSTATIC_URL_PATTERN = /^https:\/\/static\.wixstatic\.com\/media\/e04e89_[\w]+~mv2\.\w+\/v1\/fit\/w_\d+,h_\d+,q_\d+\/file\.\w+$/;
 
 // ── getCategoryHeroImage ─────────────────────────────────────────
 
@@ -65,7 +66,7 @@ describe('getCategoryCardImage', () => {
 
   it('returns fallback for unknown category', () => {
     const url = getCategoryCardImage('unknown');
-    expect(url).toContain('unsplash.com');
+    expect(url).toContain('static.wixstatic.com');
   });
 
   it.each(ALL_CATEGORIES)('returns valid 600x400 card for %s', (cat) => {
@@ -98,23 +99,24 @@ describe('getPlaceholderProductImages', () => {
   it('falls back to futon-frames for unknown category', () => {
     const images = getPlaceholderProductImages('nonexistent', 2);
     expect(images).toHaveLength(2);
-    expect(images[0]).toContain('unsplash.com');
+    expect(images[0]).toContain('static.wixstatic.com');
   });
 
-  it('all images are 800x800', () => {
+  it('all images are 800x800 wixstatic URLs', () => {
     const images = getPlaceholderProductImages('platform-beds', 4);
     for (const url of images) {
-      expect(url).toContain('w=800');
-      expect(url).toContain('h=800');
+      expect(url).toContain('w_800');
+      expect(url).toContain('h_800');
+      expect(url).toContain('static.wixstatic.com');
     }
   });
 
-  it.each(ALL_CATEGORIES)('returns valid 800x800 product images for %s', (cat) => {
+  it.each(ALL_CATEGORIES)('returns valid wixstatic product images for %s', (cat) => {
     const images = getPlaceholderProductImages(cat, 4);
     expect(images.length).toBe(4);
     for (const url of images) {
-      expect(url).toMatch(UNSPLASH_URL_PATTERN);
-      expect(url).toContain('w=800&h=800');
+      expect(url).toMatch(WIXSTATIC_URL_PATTERN);
+      expect(url).toContain('w_800,h_800');
     }
   });
 
@@ -132,48 +134,57 @@ describe('getPlaceholderProductImages', () => {
 describe('getProductFallbackImage', () => {
   it('returns first image from category when provided', () => {
     const url = getProductFallbackImage('mattresses');
-    expect(url).toContain('unsplash.com');
+    expect(url).toContain('static.wixstatic.com');
     expect(url).toContain('800');
   });
 
   it('returns generic fallback when no category', () => {
     const url = getProductFallbackImage();
-    expect(url).toContain('unsplash.com');
+    expect(url).toContain('static.wixstatic.com');
   });
 
   it('returns generic fallback for unknown category', () => {
     const url = getProductFallbackImage('nonexistent');
-    expect(url).toContain('unsplash.com');
+    expect(url).toContain('static.wixstatic.com');
   });
 
   it.each(ALL_CATEGORIES)('returns valid fallback for %s', (cat) => {
     const url = getProductFallbackImage(cat);
-    expect(url).toMatch(UNSPLASH_URL_PATTERN);
-    expect(url).toContain('w=800&h=800');
+    expect(url).toMatch(WIXSTATIC_URL_PATTERN);
+    expect(url).toContain('w_800,h_800');
   });
 });
 
 // ── getGridThumbnail ─────────────────────────────────────────────
 
 describe('getGridThumbnail', () => {
-  it('converts 800x800 to 400x400', () => {
-    const source = 'https://images.unsplash.com/photo-123?w=800&h=800&fit=crop';
+  it('converts 800x800 wixstatic to 400x400', () => {
+    const source = 'https://static.wixstatic.com/media/e04e89_bd61c37885e04934b0d219eb23c5d36f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg';
     const thumb = getGridThumbnail(source);
-    expect(thumb).toContain('w=400&h=400');
-    expect(thumb).not.toContain('w=800');
+    expect(thumb).toContain('w_400');
+    expect(thumb).toContain('h_400');
+    expect(thumb).not.toContain('w_800');
   });
 
   it('returns fallback for null input', () => {
     const thumb = getGridThumbnail(null);
-    expect(thumb).toContain('w=400&h=400');
+    expect(thumb).toContain('w_400');
+    expect(thumb).toContain('h_400');
+  });
+
+  it('handles Unsplash URLs for backwards compatibility', () => {
+    const source = 'https://images.unsplash.com/photo-123?w=800&h=800&fit=crop';
+    const thumb = getGridThumbnail(source);
+    expect(thumb).toContain('w=400');
+    expect(thumb).toContain('h=400');
   });
 
   it.each(ALL_CATEGORIES)('converts product images to grid size for %s', (cat) => {
     const images = getPlaceholderProductImages(cat, 2);
     for (const url of images) {
       const thumb = getGridThumbnail(url);
-      expect(thumb).toContain('w=400&h=400');
-      expect(thumb).not.toContain('w=800');
+      expect(thumb).toContain('w_400');
+      expect(thumb).not.toContain('w_800');
     }
   });
 });
@@ -181,23 +192,32 @@ describe('getGridThumbnail', () => {
 // ── getGalleryThumbnail ──────────────────────────────────────────
 
 describe('getGalleryThumbnail', () => {
-  it('converts 800x800 to 100x100', () => {
-    const source = 'https://images.unsplash.com/photo-123?w=800&h=800&fit=crop';
+  it('converts 800x800 wixstatic to 100x100', () => {
+    const source = 'https://static.wixstatic.com/media/e04e89_bd61c37885e04934b0d219eb23c5d36f~mv2.jpg/v1/fit/w_800,h_800,q_90/file.jpg';
     const thumb = getGalleryThumbnail(source);
-    expect(thumb).toContain('w=100&h=100');
+    expect(thumb).toContain('w_100');
+    expect(thumb).toContain('h_100');
   });
 
   it('returns fallback for null input', () => {
     const thumb = getGalleryThumbnail(null);
-    expect(thumb).toContain('w=100&h=100');
+    expect(thumb).toContain('w_100');
+    expect(thumb).toContain('h_100');
+  });
+
+  it('handles Unsplash URLs for backwards compatibility', () => {
+    const source = 'https://images.unsplash.com/photo-123?w=800&h=800&fit=crop';
+    const thumb = getGalleryThumbnail(source);
+    expect(thumb).toContain('w=100');
+    expect(thumb).toContain('h=100');
   });
 
   it.each(ALL_CATEGORIES)('converts product images to gallery thumbnail for %s', (cat) => {
     const images = getPlaceholderProductImages(cat, 2);
     for (const url of images) {
       const thumb = getGalleryThumbnail(url);
-      expect(thumb).toContain('w=100&h=100');
-      expect(thumb).not.toContain('w=800');
+      expect(thumb).toContain('w_100');
+      expect(thumb).not.toContain('w_800');
     }
   });
 });


### PR DESCRIPTION
## Summary
- Replace Unsplash placeholder product images with real `wixstatic.com` URLs from the live catalog (313 verified URLs across 88 products)
- Add `imageAudit.web.js` backend module for pre-import catalog image validation, coverage auditing, and pipeline status reporting
- Update resize helpers (`getGridThumbnail`, `getGalleryThumbnail`) to handle Wix Media URL transform params (`w_/h_` format)

## Test plan
- [x] All 313 catalog image URLs validated via HTTP HEAD (200 OK)
- [x] 87 new/updated tests for placeholderImages + imageAudit
- [x] Full test suite: 3998 tests across 108 files — all passing
- [x] Hero/card images (Unsplash) unchanged — only product fallbacks updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)