### PR TITLE
Wrap Product Page inits in try/catch — isolate failures

### DIFF
--- a/src/pages/Cart Page.js
+++ b/src/pages/Cart Page.js
@@ -340,7 +340,7 @@ function initQuantityControls() {
             } catch (err) {
               console.error('Error updating quantity:', err);
             }
-            await refreshCartTotals();
+            try { await refreshCartTotals(); } catch (e) {}
           }
         });
 
@@ -355,7 +355,7 @@ function initQuantityControls() {
           } catch (err) {
             console.error('Error updating quantity:', err);
           }
-          await refreshCartTotals();
+          try { await refreshCartTotals(); } catch (e) {}
         });
 
         $item('#removeItem').onClick(async () => {
@@ -365,7 +365,7 @@ function initQuantityControls() {
           } catch (err) {
             console.error('Error removing item:', err);
           }
-          await refreshCartTotals();
+          try { await refreshCartTotals(); } catch (e) {}
         });
       } catch (e) {}
     });

--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -102,19 +102,29 @@ async function initProductPage() {
       }
     });
 
-    initSocialShare($w, state);
-    initStickyCartBar($w, state);
-    initDeliveryEstimate($w, state);
-    initSwatchRequest($w, state);
-    initProductInfoAccordion($w);
-    initDimensionDisplay($w, state);
-    initRoomFitChecker($w, state);
-    initSizeComparisonTable($w, state);
-    initInventoryDisplay($w, state);
+    // Each init wrapped individually so one failure doesn't block the rest
+    const secondaryInits = [
+      { name: 'socialShare', init: () => initSocialShare($w, state) },
+      { name: 'stickyCartBar', init: () => initStickyCartBar($w, state) },
+      { name: 'deliveryEstimate', init: () => initDeliveryEstimate($w, state) },
+      { name: 'swatchRequest', init: () => initSwatchRequest($w, state) },
+      { name: 'productInfoAccordion', init: () => initProductInfoAccordion($w) },
+      { name: 'dimensionDisplay', init: () => initDimensionDisplay($w, state) },
+      { name: 'roomFitChecker', init: () => initRoomFitChecker($w, state) },
+      { name: 'sizeComparisonTable', init: () => initSizeComparisonTable($w, state) },
+      { name: 'inventoryDisplay', init: () => initInventoryDisplay($w, state) },
+      { name: 'collapseOnMobile', init: () => collapseOnMobile($w, ['#recentlyViewedSection', '#relatedProductsSection']) },
+      { name: 'backToTop', init: () => initBackToTop($w) },
+      { name: 'browseTracking', init: () => initBrowseTracking(state) },
+    ];
 
-    collapseOnMobile($w, ['#recentlyViewedSection', '#relatedProductsSection']);
-    initBackToTop($w);
-    initBrowseTracking(state);
+    for (const section of secondaryInits) {
+      try {
+        section.init();
+      } catch (e) {
+        console.error(`[ProductPage] "${section.name}" init failed:`, e);
+      }
+    }
 
     // Social proof toast (non-blocking, delayed)
     initProductSocialProof($w, state.product._id, state.product.name).catch(() => {});


### PR DESCRIPTION
## Summary
- **Product Page bug**: 9 init functions (initSocialShare through initInventoryDisplay) called without individual error handling after `Promise.allSettled`. One throw skipped all subsequent inits.
- **Fix**: Wrap in same isolated-failure loop pattern, logging errors per-section
- **Cart Page bug**: `refreshCartTotals()` called outside inner try/catch in quantity/remove handlers
- **Fix**: Wrap each `refreshCartTotals()` call in try/catch

## Test plan
- [x] All 4427 tests pass (1 pre-existing liveChat parse failure unrelated)
- [x] Existing productPage.test.js passes — init flow unchanged for happy path

Closes CF-sj76

🤖 Generated with [Claude Code](https://claude.com/claude-code)