### PR TITLE
Fix Category Page filter reload — use pushState

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -1067,10 +1067,13 @@ function updateUrlWithFilters(filters) {
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
       .join('&');
 
-    // Update URL without page reload
+    // Update URL without page reload using pushState (not wixLocationFrontend.to which navigates)
     try {
-      const base = wixLocationFrontend.baseUrl + '/' + (wixLocationFrontend.path?.[0] || '');
-      wixLocationFrontend.to(queryString ? `${base}?${queryString}` : base);
+      if (typeof window !== 'undefined' && window.history && window.history.pushState) {
+        const path = '/' + (wixLocationFrontend.path?.[0] || '');
+        const newUrl = queryString ? `${path}?${queryString}` : path;
+        window.history.pushState({ filters }, '', newUrl);
+      }
     } catch (e) {
       // URL update is best-effort; don't break filters if it fails
     }


### PR DESCRIPTION
## Summary
- **Bug**: `updateUrlWithFilters` used `wixLocationFrontend.to()` which triggers full page navigation, resetting all local filter/sort state on every filter change
- **Fix**: Replace with `history.pushState()` for URL-only updates — filters stay in memory, URL stays bookmarkable, no reload

## Test plan
- [x] All 4427 tests pass (1 pre-existing liveChat parse failure unrelated)

Closes CF-1bdp

🤖 Generated with [Claude Code](https://claude.com/claude-code)