### PR TITLE
Fix email dedup query + referral credit idempotency

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -309,11 +309,11 @@ export const triggerAbandonedCartRecovery = webMethod(
         if (!cart.buyerEmail || !validateEmail(cart.buyerEmail)) continue;
         if (await isUnsubscribed(cart.buyerEmail, 'cart_recovery')) continue;
 
-        // Check if recovery already queued for this cart
+        // Check if recovery already queued for this cart (flat field, not nested)
         const alreadyQueued = await wixData.query('EmailQueue')
           .eq('recipientEmail', cart.buyerEmail)
           .eq('sequenceType', 'cart_recovery')
-          .eq('variables.checkoutId', cart.checkoutId)
+          .eq('checkoutId', cart.checkoutId)
           .find();
 
         if (alreadyQueued.items.length > 0) continue;
@@ -716,6 +716,8 @@ async function queueEmail({ templateId, recipientEmail, recipientContactId, vari
     variables: variables || {},
     sequenceType,
     sequenceStep,
+    // Flat field for dedup queries (Wix Data can't query nested object fields)
+    checkoutId: variables?.checkoutId || '',
     status: 'pending',
     scheduledFor,
     sentAt: null,

--- a/src/backend/referralService.web.js
+++ b/src/backend/referralService.web.js
@@ -208,6 +208,15 @@ export const completeReferral = webMethod(
       const referral = result.items[0];
       referral.refereeMemberId = member._id;
 
+      // Idempotency: if already credited, return success without re-issuing
+      if (referral.status === 'credited') {
+        return {
+          success: true,
+          referrerCredit: REFERRER_CREDIT_AMOUNT,
+          refereeCredit: REFEREE_CREDIT_AMOUNT,
+        };
+      }
+
       // RACE FIX: Claim referral by setting status='processing' FIRST.
       // Concurrent requests querying status='signed_up' will not find this referral.
       referral.status = 'processing';
@@ -220,28 +229,42 @@ export const completeReferral = webMethod(
         return { success: false, error: 'Referral was already being processed' };
       }
 
-      // Issue credits
+      // Issue credits with idempotency — check for existing credits before inserting
       const expiresAt = new Date(Date.now() + CREDIT_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
 
-      // Credit for referrer
-      await wixData.insert(CREDITS_COLLECTION, {
-        memberId: referral.referrerMemberId,
-        amount: REFERRER_CREDIT_AMOUNT,
-        source: 'referrer_bonus',
-        referralId: referral._id,
-        status: 'available',
-        expiresAt,
-      });
+      // Credit for referrer (skip if already issued)
+      const existingReferrerCredit = await wixData.query(CREDITS_COLLECTION)
+        .eq('referralId', referral._id)
+        .eq('source', 'referrer_bonus')
+        .find();
+      if (existingReferrerCredit.items.length === 0) {
+        await wixData.insert(CREDITS_COLLECTION, {
+          memberId: referral.referrerMemberId,
+          amount: REFERRER_CREDIT_AMOUNT,
+          source: 'referrer_bonus',
+          referralId: referral._id,
+          status: 'available',
+          expiresAt,
+        });
+      }
 
-      // Credit for referee
-      await wixData.insert(CREDITS_COLLECTION, {
-        memberId: member._id,
-        amount: REFEREE_CREDIT_AMOUNT,
-        source: 'referee_bonus',
-        referralId: referral._id,
-        status: 'available',
-        expiresAt,
-      });
+      // Credit for referee (skip if already issued)
+      if (member?._id) {
+        const existingRefereeCredit = await wixData.query(CREDITS_COLLECTION)
+          .eq('referralId', referral._id)
+          .eq('source', 'referee_bonus')
+          .find();
+        if (existingRefereeCredit.items.length === 0) {
+          await wixData.insert(CREDITS_COLLECTION, {
+            memberId: member._id,
+            amount: REFEREE_CREDIT_AMOUNT,
+            source: 'referee_bonus',
+            referralId: referral._id,
+            status: 'available',
+            expiresAt,
+          });
+        }
+      }
 
       // Finalize status
       claimed.status = 'credited';

--- a/tests/emailAutomation.test.js
+++ b/tests/emailAutomation.test.js
@@ -434,6 +434,7 @@ describe('triggerAbandonedCartRecovery', () => {
       _id: 'eq-1',
       recipientEmail: 'shopper@test.com',
       sequenceType: 'cart_recovery',
+      checkoutId: 'ck-1',
       variables: { checkoutId: 'ck-1' },
       status: 'pending',
     }]);


### PR DESCRIPTION
## Summary
- **Email dedup bug**: Cart recovery dedup queried nested `variables.checkoutId` which Wix Data can't resolve — causing duplicate recovery sequences
- **Fix**: Added flat `checkoutId` field to EmailQueue records, query uses flat field
- **Referral bug**: `completeReferral` updates status, inserts credits, updates again — failure mid-sequence leaves partial credits stuck
- **Fix**: Added idempotency checks: query for existing credits before inserting, handle already-credited referrals gracefully

## Test plan
- [x] Updated email dedup test seed data with flat `checkoutId` field
- [x] 76 email automation tests pass
- [x] 49 referral service tests pass
- [x] Full suite: 4427 tests pass

Closes CF-lv0z

🤖 Generated with [Claude Code](https://claude.com/claude-code)