### PR TITLE
Fix null/empty state handling on key pages

### DIFF
--- a/src/pages/Checkout.js
+++ b/src/pages/Checkout.js
@@ -79,6 +79,13 @@ async function initCheckoutSummary() {
     const lineItems = Array.isArray(cart.lineItems) ? cart.lineItems : [];
     const itemCount = lineItems.reduce((s, i) => s + (i.quantity || 0), 0);
 
+    // Empty cart — redirect to cart page instead of showing blank checkout
+    if (itemCount === 0) {
+      const { to } = await import('wix-location-frontend');
+      to('/cart');
+      return;
+    }
+
     // Track checkout start in engagement funnel + GA4/Meta Pixel
     trackCheckoutStart(subtotal, itemCount);
     fireInitiateCheckout(lineItems, subtotal);

--- a/src/pages/Compare Page.js
+++ b/src/pages/Compare Page.js
@@ -245,7 +245,10 @@ async function initShareButton() {
         const baseUrl = wixLocationFrontend.baseUrl;
         const fullUrl = `${baseUrl}${shareUrl}`;
 
-        // Copy to clipboard via Wix
+        // Actually copy to clipboard via Wix API
+        const wixWindow = await import('wix-window-frontend');
+        await wixWindow.copyToClipboard(fullUrl);
+
         $w('#shareCompareBtn').label = 'Link Copied!';
         try { $w('#shareUrlText').text = fullUrl; } catch (e) {}
         try { $w('#shareUrlText').show(); } catch (e) {}

--- a/src/pages/Member Page.js
+++ b/src/pages/Member Page.js
@@ -31,6 +31,12 @@ async function initMemberPage() {
   try {
     currentMember = await loadCurrentMember();
 
+    if (!currentMember) {
+      const { authentication } = await import('wix-members-frontend');
+      authentication.promptLogin();
+      return;
+    }
+
     const sections = [
       { name: 'dashboard', init: initDashboard },
       { name: 'orderHistory', init: initOrderHistory },
@@ -476,6 +482,15 @@ async function initWishlist() {
         });
       });
     });
+
+    // Set initial data on the repeater (was only set on sort change)
+    applyWishlistSort();
+
+    // Show empty state if no items
+    if (wishlistData.length === 0) {
+      try { $w('#wishlistEmpty').show(); } catch (e) {}
+      try { wishlistRepeater.collapse(); } catch (e) {}
+    }
 
   } catch (e) {
     console.error('[MemberPage] Error initializing wishlist:', e);


### PR DESCRIPTION
## Summary
- **Checkout.js**: Empty cart (0 items) now redirects to `/cart` instead of showing blank checkout page with 0-value analytics events firing
- **Member Page.js**: Null member now redirects to login prompt instead of continuing with broken data ("Welcome, Member!" with null queries). Wishlist repeater now populates on initial load via `applyWishlistSort()` — was only set when sort dropdown changed. Empty wishlist shows empty state message.
- **Compare Page.js**: Share button now actually calls `wixWindow.copyToClipboard()` — was previously showing "Link Copied!" without performing the copy

## Test plan
- [x] All 4427 existing tests pass
- [x] Checkout: empty cart redirects to /cart
- [x] Member Page: null member triggers login prompt
- [x] Member Page: wishlist items visible on first load (not just after sort)
- [x] Compare Page: share button copies URL to clipboard

Closes CF-zluj

🤖 Generated with [Claude Code](https://claude.com/claude-code)