### PR TITLE
Add date validation to scheduleDelivery

### DIFF
--- a/src/backend/deliveryScheduling.web.js
+++ b/src/backend/deliveryScheduling.web.js
@@ -134,6 +134,26 @@ export const scheduleDelivery = webMethod(
         return { success: false, message: 'Invalid date format' };
       }
 
+      // Validate date is a delivery day (Wed-Sat)
+      const dateObj = new Date(date + 'T12:00:00');
+      if (!DELIVERY_DAYS.includes(dateObj.getDay())) {
+        return { success: false, message: 'Deliveries are only available Wednesday through Saturday' };
+      }
+
+      // Validate date is in the future
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      if (dateObj <= today) {
+        return { success: false, message: 'Delivery date must be in the future' };
+      }
+
+      // Validate date is within booking window
+      const maxDate = new Date(today);
+      maxDate.setDate(maxDate.getDate() + BOOKING_WINDOW_DAYS);
+      if (dateObj > maxDate) {
+        return { success: false, message: `Deliveries can only be scheduled up to ${BOOKING_WINDOW_DAYS} days in advance` };
+      }
+
       // Check for existing schedule for this order
       const existing = await wixData.query('DeliverySchedule')
         .eq('orderId', orderId)

--- a/tests/deliveryScheduling.test.js
+++ b/tests/deliveryScheduling.test.js
@@ -152,6 +152,73 @@ describe('scheduleDelivery', () => {
     const result = await scheduleDelivery(null);
     expect(result.success).toBe(false);
   });
+
+  it('rejects past dates', async () => {
+    const result = await scheduleDelivery({
+      orderId: 'order-past',
+      date: '2020-01-15',
+      timeWindow: 'morning',
+      type: 'standard',
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('future');
+  });
+
+  it('rejects non-delivery days (Sunday)', async () => {
+    const nextSun = getNextDayOfWeek(0); // Sunday
+    const dateStr = nextSun.toISOString().split('T')[0];
+    const result = await scheduleDelivery({
+      orderId: 'order-sun',
+      date: dateStr,
+      timeWindow: 'morning',
+      type: 'standard',
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Wednesday through Saturday');
+  });
+
+  it('rejects non-delivery days (Monday)', async () => {
+    const nextMon = getNextDayOfWeek(1); // Monday
+    const dateStr = nextMon.toISOString().split('T')[0];
+    const result = await scheduleDelivery({
+      orderId: 'order-mon',
+      date: dateStr,
+      timeWindow: 'afternoon',
+      type: 'standard',
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Wednesday through Saturday');
+  });
+
+  it('rejects dates beyond booking window (>21 days)', async () => {
+    const farFuture = new Date();
+    farFuture.setDate(farFuture.getDate() + 60);
+    // Ensure it's a Wed-Sat so only the window check fails
+    while (![3, 4, 5, 6].includes(farFuture.getDay())) {
+      farFuture.setDate(farFuture.getDate() + 1);
+    }
+    const dateStr = farFuture.toISOString().split('T')[0];
+    const result = await scheduleDelivery({
+      orderId: 'order-far',
+      date: dateStr,
+      timeWindow: 'morning',
+      type: 'standard',
+    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('21 days');
+  });
+
+  it('accepts valid future Wed-Sat date', async () => {
+    const nextThu = getNextDayOfWeek(4); // Thursday
+    const dateStr = nextThu.toISOString().split('T')[0];
+    const result = await scheduleDelivery({
+      orderId: 'order-thu',
+      date: dateStr,
+      timeWindow: 'afternoon',
+      type: 'white_glove',
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 // ── getMyDeliverySchedule ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `scheduleDelivery` only validated date format (YYYY-MM-DD) but accepted past dates, non-delivery days (Mon/Tue/Sun), and dates beyond the 21-day booking window
- `bookAppointment` already validated all three — applied same logic using existing `DELIVERY_DAYS` and `BOOKING_WINDOW_DAYS` constants

## Test plan
- [x] Test: rejects past dates
- [x] Test: rejects Sunday (non-delivery day)
- [x] Test: rejects Monday (non-delivery day)
- [x] Test: rejects dates >21 days out
- [x] Test: accepts valid future Thursday
- [x] All 44 delivery scheduling tests pass
- [x] Full suite: 4432/4432 pass

Closes CF-067z

🤖 Generated with [Claude Code](https://claude.com/claude-code)