### PR TITLE
Fix unsanitized IDs in fulfillment DB writes

### DIFF
--- a/src/backend/fulfillment.web.js
+++ b/src/backend/fulfillment.web.js
@@ -112,7 +112,7 @@ export const fulfillOrder = webMethod(
 
       // Save fulfillment record
       await wixData.insert('Fulfillments', {
-        orderId,
+        orderId: cleanOrderId,
         orderNumber: order.number,
         trackingNumber: shipmentResult.trackingNumber,
         carrier: 'UPS',
@@ -157,7 +157,7 @@ export const getTrackingUpdate = webMethod(
 
       // Update the fulfillment record with latest status
       const records = await wixData.query('Fulfillments')
-        .eq('trackingNumber', trackingNumber)
+        .eq('trackingNumber', cleanTracking)
         .find();
 
       if (records.items.length > 0) {

--- a/tests/fulfillment.test.js
+++ b/tests/fulfillment.test.js
@@ -287,6 +287,32 @@ describe('fulfillOrder', () => {
     expect(inserted.serviceCode).toBe('03');
   });
 
+  it('uses sanitized orderId in DB insert (not raw input)', async () => {
+    // validateId strips non-alphanumeric/dash/underscore chars
+    // A clean ID like 'order-001' passes through unchanged
+    let inserted;
+    __onInsert((col, item) => {
+      if (col === 'Fulfillments') inserted = item;
+    });
+
+    await fulfillOrder('order-001', {
+      serviceCode: '03',
+      packages: [{ length: 48, width: 30, height: 12, weight: 50 }],
+    });
+
+    // orderId in DB should match the sanitized value
+    expect(inserted.orderId).toBe('order-001');
+  });
+
+  it('rejects orderId with injection characters', async () => {
+    const result = await fulfillOrder('<script>alert(1)</script>', {
+      packages: [{ length: 48, width: 30, height: 12, weight: 50 }],
+    });
+    // validateId returns '' for non-alphanumeric IDs
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid order ID');
+  });
+
   it('returns error for non-admin users', async () => {
     loginAsNonAdmin();
     const result = await fulfillOrder('order-001', {
@@ -328,6 +354,25 @@ describe('getTrackingUpdate', () => {
     const result = await getTrackingUpdate('1Z999AA10123456784');
     // Should still return tracking info even if no CMS record to update
     expect(result.success).toBe(true);
+  });
+
+  it('queries DB with sanitized tracking number, not raw input', async () => {
+    // Tracking with special chars should be cleaned before DB query
+    __seed('Fulfillments', [{
+      _id: 'ful-001',
+      trackingNumber: '1Z999AA10123456784',
+      status: 'IN_TRANSIT',
+    }]);
+
+    let updated;
+    __onUpdate((col, item) => {
+      if (col === 'Fulfillments') updated = item;
+    });
+
+    // Pass tracking with dashes — sanitize strips non-alphanumeric
+    await getTrackingUpdate('1Z999AA1-0123-456784');
+    expect(updated).toBeDefined();
+    expect(updated.status).toBe('DELIVERED');
   });
 
   it('returns error for non-admin users', async () => {


### PR DESCRIPTION
## Summary
- `fulfillOrder` used raw `orderId` parameter in the `Fulfillments` CMS insert instead of the sanitized `cleanOrderId` from `validateId()`
- `getTrackingUpdate` used raw `trackingNumber` parameter in the DB query instead of the sanitized `cleanTracking`

Both values were properly sanitized for external API calls (UPS) but the raw unsanitized versions were used for internal database operations.

## Test plan
- [x] Test: sanitized orderId is stored in DB insert
- [x] Test: injection characters in orderId are rejected
- [x] Test: DB query uses sanitized tracking number (dashes stripped)
- [x] All 36 fulfillment tests pass

Closes CF-2cwc

🤖 Generated with [Claude Code](https://claude.com/claude-code)