### PR TITLE
Fix: sanitize utility bypassed by HTML entity encoding

### DIFF
--- a/src/backend/utils/sanitize.js
+++ b/src/backend/utils/sanitize.js
@@ -5,14 +5,39 @@
  */
 
 /**
+ * Decode HTML entities (named, numeric decimal, numeric hex).
+ * @param {string} str - String with potential HTML entities.
+ * @returns {string} Decoded string.
+ */
+function decodeHtmlEntities(str) {
+  if (!str) return '';
+  return str
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(dec))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;|&apos;/g, "'");
+}
+
+/**
  * Strip HTML tags and limit string length.
+ * Decodes HTML entities first to prevent entity-encoded XSS bypass,
+ * then strips tags from the decoded result. Repeats decode+strip to
+ * catch double-encoded payloads.
  * @param {string} str - Raw input string.
  * @param {number} [maxLen=1000] - Maximum allowed length.
  * @returns {string} Sanitized string.
  */
 export function sanitize(str, maxLen = 1000) {
   if (typeof str !== 'string') return '';
-  return str.replace(/<[^>]*>/g, '').trim().slice(0, maxLen);
+  const stripTags = s => s.replace(/<[^>]*>/g, '');
+  // Pass 1: strip literal tags, decode entities, strip any tags that emerged
+  let result = stripTags(decodeHtmlEntities(stripTags(str)));
+  // Pass 2: catch double-encoded entities (&amp;lt; → &lt; → <)
+  result = stripTags(decodeHtmlEntities(result));
+  return result.trim().slice(0, maxLen);
 }
 
 /**

--- a/tests/sanitize.test.js
+++ b/tests/sanitize.test.js
@@ -37,6 +37,31 @@ describe('sanitize', () => {
   it('handles nested HTML tags', () => {
     expect(sanitize('<div><span>text</span></div>')).toBe('text');
   });
+
+  it('neutralizes HTML entity-encoded tags (XSS bypass)', () => {
+    // Named entities
+    expect(sanitize('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe('alert(1)');
+    expect(sanitize('&lt;img src=x onerror=alert(1)&gt;')).toBe('');
+    // Numeric entities
+    expect(sanitize('&#60;script&#62;alert(1)&#60;/script&#62;')).toBe('alert(1)');
+    // Hex entities
+    expect(sanitize('&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;')).toBe('alert(1)');
+  });
+
+  it('decodes safe entities without stripping them', () => {
+    expect(sanitize('Tom &amp; Jerry')).toBe('Tom & Jerry');
+    expect(sanitize('5 &gt; 3')).toBe('5 > 3');
+    expect(sanitize('&quot;quoted&quot;')).toBe('"quoted"');
+  });
+
+  it('handles mixed entities and literal tags', () => {
+    expect(sanitize('<b>&lt;script&gt;xss&lt;/script&gt;</b>')).toBe('xss');
+  });
+
+  it('handles double-encoded entities', () => {
+    // &amp;lt; decodes to &lt; which then decodes to < — must strip that too
+    expect(sanitize('&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;')).toBe('alert(1)');
+  });
 });
 
 // ── validateEmail ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Bead:** CF-5bhi (P1 security bug)
- `sanitize()` in `backend/utils/sanitize.js` only stripped literal `<tags>` — HTML entity-encoded payloads (`&lt;script&gt;`) passed through untouched
- Added `decodeHtmlEntities()` (same pattern as `http-functions.js:stripHtmlSafe`) to decode named, numeric, and hex entities before stripping tags
- Two-pass decode+strip catches double-encoded payloads (`&amp;lt;` → `&lt;` → `<`)
- Safe entities like `&amp;` are properly decoded to their characters

## Test plan
- [x] 4 new test cases: entity-encoded XSS (named/numeric/hex), safe entity decoding, mixed entities+literal tags, double-encoded entities
- [x] All 26 sanitize tests pass
- [x] Full test suite passes (liveChat.test.js has 0 tests — pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)