### PR TITLE
Fix processRefund missing upper bound validation

### DIFF
--- a/src/backend/returnsService.web.js
+++ b/src/backend/returnsService.web.js
@@ -733,6 +733,14 @@ export const processRefund = webMethod(
         return { success: false, error: 'Cannot refund a denied return.' };
       }
 
+      const order = await wixData.get('Stores/Orders', record.orderId);
+      if (!order) return { success: false, error: 'Original order not found.' };
+
+      const orderTotal = order.totals?.total || 0;
+      if (refundAmount > orderTotal) {
+        return { success: false, error: `Refund amount exceeds order total ($${orderTotal}).` };
+      }
+
       record.status = 'refunded';
       record.refundAmount = refundAmount;
       if (notes) record.adminNotes = sanitize(notes, 2000);

--- a/tests/returnsServiceExtended.test.js
+++ b/tests/returnsServiceExtended.test.js
@@ -676,7 +676,9 @@ describe('returnsService — extended', () => {
   describe('processRefund', () => {
     it('processes refund for a valid return', async () => {
       const wixData = (await import('wix-data')).default;
-      wixData.get.mockResolvedValue({ ...existingReturn, status: 'received' });
+      wixData.get
+        .mockResolvedValueOnce({ ...existingReturn, status: 'received' })
+        .mockResolvedValueOnce(recentOrder);
 
       const result = await processRefund('return-001', 899, 'Full refund');
       expect(result.success).toBe(true);
@@ -735,6 +737,38 @@ describe('returnsService — extended', () => {
       const result = await processRefund('return-001', 899);
       expect(result.success).toBe(false);
       expect(result.error).toContain('denied');
+    });
+
+    it('rejects refund exceeding order total', async () => {
+      const wixData = (await import('wix-data')).default;
+      wixData.get
+        .mockResolvedValueOnce({ ...existingReturn, status: 'received' })
+        .mockResolvedValueOnce(recentOrder); // totals.total = 998
+
+      const result = await processRefund('return-001', 10000);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('exceeds order total');
+    });
+
+    it('allows refund exactly equal to order total', async () => {
+      const wixData = (await import('wix-data')).default;
+      wixData.get
+        .mockResolvedValueOnce({ ...existingReturn, status: 'received' })
+        .mockResolvedValueOnce(recentOrder); // totals.total = 998
+
+      const result = await processRefund('return-001', 998);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects refund when order not found', async () => {
+      const wixData = (await import('wix-data')).default;
+      wixData.get
+        .mockResolvedValueOnce({ ...existingReturn, status: 'received' })
+        .mockResolvedValueOnce(null);
+
+      const result = await processRefund('return-001', 899);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('order not found');
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Bug**: `processRefund` validated `refundAmount > 0` but had no upper bound — admin could process a $10k refund on a $500 order
- **Fix**: Fetch the original order and validate `refundAmount <= order.totals.total` before processing
- **Tests**: Added 4 tests covering exceeding order total, exact-match refund, and order-not-found scenarios (47 total tests pass)

## Test plan
- [x] `npx vitest run tests/returnsServiceExtended.test.js` — 47/47 pass
- [x] Refund exceeding order total is rejected with clear error message
- [x] Refund exactly equal to order total succeeds
- [x] Missing order returns appropriate error

Closes CF-n9a8

🤖 Generated with [Claude Code](https://claude.com/claude-code)