### PR TITLE
Fix module-level state bleed across SPA navigations

### DIFF
--- a/src/public/ProductReviews.js
+++ b/src/public/ProductReviews.js
@@ -2,8 +2,9 @@
 // Displays product reviews with star ratings, sorting, pagination,
 // submission form for logged-in members, and helpful voting.
 
-let currentSort = 'newest';
-let currentPage = 0;
+// Page-scoped review state — reset on every init to prevent SPA bleed
+const DEFAULT_SORT = 'newest';
+const DEFAULT_PAGE = 0;
 
 /**
  * Initialize the reviews section on a product page.
@@ -20,12 +21,16 @@ export async function initProductReviews($w, state) {
     const productId = state.product?._id;
     if (!productId) { section.collapse(); return; }
 
+    // Reset review state on each init to prevent SPA navigation bleed
+    state.reviewSort = DEFAULT_SORT;
+    state.reviewPage = DEFAULT_PAGE;
+
     // Load aggregate + reviews in parallel
     const { getAggregateRating, getProductReviews } = await import('backend/reviewsService.web');
 
     const [aggregate, reviewsResult] = await Promise.all([
       getAggregateRating(productId),
-      getProductReviews(productId, { sort: currentSort, page: 0 }),
+      getProductReviews(productId, { sort: state.reviewSort, page: DEFAULT_PAGE }),
     ]);
 
     // Show section
@@ -185,15 +190,15 @@ function initSortDropdown($w, state, getProductReviews) {
       { label: 'Lowest Rated', value: 'lowest' },
       { label: 'Most Helpful', value: 'helpful' },
     ];
-    dropdown.value = currentSort;
+    dropdown.value = state.reviewSort;
     try { dropdown.accessibility.ariaLabel = 'Sort reviews'; } catch (e) {}
 
     dropdown.onChange(async () => {
-      currentSort = dropdown.value;
-      currentPage = 0;
-      const result = await getProductReviews(state.product._id, { sort: currentSort, page: 0 });
+      state.reviewSort = dropdown.value;
+      state.reviewPage = 0;
+      const result = await getProductReviews(state.product._id, { sort: state.reviewSort, page: 0 });
       renderReviews($w, result);
-      updatePaginationState($w, result);
+      updatePaginationState($w, state, result);
     });
   } catch (e) {}
 }
@@ -201,17 +206,17 @@ function initSortDropdown($w, state, getProductReviews) {
 // ── Pagination ────────────────────────────────────────────────────────
 
 function initPagination($w, state, initialResult, getProductReviews) {
-  updatePaginationState($w, initialResult);
+  updatePaginationState($w, state, initialResult);
 
   try {
     const nextBtn = $w('#reviewsNextBtn');
     if (nextBtn) {
       try { nextBtn.accessibility.ariaLabel = 'Next page of reviews'; } catch (e) {}
       nextBtn.onClick(async () => {
-        currentPage++;
-        const result = await getProductReviews(state.product._id, { sort: currentSort, page: currentPage });
+        state.reviewPage++;
+        const result = await getProductReviews(state.product._id, { sort: state.reviewSort, page: state.reviewPage });
         renderReviews($w, result);
-        updatePaginationState($w, result);
+        updatePaginationState($w, state, result);
       });
     }
   } catch (e) {}
@@ -221,28 +226,28 @@ function initPagination($w, state, initialResult, getProductReviews) {
     if (prevBtn) {
       try { prevBtn.accessibility.ariaLabel = 'Previous page of reviews'; } catch (e) {}
       prevBtn.onClick(async () => {
-        currentPage = Math.max(0, currentPage - 1);
-        const result = await getProductReviews(state.product._id, { sort: currentSort, page: currentPage });
+        state.reviewPage = Math.max(0, state.reviewPage - 1);
+        const result = await getProductReviews(state.product._id, { sort: state.reviewSort, page: state.reviewPage });
         renderReviews($w, result);
-        updatePaginationState($w, result);
+        updatePaginationState($w, state, result);
       });
     }
   } catch (e) {}
 }
 
-function updatePaginationState($w, result) {
+function updatePaginationState($w, state, result) {
   const totalPages = Math.ceil(result.total / result.pageSize);
   try {
     const prevBtn = $w('#reviewsPrevBtn');
-    if (prevBtn) { currentPage > 0 ? prevBtn.enable() : prevBtn.disable(); }
+    if (prevBtn) { state.reviewPage > 0 ? prevBtn.enable() : prevBtn.disable(); }
   } catch (e) {}
   try {
     const nextBtn = $w('#reviewsNextBtn');
-    if (nextBtn) { currentPage < totalPages - 1 ? nextBtn.enable() : nextBtn.disable(); }
+    if (nextBtn) { state.reviewPage < totalPages - 1 ? nextBtn.enable() : nextBtn.disable(); }
   } catch (e) {}
   try {
     $w('#reviewsPageInfo').text = totalPages > 0
-      ? `Page ${currentPage + 1} of ${totalPages}`
+      ? `Page ${state.reviewPage + 1} of ${totalPages}`
       : '';
   } catch (e) {}
 }

--- a/src/public/product/swatchSelector.js
+++ b/src/public/product/swatchSelector.js
@@ -18,6 +18,9 @@ let selectedSwatchId = null;
  * @param {Function} [options.onSelectVariant] - Called to trigger variant change when swatch matches a finish
  */
 export async function initSwatchSelector($w, product, { onSelectVariant } = {}) {
+  // Reset module state on init to prevent SPA navigation bleed
+  selectedSwatchId = null;
+
   try {
     const swatchSection = $w('#swatchSection');
     if (!swatchSection || !product) {

--- a/tests/productReviews.test.js
+++ b/tests/productReviews.test.js
@@ -138,4 +138,66 @@ describe('ProductReviews', () => {
     await initProductReviews($w, state);
     expect($w('#reviewsEmptyState').show).toHaveBeenCalled();
   });
+
+  // ── SPA state-bleed regression tests ────────────────────────────────
+
+  it('resets sort to newest on each init (SPA navigation)', async () => {
+    const { getProductReviews } = await import('backend/reviewsService.web');
+
+    // First product page — simulate sort change via onChange handler
+    await initProductReviews($w, state);
+    const sortDropdown = $w('#reviewsSortDropdown');
+    // Simulate user changing sort to 'helpful'
+    sortDropdown.value = 'helpful';
+    const onChangeHandler = sortDropdown.onChange.mock.calls[0][0];
+    await onChangeHandler();
+
+    // Verify sort was called with 'helpful'
+    expect(getProductReviews).toHaveBeenCalledWith(
+      state.product._id,
+      expect.objectContaining({ sort: 'helpful' })
+    );
+
+    // Navigate to second product (SPA) — fresh $w and state
+    vi.clearAllMocks();
+    const $w2 = create$w();
+    const state2 = { product: { ...futonFrame, _id: 'product-2' } };
+
+    await initProductReviews($w2, state2);
+
+    // Sort dropdown should be reset to 'newest', NOT carry over 'helpful'
+    expect($w2('#reviewsSortDropdown').value).toBe('newest');
+    // Initial fetch should use 'newest' sort and page 0
+    expect(getProductReviews).toHaveBeenCalledWith(
+      'product-2',
+      expect.objectContaining({ sort: 'newest', page: 0 })
+    );
+  });
+
+  it('resets page to 0 on each init (SPA navigation)', async () => {
+    const { getProductReviews } = await import('backend/reviewsService.web');
+    getProductReviews.mockResolvedValue({ reviews: mockReviews.reviews, total: 30, page: 0, pageSize: 10 });
+
+    // First product page — simulate pagination
+    await initProductReviews($w, state);
+    const nextBtn = $w('#reviewsNextBtn');
+    const nextHandler = nextBtn.onClick.mock.calls[0][0];
+    await nextHandler(); // go to page 1
+
+    // Navigate to second product (SPA)
+    vi.clearAllMocks();
+    getProductReviews.mockResolvedValue({ reviews: mockReviews.reviews, total: 30, page: 0, pageSize: 10 });
+    const $w2 = create$w();
+    const state2 = { product: { ...futonFrame, _id: 'product-2' } };
+
+    await initProductReviews($w2, state2);
+
+    // Should fetch page 0, not page 1 carried over from previous product
+    expect(getProductReviews).toHaveBeenCalledWith(
+      'product-2',
+      expect.objectContaining({ page: 0 })
+    );
+    // Prev button should be disabled (we're on page 0)
+    expect($w2('#reviewsPrevBtn').disable).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- **ProductReviews.js**: Moved `currentSort` and `currentPage` from module-level variables to `state.reviewSort` / `state.reviewPage`, reset on every `initProductReviews()` call. This prevents review sort/page from carrying over when users navigate between product pages in the SPA.
- **swatchSelector.js** (legacy): Added `selectedSwatchId = null` reset at top of `initSwatchSelector()` to prevent stale swatch selection.
- Updated `updatePaginationState` and `initSortDropdown` signatures to thread `state` through.

## Test plan
- [x] Added 2 regression tests: sort reset and page reset across simulated SPA navigations
- [x] All 15 ProductReviews tests pass
- [x] Full test suite passes (pre-existing liveChat.test.js failure unrelated)
- [ ] Manual: navigate Product A → sort reviews by "Most Helpful" → page 2 → navigate to Product B → verify reviews show "Newest" sort, page 1

Closes CF-al43

🤖 Generated with [Claude Code](https://claude.com/claude-code)