### PR TITLE
Audit: public utils — input validation, event leaks, a11y fixes

### DIFF
--- a/src/public/LiveChat.js
+++ b/src/public/LiveChat.js
@@ -6,6 +6,7 @@
 import { isOnline, getCannedResponses, getCannedResponse, sendMessage, getChatHistory, createSupportTicket } from 'backend/liveChatService.web';
 import { trackEvent } from 'public/engagementTracker';
 import { colors } from 'public/designTokens.js';
+import { validateEmail } from 'public/validators.js';
 
 let _sessionId = null;
 let _userName = '';
@@ -93,9 +94,9 @@ function initChatToggle($w) {
       });
     } catch (e) {}
 
-    // Escape key closes chat
+    // Escape key closes chat — named handler for cleanup
     if (typeof document !== 'undefined') {
-      document.addEventListener('keydown', (e) => {
+      const handleEscapeKey = (e) => {
         if (e.key === 'Escape') {
           try {
             const widget = $w('#chatWidget');
@@ -106,7 +107,12 @@ function initChatToggle($w) {
             }
           } catch (e2) {}
         }
-      });
+      };
+      document.addEventListener('keydown', handleEscapeKey);
+      // Store cleanup reference for SPA navigation
+      if (typeof window !== 'undefined') {
+        window.__cfChatEscCleanup = () => document.removeEventListener('keydown', handleEscapeKey);
+      }
     }
 
     // Keep widget collapsed initially
@@ -142,7 +148,7 @@ function initPreChatForm($w) {
         const name = $w('#preChatName').value?.trim() || '';
         const email = $w('#preChatEmail').value?.trim() || '';
 
-        if (!email || !email.includes('@')) {
+        if (!email || !validateEmail(email)) {
           try { $w('#preChatError').text = 'Please enter a valid email'; } catch (e) {}
           try { $w('#preChatError').show(); } catch (e) {}
           return;

--- a/src/public/ProductGallery.js
+++ b/src/public/ProductGallery.js
@@ -68,7 +68,7 @@ export function initImageGallery($w, state) {
         try { mainImage.accessibility.ariaLabel = 'Product image gallery, use arrow keys to navigate'; } catch (e) {}
         try { mainImage.accessibility.ariaRoledescription = 'carousel'; } catch (e) {}
 
-        document.addEventListener('keydown', (e) => {
+        const handleGalleryKeydown = (e) => {
           // Only handle arrow keys when gallery area has focus
           try {
             const items = gallery.items || [];
@@ -96,7 +96,12 @@ export function initImageGallery($w, state) {
               trackGalleryInteraction('keyboard', 'prev');
             }
           } catch (e) {}
-        });
+        };
+        document.addEventListener('keydown', handleGalleryKeydown);
+        // Store cleanup reference for SPA navigation
+        if (typeof window !== 'undefined') {
+          window.__cfGalleryKbCleanup = () => document.removeEventListener('keydown', handleGalleryKeydown);
+        }
       }
     } catch (e) {}
 

--- a/src/public/galleryHelpers.js
+++ b/src/public/galleryHelpers.js
@@ -201,7 +201,8 @@ export function scrollToElement($w, selector) {
 // Format product description for display (strip HTML, truncate)
 export function formatDescription(html, maxLength = 200) {
   if (!html) return '';
-  const text = html.replace(/<[^>]*>/g, '').trim();
+  // Strip closed tags and unclosed/malformed tags (e.g., <br without >)
+  const text = html.replace(/<[^>]*>?/g, '').trim();
   if (text.length <= maxLength) return text;
   return text.substring(0, maxLength).replace(/\s+\S*$/, '') + '...';
 }
@@ -314,6 +315,14 @@ export function initImageLightbox(galleryElement, mainImageElement) {
       try { $w('#lightboxCounter').hide(); } catch (e) {}
     }
   }
+
+  // Set ARIA attributes for lightbox overlay
+  try { $w('#lightboxOverlay').accessibility.role = 'dialog'; } catch (e) {}
+  try { $w('#lightboxOverlay').accessibility.ariaModal = true; } catch (e) {}
+  try { $w('#lightboxOverlay').accessibility.ariaLabel = 'Image lightbox gallery'; } catch (e) {}
+  try { $w('#lightboxClose').accessibility.ariaLabel = 'Close lightbox'; } catch (e) {}
+  try { $w('#lightboxPrev').accessibility.ariaLabel = 'Previous image'; } catch (e) {}
+  try { $w('#lightboxNext').accessibility.ariaLabel = 'Next image'; } catch (e) {}
 
   function openLightbox(startIndex = 0) {
     isOpen = true;
@@ -481,9 +490,14 @@ export function buildComparisonBar() {
     // Compare button — enabled when 2+ items selected
     try {
       $w('#compareButton').onClick(() => {
-        const ids = compareList.map(p => p._id).join(',');
+        // Validate product IDs before building URL to prevent injection
+        const ids = compareList
+          .map(p => p._id)
+          .filter(id => typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id))
+          .join(',');
+        if (!ids) return;
         import('wix-location-frontend').then(({ to }) => {
-          to(`/compare?products=${ids}`);
+          to(`/compare?products=${encodeURIComponent(ids)}`);
         });
       });
       if (compareList.length >= 2) {

--- a/src/public/socialProofToast.js
+++ b/src/public/socialProofToast.js
@@ -6,6 +6,7 @@
  */
 import { getProductSocialProof, getCategorySocialProof } from 'backend/socialProof.web';
 import { isMobile } from 'public/mobileHelpers';
+import { announce } from 'public/a11yHelpers.js';
 
 const SESSION_KEY = 'cf_social_proof';
 
@@ -112,8 +113,15 @@ function showToast($w, notification, config) {
     const toastClose = $w('#socialProofClose');
     if (!toastEl || !toastMsg) return;
 
+    // Set ARIA role for screen reader announcement
+    try { toastEl.accessibility.role = 'alert'; } catch (e) {}
+    try { toastEl.accessibility.ariaLive = 'polite'; } catch (e) {}
+
     // Set message
     toastMsg.text = notification.message;
+
+    // Announce to screen readers
+    announce($w, notification.message);
 
     // Set icon based on type
     try {

--- a/tests/publicUtilsAudit.test.js
+++ b/tests/publicUtilsAudit.test.js
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { validateEmail, validateDimension } from '../src/public/validators.js';
+import { formatDescription } from '../src/public/galleryHelpers.js';
+import { sanitize, validateId } from '../src/backend/utils/sanitize.js';
+
+// ── validators.js — Client-Side Validation ─────────────────────────────
+
+describe('validators.js', () => {
+  describe('validateEmail', () => {
+    it('accepts valid email', () => {
+      expect(validateEmail('user@example.com')).toBe(true);
+    });
+
+    it('accepts email with subdomain', () => {
+      expect(validateEmail('user@mail.example.com')).toBe(true);
+    });
+
+    it('rejects missing @', () => {
+      expect(validateEmail('userexample.com')).toBe(false);
+    });
+
+    it('rejects missing domain', () => {
+      expect(validateEmail('user@')).toBe(false);
+    });
+
+    it('rejects missing TLD', () => {
+      expect(validateEmail('user@example')).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(validateEmail('')).toBe(false);
+    });
+
+    it('rejects null', () => {
+      expect(validateEmail(null)).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+      expect(validateEmail(undefined)).toBe(false);
+    });
+
+    it('rejects number', () => {
+      expect(validateEmail(12345)).toBe(false);
+    });
+
+    it('rejects email with spaces', () => {
+      expect(validateEmail('user @example.com')).toBe(false);
+    });
+
+    it('rejects email with angle brackets (XSS vector)', () => {
+      expect(validateEmail('<script>@evil.com')).toBe(false);
+    });
+
+    it('trims whitespace before validation', () => {
+      expect(validateEmail('  user@example.com  ')).toBe(true);
+    });
+  });
+
+  describe('validateDimension', () => {
+    it('accepts valid dimension', () => {
+      expect(validateDimension(72)).toBe(true);
+    });
+
+    it('rejects zero', () => {
+      expect(validateDimension(0)).toBe(false);
+    });
+
+    it('rejects negative', () => {
+      expect(validateDimension(-10)).toBe(false);
+    });
+
+    it('rejects NaN', () => {
+      expect(validateDimension(NaN)).toBe(false);
+    });
+
+    it('rejects Infinity', () => {
+      expect(validateDimension(Infinity)).toBe(false);
+    });
+
+    it('rejects string', () => {
+      expect(validateDimension('72')).toBe(false);
+    });
+
+    it('rejects value above max', () => {
+      expect(validateDimension(601)).toBe(false);
+    });
+
+    it('accepts custom min/max', () => {
+      expect(validateDimension(5, 1, 10)).toBe(true);
+      expect(validateDimension(11, 1, 10)).toBe(false);
+    });
+
+    it('accepts boundary values', () => {
+      expect(validateDimension(1)).toBe(true);
+      expect(validateDimension(600)).toBe(true);
+    });
+  });
+});
+
+// ── sanitize.js — Backend Sanitization ──────────────────────────────────
+
+describe('sanitize', () => {
+  it('strips HTML tags but preserves text content between them', () => {
+    // sanitize strips tags only, text content remains (safe for .text assignment)
+    expect(sanitize('<script>alert(1)</script>hello')).toBe('alert(1)hello');
+    expect(sanitize('<b>bold</b> text')).toBe('bold text');
+  });
+
+  it('strips nested HTML', () => {
+    expect(sanitize('<div><p>text</p></div>')).toBe('text');
+  });
+
+  it('strips img onerror XSS vector', () => {
+    expect(sanitize('<img onerror="alert(1)">text')).toBe('text');
+  });
+
+  it('handles non-string input', () => {
+    expect(sanitize(null)).toBe('');
+    expect(sanitize(undefined)).toBe('');
+    expect(sanitize(123)).toBe('');
+  });
+
+  it('respects maxLen', () => {
+    const long = 'a'.repeat(2000);
+    expect(sanitize(long, 100).length).toBe(100);
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitize('  hello  ')).toBe('hello');
+  });
+
+  it('returns empty for empty string', () => {
+    expect(sanitize('')).toBe('');
+  });
+});
+
+describe('validateId', () => {
+  it('accepts valid alphanumeric ID', () => {
+    expect(validateId('abc-123_def')).toBe('abc-123_def');
+  });
+
+  it('rejects HTML in ID', () => {
+    expect(validateId('<script>alert(1)</script>')).toBe('');
+  });
+
+  it('rejects spaces', () => {
+    expect(validateId('abc def')).toBe('');
+  });
+
+  it('rejects special characters', () => {
+    expect(validateId('abc;DROP TABLE')).toBe('');
+  });
+
+  it('truncates long IDs', () => {
+    const long = 'a'.repeat(100);
+    expect(validateId(long).length).toBe(50);
+  });
+
+  it('handles non-string input', () => {
+    expect(validateId(null)).toBe('');
+    expect(validateId(undefined)).toBe('');
+    expect(validateId(123)).toBe('');
+  });
+});
+
+// ── formatDescription — XSS via HTML stripping ─────────────────────────
+
+describe('formatDescription XSS edge cases', () => {
+  it('strips script tags', () => {
+    const result = formatDescription('<script>alert("xss")</script>text');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('text');
+  });
+
+  it('strips event handler attributes', () => {
+    const result = formatDescription('<img onerror="alert(1)">text');
+    expect(result).not.toContain('onerror');
+    expect(result).toContain('text');
+  });
+
+  it('strips nested malicious tags', () => {
+    const result = formatDescription('<div onmouseover="steal()"><a href="javascript:void">click</a></div>');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+    expect(result).toContain('click');
+  });
+
+  it('handles unclosed tags', () => {
+    const result = formatDescription('<p>text<br');
+    // After fix: unclosed tags like <br should be stripped
+    expect(result).not.toContain('<');
+    expect(result).toContain('text');
+  });
+
+  it('handles empty tags', () => {
+    const result = formatDescription('<><>text');
+    expect(result).toBe('text');
+  });
+});
+
+// ── Compare URL ID Validation ───────────────────────────────────────────
+
+describe('Compare URL product ID safety', () => {
+  it('validateId rejects injection in product IDs', () => {
+    // Product IDs passed in compare URLs should be safe
+    expect(validateId('valid-product-123')).toBe('valid-product-123');
+    expect(validateId('"><script>alert(1)</script>')).toBe('');
+    expect(validateId("'; DROP TABLE products; --")).toBe('');
+  });
+
+  it('validateId handles comma-separated IDs individually', () => {
+    // Compare URL uses IDs joined by commas — each should be validated
+    const ids = 'prod-1,prod-2,<script>alert(1)</script>';
+    const validated = ids.split(',').map(id => validateId(id.trim())).filter(Boolean);
+    expect(validated).toEqual(['prod-1', 'prod-2']);
+    expect(validated).not.toContain('');
+  });
+});
+
+// ── LiveChat Input Validation ───────────────────────────────────────────
+
+describe('LiveChat email validation strength', () => {
+  it('basic includes("@") is insufficient — validateEmail is needed', () => {
+    // The weak check `email.includes('@')` accepts these invalid emails:
+    expect('@'.includes('@')).toBe(true); // No user or domain
+    expect('user@'.includes('@')).toBe(true); // No domain
+    expect('@domain'.includes('@')).toBe(true); // No user
+
+    // But validateEmail correctly rejects them:
+    expect(validateEmail('@')).toBe(false);
+    expect(validateEmail('user@')).toBe(false);
+    expect(validateEmail('@domain')).toBe(false);
+  });
+
+  it('validateEmail rejects XSS in email field', () => {
+    expect(validateEmail('<script>@evil.com</script>')).toBe(false);
+    expect(validateEmail('"><img onerror=alert(1)>@x.com')).toBe(false);
+  });
+});
+
+// ── Chat Message Sanitization ───────────────────────────────────────────
+
+describe('Chat message content safety', () => {
+  it('sanitize strips XSS from user messages before storage', () => {
+    const malicious = '<script>document.cookie</script>How much is shipping?';
+    const clean = sanitize(malicious);
+    expect(clean).not.toContain('<script>');
+    expect(clean).toContain('How much is shipping?');
+  });
+
+  it('sanitize strips HTML from chat names', () => {
+    const malicious = '<img onerror=alert(1)>John';
+    const clean = sanitize(malicious);
+    expect(clean).not.toContain('<img');
+    expect(clean).toContain('John');
+  });
+
+  it('sanitize handles extremely long messages', () => {
+    const spam = 'x'.repeat(10000);
+    const clean = sanitize(spam, 500);
+    expect(clean.length).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- **Input validation**: Replace weak `email.includes('@')` in LiveChat with proper `validateEmail()` from `validators.js`
- **Event listener leaks**: Convert anonymous `document.addEventListener` handlers to named functions with cleanup refs in LiveChat and ProductGallery (prevents memory leaks on SPA navigation)
- **XSS hardening**: Fix `formatDescription` regex to strip unclosed/malformed HTML tags; validate and encode product IDs in compare URL
- **Accessibility**: Add ARIA dialog/modal attributes to image lightbox, add `role=alert` + screen reader announcements to social proof toasts
- **Tests**: Add 46 audit tests covering input validation edge cases, sanitization, and XSS vectors

## Files Changed
| File | Change |
|------|--------|
| `src/public/LiveChat.js` | Use `validateEmail()`, named escape handler with cleanup |
| `src/public/ProductGallery.js` | Named keyboard handler with cleanup ref |
| `src/public/galleryHelpers.js` | Fix unclosed tag regex, validate compare IDs, lightbox ARIA |
| `src/public/socialProofToast.js` | ARIA role=alert, aria-live, screen reader announce |
| `tests/publicUtilsAudit.test.js` | 46 new tests |

## Test plan
- [x] 46 new audit tests pass
- [x] 228 related tests pass (galleryHelpers, a11yHelpers, cartService, addToCart, publicUtilsAudit)
- [x] Full suite: 4503 pass, 7 fail (all pre-existing — liveChat.web.js syntax error, contentImport, errorMonitoring)
- [ ] Manual: verify lightbox keyboard navigation announces to screen readers
- [ ] Manual: verify social proof toast announced via aria-live region

Closes cf-8iy

🤖 Generated with [Claude Code](https://claude.com/claude-code)