### PR TITLE
Fix memory leaks: event listener cleanup on SPA navigation

### DIFF
--- a/src/public/LiveChat.js
+++ b/src/public/LiveChat.js
@@ -13,6 +13,7 @@ let _sessionId = null;
 let _userName = '';
 let _userEmail = '';
 let _isOnline = false;
+let _escapeKeyHandler = null;
 
 /**
  * Initialize the live chat widget. Called from masterPage.js after page load.
@@ -95,9 +96,12 @@ function initChatToggle($w) {
       });
     } catch (e) {}
 
-    // Escape key closes chat
+    // Escape key closes chat — store ref for cleanup
     if (typeof document !== 'undefined') {
-      document.addEventListener('keydown', (e) => {
+      if (_escapeKeyHandler) {
+        document.removeEventListener('keydown', _escapeKeyHandler);
+      }
+      _escapeKeyHandler = (e) => {
         if (e.key === 'Escape') {
           try {
             const widget = $w('#chatWidget');
@@ -108,7 +112,8 @@ function initChatToggle($w) {
             }
           } catch (e2) {}
         }
-      });
+      };
+      document.addEventListener('keydown', _escapeKeyHandler);
     }
 
     // Keep widget collapsed initially
@@ -294,4 +299,17 @@ function getOrCreateSessionId() {
 
   // Fallback if sessionStorage unavailable
   return `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Remove all LiveChat document event listeners.
+ * Call on SPA page navigation to prevent memory leaks.
+ */
+export function cleanupLiveChat() {
+  try {
+    if (typeof document !== 'undefined' && _escapeKeyHandler) {
+      document.removeEventListener('keydown', _escapeKeyHandler);
+      _escapeKeyHandler = null;
+    }
+  } catch (e) {}
 }

--- a/src/public/ProductGallery.js
+++ b/src/public/ProductGallery.js
@@ -9,7 +9,7 @@ import { announce } from 'public/a11yHelpers.js';
 export function initImageGallery($w, state) {
   try {
     const product = state.product;
-    if (!product) return;
+    if (!product) return { destroy() {} };
 
     const mainImage = $w('#productMainImage');
     if (mainImage) {
@@ -62,13 +62,14 @@ export function initImageGallery($w, state) {
     }
 
     // Keyboard arrow key navigation for gallery (WCAG 2.1.1)
+    let galleryKeyHandler = null;
     try {
       if (typeof document !== 'undefined' && gallery) {
         let kbIdx = 0;
         try { mainImage.accessibility.ariaLabel = 'Product image gallery, use arrow keys to navigate'; } catch (e) {}
         try { mainImage.accessibility.ariaRoledescription = 'carousel'; } catch (e) {}
 
-        document.addEventListener('keydown', (e) => {
+        galleryKeyHandler = (e) => {
           // Only handle arrow keys when gallery area has focus
           try {
             const items = gallery.items || [];
@@ -96,13 +97,28 @@ export function initImageGallery($w, state) {
               trackGalleryInteraction('keyboard', 'prev');
             }
           } catch (e) {}
-        });
+        };
+        document.addEventListener('keydown', galleryKeyHandler);
       }
     } catch (e) {}
 
-    initImageLightbox($w, $w('#productGallery'), $w('#productMainImage'));
+    const lightbox = initImageLightbox($w, $w('#productGallery'), $w('#productMainImage'));
     initImageZoom($w, $w('#productMainImage'));
+
+    // Return cleanup function for SPA navigation
+    return {
+      destroy() {
+        try {
+          if (typeof document !== 'undefined' && galleryKeyHandler) {
+            document.removeEventListener('keydown', galleryKeyHandler);
+            galleryKeyHandler = null;
+          }
+          if (lightbox && lightbox.destroy) lightbox.destroy();
+        } catch (e) {}
+      },
+    };
   } catch (e) {}
+  return { destroy() {} };
 }
 
 export function initProductBadge($w, state) {

--- a/src/public/galleryHelpers.js
+++ b/src/public/galleryHelpers.js
@@ -44,14 +44,23 @@ export function trackProductView(product) {
 
 const BROWSE_DATA_KEY = 'cf_browse_data';
 
+// Store refs for cleanup on SPA navigation
+let _browseScrollHandler = null;
+let _browseUnloadHandler = null;
+let _browseVisChangeHandler = null;
+
 function startBrowseTracking(productId) {
+  // Clean up any previous tracking listeners first
+  cleanupBrowseTracking();
+
   try {
     const startTime = Date.now();
     let scrolledToPricing = false;
     let variantInteractions = 0;
 
     // Track scroll to pricing section using DOM API (no $w in public modules)
-    const checkPricingScroll = () => {
+    // Store handler reference for SPA cleanup
+    _browseScrollHandler = () => {
       try {
         if (typeof document !== 'undefined') {
           const pricingEl = document.querySelector('[data-testid="product-price"], [id*="productPrice"]');
@@ -59,7 +68,8 @@ function startBrowseTracking(productId) {
             const rect = pricingEl.getBoundingClientRect();
             if (rect.top < window.innerHeight) {
               scrolledToPricing = true;
-              window.removeEventListener('scroll', checkPricingScroll);
+              window.removeEventListener('scroll', _browseScrollHandler);
+              _browseScrollHandler = null;
             }
           }
         }
@@ -67,7 +77,7 @@ function startBrowseTracking(productId) {
     };
 
     if (typeof window !== 'undefined') {
-      window.addEventListener('scroll', checkPricingScroll, { passive: true });
+      window.addEventListener('scroll', _browseScrollHandler, { passive: true });
     }
 
     // Variant interactions are tracked by page-level code which has $w access.
@@ -91,18 +101,43 @@ function startBrowseTracking(productId) {
       } catch (e) {}
     };
 
+    _browseUnloadHandler = recordBrowseData;
+    _browseVisChangeHandler = () => {
+      if (document.visibilityState === 'hidden') {
+        recordBrowseData();
+      }
+    };
+
     if (typeof window !== 'undefined') {
-      window.addEventListener('beforeunload', recordBrowseData);
-      // Also capture on visibility change (mobile tab switches)
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'hidden') {
-          recordBrowseData();
-        }
-      });
+      window.addEventListener('beforeunload', _browseUnloadHandler);
+      document.addEventListener('visibilitychange', _browseVisChangeHandler);
     }
   } catch (e) {
     // Browse tracking is non-critical
   }
+}
+
+/**
+ * Remove all browse tracking event listeners.
+ * Call on SPA page navigation to prevent memory leaks.
+ */
+export function cleanupBrowseTracking() {
+  try {
+    if (typeof window !== 'undefined') {
+      if (_browseScrollHandler) {
+        window.removeEventListener('scroll', _browseScrollHandler);
+        _browseScrollHandler = null;
+      }
+      if (_browseUnloadHandler) {
+        window.removeEventListener('beforeunload', _browseUnloadHandler);
+        _browseUnloadHandler = null;
+      }
+    }
+    if (typeof document !== 'undefined' && _browseVisChangeHandler) {
+      document.removeEventListener('visibilitychange', _browseVisChangeHandler);
+      _browseVisChangeHandler = null;
+    }
+  } catch (e) {}
 }
 
 export function getBrowseData() {
@@ -379,7 +414,15 @@ export function initImageLightbox($w, galleryElement, mainImageElement) {
     }
   } catch (e) {}
 
-  return { open: openLightbox, close: closeLightbox, handleKeydown };
+  function destroy() {
+    try {
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('keydown', handleKeydown);
+      }
+    } catch (e) {}
+  }
+
+  return { open: openLightbox, close: closeLightbox, handleKeydown, destroy };
 }
 
 // ── Image Zoom ──────────────────────────────────────────────────────

--- a/src/public/socialProofToast.js
+++ b/src/public/socialProofToast.js
@@ -9,6 +9,8 @@ import { isMobile } from 'public/mobileHelpers';
 import { announce } from 'public/a11yHelpers';
 
 const SESSION_KEY = 'cf_social_proof';
+let _closeHandlerBound = false;
+let _currentDismissTimer = null;
 
 function getSessionState() {
   try {
@@ -137,16 +139,35 @@ function showToast($w, notification, config) {
     setSessionState({ count: state.count + 1, lastShown: now });
 
     // Auto-dismiss
-    const dismissTimer = setTimeout(() => {
+    if (_currentDismissTimer) clearTimeout(_currentDismissTimer);
+    _currentDismissTimer = setTimeout(() => {
       try { toastEl.hide('fade', { duration: 300 }); } catch (e) {}
+      _currentDismissTimer = null;
     }, config.autoDismissMs);
 
-    // Manual close
-    try {
-      toastClose.onClick(() => {
-        clearTimeout(dismissTimer);
-        try { toastEl.hide('fade', { duration: 200 }); } catch (e) {}
-      });
-    } catch (e) {}
+    // Manual close — bind once to avoid stacking handlers
+    if (!_closeHandlerBound && toastClose) {
+      try {
+        toastClose.onClick(() => {
+          if (_currentDismissTimer) {
+            clearTimeout(_currentDismissTimer);
+            _currentDismissTimer = null;
+          }
+          try { toastEl.hide('fade', { duration: 200 }); } catch (e) {}
+        });
+        _closeHandlerBound = true;
+      } catch (e) {}
+    }
   } catch (e) {}
+}
+
+/**
+ * Reset toast state for SPA navigation cleanup.
+ */
+export function cleanupToast() {
+  if (_currentDismissTimer) {
+    clearTimeout(_currentDismissTimer);
+    _currentDismissTimer = null;
+  }
+  _closeHandlerBound = false;
 }

--- a/tests/memoryLeaks.test.js
+++ b/tests/memoryLeaks.test.js
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ═══════════════════════════════════════════════════════════════════
+// CF-wy0m: Memory leak tests — event listener cleanup
+//
+// Tests verify that init functions return cleanup/destroy methods
+// and that event listeners can be properly removed on SPA navigation.
+// ═══════════════════════════════════════════════════════════════════
+
+// ── Shared listener tracker ────────────────────────────────────────
+
+let docListeners, winListeners;
+let origDocAdd, origDocRemove, origWinAdd, origWinRemove;
+
+beforeEach(() => {
+  docListeners = [];
+  winListeners = [];
+
+  // Ensure document exists
+  if (typeof globalThis.document === 'undefined') {
+    globalThis.document = {};
+  }
+  if (typeof globalThis.window === 'undefined') {
+    globalThis.window = {
+      innerWidth: 1200,
+      location: { pathname: '/' },
+      matchMedia: () => ({ matches: false }),
+    };
+  }
+
+  // Wrap addEventListener/removeEventListener to track calls
+  origDocAdd = globalThis.document.addEventListener;
+  origDocRemove = globalThis.document.removeEventListener;
+  origWinAdd = globalThis.window.addEventListener;
+  origWinRemove = globalThis.window.removeEventListener;
+
+  globalThis.document.addEventListener = vi.fn((type, handler, opts) => {
+    docListeners.push({ type, handler });
+  });
+  globalThis.document.removeEventListener = vi.fn((type, handler) => {
+    docListeners = docListeners.filter(l => !(l.type === type && l.handler === handler));
+  });
+  globalThis.window.addEventListener = vi.fn((type, handler, opts) => {
+    winListeners.push({ type, handler });
+  });
+  globalThis.window.removeEventListener = vi.fn((type, handler) => {
+    winListeners = winListeners.filter(l => !(l.type === type && l.handler === handler));
+  });
+
+  // document.activeElement needed by ProductGallery
+  globalThis.document.activeElement = null;
+  globalThis.document.visibilityState = 'visible';
+});
+
+afterEach(() => {
+  // Restore originals if they existed
+  if (origDocAdd) globalThis.document.addEventListener = origDocAdd;
+  if (origDocRemove) globalThis.document.removeEventListener = origDocRemove;
+  if (origWinAdd) globalThis.window.addEventListener = origWinAdd;
+  if (origWinRemove) globalThis.window.removeEventListener = origWinRemove;
+  vi.restoreAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. galleryHelpers: initImageLightbox cleanup
+// ═══════════════════════════════════════════════════════════════════
+
+describe('galleryHelpers: initImageLightbox returns cleanup', () => {
+  it('returns a destroy function that removes keydown listener', async () => {
+    const { initImageLightbox } = await import('../src/public/galleryHelpers.js');
+
+    const mockGallery = {
+      items: [{ src: 'img1.jpg' }, { src: 'img2.jpg' }],
+      onItemClicked: vi.fn(),
+    };
+    const mockMainImage = { src: 'img1.jpg', onClick: vi.fn() };
+
+    const result = initImageLightbox(mockGallery, mockMainImage);
+
+    expect(result).not.toBeNull();
+    expect(typeof result.destroy).toBe('function');
+
+    // A keydown listener should have been added
+    const keydownsBefore = docListeners.filter(l => l.type === 'keydown');
+    expect(keydownsBefore.length).toBeGreaterThan(0);
+
+    // After destroy, the keydown listener should be removed
+    result.destroy();
+    const keydownsAfter = docListeners.filter(l => l.type === 'keydown');
+    expect(keydownsAfter.length).toBe(0);
+  });
+
+  it('destroy is safe to call multiple times', async () => {
+    const { initImageLightbox } = await import('../src/public/galleryHelpers.js');
+
+    const mockGallery = {
+      items: [{ src: 'img1.jpg' }],
+      onItemClicked: vi.fn(),
+    };
+    const mockMainImage = { src: 'img1.jpg', onClick: vi.fn() };
+
+    const result = initImageLightbox(mockGallery, mockMainImage);
+    expect(() => {
+      result.destroy();
+      result.destroy();
+    }).not.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. galleryHelpers: browse tracking cleanup
+// ═══════════════════════════════════════════════════════════════════
+
+describe('galleryHelpers: browse tracking cleanup', () => {
+  it('cleanupBrowseTracking removes window/document listeners', async () => {
+    const { trackProductView, cleanupBrowseTracking } = await import('../src/public/galleryHelpers.js');
+
+    // Trigger browse tracking
+    trackProductView({ _id: 'prod-leak-1', name: 'Test', slug: 'test', formattedPrice: '$100', mainMedia: '' });
+
+    // Should have added listeners (scroll, beforeunload on window; visibilitychange on document)
+    const hasBeforeunload = winListeners.some(l => l.type === 'beforeunload');
+    const hasVischange = docListeners.some(l => l.type === 'visibilitychange');
+    expect(hasBeforeunload || hasVischange).toBe(true);
+
+    // Cleanup should remove them
+    cleanupBrowseTracking();
+
+    const scrollAfter = winListeners.filter(l => l.type === 'scroll');
+    const beforeunloadAfter = winListeners.filter(l => l.type === 'beforeunload');
+    const vischangeAfter = docListeners.filter(l => l.type === 'visibilitychange');
+    expect(scrollAfter.length).toBe(0);
+    expect(beforeunloadAfter.length).toBe(0);
+    expect(vischangeAfter.length).toBe(0);
+  });
+
+  it('cleanupBrowseTracking is safe when no tracking active', async () => {
+    const { cleanupBrowseTracking } = await import('../src/public/galleryHelpers.js');
+    // Call cleanup first to clear any prior state
+    cleanupBrowseTracking();
+    // Call again — should not throw
+    expect(() => cleanupBrowseTracking()).not.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. socialProofToast: cleanup export
+// ═══════════════════════════════════════════════════════════════════
+
+describe('socialProofToast: cleanup', () => {
+  it('exports a cleanupToast function', async () => {
+    const mod = await import('../src/public/socialProofToast.js');
+    expect(typeof mod.cleanupToast).toBe('function');
+  });
+
+  it('cleanupToast is safe to call multiple times', async () => {
+    const { cleanupToast } = await import('../src/public/socialProofToast.js');
+    expect(() => {
+      cleanupToast();
+      cleanupToast();
+    }).not.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. LiveChat: Escape key listener cleanup
+// ═══════════════════════════════════════════════════════════════════
+
+describe('LiveChat: event listener cleanup', () => {
+  it('exports a cleanupLiveChat function', async () => {
+    const mod = await import('../src/public/LiveChat.js');
+    expect(typeof mod.cleanupLiveChat).toBe('function');
+  });
+
+  it('cleanupLiveChat is safe to call multiple times', async () => {
+    const { cleanupLiveChat } = await import('../src/public/LiveChat.js');
+    expect(() => {
+      cleanupLiveChat();
+      cleanupLiveChat();
+    }).not.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 5. ProductGallery: keyboard handler cleanup
+// ═══════════════════════════════════════════════════════════════════
+
+describe('ProductGallery: keyboard handler cleanup', () => {
+  it('initImageGallery returns object with destroy function', async () => {
+    const { initImageGallery } = await import('../src/public/ProductGallery.js');
+
+    const mockElement = (overrides = {}) => ({
+      show: vi.fn(), hide: vi.fn(), collapse: vi.fn(), expand: vi.fn(),
+      text: '', src: '', alt: '', accessibility: {},
+      onClick: vi.fn(), onMouseIn: vi.fn(), onMouseOut: vi.fn(),
+      onItemClicked: vi.fn(), onKeyPress: vi.fn(),
+      items: [], getElement: () => null,
+      ...overrides,
+    });
+
+    const elements = {
+      '#productMainImage': mockElement({ src: 'img1.jpg' }),
+      '#productGallery': mockElement({ items: [{ src: 'img1.jpg' }] }),
+      '#lightboxOverlay': mockElement(),
+      '#lightboxImage': mockElement(),
+      '#lightboxCounter': mockElement(),
+      '#lightboxPrev': mockElement(),
+      '#lightboxNext': mockElement(),
+      '#lightboxClose': mockElement(),
+      '#imageZoomOverlay': mockElement(),
+      '#imageZoomImage': mockElement(),
+      '#a11yLiveRegion': mockElement(),
+    };
+
+    const $w = vi.fn((sel) => elements[sel] || mockElement());
+    const state = { product: { _id: 'p1', name: 'Test', collections: ['futon-frames'], mediaItems: [] } };
+
+    const result = initImageGallery($w, state);
+
+    // Should return an object with destroy function (even if internal
+    // listeners weren't registered due to mock limitations)
+    expect(result).toBeDefined();
+    expect(typeof result.destroy).toBe('function');
+
+    // destroy should be safe to call
+    expect(() => result.destroy()).not.toThrow();
+  });
+
+  it('destroy is safe to call when no gallery exists', async () => {
+    const { initImageGallery } = await import('../src/public/ProductGallery.js');
+    const $w = vi.fn(() => null);
+    const result = initImageGallery($w, { product: null });
+    expect(result).toBeDefined();
+    expect(() => result.destroy()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- **CF-wy0m (P1)**: Multiple document/window event listeners were registered but never removed, stacking on each SPA page view causing memory leaks
- Store all listener refs in module-level variables and export cleanup/destroy functions
- Prevents listener stacking on repeated init calls (e.g. socialProofToast onClick)

## Files Changed
| File | Fix |
|------|-----|
| `ProductGallery.js` | Store keydown ref, return `{ destroy() }` from `initImageGallery` |
| `galleryHelpers.js` | Store scroll/beforeunload/visibilitychange refs, export `cleanupBrowseTracking()`; add `destroy()` to lightbox |
| `LiveChat.js` | Store escape key ref, export `cleanupLiveChat()` |
| `socialProofToast.js` | Bind onClick once (not per show), export `cleanupToast()` |

## Test plan
- [x] 10 new tests in `tests/memoryLeaks.test.js` — all passing
- [x] Tests verify cleanup functions exist and are callable
- [x] Tests verify listeners are actually removed (tracked via mock addEventListener/removeEventListener)
- [x] Tests verify double-call safety (no throws on repeated cleanup)
- [x] Tests verify null/missing state safety (no gallery, no tracking active)
- [x] Full test suite: 4485 pass, 1 fail (pre-existing errorMonitoring test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)