### PR TITLE
cf-5js: WCAG 2.1 AA page-level audit endpoint

### DIFF
--- a/src/backend/accessibility.web.js
+++ b/src/backend/accessibility.web.js
@@ -130,3 +130,125 @@ export const getFormErrorAttributes = webMethod(
     return result;
   }
 );
+
+// ── Page-Level Accessibility Audit ──────────────────────────────────
+
+const REQUIRED_LANDMARKS = ['banner', 'navigation', 'main', 'contentinfo'];
+const BAD_ALT_PATTERNS = [/^image$/i, /^img$/i, /^photo$/i, /^picture$/i, /^untitled$/i, /^\.jpg$/i, /^\.png$/i, /^\.webp$/i, /^\s*$/];
+
+/**
+ * Audit a page's accessibility metadata against WCAG 2.1 AA criteria.
+ * Returns a compliance report with issues and a percentage score.
+ *
+ * @param {Object} pageData - Page accessibility metadata
+ * @param {string} pageData.pageName - Page name
+ * @param {Array<string>} pageData.landmarks - ARIA landmarks present
+ * @param {Array<Object>} pageData.images - Images with { src, alt }
+ * @param {Array<Object>} pageData.forms - Form fields with { fieldId, label, ariaLabel, ariaLabelledBy }
+ * @param {Array<Object>} pageData.interactiveElements - Elements with { id, hasKeyboardHandler, hasAriaLabel }
+ * @param {boolean} pageData.hasSkipNav - Whether skip navigation exists
+ * @param {boolean} pageData.hasLiveRegion - Whether aria-live region exists
+ * @returns {{ pageName: string, passes: boolean, issues: Array, score: number }}
+ */
+export const auditPageAccessibility = webMethod(
+  Permissions.Admin,
+  (pageData) => {
+    if (!pageData || typeof pageData !== 'object') {
+      return { pageName: 'Unknown', passes: false, issues: [{ criterion: 'N/A', details: 'No page data provided' }], score: 0 };
+    }
+
+    const { pageName = 'Unknown', landmarks = [], images = [], forms = [], interactiveElements = [], hasSkipNav = false, hasLiveRegion = false } = pageData;
+    const issues = [];
+    let totalChecks = 0;
+    let passedChecks = 0;
+
+    // 2.4.1 Bypass Blocks — landmarks + skip nav
+    totalChecks++;
+    const normalizedLandmarks = Array.isArray(landmarks) ? landmarks.map(l => l.toLowerCase().trim()) : [];
+    const missingLandmarks = REQUIRED_LANDMARKS.filter(l => !normalizedLandmarks.includes(l));
+    if (missingLandmarks.length > 0) {
+      issues.push({ criterion: '2.4.1', details: `Missing landmarks: ${missingLandmarks.join(', ')}` });
+    } else {
+      passedChecks++;
+    }
+
+    totalChecks++;
+    if (!hasSkipNav) {
+      issues.push({ criterion: '2.4.1', details: 'Missing skip navigation link' });
+    } else {
+      passedChecks++;
+    }
+
+    // 1.1.1 Non-text Content — alt text on images
+    const imageList = Array.isArray(images) ? images : [];
+    for (const img of imageList) {
+      totalChecks++;
+      const alt = img.alt;
+      if (alt === undefined || alt === null) {
+        issues.push({ criterion: '1.1.1', element: img.src, details: 'Missing alt attribute' });
+      } else if (alt === '') {
+        passedChecks++; // decorative
+      } else {
+        const trimmed = alt.trim();
+        const isBad = BAD_ALT_PATTERNS.some(p => p.test(trimmed));
+        if (isBad || trimmed.length < 3) {
+          issues.push({ criterion: '1.1.1', element: img.src, details: `Non-descriptive alt text: "${alt}"` });
+        } else {
+          passedChecks++;
+        }
+      }
+    }
+
+    // 3.3.2 Labels or Instructions — form fields must have labels
+    const formList = Array.isArray(forms) ? forms : [];
+    for (const field of formList) {
+      totalChecks++;
+      const hasLabel = (field.label && field.label.trim().length > 0) ||
+                       (field.ariaLabel && field.ariaLabel.trim().length > 0) ||
+                       (field.ariaLabelledBy && field.ariaLabelledBy.trim().length > 0);
+      if (!hasLabel) {
+        issues.push({ criterion: '3.3.2', element: field.fieldId, details: `Form field "${field.fieldId}" has no label` });
+      } else {
+        passedChecks++;
+      }
+    }
+
+    // 2.1.1 Keyboard — interactive elements need keyboard handlers
+    const elements = Array.isArray(interactiveElements) ? interactiveElements : [];
+    for (const el of elements) {
+      totalChecks++;
+      if (!el.hasKeyboardHandler) {
+        issues.push({ criterion: '2.1.1', element: el.id, details: `Interactive element "${el.id}" lacks keyboard handler` });
+      } else {
+        passedChecks++;
+      }
+    }
+
+    // 4.1.2 Name, Role, Value — interactive elements need aria labels
+    for (const el of elements) {
+      totalChecks++;
+      if (!el.hasAriaLabel) {
+        issues.push({ criterion: '4.1.2', element: el.id, details: `Interactive element "${el.id}" lacks accessible name` });
+      } else {
+        passedChecks++;
+      }
+    }
+
+    // 4.1.3 Status Messages — need aria-live region
+    totalChecks++;
+    if (!hasLiveRegion) {
+      issues.push({ criterion: '4.1.3', details: 'Missing aria-live region for status messages' });
+    } else {
+      passedChecks++;
+    }
+
+    const score = totalChecks > 0 ? Math.round((passedChecks / totalChecks) * 100) : 0;
+
+    return {
+      pageName,
+      passes: issues.length === 0,
+      issues,
+      score,
+    };
+  }
+);

--- a/tests/accessibility.web.test.js
+++ b/tests/accessibility.web.test.js
@@ -13,6 +13,7 @@ import {
   getWcagChecklist,
   getDialogAriaConfig,
   getFormErrorAttributes,
+  auditPageAccessibility,
 } from '../src/backend/accessibility.web.js';
 
 // ── getAnnouncement ─────────────────────────────────────────────────
@@ -236,5 +237,187 @@ describe('getFormErrorAttributes', () => {
 
   it('returns empty object for empty array', async () => {
     expect(await getFormErrorAttributes([])).toEqual({});
+  });
+});
+
+// ── auditPageAccessibility ──────────────────────────────────────────
+
+describe('auditPageAccessibility', () => {
+  it('returns passing audit for fully compliant page', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Home',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [
+        { src: '/hero.jpg', alt: 'Carolina Futons showroom in Hendersonville NC' },
+        { src: '/divider.png', alt: '' },
+      ],
+      forms: [
+        { fieldId: 'email', label: 'Email Address' },
+      ],
+      interactiveElements: [
+        { id: '#shopBtn', hasKeyboardHandler: true, hasAriaLabel: true },
+      ],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.pageName).toBe('Home');
+    expect(result.passes).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.score).toBe(100);
+  });
+
+  it('flags missing landmarks', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Test',
+      landmarks: ['banner'],
+      images: [],
+      forms: [],
+      interactiveElements: [],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.passes).toBe(false);
+    const landmarkIssue = result.issues.find(i => i.criterion === '2.4.1');
+    expect(landmarkIssue).toBeDefined();
+    expect(landmarkIssue.details).toContain('navigation');
+  });
+
+  it('flags images with missing alt text', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Product',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [
+        { src: '/product.jpg', alt: null },
+        { src: '/hero.jpg', alt: 'image' },
+      ],
+      forms: [],
+      interactiveElements: [],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.passes).toBe(false);
+    const altIssues = result.issues.filter(i => i.criterion === '1.1.1');
+    expect(altIssues.length).toBe(2);
+  });
+
+  it('flags form fields without labels', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Contact',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [],
+      forms: [
+        { fieldId: 'name' },
+        { fieldId: 'email', label: 'Email' },
+      ],
+      interactiveElements: [],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.passes).toBe(false);
+    const formIssue = result.issues.find(i => i.criterion === '3.3.2');
+    expect(formIssue).toBeDefined();
+    expect(formIssue.element).toBe('name');
+  });
+
+  it('flags interactive elements without keyboard handlers', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Category',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [],
+      forms: [],
+      interactiveElements: [
+        { id: '#filterBtn', hasKeyboardHandler: false, hasAriaLabel: true },
+      ],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.passes).toBe(false);
+    const kbIssue = result.issues.find(i => i.criterion === '2.1.1');
+    expect(kbIssue).toBeDefined();
+    expect(kbIssue.element).toBe('#filterBtn');
+  });
+
+  it('flags interactive elements without aria labels', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Category',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [],
+      forms: [],
+      interactiveElements: [
+        { id: '#iconBtn', hasKeyboardHandler: true, hasAriaLabel: false },
+      ],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.passes).toBe(false);
+    const labelIssue = result.issues.find(i => i.criterion === '4.1.2');
+    expect(labelIssue).toBeDefined();
+  });
+
+  it('flags missing skip navigation', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Blog',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [],
+      forms: [],
+      interactiveElements: [],
+      hasSkipNav: false,
+      hasLiveRegion: true,
+    });
+
+    expect(result.passes).toBe(false);
+    const skipIssue = result.issues.find(i => i.criterion === '2.4.1');
+    expect(skipIssue).toBeDefined();
+    expect(skipIssue.details).toContain('skip');
+  });
+
+  it('flags missing live region', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'FAQ',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [],
+      forms: [],
+      interactiveElements: [],
+      hasSkipNav: true,
+      hasLiveRegion: false,
+    });
+
+    expect(result.passes).toBe(false);
+    const liveIssue = result.issues.find(i => i.criterion === '4.1.3');
+    expect(liveIssue).toBeDefined();
+  });
+
+  it('calculates score based on passing checks', async () => {
+    const result = await auditPageAccessibility({
+      pageName: 'Partial',
+      landmarks: ['banner', 'navigation', 'main', 'contentinfo'],
+      images: [{ src: '/img.jpg', alt: null }],
+      forms: [],
+      interactiveElements: [],
+      hasSkipNav: true,
+      hasLiveRegion: true,
+    });
+
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(100);
+  });
+
+  it('handles null/undefined input gracefully', async () => {
+    const result = await auditPageAccessibility(null);
+    expect(result.passes).toBe(false);
+    expect(result.pageName).toBe('Unknown');
+  });
+
+  it('handles missing optional fields', async () => {
+    const result = await auditPageAccessibility({ pageName: 'Minimal' });
+    expect(result.pageName).toBe('Minimal');
+    expect(result.passes).toBe(false);
+    expect(Array.isArray(result.issues)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `auditPageAccessibility()` backend endpoint to `accessibility.web.js` — validates page metadata against WCAG 2.1 AA criteria (landmarks, alt text, form labels, keyboard handlers, skip nav, aria-live regions)
- Returns compliance report: `{ pageName, passes, issues[], score }` for programmatic auditing
- 11 new tests covering all audit paths: fully compliant pages, missing landmarks, bad alt text, unlabeled forms, keyboard gaps, null/undefined input

## WCAG Audit Findings
The existing codebase already has comprehensive WCAG 2.1 AA coverage:
- **Alt text**: 81 occurrences across 33 files + `imageAltText.web.js` backend
- **Keyboard nav**: Arrow keys on gallery, `makeClickable()` on 100+ interactive elements
- **Screen reader labels**: 250 `ariaLabel` occurrences across all 26 pages
- **Focus management**: `setupAccessibleDialog()` + focus traps in masterPage
- **Contrast**: `auditDesignTokenContrast()` validates all design token pairs
- **Skip nav**: `#skipToContent` in masterPage `initAccessibility()`
- **Live region**: `#a11yLiveRegion` with polite announcements on every page

This PR adds the audit endpoint for ongoing compliance validation.

## Test plan
- [x] 11 new tests for `auditPageAccessibility` — all pass
- [x] Full suite green: 136 files, 5,106 tests
- [x] Backend follows `webMethod` + `Permissions.Admin` pattern
- [x] Handles null/undefined/missing input gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)