### PR TITLE
cf-a1ps: Kill pink-lavender, apply brand palette

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -58,7 +58,7 @@ const CATEGORY_CONTENT = {
   'platform-beds': {
     title: 'Platform Beds',
     subtitle: 'Modern simplicity meets mountain craftsmanship',
-    heroGradient: `linear-gradient(135deg, ${colors.sandBase} 0%, ${colors.mauve} 100%)`,
+    heroGradient: `linear-gradient(135deg, ${colors.sandBase} 0%, ${colors.sandDark} 100%)`,
   },
   'casegoods-accessories': {
     title: 'Casegoods & Accessories',

--- a/src/public/galleryHelpers.js
+++ b/src/public/galleryHelpers.js
@@ -1,6 +1,7 @@
 // Gallery and product engagement helpers
 // Used across multiple pages for consistent product display behavior
 import { session } from 'wix-storage-frontend';
+import { colors } from 'public/designTokens.js';
 
 // Recently viewed products tracking (stored in session storage)
 const RECENTLY_VIEWED_KEY = 'cf_recently_viewed';
@@ -307,7 +308,7 @@ export function buildProductBadgeOverlay(product) {
     Sale:            { text: 'Sale',          bgColor: colors.sunsetCoral,  textColor: colors.white },
     New:             { text: 'New',           bgColor: colors.mountainBlue, textColor: colors.white },
     Featured:        { text: 'Featured',      bgColor: colors.espresso,     textColor: colors.sandBase },
-    'In-Store Only': { text: 'In-Store Only', bgColor: colors.mauve,        textColor: colors.espresso },
+    'In-Store Only': { text: 'In-Store Only', bgColor: colors.sandDark,      textColor: colors.espresso },
   };
 
   return configs[badge] || { text: badge, bgColor: colors.espresso, textColor: colors.white };

--- a/src/public/sharedTokens.js
+++ b/src/public/sharedTokens.js
@@ -24,7 +24,6 @@ export const colors = {
   sunsetCoral: '#E8845C',
   sunsetCoralDark: '#C96B44',
   sunsetCoralLight: '#F2A882',
-  mauve: '#C9A0A0',
   white: '#FFFFFF',
 
   // Decorative

--- a/tests/brandPalette.test.js
+++ b/tests/brandPalette.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { colors } from '../src/public/sharedTokens.js';
+import { buildProductBadgeOverlay } from '../src/public/galleryHelpers.js';
+
+// ═══════════════════════════════════════════════════════════════════
+// CF-a1ps: Brand Palette Compliance
+// Ensures no pink/lavender/mauve colors appear in customer-facing UI.
+// Brand palette: Sand, Espresso, Mountain Blue, Coral, Off-White.
+// ═══════════════════════════════════════════════════════════════════
+
+// Allowed brand palette colors (hex values, lowercase)
+const BRAND_PALETTE = new Set([
+  '#e8d5b7',  // sandBase
+  '#f2e8d5',  // sandLight
+  '#d4bc96',  // sandDark
+  '#3a2518',  // espresso
+  '#5c4033',  // espressoLight
+  '#5b8fa8',  // mountainBlue
+  '#3d6b80',  // mountainBlueDark
+  '#a8ccd8',  // mountainBlueLight
+  '#e8845c',  // sunsetCoral
+  '#c96b44',  // sunsetCoralDark
+  '#f2a882',  // sunsetCoralLight
+  '#ffffff',  // white
+  '#b8d4e3',  // skyGradientTop
+  '#f0c87a',  // skyGradientBottom
+  '#4a7c59',  // success
+  '#999999',  // muted
+  '#8b7355',  // mutedBrown
+]);
+
+describe('Brand palette compliance (CF-a1ps)', () => {
+  it('colors.mauve (#C9A0A0) is NOT used in any badge background', () => {
+    const inStoreBadge = buildProductBadgeOverlay({ inStoreOnly: true, name: 'Test' });
+    expect(inStoreBadge).toBeTruthy();
+    expect(inStoreBadge.bgColor).not.toBe('#C9A0A0');
+    expect(inStoreBadge.bgColor).not.toBe(colors.mauve);
+    // Should use a brand-approved color instead
+    expect(BRAND_PALETTE.has(inStoreBadge.bgColor.toLowerCase())).toBe(true);
+  });
+
+  it('all badge configs use brand palette colors', () => {
+    const badges = [
+      buildProductBadgeOverlay({ ribbon: 'Sale', name: 'Test' }),
+      buildProductBadgeOverlay({ ribbon: 'New', name: 'Test' }),
+      buildProductBadgeOverlay({ ribbon: 'Featured', name: 'Test' }),
+      buildProductBadgeOverlay({ inStoreOnly: true, name: 'Test' }),
+    ];
+
+    for (const badge of badges) {
+      expect(badge).toBeTruthy();
+      expect(BRAND_PALETTE.has(badge.bgColor.toLowerCase()),
+        `Badge "${badge.text}" uses off-brand bgColor: ${badge.bgColor}`
+      ).toBe(true);
+      expect(BRAND_PALETTE.has(badge.textColor.toLowerCase()),
+        `Badge "${badge.text}" uses off-brand textColor: ${badge.textColor}`
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **Platform beds hero gradient**: replaced `sandBase→mauve` with `sandBase→sandDark` — warm neutral instead of pink-lavender
- **"In-Store Only" badge**: background changed from `mauve` to `sandDark` — matches brand palette
- **Missing import fixed**: `galleryHelpers.js` used `colors` without importing it (latent runtime crash)
- **Removed `mauve` from shared tokens**: `#C9A0A0` is no longer part of the design system
- **Brand palette compliance test**: `brandPalette.test.js` enforces all badge colors are brand-approved hex values

## Test plan
- [x] All 5184 tests pass (`npm test`)
- [x] New `brandPalette.test.js` validates badge colors against allowed palette
- [x] Grep confirms zero remaining `mauve` references in `src/`
- [x] No pink/lavender colors remain in any gradient or badge config

🤖 Generated with [Claude Code](https://claude.com/claude-code)