### PR TITLE
cf-b0sr: Category showcase — lifestyle cards

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -8,6 +8,7 @@ import { getCategoryHeroImage, getCategoryCardImage } from 'public/placeholderIm
 import { isMobile, collapseOnMobile, initBackToTop, limitForViewport } from 'public/mobileHelpers';
 import { trackEvent } from 'public/engagementTracker';
 import { announce, makeClickable } from 'public/a11yHelpers';
+import { colors } from 'public/designTokens.js';
 import wixData from 'wix-data';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -224,7 +225,7 @@ async function initCategoryShowcase() {
           const card = $item('#categoryCard');
           if (card) {
             card.onMouseIn(() => {
-              try { card.style.backgroundColor = '#E8845C'; } catch (e) {}
+              try { card.style.backgroundColor = colors.sunsetCoral; } catch (e) {}
             });
             card.onMouseOut(() => {
               try { card.style.backgroundColor = ''; } catch (e) {}

--- a/src/public/placeholderImages.js
+++ b/src/public/placeholderImages.js
@@ -4,25 +4,28 @@
 
 // ── Category Hero Images (1920x600) ─────────────────────────────────
 // These are page-level decorative images — replace with Wix Media uploads per MEDIA_MANIFEST.md
+// Curated lifestyle room scenes — warm interiors, styled rooms matching Blue Ridge aesthetic
 const categoryHeroImages = {
-  'futon-frames': 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=1920&h=600&fit=crop&crop=center',
-  'mattresses': 'https://images.unsplash.com/photo-1631049307264-da0ec9d70304?w=1920&h=600&fit=crop&crop=center',
-  'murphy-cabinet-beds': 'https://images.unsplash.com/photo-1616594039964-ae9021a400a0?w=1920&h=600&fit=crop&crop=center',
-  'platform-beds': 'https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?w=1920&h=600&fit=crop&crop=center',
-  'casegoods-accessories': 'https://images.unsplash.com/photo-1595428774223-ef52624120d2?w=1920&h=600&fit=crop&crop=center',
-  'wall-huggers': 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=1920&h=600&fit=crop&crop=center',
-  'unfinished-wood': 'https://images.unsplash.com/photo-1538688525198-9b88f6f53126?w=1920&h=600&fit=crop&crop=center',
+  'futon-frames': 'https://images.unsplash.com/photo-1540574163026-643ea20ade25?w=1920&h=600&fit=crop&crop=center',
+  'mattresses': 'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?w=1920&h=600&fit=crop&crop=center',
+  'murphy-cabinet-beds': 'https://images.unsplash.com/photo-1618220179428-22790b461013?w=1920&h=600&fit=crop&crop=center',
+  'platform-beds': 'https://images.unsplash.com/photo-1616627561839-074385245ff6?w=1920&h=600&fit=crop&crop=center',
+  'casegoods-accessories': 'https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=1920&h=600&fit=crop&crop=center',
+  'wall-huggers': 'https://images.unsplash.com/photo-1615874959474-d609969a20ed?w=1920&h=600&fit=crop&crop=center',
+  'unfinished-wood': 'https://images.unsplash.com/photo-1595515106969-1ce29566ff1c?w=1920&h=600&fit=crop&crop=center',
 };
 
 // ── Category Card Images (600x400, 3:2 ratio for homepage) ──────────
+// Curated lifestyle room scenes — Castlery/Article style (warm, styled rooms)
 const categoryCategoryCards = {
-  'futon-frames': 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=600&h=400&fit=crop&crop=center',
-  'mattresses': 'https://images.unsplash.com/photo-1631049307264-da0ec9d70304?w=600&h=400&fit=crop&crop=center',
-  'murphy-cabinet-beds': 'https://images.unsplash.com/photo-1616594039964-ae9021a400a0?w=600&h=400&fit=crop&crop=center',
-  'platform-beds': 'https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?w=600&h=400&fit=crop&crop=center',
-  'casegoods-accessories': 'https://images.unsplash.com/photo-1595428774223-ef52624120d2?w=600&h=400&fit=crop&crop=center',
-  'wall-huggers': 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=600&h=400&fit=crop&crop=center',
-  'unfinished-wood': 'https://images.unsplash.com/photo-1538688525198-9b88f6f53126?w=600&h=400&fit=crop&crop=center',
+  'futon-frames': 'https://images.unsplash.com/photo-1540574163026-643ea20ade25?w=600&h=400&fit=crop&crop=center',
+  'mattresses': 'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?w=600&h=400&fit=crop&crop=center',
+  'murphy-cabinet-beds': 'https://images.unsplash.com/photo-1618220179428-22790b461013?w=600&h=400&fit=crop&crop=center',
+  'platform-beds': 'https://images.unsplash.com/photo-1616627561839-074385245ff6?w=600&h=400&fit=crop&crop=center',
+  'casegoods-accessories': 'https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=600&h=400&fit=crop&crop=center',
+  'wall-huggers': 'https://images.unsplash.com/photo-1615874959474-d609969a20ed?w=600&h=400&fit=crop&crop=center',
+  'unfinished-wood': 'https://images.unsplash.com/photo-1595515106969-1ce29566ff1c?w=600&h=400&fit=crop&crop=center',
+  'sales': 'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=600&h=400&fit=crop&crop=center',
 };
 
 // ── Product Fallback Images (real wixstatic.com catalog images) ──────

--- a/tests/placeholderImages.test.js
+++ b/tests/placeholderImages.test.js
@@ -79,6 +79,11 @@ describe('getCategoryCardImage', () => {
     const urls = ALL_CATEGORIES.map(getCategoryCardImage);
     expect(new Set(urls).size).toBe(7);
   });
+
+  it('sales category has a card image', () => {
+    const url = getCategoryCardImage('sales');
+    expect(url).toContain('w=600&h=400');
+  });
 });
 
 // ── getPlaceholderProductImages ──────────────────────────────────


### PR DESCRIPTION
## Summary
- **Upgraded all category images**: Replaced generic Unsplash photos with curated lifestyle room scenes matching Castlery/Article aesthetic (warm, styled interiors)
- **Added sales category card image**: `categoryCategoryCards` now includes a `sales` entry
- **Token cleanup**: Home.js hover color changed from hardcoded `#E8845C` to `colors.sunsetCoral` via design tokens import
- **Test coverage**: Added test for sales category card image

The `initCategoryShowcase()` code infrastructure was already solid — this PR focuses on upgrading the visual assets and cleaning up token usage.

## Test plan
- [x] All 5359 tests pass (2 pre-existing failures in notificationService unrelated to this PR)
- [x] All 133 placeholder image + homepage hero tests pass
- [x] New sales card image test passes
- [x] Existing category card uniqueness tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)