### PR TITLE
feat(CF-dgiy): Product card grid with color swatches & Quick View

### DIFF
--- a/src/backend/productRecommendations.web.js
+++ b/src/backend/productRecommendations.web.js
@@ -523,5 +523,7 @@ function formatProduct(item) {
     sku: item.sku,
     ribbon: item.ribbon,
     collections: item.collections,
+    color: item.color || null,
+    productOptions: item.productOptions || [],
   };
 }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -50,6 +50,7 @@ $w.onReady(async function () {
     { name: 'testimonials', init: initTestimonials },
     { name: 'videoShowcase', init: initVideoShowcase },
     { name: 'quizCTA', init: initQuizCTA },
+    { name: 'featuredQuickView', init: initFeaturedQuickView },
     { name: 'newsletter', init: initNewsletterSection },
     { name: 'ridgeline', init: initRidgelineHeader },
   ];
@@ -81,10 +82,13 @@ $w.onReady(async function () {
 
 // ── Featured Products ("Our Favorite Finds") ────────────────────────
 
+let currentFeaturedQvProduct = null;
+
 /**
  * Load and display featured product cards in the homepage grid.
- * Sets section heading, fetches products from backend, and wires
- * repeater with product data, sale badges, and ribbon badges.
+ * Castlery-style cards: image + name + price + color swatches +
+ * badge (Bestseller/Sale/New) + hover Quick View button.
+ * 4-column desktop, 2-column mobile (layout set in Wix editor).
  * @returns {Promise<void>}
  */
 async function loadFeaturedProducts() {
@@ -99,6 +103,7 @@ async function loadFeaturedProducts() {
     if (!repeater || featured.length === 0) return;
 
     repeater.onItemReady(($item, itemData) => {
+      // Product image + alt
       $item('#featuredImage').src = itemData.mainMedia;
       $item('#featuredImage').alt = buildProductAlt(itemData, 'featured');
       $item('#featuredName').text = itemData.name;
@@ -116,7 +121,7 @@ async function loadFeaturedProducts() {
         } catch (e) { /* optional elements */ }
       }
 
-      // Show ribbon badge (Featured, New, Clearance, etc.)
+      // Show ribbon badge (Featured, New, Clearance, Bestseller, etc.)
       try {
         if (itemData.ribbon) {
           $item('#featuredRibbon').text = itemData.ribbon;
@@ -125,6 +130,25 @@ async function loadFeaturedProducts() {
           $item('#featuredRibbon').hide();
         }
       } catch (e) { /* ribbon element optional */ }
+
+      // Color swatches — show finish count from productOptions
+      try {
+        const colorOpts = getColorOptions(itemData);
+        if (colorOpts.length > 0) {
+          $item('#featuredColorText').text = `${colorOpts.length} finishes`;
+          $item('#featuredSwatchContainer').show();
+        } else {
+          $item('#featuredSwatchContainer').hide();
+        }
+      } catch (e) { /* swatch elements optional */ }
+
+      // Quick View button on card
+      try {
+        $item('#featuredQuickViewBtn').onClick(() => {
+          openFeaturedQuickView(itemData);
+        });
+        $item('#featuredQuickViewBtn').accessibility.ariaLabel = `Quick view ${itemData.name}`;
+      } catch (e) { /* Quick View button optional */ }
 
       // Navigate to product page on click/keyboard
       const slug = safeSlug(itemData.slug);
@@ -135,6 +159,96 @@ async function loadFeaturedProducts() {
     repeater.data = featured;
   } catch (err) {
     console.error('[Home] Error loading featured products:', err);
+  }
+}
+
+/**
+ * Extract color/finish choices from a product's productOptions array.
+ * Returns array of choice objects for color-type options.
+ * @param {Object} product - Product data with productOptions
+ * @returns {Array} Color choice objects
+ */
+function getColorOptions(product) {
+  if (!product.productOptions || !Array.isArray(product.productOptions)) return [];
+  const colorOpt = product.productOptions.find(
+    opt => opt.optionType === 'color' || (opt.name && /finish|color/i.test(opt.name))
+  );
+  if (!colorOpt || !Array.isArray(colorOpt.choices)) return [];
+  return colorOpt.choices.filter(c => c.inStock !== false);
+}
+
+// ── Featured Quick View Modal ───────────────────────────────────────
+
+/**
+ * Register Quick View modal handlers for the featured products section.
+ * Wires close, "View Full Details", and "Add to Cart" buttons once
+ * to avoid accumulation on repeated calls.
+ */
+function initFeaturedQuickView() {
+  try {
+    try { $w('#featuredQvViewFull').accessibility.ariaLabel = 'View full product details'; } catch (e) {}
+    try { $w('#featuredQvAddToCart').accessibility.ariaLabel = 'Add to cart'; } catch (e) {}
+    try { $w('#featuredQvClose').accessibility.ariaLabel = 'Close quick view'; } catch (e) {}
+
+    $w('#featuredQvViewFull').onClick(() => {
+      if (currentFeaturedQvProduct) {
+        const slug = safeSlug(currentFeaturedQvProduct.slug);
+        import('wix-location-frontend').then(({ to }) => to(`/product-page/${slug}`));
+      }
+    });
+
+    $w('#featuredQvAddToCart').onClick(async () => {
+      if (!currentFeaturedQvProduct) return;
+      try {
+        $w('#featuredQvAddToCart').disable();
+        $w('#featuredQvAddToCart').label = 'Adding...';
+        const { addToCart } = await import('public/cartService');
+        await addToCart(currentFeaturedQvProduct._id);
+        $w('#featuredQvAddToCart').label = 'Added!';
+        announce(`${currentFeaturedQvProduct.name} added to cart`);
+        setTimeout(() => {
+          try { $w('#featuredQuickViewModal').hide('fade', { duration: 200 }); } catch (e) {}
+        }, 1000);
+      } catch (err) {
+        console.error('[Home] Quick View add to cart error:', err);
+        try { $w('#featuredQvAddToCart').label = 'Add to Cart'; } catch (e) {}
+        try { $w('#featuredQvAddToCart').enable(); } catch (e) {}
+      }
+    });
+
+    $w('#featuredQvClose').onClick(() => {
+      $w('#featuredQuickViewModal').hide('fade', { duration: 200 });
+      announce('Quick view closed');
+    });
+  } catch (e) {
+    // Quick View modal elements may not exist in editor
+  }
+}
+
+/**
+ * Open the Quick View modal for a featured product.
+ * Populates image, name, price, and ARIA attributes.
+ * @param {Object} product - Product data to display
+ */
+function openFeaturedQuickView(product) {
+  try {
+    currentFeaturedQvProduct = product;
+    $w('#featuredQvImage').src = product.mainMedia;
+    $w('#featuredQvImage').alt = buildProductAlt(product, 'featured');
+    $w('#featuredQvName').text = product.name;
+    $w('#featuredQvPrice').text = product.formattedDiscountedPrice || product.formattedPrice;
+    try { $w('#featuredQvAddToCart').label = 'Add to Cart'; } catch (e) {}
+    try { $w('#featuredQvAddToCart').enable(); } catch (e) {}
+
+    // ARIA dialog attributes
+    try { $w('#featuredQuickViewModal').accessibility.role = 'dialog'; } catch (e) {}
+    try { $w('#featuredQuickViewModal').accessibility.ariaModal = true; } catch (e) {}
+    try { $w('#featuredQuickViewModal').accessibility.ariaLabel = `Quick view: ${product.name}`; } catch (e) {}
+
+    $w('#featuredQuickViewModal').show('fade', { duration: 200 });
+    announce(`Quick view opened for ${product.name}`);
+  } catch (e) {
+    console.error('[Home] Error opening Quick View:', e);
   }
 }
 

--- a/tests/homeProductCardGrid.test.js
+++ b/tests/homeProductCardGrid.test.js
@@ -1,0 +1,504 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { futonFrame, futonMattress, wallHuggerFrame, saleProduct, outdoorFrame } from './fixtures/products.js';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '',
+    src: '',
+    alt: '',
+    value: '',
+    label: '',
+    html: '',
+    options: [],
+    data: [],
+    style: { color: '', backgroundColor: '', opacity: '' },
+    accessibility: { ariaLabel: '', ariaModal: false, role: '' },
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(),
+    expand: vi.fn(),
+    scrollTo: vi.fn(),
+    postMessage: vi.fn(),
+    onClick: vi.fn(),
+    onChange: vi.fn(),
+    onInput: vi.fn(),
+    onKeyPress: vi.fn(),
+    onMouseIn: vi.fn(),
+    onMouseOut: vi.fn(),
+    onItemReady: vi.fn(),
+    onItemClicked: vi.fn(),
+    onReady: vi.fn(() => Promise.resolve()),
+    onCurrentIndexChanged: vi.fn(),
+    getCurrentItem: vi.fn(),
+    getTotalCount: vi.fn(() => 0),
+    getItems: vi.fn(() => ({ items: [] })),
+    setSort: vi.fn(),
+    setFilter: vi.fn(),
+    disable: vi.fn(),
+    enable: vi.fn(),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Product fixtures with color/options data ────────────────────────
+
+const featuredWithColor = {
+  ...wallHuggerFrame,
+  color: 'walnut',
+  productOptions: [
+    { name: 'Finish', optionType: 'color', choices: [
+      { value: 'Black Walnut', inStock: true },
+      { value: 'Natural', inStock: true },
+      { value: 'Espresso', inStock: true },
+    ] },
+  ],
+};
+
+const frameWithColor = {
+  ...futonFrame,
+  color: 'natural',
+  productOptions: [
+    { name: 'Finish', optionType: 'color', choices: [
+      { value: 'Natural', inStock: true },
+      { value: 'Cherry', inStock: true },
+    ] },
+  ],
+};
+
+const mattressWithColor = {
+  ...futonMattress,
+  color: 'white',
+  productOptions: [],
+};
+
+const noColorProduct = {
+  ...outdoorFrame,
+  color: undefined,
+  productOptions: undefined,
+};
+
+const mockFeatured = [featuredWithColor, frameWithColor, mattressWithColor];
+const mockSaleItems = [saleProduct, futonMattress];
+
+// ── Mock Backend Modules ────────────────────────────────────────────
+
+vi.mock('backend/productRecommendations.web', () => ({
+  getFeaturedProducts: vi.fn().mockResolvedValue(mockFeatured),
+  getSaleProducts: vi.fn().mockResolvedValue(mockSaleItems),
+}));
+
+vi.mock('backend/seoHelpers.web', () => ({
+  getWebSiteSchema: vi.fn().mockResolvedValue('{"@type":"WebSite"}'),
+}));
+
+vi.mock('backend/newsletterService.web', () => ({
+  subscribeToNewsletter: vi.fn().mockResolvedValue({ success: true, discountCode: 'WELCOME10' }),
+}));
+
+vi.mock('public/galleryHelpers.js', () => ({
+  getRecentlyViewed: vi.fn().mockReturnValue([]),
+  buildRecentlyViewedSection: vi.fn(),
+}));
+
+vi.mock('public/placeholderImages.js', () => ({
+  getCategoryHeroImage: vi.fn().mockReturnValue('https://example.com/hero.jpg'),
+  getCategoryCardImage: vi.fn((slug) => `https://example.com/card-${slug}.jpg`),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  isMobile: vi.fn().mockReturnValue(false),
+  collapseOnMobile: vi.fn(),
+  initBackToTop: vi.fn(),
+  limitForViewport: vi.fn((items) => items),
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+  makeClickable: vi.fn((el, handler, opts) => {
+    if (el && typeof el.onClick === 'function') el.onClick(handler);
+    if (el && opts?.ariaLabel) {
+      try { el.accessibility.ariaLabel = opts.ariaLabel; } catch (e) {}
+    }
+  }),
+}));
+
+vi.mock('wix-data', () => {
+  const mockQuery = {
+    hasSome: vi.fn().mockReturnThis(),
+    count: vi.fn().mockResolvedValue(12),
+    find: vi.fn().mockResolvedValue({ items: [] }),
+    eq: vi.fn().mockReturnThis(),
+    ne: vi.fn().mockReturnThis(),
+    gt: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    descending: vi.fn().mockReturnThis(),
+    ascending: vi.fn().mockReturnThis(),
+  };
+  return { default: { query: vi.fn(() => mockQuery) } };
+});
+
+vi.mock('public/cartService', () => ({
+  addToCart: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// ── Import Page ─────────────────────────────────────────────────────
+
+describe('Home Page — Product Card Grid', () => {
+  beforeAll(async () => {
+    await import('../src/pages/Home.js');
+  });
+
+  beforeEach(() => {
+    elements.clear();
+  });
+
+  // ── Helper: invoke onItemReady callback with an item scope ──────
+
+  function getItemReadyCb(repeaterId) {
+    const repeater = getEl(repeaterId);
+    const calls = repeater.onItemReady.mock.calls;
+    if (calls.length === 0) return null;
+    return calls[calls.length - 1][0];
+  }
+
+  function createItemScope() {
+    const itemElements = {};
+    const $item = (sel) => {
+      if (!itemElements[sel]) {
+        itemElements[sel] = {
+          text: '', src: '', alt: '', html: '', label: '',
+          style: { color: '', backgroundColor: '', opacity: '' },
+          accessibility: { ariaLabel: '', ariaModal: false, role: '' },
+          show: vi.fn(() => Promise.resolve()),
+          hide: vi.fn(() => Promise.resolve()),
+          collapse: vi.fn(),
+          expand: vi.fn(),
+          onClick: vi.fn(),
+          onMouseIn: vi.fn(),
+          onMouseOut: vi.fn(),
+          disable: vi.fn(),
+          enable: vi.fn(),
+        };
+      }
+      return itemElements[sel];
+    };
+    return { $item, itemElements };
+  }
+
+  // ── Featured Products Card Rendering ────────────────────────────
+
+  describe('featured product card rendering', () => {
+    it('sets section heading and subtitle', async () => {
+      await onReadyHandler();
+      expect(getEl('#featuredTitle').text).toBe('Our Favorite Finds');
+      expect(getEl('#featuredSubtitle').text).toContain('Handpicked');
+    });
+
+    it('populates featured repeater with product data', async () => {
+      await onReadyHandler();
+      expect(getEl('#featuredRepeater').data).toEqual(mockFeatured);
+    });
+
+    it('onItemReady sets image, name, and price on card', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      expect(cb).toBeTruthy();
+
+      const { $item, itemElements } = createItemScope();
+      cb($item, featuredWithColor);
+
+      expect(itemElements['#featuredImage'].src).toBe(wallHuggerFrame.mainMedia);
+      expect(itemElements['#featuredName'].text).toBe(wallHuggerFrame.name);
+      expect(itemElements['#featuredPrice'].text).toBe(wallHuggerFrame.formattedPrice);
+    });
+
+    it('onItemReady sets SEO alt text on product image', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, frameWithColor);
+      expect(itemElements['#featuredImage'].alt).toContain('Eureka');
+      expect(itemElements['#featuredImage'].alt).toContain('Carolina Futons');
+    });
+  });
+
+  // ── Sale Badge + Pricing ────────────────────────────────────────
+
+  describe('sale badge and pricing', () => {
+    it('shows discounted price and original strikethrough for sale items', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, mattressWithColor);
+      expect(itemElements['#featuredPrice'].text).toBe(futonMattress.formattedDiscountedPrice);
+      expect(itemElements['#featuredOriginalPrice'].text).toBe(futonMattress.formattedPrice);
+      expect(itemElements['#featuredOriginalPrice'].show).toHaveBeenCalled();
+      expect(itemElements['#featuredSaleBadge'].show).toHaveBeenCalled();
+    });
+
+    it('does NOT show sale badge for non-discounted products', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      // Price should be regular price (no discount)
+      expect(itemElements['#featuredPrice'].text).toBe(wallHuggerFrame.formattedPrice);
+      // Sale badge element should not be accessed for non-discounted products
+      expect(itemElements['#featuredSaleBadge']).toBeUndefined();
+    });
+  });
+
+  // ── Ribbon Badges ───────────────────────────────────────────────
+
+  describe('ribbon badges', () => {
+    it('shows ribbon badge text for products with ribbon', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor); // wallHuggerFrame has ribbon: 'Featured'
+      expect(itemElements['#featuredRibbon'].text).toBe('Featured');
+      expect(itemElements['#featuredRibbon'].show).toHaveBeenCalled();
+    });
+
+    it('hides ribbon for products without ribbon', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, frameWithColor); // futonFrame has ribbon: ''
+      expect(itemElements['#featuredRibbon'].hide).toHaveBeenCalled();
+    });
+  });
+
+  // ── Color Swatches ──────────────────────────────────────────────
+
+  describe('color swatches', () => {
+    it('displays color indicator text for products with color options', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      // Product has 3 color choices — should show swatch count or color text
+      expect(itemElements['#featuredColorText'].text).toMatch(/3|finish/i);
+    });
+
+    it('shows color swatch container for products with options', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      expect(itemElements['#featuredSwatchContainer'].show).toHaveBeenCalled();
+    });
+
+    it('hides color swatch container for products without color options', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, mattressWithColor); // empty productOptions
+      expect(itemElements['#featuredSwatchContainer'].hide).toHaveBeenCalled();
+    });
+
+    it('handles missing productOptions gracefully', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item } = createItemScope();
+
+      expect(() => cb($item, noColorProduct)).not.toThrow();
+    });
+  });
+
+  // ── Quick View ──────────────────────────────────────────────────
+
+  describe('Quick View button', () => {
+    it('wires Quick View button click handler on each card', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      expect(itemElements['#featuredQuickViewBtn'].onClick).toHaveBeenCalled();
+    });
+
+    it('Quick View button has accessible label', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      expect(itemElements['#featuredQuickViewBtn'].accessibility.ariaLabel)
+        .toContain('Quick view');
+    });
+  });
+
+  describe('Quick View modal', () => {
+    it('registers Quick View modal handlers during page init', async () => {
+      await onReadyHandler();
+
+      // Close button should have onClick registered
+      expect(getEl('#featuredQvClose').onClick).toHaveBeenCalled();
+      // View Full button should have onClick registered
+      expect(getEl('#featuredQvViewFull').onClick).toHaveBeenCalled();
+      // Add to Cart button should have onClick registered
+      expect(getEl('#featuredQvAddToCart').onClick).toHaveBeenCalled();
+    });
+
+    it('opening Quick View populates modal with product data', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+
+      // Simulate clicking the Quick View button
+      const qvClickHandler = itemElements['#featuredQuickViewBtn'].onClick.mock.calls[0][0];
+      qvClickHandler();
+
+      // Modal should be populated
+      expect(getEl('#featuredQvImage').src).toBe(wallHuggerFrame.mainMedia);
+      expect(getEl('#featuredQvName').text).toBe(wallHuggerFrame.name);
+      expect(getEl('#featuredQvPrice').text).toBe(wallHuggerFrame.formattedPrice);
+    });
+
+    it('opening Quick View shows the modal with fade', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      const qvClickHandler = itemElements['#featuredQuickViewBtn'].onClick.mock.calls[0][0];
+      qvClickHandler();
+
+      expect(getEl('#featuredQuickViewModal').show).toHaveBeenCalledWith(
+        'fade',
+        expect.objectContaining({ duration: 200 })
+      );
+    });
+
+    it('closing Quick View hides the modal', async () => {
+      await onReadyHandler();
+
+      // Trigger close
+      const closeHandler = getEl('#featuredQvClose').onClick.mock.calls[0][0];
+      closeHandler();
+
+      expect(getEl('#featuredQuickViewModal').hide).toHaveBeenCalledWith(
+        'fade',
+        expect.objectContaining({ duration: 200 })
+      );
+    });
+
+    it('Quick View modal has ARIA dialog attributes', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      const qvClickHandler = itemElements['#featuredQuickViewBtn'].onClick.mock.calls[0][0];
+      qvClickHandler();
+
+      const modal = getEl('#featuredQuickViewModal');
+      expect(modal.accessibility.role).toBe('dialog');
+      expect(modal.accessibility.ariaModal).toBe(true);
+    });
+  });
+
+  // ── Card Click Navigation ───────────────────────────────────────
+
+  describe('card click navigation', () => {
+    it('registers click handlers on image and name for navigation', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, frameWithColor);
+      expect(itemElements['#featuredImage'].onClick).toHaveBeenCalled();
+      expect(itemElements['#featuredName'].onClick).toHaveBeenCalled();
+    });
+
+    it('image click handler navigates to safe-slugified product URL', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, frameWithColor);
+      // makeClickable was called — just confirm onClick was wired
+      expect(itemElements['#featuredImage'].onClick).toHaveBeenCalled();
+    });
+  });
+
+  // ── Accessibility ───────────────────────────────────────────────
+
+  describe('accessibility', () => {
+    it('sets aria labels on product image', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      expect(itemElements['#featuredImage'].accessibility.ariaLabel)
+        .toContain(wallHuggerFrame.name);
+    });
+
+    it('sets aria labels on product name', async () => {
+      await onReadyHandler();
+      const cb = getItemReadyCb('#featuredRepeater');
+      const { $item, itemElements } = createItemScope();
+
+      cb($item, featuredWithColor);
+      expect(itemElements['#featuredName'].accessibility.ariaLabel)
+        .toContain(wallHuggerFrame.name);
+    });
+  });
+
+  // ── Error Handling ──────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('handles empty featured products gracefully', async () => {
+      const { getFeaturedProducts } = await import('backend/productRecommendations.web');
+      getFeaturedProducts.mockResolvedValueOnce([]);
+
+      await expect(onReadyHandler()).resolves.not.toThrow();
+    });
+
+    it('handles getFeaturedProducts rejection gracefully', async () => {
+      const { getFeaturedProducts } = await import('backend/productRecommendations.web');
+      getFeaturedProducts.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(onReadyHandler()).resolves.not.toThrow();
+    });
+
+    it('handles missing repeater element gracefully', async () => {
+      // Clear to simulate missing repeater — the get will return mock with no data assignment
+      const { getFeaturedProducts } = await import('backend/productRecommendations.web');
+      getFeaturedProducts.mockResolvedValueOnce([]);
+
+      await expect(onReadyHandler()).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces plain featured products repeater with **Castlery-style card grid**: image + name + price + color swatches + badge + hover Quick View
- Color swatch indicators show available finishes from `productOptions` data
- Quick View modal with image, name, price, Add to Cart, View Full Details, ARIA dialog attributes
- Enhanced `formatProduct()` backend to include `color` and `productOptions` fields
- 26 new tests covering card rendering, swatches, Quick View lifecycle, accessibility, error states

## Files Changed
- `src/pages/Home.js` — Enhanced `loadFeaturedProducts()`, added `getColorOptions()`, `initFeaturedQuickView()`, `openFeaturedQuickView()`
- `src/backend/productRecommendations.web.js` — Added `color` and `productOptions` to `formatProduct()`
- `tests/homeProductCardGrid.test.js` — 26 comprehensive tests (TDD)

## Test plan
- [x] All 26 new tests pass
- [x] All 81 existing home page tests still pass
- [x] Full suite: 5368 pass (8 pre-existing failures in unrelated files)
- [ ] Verify card grid layout in Wix Studio editor (4-col desktop, 2-col mobile)
- [ ] Test Quick View modal interaction in preview mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)