### PR TITLE
CF-y8je: Free Swatches nav link + homepage promo section

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -51,6 +51,7 @@ $w.onReady(async function () {
     { name: 'videoShowcase', init: initVideoShowcase },
     { name: 'quizCTA', init: initQuizCTA },
     { name: 'featuredQuickView', init: initFeaturedQuickView },
+    { name: 'swatchPromo', init: initSwatchPromo },
     { name: 'newsletter', init: initNewsletterSection },
     { name: 'ridgeline', init: initRidgelineHeader },
   ];
@@ -687,6 +688,36 @@ async function injectHomeSchemas() {
     }
   } catch (e) {
     console.error('[Home] Schema injection failed:', e);
+  }
+}
+
+// ── Swatch Promo Section ─────────────────────────────────────────────
+
+/**
+ * Initialize the "700+ Free Fabric Swatches" promotion section.
+ * CTA navigates to /free-swatches landing page.
+ */
+function initSwatchPromo() {
+  try {
+    const section = $w('#swatchPromoSection');
+    if (!section) return;
+
+    try { $w('#swatchPromoTitle').text = '700+ Free Fabric Swatches'; } catch (e) {}
+    try {
+      $w('#swatchPromoSubtitle').text =
+        'Feel the quality before you buy — we\'ll ship up to 6 swatches to your door, free.';
+    } catch (e) {}
+
+    try {
+      $w('#swatchPromoCTA').onClick(() => {
+        import('wix-location-frontend').then(({ to }) => to('/free-swatches'));
+      });
+      try { $w('#swatchPromoCTA').accessibility.ariaLabel = 'Request free fabric swatches'; } catch (e) {}
+    } catch (e) {}
+
+    section.expand();
+  } catch (e) {
+    // Swatch promo section is optional
   }
 }
 

--- a/src/public/navigationHelpers.js
+++ b/src/public/navigationHelpers.js
@@ -37,6 +37,7 @@ export const NAV_LINKS = {
   '#navFAQ': { path: '/faq', label: 'FAQ' },
   '#navAbout': { path: '/about', label: 'About' },
   '#navBlog': { path: '/blog', label: 'Blog' },
+  '#navFreeSwatches': { path: '/free-swatches', label: 'Free Swatches' },
 };
 
 /**
@@ -64,6 +65,7 @@ export const MEGA_MENU_CATEGORIES = [
       { id: '#navSale', label: 'Sale', path: '/sales' },
       { id: '#navProductVideos', label: 'Product Videos', path: '/product-videos' },
       { id: '#navGettingItHome', label: 'Getting It Home', path: '/getting-it-home' },
+      { id: '#navFreeSwatches', label: 'Free Swatches', path: '/free-swatches' },
     ],
   },
 ];

--- a/tests/homePage.test.js
+++ b/tests/homePage.test.js
@@ -310,4 +310,24 @@ describe('Home Page', () => {
       );
     });
   });
+
+  // ── Swatch Promo Section ──────────────────────────────────────────
+
+  describe('swatch promo section', () => {
+    it('sets swatch promo title and subtitle', async () => {
+      await onReadyHandler();
+      expect(getEl('#swatchPromoTitle').text).toBe('700+ Free Fabric Swatches');
+      expect(getEl('#swatchPromoSubtitle').text).toContain('Feel the quality');
+    });
+
+    it('expands swatch promo section', async () => {
+      await onReadyHandler();
+      expect(getEl('#swatchPromoSection').expand).toHaveBeenCalled();
+    });
+
+    it('registers click handler on swatch promo CTA', async () => {
+      await onReadyHandler();
+      expect(getEl('#swatchPromoCTA').onClick).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -663,6 +663,7 @@ describe('Navigation Helpers', () => {
       expect(ids).toContain('#navFAQ');
       expect(ids).toContain('#navAbout');
       expect(ids).toContain('#navBlog');
+      expect(ids).toContain('#navFreeSwatches');
     });
 
     it('every nav link has path and label', () => {
@@ -670,6 +671,11 @@ describe('Navigation Helpers', () => {
         expect(config.path).toBeTruthy();
         expect(config.label).toBeTruthy();
       });
+    });
+
+    it('Free Swatches nav link points to /free-swatches', () => {
+      expect(NAV_LINKS['#navFreeSwatches'].path).toBe('/free-swatches');
+      expect(NAV_LINKS['#navFreeSwatches'].label).toBe('Free Swatches');
     });
   });
 
@@ -688,6 +694,15 @@ describe('Navigation Helpers', () => {
           expect(item.path).toBeTruthy();
         });
       });
+    });
+
+    it('includes Free Swatches in More group', () => {
+      const moreGroup = MEGA_MENU_CATEGORIES.find(g => g.title === 'More');
+      expect(moreGroup).toBeTruthy();
+      const swatchItem = moreGroup.items.find(i => i.label === 'Free Swatches');
+      expect(swatchItem).toBeTruthy();
+      expect(swatchItem.path).toBe('/free-swatches');
+      expect(swatchItem.id).toBe('#navFreeSwatches');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added `#navFreeSwatches` entry to `NAV_LINKS` pointing to `/free-swatches` and added it to the "More" group in `MEGA_MENU_CATEGORIES`
- Added homepage "700+ Free Fabric Swatches" promo section with CTA linking to `/free-swatches`
- Product page swatch CTA (`initSwatchCTA` + `initSwatchRequest`) was already wired from CF-isru

## Test plan
- [x] Nav link test: `#navFreeSwatches` exists with correct path/label
- [x] Mega menu test: "Free Swatches" appears in "More" group
- [x] Homepage test: swatch promo title, subtitle, section expand, CTA click handler
- [x] Full test suite: 5483 passed (2 pre-existing failures in notificationService unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)