### PR TITLE
cf-yp3o: Fix deferred sections blocking LCP

### DIFF
--- a/src/public/performanceHelpers.js
+++ b/src/public/performanceHelpers.js
@@ -1,6 +1,8 @@
 // Performance optimization helpers
 // Deferred loading, IntersectionObserver image lazy loading, CLS prevention
 
+import { logError } from 'backend/errorMonitoring.web';
+
 // ── deferInit ────────────────────────────────────────────────────────
 // Schedule non-critical initialization for idle time.
 // Uses requestIdleCallback when available, falls back to setTimeout.
@@ -28,7 +30,7 @@ export function deferInit(fn, opts = {}) {
 
 export async function prioritizeSections(sections) {
   if (!sections || sections.length === 0) {
-    return { critical: [], deferred: [] };
+    return { critical: [] };
   }
 
   const critical = sections.filter(s => s.critical);
@@ -46,19 +48,21 @@ export async function prioritizeSections(sections) {
     }
   });
 
-  // Run deferred sections after critical content is rendered.
-  // This ensures above-fold content paints before below-fold starts loading.
-  const deferredResults = await Promise.allSettled(
-    deferred.map(s => s.init())
-  );
+  // Fire-and-forget deferred sections — do NOT await.
+  // Awaiting deferred sections blocks onReady and hurts LCP.
+  if (deferred.length > 0) {
+    Promise.allSettled(deferred.map(s => s.init())).then(results => {
+      results.forEach((result, i) => {
+        if (result.status === 'rejected') {
+          try {
+            logError(new Error(`Deferred section "${deferred[i].name}" failed: ${result.reason?.message || result.reason}`));
+          } catch (e) {}
+        }
+      });
+    });
+  }
 
-  deferredResults.forEach((result, i) => {
-    if (result.status === 'rejected') {
-      console.error(`[perf] Deferred section "${deferred[i].name}" failed:`, result.reason);
-    }
-  });
-
-  return { critical: criticalResults, deferred: deferredResults };
+  return { critical: criticalResults };
 }
 
 // ── createImageObserver ──────────────────────────────────────────────

--- a/tests/performanceHelpers.test.js
+++ b/tests/performanceHelpers.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+vi.mock('backend/errorMonitoring.web', () => ({
+  logError: vi.fn(),
+}));
+
 // ── deferInit ────────────────────────────────────────────────────────
 
 describe('deferInit', () => {
@@ -105,13 +109,35 @@ describe('prioritizeSections', () => {
     expect(deferredFn).toHaveBeenCalledOnce();
     expect(result.critical).toHaveLength(1);
     expect(result.critical[0].status).toBe('fulfilled');
-    expect(result.deferred).toHaveLength(1);
-    expect(result.deferred[0].status).toBe('fulfilled');
+    // Deferred results are fire-and-forget — not in return value
+    expect(result.deferred).toBeUndefined();
     // Critical runs before deferred
     expect(callOrder[0]).toBe('critical');
   });
 
-  it('runs deferred sections after critical', async () => {
+  it('resolves immediately after critical sections without waiting for deferred', async () => {
+    let deferredResolved = false;
+    const criticalFn = vi.fn().mockResolvedValue('ok');
+    const deferredFn = vi.fn().mockImplementation(() =>
+      new Promise(resolve => {
+        setTimeout(() => { deferredResolved = true; resolve('deferred-ok'); }, 5000);
+      })
+    );
+
+    const sections = [
+      { name: 'hero', init: criticalFn, critical: true },
+      { name: 'video', init: deferredFn, critical: false },
+    ];
+
+    // prioritizeSections should resolve right after critical, NOT wait for deferred
+    const result = await prioritizeSections(sections);
+    expect(criticalFn).toHaveBeenCalledOnce();
+    expect(deferredFn).toHaveBeenCalledOnce(); // started but not awaited
+    expect(deferredResolved).toBe(false); // deferred still pending
+    expect(result.critical).toHaveLength(1);
+  });
+
+  it('deferred sections do not appear in returned results', async () => {
     const criticalFn = vi.fn().mockResolvedValue('ok');
     const deferredFn = vi.fn().mockResolvedValue('deferred-ok');
 
@@ -121,9 +147,8 @@ describe('prioritizeSections', () => {
     ];
 
     const result = await prioritizeSections(sections);
-    expect(criticalFn).toHaveBeenCalledOnce();
-    expect(deferredFn).toHaveBeenCalledOnce();
-    expect(result.deferred[0].status).toBe('fulfilled');
+    // Deferred results should not be returned (they're fire-and-forget)
+    expect(result.deferred).toBeUndefined();
   });
 
   it('handles critical section failures without breaking deferred', async () => {
@@ -138,13 +163,35 @@ describe('prioritizeSections', () => {
     const result = await prioritizeSections(sections);
     expect(result.critical[0].status).toBe('rejected');
     expect(deferredFn).toHaveBeenCalledOnce();
-    expect(result.deferred[0].status).toBe('fulfilled');
   });
 
-  it('returns empty arrays for empty input', async () => {
+  it('reports deferred section failures to errorMonitoring', async () => {
+    const { logError } = await import('backend/errorMonitoring.web');
+    const criticalFn = vi.fn().mockResolvedValue('ok');
+    const failingDeferredFn = vi.fn().mockRejectedValue(new Error('deferred boom'));
+
+    const sections = [
+      { name: 'hero', init: criticalFn, critical: true },
+      { name: 'broken-deferred', init: failingDeferredFn, critical: false },
+    ];
+
+    await prioritizeSections(sections);
+
+    // Flush microtask queue so fire-and-forget deferred settles
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('broken-deferred'),
+      })
+    );
+  });
+
+  it('returns empty critical array for empty input', async () => {
     const result = await prioritizeSections([]);
     expect(result.critical).toHaveLength(0);
-    expect(result.deferred).toHaveLength(0);
   });
 
   it('treats all sections as critical when none marked deferred', async () => {
@@ -160,7 +207,6 @@ describe('prioritizeSections', () => {
     expect(fn1).toHaveBeenCalledOnce();
     expect(fn2).toHaveBeenCalledOnce();
     expect(result.critical).toHaveLength(2);
-    expect(result.deferred).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Bug**: `prioritizeSections` awaited deferred sections via `Promise.allSettled`, blocking `onReady` and hurting LCP
- **Fix**: Deferred sections are now fire-and-forget — started but not awaited, so critical sections resolve immediately
- **Error reporting**: Deferred failures now report to `logError` (errorMonitoring.web) instead of `console.error`

## Changes
- `src/public/performanceHelpers.js`: Remove `await` on deferred allSettled, wire `.then()` error handler to `logError`, remove `deferred` from return value
- `tests/performanceHelpers.test.js`: Add mock for errorMonitoring.web, add 3 new tests (fire-and-forget timing, no deferred in return, logError wiring), update 3 existing tests for new return shape

## Test plan
- [x] 28/28 performanceHelpers tests pass
- [x] 151/151 test files pass (5708 tests, 0 failures)
- [x] Verified RED: 3 new tests fail against unmodified code
- [x] Verified GREEN: all pass after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)