### PR TITLE
cf-t2px: Wire mobile hamburger nav with scroll lock and design tokens

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -189,8 +189,8 @@ function initEnhancedNavigation() {
   // Mega menu for desktop shop dropdown (skip on mobile — drawer handles it)
   try { if (!isMobile()) initMegaMenu($w); } catch (e) {}
 
-  // Mobile drawer with focus trap and accessible close
-  try { initMobileDrawer($w); } catch (e) {}
+  // Mobile drawer with focus trap, scroll lock, and accessible close
+  try { initMobileDrawer($w, currentPath); } catch (e) {}
 
   // Breadcrumbs with schema.org JSON-LD
   try {

--- a/src/public/navigationHelpers.js
+++ b/src/public/navigationHelpers.js
@@ -189,15 +189,50 @@ export function initMegaMenu($w) {
 // ── Mobile Drawer ────────────────────────────────────────────────────
 
 /**
+ * Mobile nav link mapping — element IDs to their NAV_LINKS counterparts.
+ * Used by initMobileDrawer to populate and style the mobile menu.
+ */
+const MOBILE_NAV_MAP = [
+  { mobileId: '#mobileNavHome', desktopId: '#navHome' },
+  { mobileId: '#mobileNavShop', desktopId: '#navShop' },
+  { mobileId: '#mobileNavFutonFrames', desktopId: '#navFutonFrames' },
+  { mobileId: '#mobileNavMattresses', desktopId: '#navMattresses' },
+  { mobileId: '#mobileNavMurphy', desktopId: '#navMurphy' },
+  { mobileId: '#mobileNavPlatformBeds', desktopId: '#navPlatformBeds' },
+  { mobileId: '#mobileNavSale', desktopId: '#navSale' },
+  { mobileId: '#mobileNavContact', desktopId: '#navContact' },
+  { mobileId: '#mobileNavFAQ', desktopId: '#navFAQ' },
+  { mobileId: '#mobileNavAbout', desktopId: '#navAbout' },
+];
+
+/**
  * Initialize mobile navigation drawer with slide-out animation,
- * category accordions, and focus trap.
+ * category accordions, focus trap, scroll lock, and nav link population.
  *
  * @param {Function} $w - Wix selector
+ * @param {string} [currentPath] - Current page path for active link highlighting
  * @returns {{ open: Function, close: Function }} Control object
  */
-export function initMobileDrawer($w) {
+export function initMobileDrawer($w, currentPath) {
   let isOpen = false;
   let focusTrap = null;
+  let escHandler = null;
+
+  function lockScroll() {
+    try {
+      if (typeof document !== 'undefined' && document.body) {
+        document.body.style.overflow = 'hidden';
+      }
+    } catch (e) {}
+  }
+
+  function unlockScroll() {
+    try {
+      if (typeof document !== 'undefined' && document.body) {
+        document.body.style.overflow = '';
+      }
+    } catch (e) {}
+  }
 
   function open() {
     if (isOpen) return;
@@ -205,19 +240,13 @@ export function initMobileDrawer($w) {
     try {
       $w('#mobileMenuOverlay').show('fade', { duration: transitions.medium });
       try { $w('#mobileMenuButton').accessibility.ariaExpanded = true; } catch (e) {}
+      lockScroll();
 
       // Create focus trap inside the drawer
       focusTrap = createFocusTrap($w, '#mobileMenuOverlay', [
         '#mobileMenuClose',
         '#mobileSearchInput',
-        '#mobileNavHome',
-        '#mobileNavShop',
-        '#mobileNavFutonFrames',
-        '#mobileNavMattresses',
-        '#mobileNavMurphy',
-        '#mobileNavPlatformBeds',
-        '#mobileNavSale',
-        '#mobileNavContact',
+        ...MOBILE_NAV_MAP.map(m => m.mobileId),
       ]);
 
       try { $w('#mobileMenuClose').focus(); } catch (e) {}
@@ -231,6 +260,7 @@ export function initMobileDrawer($w) {
     try {
       $w('#mobileMenuOverlay').hide('slide', { direction: 'left', duration: transitions.medium });
       try { $w('#mobileMenuButton').accessibility.ariaExpanded = false; } catch (e) {}
+      unlockScroll();
       if (focusTrap) {
         focusTrap.release();
         focusTrap = null;
@@ -239,6 +269,50 @@ export function initMobileDrawer($w) {
       announce($w, 'Navigation menu closed');
     } catch (e) {}
   }
+
+  // Escape key closes menu
+  try {
+    if (typeof document !== 'undefined') {
+      escHandler = (e) => {
+        if (e.key === 'Escape') close();
+      };
+      document.addEventListener('keydown', escHandler);
+    }
+  } catch (e) {}
+
+  // Responsive: show/hide button based on viewport
+  try {
+    if (isMobile()) {
+      $w('#mobileMenuButton').show();
+    } else {
+      $w('#mobileMenuButton').hide();
+    }
+  } catch (e) {}
+
+  // Style overlay with design tokens
+  try {
+    $w('#mobileMenuOverlay').style.backgroundColor = colors.sandLight;
+  } catch (e) {}
+
+  // Populate nav links with labels, colors, and click handlers
+  const activeNavId = currentPath ? getActiveNavId(currentPath) : null;
+  MOBILE_NAV_MAP.forEach(({ mobileId, desktopId }) => {
+    try {
+      const el = $w(mobileId);
+      const config = NAV_LINKS[desktopId];
+      if (!el || !config) return;
+
+      el.text = config.label;
+      el.style.color = (desktopId === activeNavId) ? colors.sunsetCoral : colors.espresso;
+
+      el.onClick(() => {
+        import('wix-location-frontend').then(({ to }) => {
+          to(config.path);
+        }).catch(() => {});
+        close();
+      });
+    } catch (e) {}
+  });
 
   // Wire menu button
   try {
@@ -256,6 +330,11 @@ export function initMobileDrawer($w) {
     if (closeBtn) {
       makeClickable(closeBtn, () => close(), { ariaLabel: 'Close navigation menu' });
     }
+  } catch (e) {}
+
+  // Wire overlay backdrop click to close
+  try {
+    $w('#mobileMenuOverlay').onClick(() => close());
   } catch (e) {}
 
   return { open, close };

--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -15,7 +15,7 @@ function createMockElement(id) {
     html: '',
     data: [],
     hidden: true,
-    style: { color: '', fontWeight: '', boxShadow: '' },
+    style: { color: '', fontWeight: '', boxShadow: '', backgroundColor: '' },
     accessibility: {
       ariaLabel: '',
       ariaExpanded: undefined,
@@ -362,6 +362,167 @@ describe('Navigation Helpers', () => {
       ctrl.open();
       // show called only once
       expect(getEl('#mobileMenuOverlay').show).toHaveBeenCalledTimes(1);
+    });
+
+    // ── cf-t2px: Mobile Hamburger Nav enhancements ──────────────────
+
+    describe('body scroll lock', () => {
+      let origDoc;
+      beforeEach(() => {
+        origDoc = globalThis.document;
+        globalThis.document = {
+          body: { style: { overflow: '' } },
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          activeElement: null,
+        };
+      });
+      afterEach(() => {
+        globalThis.document = origDoc;
+      });
+
+      it('sets body overflow hidden when menu opens', () => {
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+        expect(globalThis.document.body.style.overflow).toBe('hidden');
+      });
+
+      it('restores body overflow when menu closes', () => {
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+        ctrl.close();
+        expect(globalThis.document.body.style.overflow).toBe('');
+      });
+    });
+
+    describe('escape key closes menu', () => {
+      let origDoc;
+      let keydownHandlers;
+      beforeEach(() => {
+        origDoc = globalThis.document;
+        keydownHandlers = [];
+        globalThis.document = {
+          body: { style: { overflow: '' } },
+          addEventListener: vi.fn((event, handler) => {
+            if (event === 'keydown') keydownHandlers.push(handler);
+          }),
+          removeEventListener: vi.fn(),
+          activeElement: null,
+        };
+      });
+      afterEach(() => {
+        globalThis.document = origDoc;
+      });
+
+      it('closes menu and restores state on Escape', () => {
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+
+        keydownHandlers.forEach(h => h({ key: 'Escape' }));
+
+        expect(getEl('#mobileMenuOverlay').hide).toHaveBeenCalled();
+        expect(getEl('#mobileMenuButton').accessibility.ariaExpanded).toBe(false);
+        expect(globalThis.document.body.style.overflow).toBe('');
+      });
+
+      it('does not close on non-Escape keys', () => {
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+
+        keydownHandlers.forEach(h => h({ key: 'Enter' }));
+
+        // Menu should still be open — hide should not have been called
+        expect(getEl('#mobileMenuOverlay').hide).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('overlay backdrop click closes menu', () => {
+      it('wires onClick on overlay element', () => {
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileMenuOverlay').onClick).toHaveBeenCalled();
+      });
+
+      it('closes menu when overlay backdrop is clicked', () => {
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+
+        const overlayClicks = getEl('#mobileMenuOverlay').onClick.mock.calls;
+        const backdropHandler = overlayClicks[overlayClicks.length - 1][0];
+        backdropHandler();
+
+        expect(getEl('#mobileMenuOverlay').hide).toHaveBeenCalled();
+        expect(getEl('#mobileMenuButton').accessibility.ariaExpanded).toBe(false);
+      });
+    });
+
+    describe('nav link population and navigation', () => {
+      it('sets text labels on mobile nav elements', () => {
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileNavHome').text).toBe('Home');
+        expect(getEl('#mobileNavShop').text).toBe('Shop All');
+        expect(getEl('#mobileNavFutonFrames').text).toBe('Futon Frames');
+        expect(getEl('#mobileNavMattresses').text).toBe('Mattresses');
+      });
+
+      it('wires onClick on nav links', () => {
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileNavHome').onClick).toHaveBeenCalled();
+        expect(getEl('#mobileNavFutonFrames').onClick).toHaveBeenCalled();
+      });
+
+      it('closes menu when a nav link is clicked', () => {
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+
+        const clickHandler = getEl('#mobileNavHome').onClick.mock.calls[0][0];
+        clickHandler();
+
+        expect(getEl('#mobileMenuOverlay').hide).toHaveBeenCalled();
+      });
+    });
+
+    describe('design token colors', () => {
+      it('sets sandLight background on overlay', () => {
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileMenuOverlay').style.backgroundColor).toBe('#F2E8D5');
+      });
+
+      it('sets espresso text color on nav links', () => {
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileNavHome').style.color).toBe('#3A2518');
+        expect(getEl('#mobileNavFutonFrames').style.color).toBe('#3A2518');
+      });
+
+      it('sets coral color on active nav link for current path', () => {
+        initMobileDrawer(getEl, '/futon-frames');
+        expect(getEl('#mobileNavFutonFrames').style.color).toBe('#E8845C');
+      });
+
+      it('keeps espresso on non-active links when path provided', () => {
+        initMobileDrawer(getEl, '/futon-frames');
+        expect(getEl('#mobileNavHome').style.color).toBe('#3A2518');
+        expect(getEl('#mobileNavMattresses').style.color).toBe('#3A2518');
+      });
+    });
+
+    describe('responsive: desktop breakpoint', () => {
+      it('hides mobile menu button on desktop', () => {
+        mockIsMobile.mockReturnValue(false);
+        mockGetViewport.mockReturnValue('desktop');
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileMenuButton').hide).toHaveBeenCalled();
+        mockIsMobile.mockReturnValue(false);
+        mockGetViewport.mockReturnValue('desktop');
+      });
+
+      it('shows mobile menu button on mobile', () => {
+        mockIsMobile.mockReturnValue(true);
+        mockGetViewport.mockReturnValue('mobile');
+        initMobileDrawer(getEl);
+        expect(getEl('#mobileMenuButton').show).toHaveBeenCalled();
+        mockIsMobile.mockReturnValue(false);
+        mockGetViewport.mockReturnValue('desktop');
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Enhances `initMobileDrawer` in `navigationHelpers.js` with body scroll lock, Escape key close, nav link population from `NAV_LINKS`, overlay backdrop click dismiss, design token colors (sandLight bg, espresso text, coral active), and responsive viewport-based button visibility
- Passes `currentPath` from `masterPage.js` for active link highlighting in the mobile drawer
- 13 new TDD tests covering all bead acceptance criteria (body scroll lock, escape key, backdrop click, nav links, colors, responsive breakpoint)

## Test plan
- [x] 13 new tests written TDD (RED → GREEN verified)
- [x] All 108 masterPage.test.js tests pass
- [x] Full suite: 6345 pass, 1 pre-existing brandPalette failure (unrelated mauve color)
- [ ] Manual: verify hamburger menu opens/closes on mobile viewport in Wix Studio preview
- [ ] Manual: verify nav links navigate correctly and close menu
- [ ] Manual: verify Escape key dismisses menu

Closes cf-t2px

🤖 Generated with [Claude Code](https://claude.com/claude-code)