### PR TITLE
cf-cnxo: Remove banned mauve color from sharedTokens

### DIFF
--- a/src/public/sharedTokens.js
+++ b/src/public/sharedTokens.js
@@ -24,7 +24,6 @@ export const colors = {
   sunsetCoral: '#E8845C',
   sunsetCoralDark: '#C96B44',
   sunsetCoralLight: '#F2A882',
-  mauve: '#C9A0A0',
   offWhite: '#FAF7F2',
   white: '#FFFFFF',
 


### PR DESCRIPTION
## Summary
- Removes `mauve: '#C9A0A0'` from `sharedTokens.js` — this off-brand pink/lavender color violated brand palette compliance
- No production code referenced `colors.mauve` (only the test itself used it for verification)
- Fixes the pre-existing `brandPalette` test failure that was blocking CI green across all PRs

## Test plan
- [x] `brandPalette.test.js`: all 5 tests pass (0 failures)
- [x] Full suite: 6522/6522 pass, **zero failures**
- [x] Verified no production code imports or references `colors.mauve`

Closes cf-cnxo

🤖 Generated with [Claude Code](https://claude.com/claude-code)