### PR TITLE
fix: cf-t2px event listener leak + desktop nav visibility

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -106,8 +106,7 @@ function initAccessibility() {
           // Close promo lightbox
           try { $w('#promoLightbox').hide('fade', { duration: 200 }); } catch (e) {}
           try { $w('#promoOverlay').hide('fade', { duration: 200 }); } catch (e) {}
-          // Close mobile menu
-          try { $w('#mobileMenuOverlay').hide('fade', { duration: 200 }); } catch (e) {}
+          // Mobile menu Escape is handled by initMobileDrawer's own keydown handler
           // Close exit intent popup
           try { $w('#exitIntentPopup').hide('fade', { duration: 200 }); } catch (e) {}
           try { $w('#exitOverlay').hide('fade', { duration: 200 }); } catch (e) {}

--- a/src/public/navigationHelpers.js
+++ b/src/public/navigationHelpers.js
@@ -241,6 +241,7 @@ export function initMobileDrawer($w, currentPath) {
       $w('#mobileMenuOverlay').show('fade', { duration: transitions.medium });
       try { $w('#mobileMenuButton').accessibility.ariaExpanded = true; } catch (e) {}
       lockScroll();
+      addEscHandler();
 
       // Create focus trap inside the drawer
       focusTrap = createFocusTrap($w, '#mobileMenuOverlay', [
@@ -254,6 +255,26 @@ export function initMobileDrawer($w, currentPath) {
     } catch (e) {}
   }
 
+  function addEscHandler() {
+    try {
+      if (typeof document !== 'undefined' && !escHandler) {
+        escHandler = (e) => {
+          if (e.key === 'Escape') close();
+        };
+        document.addEventListener('keydown', escHandler);
+      }
+    } catch (e) {}
+  }
+
+  function removeEscHandler() {
+    try {
+      if (typeof document !== 'undefined' && escHandler) {
+        document.removeEventListener('keydown', escHandler);
+        escHandler = null;
+      }
+    } catch (e) {}
+  }
+
   function close() {
     if (!isOpen) return;
     isOpen = false;
@@ -261,6 +282,7 @@ export function initMobileDrawer($w, currentPath) {
       $w('#mobileMenuOverlay').hide('slide', { direction: 'left', duration: transitions.medium });
       try { $w('#mobileMenuButton').accessibility.ariaExpanded = false; } catch (e) {}
       unlockScroll();
+      removeEscHandler();
       if (focusTrap) {
         focusTrap.release();
         focusTrap = null;
@@ -270,22 +292,14 @@ export function initMobileDrawer($w, currentPath) {
     } catch (e) {}
   }
 
-  // Escape key closes menu
-  try {
-    if (typeof document !== 'undefined') {
-      escHandler = (e) => {
-        if (e.key === 'Escape') close();
-      };
-      document.addEventListener('keydown', escHandler);
-    }
-  } catch (e) {}
-
-  // Responsive: show/hide button based on viewport
+  // Responsive: show/hide nav elements based on viewport
   try {
     if (isMobile()) {
       $w('#mobileMenuButton').show();
+      try { $w('#desktopNavBar').hide(); } catch (e) {}
     } else {
       $w('#mobileMenuButton').hide();
+      try { $w('#desktopNavBar').show(); } catch (e) {}
     }
   } catch (e) {}
 

--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -434,6 +434,29 @@ describe('Navigation Helpers', () => {
         // Menu should still be open — hide should not have been called
         expect(getEl('#mobileMenuOverlay').hide).not.toHaveBeenCalled();
       });
+
+      it('removes escape keydown listener on close so it does not leak', () => {
+        // Track which specific handlers are added/removed for 'keydown'
+        const addedFns = [];
+        const removedFns = [];
+        globalThis.document.addEventListener = vi.fn((event, fn) => {
+          if (event === 'keydown') addedFns.push(fn);
+        });
+        globalThis.document.removeEventListener = vi.fn((event, fn) => {
+          if (event === 'keydown') removedFns.push(fn);
+        });
+
+        const ctrl = initMobileDrawer(getEl);
+        ctrl.open();
+        const addedDuringInitAndOpen = [...addedFns];
+
+        ctrl.close();
+
+        // Every keydown handler added should have a matching removeEventListener
+        for (const fn of addedDuringInitAndOpen) {
+          expect(removedFns).toContain(fn);
+        }
+      });
     });
 
     describe('overlay backdrop click closes menu', () => {
@@ -522,6 +545,25 @@ describe('Navigation Helpers', () => {
         expect(getEl('#mobileMenuButton').show).toHaveBeenCalled();
         mockIsMobile.mockReturnValue(false);
         mockGetViewport.mockReturnValue('desktop');
+      });
+
+      it('hides desktop nav elements at mobile breakpoint', () => {
+        mockIsMobile.mockReturnValue(true);
+        mockGetViewport.mockReturnValue('mobile');
+        initMobileDrawer(getEl);
+
+        // Desktop nav bar should be hidden on mobile
+        expect(getEl('#desktopNavBar').hide).toHaveBeenCalled();
+        mockIsMobile.mockReturnValue(false);
+        mockGetViewport.mockReturnValue('desktop');
+      });
+
+      it('shows desktop nav elements on desktop', () => {
+        mockIsMobile.mockReturnValue(false);
+        mockGetViewport.mockReturnValue('desktop');
+        initMobileDrawer(getEl);
+
+        expect(getEl('#desktopNavBar').show).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Summary
- Fix event listener leak: escape keydown handler in `initMobileDrawer` now added on open, removed on close (was added at init, never removed)
- Remove duplicate mobile menu Escape handling from masterPage.js global handler — `initMobileDrawer` owns its own Escape lifecycle
- Hide `#desktopNavBar` on mobile viewport, show on desktop in `initMobileDrawer`

## Addresses
Melania's PR #110 review: event listener leak at navigationHelpers.js:279, duplicate global Escape handler in masterPage.js:100, desktop nav visibility at mobile breakpoint.

## Test plan
- [x] 3 new TDD tests: listener cleanup on close, desktop nav hidden at mobile, desktop nav shown at desktop
- [x] All 6524 tests pass (1 pre-existing brandPalette failure, cf-cnxo)
- [ ] Manual: verify hamburger nav opens/closes, Escape works, desktop nav hides on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)