### PR TITLE
cf-a0sh: Audit and replace non-brand colors with designToken refs

### DIFF
--- a/src/backend/paymentOptions.web.js
+++ b/src/backend/paymentOptions.web.js
@@ -21,6 +21,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
+import { colors } from 'public/sharedTokens.js';
 
 // Afterpay configuration
 const AFTERPAY_CONFIG = {
@@ -119,8 +120,8 @@ export const getBatchPaymentBadges = webMethod(
           badgeList.push({
             type: 'afterpay',
             label: `4 payments of $${afterpay.installmentAmount}`,
-            color: '#B2FCE4',
-            textColor: '#000000',
+            color: colors.sandLight,
+            textColor: colors.espresso,
           });
         }
 
@@ -128,8 +129,8 @@ export const getBatchPaymentBadges = webMethod(
           badgeList.push({
             type: 'financing',
             label: financing.bestTier.label,
-            color: '#E8F5E9',
-            textColor: '#1B5E20',
+            color: colors.sandLight,
+            textColor: colors.espresso,
           });
         }
 
@@ -341,7 +342,7 @@ function getAvailableMethods(price) {
 
 function getPaymentBadges(price) {
   const badges = [
-    { type: 'secure', label: 'Secure Checkout', icon: 'lock', color: '#1B5E20' },
+    { type: 'secure', label: 'Secure Checkout', icon: 'lock', color: colors.success },
   ];
 
   if (price >= AFTERPAY_CONFIG.minAmount && price <= AFTERPAY_CONFIG.maxAmount) {
@@ -349,7 +350,7 @@ function getPaymentBadges(price) {
       type: 'afterpay',
       label: `4 payments of $${(price / 4).toFixed(2)}`,
       icon: 'afterpay',
-      color: '#B2FCE4',
+      color: colors.sandLight,
     });
   }
 
@@ -359,7 +360,7 @@ function getPaymentBadges(price) {
       type: 'financing',
       label: financing.bestTier.label,
       icon: 'calendar',
-      color: '#E8F5E9',
+      color: colors.sandLight,
     });
   }
 
@@ -368,7 +369,7 @@ function getPaymentBadges(price) {
       type: 'free-shipping',
       label: 'Free Shipping',
       icon: 'truck',
-      color: '#E3F2FD',
+      color: colors.mountainBlueLight,
     });
   }
 

--- a/src/backend/sustainabilityService.web.js
+++ b/src/backend/sustainabilityService.web.js
@@ -40,6 +40,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { colors } from 'public/sharedTokens.js';
 
 const SUSTAINABILITY_COLLECTION = 'ProductSustainability';
 const TRADEIN_COLLECTION = 'TradeInRequests';
@@ -154,23 +155,23 @@ export const getBatchSustainabilityBadges = webMethod(
         const badgeList = [];
 
         if (item.ecoScore === 'A' || item.ecoScore === 'B') {
-          badgeList.push({ type: 'eco-score', label: `Eco Score: ${item.ecoScore}`, color: item.ecoScore === 'A' ? '#2E7D32' : '#558B2F' });
+          badgeList.push({ type: 'eco-score', label: `Eco Score: ${item.ecoScore}`, color: colors.success });
         }
 
         if (item.certifications && item.certifications.length > 0) {
-          badgeList.push({ type: 'certified', label: item.certifications[0], color: '#1565C0' });
+          badgeList.push({ type: 'certified', label: item.certifications[0], color: colors.mountainBlue });
         }
 
         if (item.durabilityRating >= 4) {
-          badgeList.push({ type: 'durable', label: `${item.durabilityRating}/5 Durability`, color: '#6A1B9A' });
+          badgeList.push({ type: 'durable', label: `${item.durabilityRating}/5 Durability`, color: colors.espressoLight });
         }
 
         if (item.recyclabilityPercent >= 75) {
-          badgeList.push({ type: 'recyclable', label: `${item.recyclabilityPercent}% Recyclable`, color: '#00695C' });
+          badgeList.push({ type: 'recyclable', label: `${item.recyclabilityPercent}% Recyclable`, color: colors.success });
         }
 
         if (item.tradeInEligible) {
-          badgeList.push({ type: 'trade-in', label: 'Trade-In Eligible', color: '#E65100' });
+          badgeList.push({ type: 'trade-in', label: 'Trade-In Eligible', color: colors.sunsetCoral });
         }
 
         if (badgeList.length > 0) {

--- a/src/pages/Blog.js
+++ b/src/pages/Blog.js
@@ -9,6 +9,7 @@ import { limitForViewport, initBackToTop } from 'public/mobileHelpers';
 import { trackEvent } from 'public/engagementTracker';
 import { fireCustomEvent } from 'public/ga4Tracking';
 import { announce, makeClickable } from 'public/a11yHelpers';
+import { colors } from 'public/designTokens.js';
 import {
   getCategories,
   filterPostsByCategory,
@@ -126,8 +127,8 @@ function initCategoryFilters(posts) {
         $item('#filterLabel').text = itemData.label;
         const isActive = itemData.value === _activeCategory;
         try {
-          $item('#filterChip').style.backgroundColor = isActive ? '#5B8FA8' : '#F2E8D5';
-          $item('#filterLabel').style.color = isActive ? '#FFFFFF' : '#3A2518';
+          $item('#filterChip').style.backgroundColor = isActive ? colors.mountainBlue : colors.sandLight;
+          $item('#filterLabel').style.color = isActive ? colors.white : colors.espresso;
         } catch (e) {}
 
         makeClickable($item('#filterChip'), () => {

--- a/src/pages/Compare Page.js
+++ b/src/pages/Compare Page.js
@@ -194,7 +194,7 @@ function renderComparisonRows() {
 
         // Highlight differing cells
         if (itemData.differs) {
-          try { $item(cellId).style.backgroundColor = colors.sandLight || '#FFF8F0'; } catch (e) {}
+          try { $item(cellId).style.backgroundColor = colors.sandLight; } catch (e) {}
         }
       }
 

--- a/src/pages/Order Tracking.js
+++ b/src/pages/Order Tracking.js
@@ -183,7 +183,7 @@ function renderTimeline(timeline, order) {
           } else if (step.current) {
             dotEl.style.backgroundColor = colors.mountainBlue;
           } else {
-            dotEl.style.backgroundColor = colors.muted || '#D1D5DB';
+            dotEl.style.backgroundColor = colors.muted;
           }
         }
 
@@ -196,7 +196,7 @@ function renderTimeline(timeline, order) {
             labelEl.style.color = colors.success;
             try { labelEl.accessibility.ariaLabel = `Completed: ${step.label}`; } catch (e) {}
           } else {
-            labelEl.style.color = colors.mutedBrown || colors.muted || '#9CA3AF';
+            labelEl.style.color = colors.mutedBrown || colors.muted;
             try { labelEl.accessibility.ariaLabel = `Pending: ${step.label}`; } catch (e) {}
           }
         }
@@ -540,6 +540,6 @@ function getStatusColor(fulfillmentStatus) {
     case 'LABEL_CREATED': return colors.mountainBlue;
     case 'EXCEPTION':
     case 'RETURNED': return colors.sunsetCoral;
-    default: return colors.mutedBrown || colors.muted || '#6B7280';
+    default: return colors.mutedBrown || colors.muted;
   }
 }

--- a/src/pages/Style Quiz.js
+++ b/src/pages/Style Quiz.js
@@ -4,6 +4,7 @@ import { getQuizRecommendations, getQuizOptions } from 'backend/styleQuiz.web';
 import { trackEvent } from 'public/engagementTracker';
 import { initBackToTop } from 'public/mobileHelpers';
 import { announce } from 'public/a11yHelpers';
+import { colors } from 'public/designTokens.js';
 
 const state = {
   step: 0,
@@ -115,10 +116,10 @@ function renderOptions(key) {
       // Highlight if already selected
       const isSelected = state.answers[key] === itemData.value;
       try {
-        $item('#optionContainer').style.backgroundColor = isSelected ? '#5B8FA8' : '#FFFFFF';
+        $item('#optionContainer').style.backgroundColor = isSelected ? colors.mountainBlue : colors.white;
       } catch (e) {}
       try {
-        $item('#optionLabel').style.color = isSelected ? '#FFFFFF' : '#3A2518';
+        $item('#optionLabel').style.color = isSelected ? colors.white : colors.espresso;
       } catch (e) {}
 
       // ARIA

--- a/src/public/ProductDetails.js
+++ b/src/public/ProductDetails.js
@@ -4,6 +4,7 @@ import { submitSwatchRequest } from 'backend/emailService.web';
 import { getCategoryFromCollections, addBusinessDays } from 'public/productPageUtils.js';
 import { trackSocialShare } from 'public/engagementTracker';
 import { makeClickable } from 'public/a11yHelpers';
+import { colors } from 'public/designTokens.js';
 import { validateEmail } from 'public/validators.js';
 
 // ── Breadcrumbs ───────────────────────────────────────────────────────
@@ -302,8 +303,8 @@ export function initSwatchCTA($w, state) {
     if (!btn || !state?.product) return;
     const hasFabricOptions = state.product.productOptions?.some(opt => /finish|fabric|color|cover/i.test(opt.name));
     btn.label = hasFabricOptions ? 'Get Free Swatches' : 'Request Free Swatches';
-    try { btn.style.backgroundColor = '#E8845C'; } catch (e) {}
-    try { btn.style.color = '#FFFFFF'; } catch (e) {}
+    try { btn.style.backgroundColor = colors.sunsetCoral; } catch (e) {}
+    try { btn.style.color = colors.white; } catch (e) {}
     try { btn.accessibility.ariaLabel = 'Request free fabric swatches shipped to your door'; } catch (e) {}
     btn.show();
     btn.onClick(() => openSwatchModal($w, state));

--- a/tests/ctaCoralAudit.test.js
+++ b/tests/ctaCoralAudit.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { colors } from '../src/public/sharedTokens.js';
+
+// ═══════════════════════════════════════════════════════════════════
+// CF-a0sh: CTA Coral Audit — Non-brand color elimination
+// Ensures all badge colors and UI-facing hex values use brand palette.
+// Ranks 1+3 from HOMOGENIZATION-ANALYSIS: green → coral, lavender → sand.
+// ═══════════════════════════════════════════════════════════════════
+
+// Brand palette (lowercase hex) — all allowed colors
+const BRAND_PALETTE = new Set([
+  '#e8d5b7', '#f2e8d5', '#d4bc96', '#faf7f2',
+  '#3a2518', '#5c4033',
+  '#5b8fa8', '#3d6b80', '#a8ccd8',
+  '#e8845c', '#c96b44', '#f2a882',
+  '#c9a0a0', '#ffffff',
+  '#b8d4e3', '#f0c87a',
+  '#4a7c59', '#999999', '#8b7355',
+]);
+
+function isBrandColor(hex) {
+  return BRAND_PALETTE.has(hex.toLowerCase());
+}
+
+function readSource(relPath) {
+  return readFileSync(join(process.cwd(), relPath), 'utf-8');
+}
+
+// Extract all hex color literals from a source string
+function findHexColors(source) {
+  const matches = [];
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip comment-only lines
+    if (line.trim().startsWith('//')) continue;
+    // Find all hex colors
+    const re = /'#([0-9A-Fa-f]{6})'/g;
+    let m;
+    while ((m = re.exec(line)) !== null) {
+      matches.push({ line: i + 1, hex: `#${m[1]}`, content: line.trim() });
+    }
+  }
+  return matches;
+}
+
+// ── Static audit: page files must not hardcode hex in style assignments ──
+
+describe('CF-a0sh: page files use token imports, not hardcoded hex', () => {
+  const PAGE_FILES = [
+    'src/pages/Blog.js',
+    'src/pages/Style Quiz.js',
+  ];
+
+  for (const relPath of PAGE_FILES) {
+    it(`${relPath} has no hardcoded hex in style assignments`, () => {
+      const source = readSource(relPath);
+      const lines = source.split('\n');
+      const violations = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.trim().startsWith('//') || line.trim().startsWith('import')) continue;
+        if (line.includes('.style.') && /'#[0-9A-Fa-f]{6}'/.test(line)) {
+          violations.push({ line: i + 1, content: line.trim() });
+        }
+      }
+
+      expect(violations, `Hardcoded hex in ${relPath}:\n${violations.map(v => `  L${v.line}: ${v.content}`).join('\n')}`).toEqual([]);
+    });
+  }
+});
+
+// ── Static audit: ProductDetails.js ─────────────────────────────
+
+describe('CF-a0sh: ProductDetails.js uses token imports, not hardcoded hex', () => {
+  it('no hardcoded hex in style assignments', () => {
+    const source = readSource('src/public/ProductDetails.js');
+    const lines = source.split('\n');
+    const violations = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.trim().startsWith('//') || line.trim().startsWith('import')) continue;
+      if (line.includes('.style.') && /'#[0-9A-Fa-f]{6}'/.test(line)) {
+        violations.push({ line: i + 1, content: line.trim() });
+      }
+    }
+
+    expect(violations, `Hardcoded hex in ProductDetails.js:\n${violations.map(v => `  L${v.line}: ${v.content}`).join('\n')}`).toEqual([]);
+  });
+});
+
+// ── Static audit: sustainabilityService badge colors ────────────
+
+describe('CF-a0sh: sustainabilityService.web.js uses only brand colors', () => {
+  const source = readSource('src/backend/sustainabilityService.web.js');
+  const allHex = findHexColors(source);
+
+  it('contains no non-brand hex color literals', () => {
+    const nonBrand = allHex.filter(h => !isBrandColor(h.hex));
+    expect(nonBrand, `Non-brand colors in sustainabilityService:\n${nonBrand.map(h => `  L${h.line}: ${h.hex} — ${h.content}`).join('\n')}`).toEqual([]);
+  });
+
+  // Specific banned colors from the audit
+  const BANNED = ['#2E7D32', '#558B2F', '#1565C0', '#6A1B9A', '#00695C', '#E65100'];
+  for (const banned of BANNED) {
+    it(`does not contain banned color ${banned}`, () => {
+      expect(source).not.toContain(`'${banned}'`);
+    });
+  }
+});
+
+// ── Static audit: paymentOptions badge colors ───────────────────
+
+describe('CF-a0sh: paymentOptions.web.js uses only brand colors', () => {
+  const source = readSource('src/backend/paymentOptions.web.js');
+  const allHex = findHexColors(source);
+
+  it('contains no non-brand hex color literals', () => {
+    const nonBrand = allHex.filter(h => !isBrandColor(h.hex));
+    expect(nonBrand, `Non-brand colors in paymentOptions:\n${nonBrand.map(h => `  L${h.line}: ${h.hex} — ${h.content}`).join('\n')}`).toEqual([]);
+  });
+
+  const BANNED = ['#B2FCE4', '#000000', '#E8F5E9', '#1B5E20', '#E3F2FD'];
+  for (const banned of BANNED) {
+    it(`does not contain banned color ${banned}`, () => {
+      expect(source).not.toContain(`'${banned}'`);
+    });
+  }
+});
+
+// ── Static audit: Order Tracking fallback colors ────────────────
+
+describe('CF-a0sh: Order Tracking.js uses no non-brand fallback colors', () => {
+  const source = readSource('src/pages/Order Tracking.js');
+
+  const BANNED_FALLBACKS = ['#D1D5DB', '#9CA3AF', '#6B7280'];
+  for (const banned of BANNED_FALLBACKS) {
+    it(`does not contain non-brand fallback ${banned}`, () => {
+      expect(source).not.toContain(`'${banned}'`);
+    });
+  }
+});
+
+// ── Static audit: Compare Page fallback color ───────────────────
+
+describe('CF-a0sh: Compare Page.js uses no non-brand fallback colors', () => {
+  it('does not contain non-brand fallback #FFF8F0', () => {
+    const source = readSource('src/pages/Compare Page.js');
+    expect(source).not.toContain("'#FFF8F0'");
+  });
+});
+
+// ── Comprehensive: no #3ECF8E green anywhere in src/ ────────────
+
+describe('CF-a0sh: no green #3ECF8E in any source file', () => {
+  it('sharedTokens.js does not contain #3ECF8E', () => {
+    const source = readSource('src/public/sharedTokens.js');
+    expect(source.toLowerCase()).not.toContain('#3ecf8e');
+  });
+
+  it('designTokens.js does not contain #3ECF8E', () => {
+    const source = readSource('src/public/designTokens.js');
+    expect(source.toLowerCase()).not.toContain('#3ecf8e');
+  });
+});


### PR DESCRIPTION
## Summary
- Audited all Velo source files for non-brand hardcoded hex colors per HOMOGENIZATION-ANALYSIS Ranks 1+3
- Replaced 14 unique non-brand colors across 7 files with `colors.*` token references from `sharedTokens.js`/`designTokens.js`
- Added `colors` import to Blog.js, Style Quiz.js, ProductDetails.js, sustainabilityService.web.js, paymentOptions.web.js
- Removed non-brand fallback colors from Order Tracking.js and Compare Page.js (tokens are always defined)

**Files changed:** sustainabilityService.web.js, paymentOptions.web.js, Blog.js, Style Quiz.js, ProductDetails.js, Order Tracking.js, Compare Page.js

**Note:** `#3ECF8E` (green) was NOT found in any Velo source — the analysis confirms it's a Wix Studio editor-level override, not a code issue.

## Test plan
- [x] 22 new tests in `ctaCoralAudit.test.js` — static source scans + banned color checks
- [x] All 6543 existing tests pass (1 pre-existing failure in brandPalette.test.js unrelated to this PR)
- [ ] Verify badge colors render correctly on product pages
- [ ] Verify filter chip colors on Blog page
- [ ] Verify quiz option styling on Style Quiz page

🤖 Generated with [Claude Code](https://claude.com/claude-code)