### PR TITLE
feat(cf-4com): category filter helpers, QV size select, search consolidation

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -8,8 +8,9 @@ import { getCollectionSchema, getBreadcrumbSchema, getCategoryMetaDescription, g
 import { getProductBadge, getRecentlyViewed, addToCompare, removeFromCompare, getCompareList } from 'public/galleryHelpers';
 import { getProductFallbackImage } from 'public/placeholderImages.js';
 import { getSwatchPreviewColors } from 'backend/swatchService.web';
-import { searchProducts, getFilterValues } from 'backend/searchService.web';
-import { suggestFilterRelaxation } from 'backend/categorySearch.web';
+import { getFilterValues } from 'backend/searchService.web';
+import { searchProducts, suggestFilterRelaxation, getFacetMetadata } from 'backend/categorySearch.web';
+import { buildFilterChips, removeFilter, clearAllFilters, serializeFiltersToUrl, deserializeFiltersFromUrl, formatFeatureLabel, sanitizeFilterInput } from 'public/categoryFilterHelpers';
 import { isMobile, initBackToTop } from 'public/mobileHelpers';
 import { trackEvent } from 'public/engagementTracker';
 import { colors } from 'public/designTokens.js';
@@ -29,17 +30,8 @@ let _debounceTimer = null;
 let _filterSessionState = {}; // persists across category nav within session
 let _wishlistSet = new Set(); // cached wishlist status for product cards
 
-/**
- * Sanitize user input from URL params — strip HTML tags, decode entities, limit length.
- * Frontend-safe equivalent of backend/utils/sanitize for page code.
- */
-function sanitizeInput(str, maxLen = 200) {
-  if (typeof str !== 'string') return '';
-  let result = str.replace(/<[^>]*>/g, '');
-  result = result.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#039;/g, "'");
-  result = result.replace(/<[^>]*>/g, '');
-  return result.trim().slice(0, maxLen);
-}
+// sanitizeInput aliased from shared module
+const sanitizeInput = sanitizeFilterInput;
 
 // ── Category Content Map ─────────────────────────────────────────────
 // Marketing copy and hero config for each category
@@ -624,6 +616,21 @@ function openQuickView(product) {
     $w('#qvAddToCart').label = 'Add to Cart';
     $w('#qvAddToCart').enable();
 
+    // Size selector — show if product has size option
+    try {
+      const sizeSelect = $w('#qvSizeSelect');
+      const productSize = product.options?.size;
+      if (productSize) {
+        const sizes = ['Twin', 'Full', 'Queen', 'King'].filter(s => s);
+        sizeSelect.options = sizes.map(s => ({ label: s, value: s }));
+        sizeSelect.value = productSize;
+        sizeSelect.show();
+        try { sizeSelect.accessibility.ariaLabel = 'Select size'; } catch (e) {}
+      } else {
+        sizeSelect.hide();
+      }
+    } catch (e) {}
+
     // Set dialog ARIA attributes for quick view modal
     try { $w('#quickViewModal').accessibility.role = 'dialog'; } catch (e) {}
     try { $w('#quickViewModal').accessibility.ariaModal = true; } catch (e) {}
@@ -955,37 +962,44 @@ async function applyAdvancedFilters(currentPath) {
     try { $w('#filterLoadingIndicator').show(); } catch (e) {}
     try { $w('#productGridRepeater').hide('fade', { duration: 150 }); } catch (e) {}
 
+    // Parse price range string into min/max numbers
+    let priceMin, priceMax;
+    if (currentFilters.priceRange) {
+      const parts = currentFilters.priceRange.split('-').map(Number);
+      if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
+        priceMin = parts[0];
+        priceMax = parts[1];
+      }
+    }
+
     const result = await searchProducts({
       category: currentPath,
-      priceRange: currentFilters.priceRange || undefined,
-      material: currentFilters.material || undefined,
-      color: currentFilters.color || undefined,
-      features: currentFilters.features || undefined,
-      widthRange: currentFilters.widthRange || undefined,
-      depthRange: currentFilters.depthRange || undefined,
-      sortBy: currentSort === 'bestselling' ? 'bestselling'
-        : currentSort === 'price-asc' ? 'price-asc'
-        : currentSort === 'price-desc' ? 'price-desc'
-        : currentSort === 'name-asc' ? 'name-asc'
-        : currentSort === 'name-desc' ? 'name-desc'
-        : currentSort === 'date-desc' ? 'newest'
-        : 'bestselling',
+      priceMin,
+      priceMax,
+      materials: currentFilters.material ? [currentFilters.material] : undefined,
+      colors: currentFilters.color ? [currentFilters.color] : undefined,
+      featureTags: currentFilters.features || undefined,
+      widthMin: currentFilters.widthRange?.[0] || undefined,
+      widthMax: currentFilters.widthRange?.[1] || undefined,
+      depthMin: currentFilters.depthRange?.[0] || undefined,
+      depthMax: currentFilters.depthRange?.[1] || undefined,
+      sort: currentSort,
       limit: 50,
     });
 
     // Update live result count
     try {
-      $w('#filterResultCount').text = `${result.total} product${result.total !== 1 ? 's' : ''}`;
+      $w('#filterResultCount').text = `${result.totalCount} product${result.totalCount !== 1 ? 's' : ''}`;
     } catch (e) {}
     try {
-      $w('#resultCount').text = `${result.total} product${result.total !== 1 ? 's' : ''}`;
+      $w('#resultCount').text = `${result.totalCount} product${result.totalCount !== 1 ? 's' : ''}`;
     } catch (e) {}
 
     // Announce result count to screen readers
-    announce($w, `Showing ${result.total} product${result.total !== 1 ? 's' : ''}`);
+    announce($w, `Showing ${result.totalCount} product${result.totalCount !== 1 ? 's' : ''}`);
 
     // Handle zero results
-    if (result.total === 0) {
+    if (result.totalCount === 0) {
       showNoMatchesState(currentPath);
     } else {
       try { $w('#noMatchesSection').hide(); } catch (e) {}
@@ -1002,7 +1016,7 @@ async function applyAdvancedFilters(currentPath) {
     trackEvent('filter_applied', {
       category: currentPath,
       filters: Object.keys(currentFilters).filter(k => currentFilters[k]),
-      resultCount: result.total,
+      resultCount: result.totalCount,
     });
 
     // Hide loading indicator and restore grid
@@ -1021,7 +1035,7 @@ async function applyAdvancedFilters(currentPath) {
 }
 
 function clearAllAdvancedFilters(currentPath) {
-  currentFilters = {};
+  currentFilters = clearAllFilters();
 
   // Reset all filter UI elements
   try { $w('#filterMaterial').value = ''; } catch (e) {}
@@ -1058,20 +1072,7 @@ function renderFilterChips() {
     const container = $w('#activeFilterChips');
     if (!container) return;
 
-    const chips = [];
-    if (currentFilters.material) chips.push({ _id: 'chip-material', label: `Material: ${currentFilters.material}`, key: 'material' });
-    if (currentFilters.color) chips.push({ _id: 'chip-color', label: `Color: ${currentFilters.color}`, key: 'color' });
-    if (currentFilters.features && currentFilters.features.length > 0) {
-      currentFilters.features.forEach((f, i) => {
-        chips.push({ _id: `chip-feature-${i}`, label: `Feature: ${formatFeatureLabel(f)}`, key: 'features', value: f });
-      });
-    }
-    if (currentFilters.priceRange) chips.push({ _id: 'chip-price', label: `Price: ${currentFilters.priceRange}`, key: 'priceRange' });
-    if (currentFilters.brand) chips.push({ _id: 'chip-brand', label: `Brand: ${currentFilters.brand}`, key: 'brand' });
-    if (currentFilters.size) chips.push({ _id: 'chip-size', label: `Size: ${currentFilters.size}`, key: 'size' });
-    if (currentFilters.comfortLevel) chips.push({ _id: 'chip-comfort', label: `Comfort: ${currentFilters.comfortLevel}`, key: 'comfortLevel' });
-    if (currentFilters.widthRange) chips.push({ _id: 'chip-width', label: `Width: ${currentFilters.widthRange[0]}"-${currentFilters.widthRange[1]}"`, key: 'widthRange' });
-    if (currentFilters.depthRange) chips.push({ _id: 'chip-depth', label: `Depth: ${currentFilters.depthRange[0]}"-${currentFilters.depthRange[1]}"`, key: 'depthRange' });
+    const chips = buildFilterChips(currentFilters);
 
     if (chips.length === 0) {
       container.hide();
@@ -1112,32 +1113,28 @@ function renderFilterChips() {
 function removeFilterChip(key, value) {
   const currentPath = wixLocationFrontend.path?.[0] || '';
 
-  if (key === 'features' && value) {
-    currentFilters.features = (currentFilters.features || []).filter(f => f !== value);
-    if (currentFilters.features.length === 0) delete currentFilters.features;
+  currentFilters = removeFilter(currentFilters, key, value);
+
+  // Reset corresponding filter UI elements
+  const filterUiMap = {
+    material: '#filterMaterial',
+    color: '#filterColor',
+    priceRange: '#filterPriceRange',
+    brand: '#filterBrand',
+    size: '#filterSize',
+    comfortLevel: '#filterComfortLevel',
+  };
+
+  if (key === 'features') {
     try { $w('#filterFeatures').value = currentFilters.features || []; } catch (e) {}
   } else if (key === 'widthRange') {
-    delete currentFilters.widthRange;
     try { $w('#filterWidthMin').value = ''; } catch (e) {}
     try { $w('#filterWidthMax').value = ''; } catch (e) {}
   } else if (key === 'depthRange') {
-    delete currentFilters.depthRange;
     try { $w('#filterDepthMin').value = ''; } catch (e) {}
     try { $w('#filterDepthMax').value = ''; } catch (e) {}
-  } else {
-    delete currentFilters[key];
-    // Reset corresponding filter UI
-    const filterMap = {
-      material: '#filterMaterial',
-      color: '#filterColor',
-      priceRange: '#filterPriceRange',
-      brand: '#filterBrand',
-      size: '#filterSize',
-      comfortLevel: '#filterComfortLevel',
-    };
-    if (filterMap[key]) {
-      try { $w(filterMap[key]).value = ''; } catch (e) {}
-    }
+  } else if (filterUiMap[key]) {
+    try { $w(filterUiMap[key]).value = ''; } catch (e) {}
   }
 
   debouncedApplyAdvancedFilters(currentPath);
@@ -1195,21 +1192,7 @@ async function showNoMatchesState(currentPath) {
 
 function updateUrlWithFilters(filters) {
   try {
-    const params = {};
-    if (filters.priceRange) params.price = filters.priceRange;
-    if (filters.material) params.material = filters.material;
-    if (filters.color) params.color = filters.color;
-    if (filters.features && filters.features.length > 0) params.features = filters.features.join(',');
-    if (filters.widthRange) params.width = filters.widthRange.join('-');
-    if (filters.depthRange) params.depth = filters.depthRange.join('-');
-    if (filters.brand) params.brand = filters.brand;
-    if (filters.price) params.priceDropdown = filters.price;
-    if (filters.size) params.size = filters.size;
-    if (filters.comfortLevel) params.comfort = filters.comfortLevel;
-
-    const queryString = Object.entries(params)
-      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-      .join('&');
+    const queryString = serializeFiltersToUrl(filters);
 
     // Update URL without page reload using pushState (not wixLocationFrontend.to which navigates)
     try {
@@ -1227,28 +1210,14 @@ function updateUrlWithFilters(filters) {
 function restoreFiltersFromUrl(currentPath) {
   try {
     const query = wixLocationFrontend.query || {};
-
-    // Restore from URL params (sanitized to prevent XSS via crafted URLs)
-    if (query.price) currentFilters.priceRange = sanitizeInput(query.price, 20);
-    if (query.material) currentFilters.material = sanitizeInput(query.material, 100);
-    if (query.color) currentFilters.color = sanitizeInput(query.color, 50);
-    if (query.features) currentFilters.features = sanitizeInput(query.features, 500).split(',').map(f => sanitizeInput(f, 50)).filter(Boolean);
-    if (query.width) {
-      const [min, max] = sanitizeInput(query.width, 20).split('-').map(Number);
-      if (!isNaN(min) && !isNaN(max)) currentFilters.widthRange = [min, max];
-    }
-    if (query.depth) {
-      const [min, max] = sanitizeInput(query.depth, 20).split('-').map(Number);
-      if (!isNaN(min) && !isNaN(max)) currentFilters.depthRange = [min, max];
-    }
-    if (query.brand) currentFilters.brand = sanitizeInput(query.brand, 100);
-    if (query.size) currentFilters.size = sanitizeInput(query.size, 50);
-    if (query.comfort) currentFilters.comfortLevel = sanitizeInput(query.comfort, 50);
+    const restored = deserializeFiltersFromUrl(query);
 
     // Or restore from session state if no URL params
-    if (Object.keys(currentFilters).length === 0 && _filterSessionState[currentPath]) {
-      Object.assign(currentFilters, _filterSessionState[currentPath]);
+    if (Object.keys(restored).length === 0 && _filterSessionState[currentPath]) {
+      Object.assign(restored, _filterSessionState[currentPath]);
     }
+
+    Object.assign(currentFilters, restored);
 
     // Apply restored filters if any
     if (Object.keys(currentFilters).length > 0) {
@@ -1324,9 +1293,7 @@ function initFilterDrawer() {
   } catch (e) {}
 }
 
-function formatFeatureLabel(tag) {
-  return tag.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
-}
+// formatFeatureLabel imported from categoryFilterHelpers
 
 // ── Helpers ─────────────────────────────────────────────────────────
 

--- a/src/public/categoryFilterHelpers.js
+++ b/src/public/categoryFilterHelpers.js
@@ -1,0 +1,168 @@
+/**
+ * @module categoryFilterHelpers
+ * @description Shared filter state utilities for category page faceted navigation.
+ * Handles filter chip generation, URL serialization/deserialization, and
+ * filter state manipulation. Pure functions — no $w or DOM dependencies.
+ */
+
+/**
+ * Sanitize user input — strip HTML tags, decode entities, limit length.
+ * @param {*} str - Input to sanitize
+ * @param {number} [maxLen=200] - Maximum output length
+ * @returns {string} Sanitized string
+ */
+export function sanitizeFilterInput(str, maxLen = 200) {
+  if (typeof str !== 'string') return '';
+  // Strip script/style tags and their contents first
+  let result = str.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '');
+  result = result.replace(/<[^>]*>/g, '');
+  result = result.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#039;/g, "'");
+  result = result.replace(/<[^>]*>/g, '');
+  return result.trim().slice(0, maxLen);
+}
+
+/**
+ * Format a hyphenated feature tag into a display label.
+ * @param {string} tag - e.g. "wall-hugger"
+ * @returns {string} e.g. "Wall Hugger"
+ */
+export function formatFeatureLabel(tag) {
+  if (!tag) return '';
+  return tag.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
+/**
+ * Build an array of filter chip objects from the current filter state.
+ * @param {Object} filters - Current filter state
+ * @returns {Array<{_id: string, label: string, key: string, value?: string}>}
+ */
+export function buildFilterChips(filters) {
+  if (!filters) return [];
+  const chips = [];
+
+  if (filters.material) {
+    chips.push({ _id: 'chip-material', label: `Material: ${filters.material}`, key: 'material' });
+  }
+  if (filters.color) {
+    chips.push({ _id: 'chip-color', label: `Color: ${filters.color}`, key: 'color' });
+  }
+  if (Array.isArray(filters.features) && filters.features.length > 0) {
+    filters.features.forEach((f, i) => {
+      chips.push({ _id: `chip-feature-${i}`, label: `Feature: ${formatFeatureLabel(f)}`, key: 'features', value: f });
+    });
+  }
+  if (filters.priceRange) {
+    chips.push({ _id: 'chip-price', label: `Price: ${filters.priceRange}`, key: 'priceRange' });
+  }
+  if (filters.brand) {
+    chips.push({ _id: 'chip-brand', label: `Brand: ${filters.brand}`, key: 'brand' });
+  }
+  if (filters.size) {
+    chips.push({ _id: 'chip-size', label: `Size: ${filters.size}`, key: 'size' });
+  }
+  if (filters.comfortLevel) {
+    chips.push({ _id: 'chip-comfort', label: `Comfort: ${filters.comfortLevel}`, key: 'comfortLevel' });
+  }
+  if (filters.widthRange) {
+    chips.push({ _id: 'chip-width', label: `Width: ${filters.widthRange[0]}"-${filters.widthRange[1]}"`, key: 'widthRange' });
+  }
+  if (filters.depthRange) {
+    chips.push({ _id: 'chip-depth', label: `Depth: ${filters.depthRange[0]}"-${filters.depthRange[1]}"`, key: 'depthRange' });
+  }
+
+  return chips;
+}
+
+/**
+ * Remove a filter from the state. Returns a new object (does not mutate).
+ * @param {Object} filters - Current filter state
+ * @param {string} key - Filter key to remove
+ * @param {string} [value] - Specific value to remove (for array filters like features)
+ * @returns {Object} New filter state
+ */
+export function removeFilter(filters, key, value) {
+  const result = { ...filters };
+
+  if (key === 'features' && value) {
+    const remaining = (result.features || []).filter(f => f !== value);
+    if (remaining.length === 0) {
+      delete result.features;
+    } else {
+      result.features = remaining;
+    }
+  } else {
+    delete result[key];
+  }
+
+  return result;
+}
+
+/**
+ * Returns an empty filter state.
+ * @returns {Object} Empty filters
+ */
+export function clearAllFilters() {
+  return {};
+}
+
+/**
+ * Serialize filter state to a URL query string.
+ * @param {Object} filters - Filter state
+ * @returns {string} Query string (without leading ?)
+ */
+export function serializeFiltersToUrl(filters) {
+  if (!filters) return '';
+  const params = {};
+
+  if (filters.priceRange) params.price = filters.priceRange;
+  if (filters.material) params.material = filters.material;
+  if (filters.color) params.color = filters.color;
+  if (Array.isArray(filters.features) && filters.features.length > 0) params.features = filters.features.join(',');
+  if (filters.widthRange) params.width = filters.widthRange.join('-');
+  if (filters.depthRange) params.depth = filters.depthRange.join('-');
+  if (filters.brand) params.brand = filters.brand;
+  if (filters.price) params.priceDropdown = filters.price;
+  if (filters.size) params.size = filters.size;
+  if (filters.comfortLevel) params.comfort = filters.comfortLevel;
+
+  const entries = Object.entries(params).filter(([, v]) => v != null && v !== '');
+  if (entries.length === 0) return '';
+
+  return entries
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+/**
+ * Deserialize URL query params back into filter state.
+ * All values are sanitized to prevent XSS from crafted URLs.
+ * @param {Object} query - URL query params object
+ * @returns {Object} Filter state
+ */
+export function deserializeFiltersFromUrl(query) {
+  if (!query) return {};
+  const filters = {};
+
+  if (query.price) filters.priceRange = sanitizeFilterInput(query.price, 20);
+  if (query.material) filters.material = sanitizeFilterInput(query.material, 100);
+  if (query.color) filters.color = sanitizeFilterInput(query.color, 50);
+  if (query.features) {
+    filters.features = sanitizeFilterInput(query.features, 500)
+      .split(',')
+      .map(f => sanitizeFilterInput(f, 50))
+      .filter(Boolean);
+  }
+  if (query.width) {
+    const [min, max] = sanitizeFilterInput(query.width, 20).split('-').map(Number);
+    if (!isNaN(min) && !isNaN(max)) filters.widthRange = [min, max];
+  }
+  if (query.depth) {
+    const [min, max] = sanitizeFilterInput(query.depth, 20).split('-').map(Number);
+    if (!isNaN(min) && !isNaN(max)) filters.depthRange = [min, max];
+  }
+  if (query.brand) filters.brand = sanitizeFilterInput(query.brand, 100);
+  if (query.size) filters.size = sanitizeFilterInput(query.size, 50);
+  if (query.comfort) filters.comfortLevel = sanitizeFilterInput(query.comfort, 50);
+
+  return filters;
+}

--- a/tests/categoryFilterHelpers.test.js
+++ b/tests/categoryFilterHelpers.test.js
@@ -1,0 +1,397 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFilterChips,
+  removeFilter,
+  clearAllFilters,
+  serializeFiltersToUrl,
+  deserializeFiltersFromUrl,
+  formatFeatureLabel,
+  sanitizeFilterInput,
+} from '../src/public/categoryFilterHelpers.js';
+
+// ── sanitizeFilterInput ───────────────────────────────────────────
+
+describe('sanitizeFilterInput', () => {
+  it('strips HTML tags from input', () => {
+    expect(sanitizeFilterInput('<b>bold</b>')).toBe('bold');
+  });
+
+  it('strips script tags', () => {
+    expect(sanitizeFilterInput('<script>alert("xss")</script>hardwood')).toBe('hardwood');
+  });
+
+  it('decodes HTML entities', () => {
+    expect(sanitizeFilterInput('Night &amp; Day')).toBe('Night & Day');
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizeFilterInput('  hardwood  ')).toBe('hardwood');
+  });
+
+  it('truncates to maxLen', () => {
+    const long = 'a'.repeat(300);
+    expect(sanitizeFilterInput(long, 100)).toHaveLength(100);
+  });
+
+  it('returns empty string for non-string input', () => {
+    expect(sanitizeFilterInput(null)).toBe('');
+    expect(sanitizeFilterInput(undefined)).toBe('');
+    expect(sanitizeFilterInput(42)).toBe('');
+  });
+
+  it('defaults maxLen to 200', () => {
+    const long = 'b'.repeat(250);
+    expect(sanitizeFilterInput(long)).toHaveLength(200);
+  });
+
+  it('handles nested HTML tags', () => {
+    expect(sanitizeFilterInput('<div><img onerror=alert(1)>wood</div>')).toBe('wood');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(sanitizeFilterInput('')).toBe('');
+  });
+});
+
+// ── formatFeatureLabel ───────────────────────────────────────────
+
+describe('formatFeatureLabel', () => {
+  it('capitalizes hyphenated words', () => {
+    expect(formatFeatureLabel('wall-hugger')).toBe('Wall Hugger');
+  });
+
+  it('capitalizes single word', () => {
+    expect(formatFeatureLabel('sleeper')).toBe('Sleeper');
+  });
+
+  it('handles multiple hyphens', () => {
+    expect(formatFeatureLabel('extra-firm-support')).toBe('Extra Firm Support');
+  });
+
+  it('handles empty string', () => {
+    expect(formatFeatureLabel('')).toBe('');
+  });
+});
+
+// ── buildFilterChips ─────────────────────────────────────────────
+
+describe('buildFilterChips', () => {
+  it('returns empty array when no filters active', () => {
+    expect(buildFilterChips({})).toEqual([]);
+  });
+
+  it('builds chip for material filter', () => {
+    const chips = buildFilterChips({ material: 'hardwood' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toEqual({
+      _id: 'chip-material',
+      label: 'Material: hardwood',
+      key: 'material',
+    });
+  });
+
+  it('builds chip for color filter', () => {
+    const chips = buildFilterChips({ color: 'walnut' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Color: walnut');
+    expect(chips[0].key).toBe('color');
+  });
+
+  it('builds chips for multiple feature tags', () => {
+    const chips = buildFilterChips({ features: ['wall-hugger', 'sleeper'] });
+    expect(chips).toHaveLength(2);
+    expect(chips[0].label).toBe('Feature: Wall Hugger');
+    expect(chips[0].key).toBe('features');
+    expect(chips[0].value).toBe('wall-hugger');
+    expect(chips[1].label).toBe('Feature: Sleeper');
+    expect(chips[1].value).toBe('sleeper');
+  });
+
+  it('builds chip for price range', () => {
+    const chips = buildFilterChips({ priceRange: '300-500' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Price: 300-500');
+    expect(chips[0].key).toBe('priceRange');
+  });
+
+  it('builds chip for brand', () => {
+    const chips = buildFilterChips({ brand: 'Strata' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Brand: Strata');
+  });
+
+  it('builds chip for size', () => {
+    const chips = buildFilterChips({ size: 'Queen' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Size: Queen');
+  });
+
+  it('builds chip for comfort level', () => {
+    const chips = buildFilterChips({ comfortLevel: '3' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Comfort: 3');
+  });
+
+  it('builds chips for width range', () => {
+    const chips = buildFilterChips({ widthRange: [30, 80] });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Width: 30"-80"');
+  });
+
+  it('builds chips for depth range', () => {
+    const chips = buildFilterChips({ depthRange: [20, 60] });
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('Depth: 20"-60"');
+  });
+
+  it('builds multiple chips from combined filters', () => {
+    const chips = buildFilterChips({
+      material: 'hardwood',
+      brand: 'Strata',
+      priceRange: '500-800',
+    });
+    expect(chips).toHaveLength(3);
+    const keys = chips.map(c => c.key);
+    expect(keys).toContain('material');
+    expect(keys).toContain('brand');
+    expect(keys).toContain('priceRange');
+  });
+
+  it('ignores empty features array', () => {
+    const chips = buildFilterChips({ features: [] });
+    expect(chips).toEqual([]);
+  });
+
+  it('ignores falsy filter values', () => {
+    const chips = buildFilterChips({ material: '', brand: null, color: undefined });
+    expect(chips).toEqual([]);
+  });
+});
+
+// ── removeFilter ─────────────────────────────────────────────────
+
+describe('removeFilter', () => {
+  it('removes a simple key', () => {
+    const filters = { material: 'hardwood', brand: 'Strata' };
+    const result = removeFilter(filters, 'material');
+    expect(result.material).toBeUndefined();
+    expect(result.brand).toBe('Strata');
+  });
+
+  it('removes a specific feature value', () => {
+    const filters = { features: ['wall-hugger', 'sleeper', 'outdoor'] };
+    const result = removeFilter(filters, 'features', 'sleeper');
+    expect(result.features).toEqual(['wall-hugger', 'outdoor']);
+  });
+
+  it('removes features key when last feature removed', () => {
+    const filters = { features: ['sleeper'] };
+    const result = removeFilter(filters, 'features', 'sleeper');
+    expect(result.features).toBeUndefined();
+  });
+
+  it('removes widthRange and returns clean state', () => {
+    const filters = { widthRange: [30, 80], material: 'metal' };
+    const result = removeFilter(filters, 'widthRange');
+    expect(result.widthRange).toBeUndefined();
+    expect(result.material).toBe('metal');
+  });
+
+  it('removes depthRange', () => {
+    const filters = { depthRange: [20, 60] };
+    const result = removeFilter(filters, 'depthRange');
+    expect(result.depthRange).toBeUndefined();
+  });
+
+  it('does not mutate the original filters object', () => {
+    const filters = { material: 'hardwood', brand: 'Strata' };
+    const result = removeFilter(filters, 'material');
+    expect(filters.material).toBe('hardwood');
+    expect(result).not.toBe(filters);
+  });
+
+  it('handles removing non-existent key gracefully', () => {
+    const filters = { brand: 'Strata' };
+    const result = removeFilter(filters, 'color');
+    expect(result).toEqual({ brand: 'Strata' });
+  });
+});
+
+// ── clearAllFilters ─────────────────────────────────────────────
+
+describe('clearAllFilters', () => {
+  it('returns empty object', () => {
+    expect(clearAllFilters()).toEqual({});
+  });
+});
+
+// ── serializeFiltersToUrl ───────────────────────────────────────
+
+describe('serializeFiltersToUrl', () => {
+  it('returns empty string for empty filters', () => {
+    expect(serializeFiltersToUrl({})).toBe('');
+  });
+
+  it('serializes material filter', () => {
+    const qs = serializeFiltersToUrl({ material: 'hardwood' });
+    expect(qs).toBe('material=hardwood');
+  });
+
+  it('serializes price range', () => {
+    const qs = serializeFiltersToUrl({ priceRange: '300-500' });
+    expect(qs).toBe('price=300-500');
+  });
+
+  it('serializes features as comma-separated', () => {
+    const qs = serializeFiltersToUrl({ features: ['sleeper', 'wall-hugger'] });
+    expect(qs).toBe('features=sleeper%2Cwall-hugger');
+  });
+
+  it('serializes width range as dash-separated', () => {
+    const qs = serializeFiltersToUrl({ widthRange: [30, 80] });
+    expect(qs).toBe('width=30-80');
+  });
+
+  it('serializes depth range', () => {
+    const qs = serializeFiltersToUrl({ depthRange: [20, 60] });
+    expect(qs).toBe('depth=20-60');
+  });
+
+  it('serializes brand', () => {
+    const qs = serializeFiltersToUrl({ brand: 'Night & Day' });
+    expect(qs).toBe('brand=Night%20%26%20Day');
+  });
+
+  it('serializes size', () => {
+    const qs = serializeFiltersToUrl({ size: 'Queen' });
+    expect(qs).toBe('size=Queen');
+  });
+
+  it('serializes comfort level', () => {
+    const qs = serializeFiltersToUrl({ comfortLevel: '3' });
+    expect(qs).toBe('comfort=3');
+  });
+
+  it('serializes dropdown price as priceDropdown', () => {
+    const qs = serializeFiltersToUrl({ price: '0-300' });
+    expect(qs).toBe('priceDropdown=0-300');
+  });
+
+  it('serializes multiple filters joined with &', () => {
+    const qs = serializeFiltersToUrl({ material: 'hardwood', brand: 'Strata' });
+    expect(qs).toContain('material=hardwood');
+    expect(qs).toContain('brand=Strata');
+    expect(qs).toContain('&');
+  });
+
+  it('omits falsy values', () => {
+    const qs = serializeFiltersToUrl({ material: '', brand: null, color: undefined });
+    expect(qs).toBe('');
+  });
+
+  it('omits empty features array', () => {
+    const qs = serializeFiltersToUrl({ features: [] });
+    expect(qs).toBe('');
+  });
+});
+
+// ── deserializeFiltersFromUrl ───────────────────────────────────
+
+describe('deserializeFiltersFromUrl', () => {
+  it('returns empty object for empty query', () => {
+    expect(deserializeFiltersFromUrl({})).toEqual({});
+  });
+
+  it('deserializes material', () => {
+    const result = deserializeFiltersFromUrl({ material: 'hardwood' });
+    expect(result.material).toBe('hardwood');
+  });
+
+  it('deserializes price to priceRange', () => {
+    const result = deserializeFiltersFromUrl({ price: '300-500' });
+    expect(result.priceRange).toBe('300-500');
+  });
+
+  it('deserializes features from comma-separated', () => {
+    const result = deserializeFiltersFromUrl({ features: 'sleeper,wall-hugger' });
+    expect(result.features).toEqual(['sleeper', 'wall-hugger']);
+  });
+
+  it('deserializes width range', () => {
+    const result = deserializeFiltersFromUrl({ width: '30-80' });
+    expect(result.widthRange).toEqual([30, 80]);
+  });
+
+  it('deserializes depth range', () => {
+    const result = deserializeFiltersFromUrl({ depth: '20-60' });
+    expect(result.depthRange).toEqual([20, 60]);
+  });
+
+  it('deserializes brand', () => {
+    const result = deserializeFiltersFromUrl({ brand: 'Strata' });
+    expect(result.brand).toBe('Strata');
+  });
+
+  it('deserializes size', () => {
+    const result = deserializeFiltersFromUrl({ size: 'Queen' });
+    expect(result.size).toBe('Queen');
+  });
+
+  it('deserializes comfort', () => {
+    const result = deserializeFiltersFromUrl({ comfort: '3' });
+    expect(result.comfortLevel).toBe('3');
+  });
+
+  it('sanitizes all values to prevent XSS', () => {
+    const result = deserializeFiltersFromUrl({
+      material: '<script>alert(1)</script>hardwood',
+    });
+    expect(result.material).toBe('hardwood');
+    expect(result.material).not.toContain('<script>');
+  });
+
+  it('sanitizes features individually', () => {
+    const result = deserializeFiltersFromUrl({
+      features: '<b>bold</b>,normal',
+    });
+    expect(result.features).toEqual(['bold', 'normal']);
+  });
+
+  it('rejects invalid width range (NaN)', () => {
+    const result = deserializeFiltersFromUrl({ width: 'abc-def' });
+    expect(result.widthRange).toBeUndefined();
+  });
+
+  it('rejects invalid depth range', () => {
+    const result = deserializeFiltersFromUrl({ depth: 'not-numbers' });
+    expect(result.depthRange).toBeUndefined();
+  });
+
+  it('ignores unknown query params', () => {
+    const result = deserializeFiltersFromUrl({ unknown: 'value', material: 'metal' });
+    expect(result.unknown).toBeUndefined();
+    expect(result.material).toBe('metal');
+  });
+
+  it('handles null query', () => {
+    expect(deserializeFiltersFromUrl(null)).toEqual({});
+  });
+
+  it('handles undefined query', () => {
+    expect(deserializeFiltersFromUrl(undefined)).toEqual({});
+  });
+
+  it('roundtrips with serializeFiltersToUrl for simple filters', () => {
+    const original = { material: 'hardwood', brand: 'Strata', size: 'Queen' };
+    const qs = serializeFiltersToUrl(original);
+    const params = {};
+    qs.split('&').forEach(pair => {
+      const [k, v] = pair.split('=');
+      params[decodeURIComponent(k)] = decodeURIComponent(v);
+    });
+    const restored = deserializeFiltersFromUrl(params);
+    expect(restored.material).toBe('hardwood');
+    expect(restored.brand).toBe('Strata');
+    expect(restored.size).toBe('Queen');
+  });
+});

--- a/tests/categoryPage.test.js
+++ b/tests/categoryPage.test.js
@@ -429,6 +429,59 @@ describe('Category Page', () => {
       expect(getEl('#qvImage').src).toBe(futonFrame.mainMedia);
       expect(getEl('#quickViewModal').show).toHaveBeenCalled();
     });
+
+    it('quick view populates size selector when product has size option', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const itemElements = {};
+      const $item = (sel) => {
+        if (!itemElements[sel]) {
+          itemElements[sel] = {
+            text: '', src: '', alt: '', options: [], value: '',
+            show: vi.fn(), hide: vi.fn(), onClick: vi.fn(),
+          };
+        }
+        return itemElements[sel];
+      };
+
+      itemReadyCb($item, futonFrame);
+
+      const quickViewClick = itemElements['#quickViewBtn'].onClick.mock.calls[0][0];
+      quickViewClick();
+
+      // Quick view should show size dropdown with options
+      const sizeSelect = getEl('#qvSizeSelect');
+      expect(sizeSelect.options.length).toBeGreaterThan(0);
+      expect(sizeSelect.show).toHaveBeenCalled();
+    });
+
+    it('quick view hides size selector when product has no size option', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const itemElements = {};
+      const $item = (sel) => {
+        if (!itemElements[sel]) {
+          itemElements[sel] = {
+            text: '', src: '', alt: '', options: [], value: '',
+            show: vi.fn(), hide: vi.fn(), onClick: vi.fn(),
+          };
+        }
+        return itemElements[sel];
+      };
+
+      // wallHuggerFrame has no size option
+      itemReadyCb($item, wallHuggerFrame);
+
+      const quickViewClick = itemElements['#quickViewBtn'].onClick.mock.calls[0][0];
+      quickViewClick();
+
+      const sizeSelect = getEl('#qvSizeSelect');
+      expect(sizeSelect.hide).toHaveBeenCalled();
+    });
   });
 
   // ── Result Count ──────────────────────────────────────────────────

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -210,6 +210,8 @@ export default defineConfig({
       'public/LifestyleGallery': path.resolve(__dirname, 'src/public/LifestyleGallery.js'),
       'public/FeelAndComfort.js': path.resolve(__dirname, 'src/public/FeelAndComfort.js'),
       'public/FeelAndComfort': path.resolve(__dirname, 'src/public/FeelAndComfort.js'),
+      'public/categoryFilterHelpers.js': path.resolve(__dirname, 'src/public/categoryFilterHelpers.js'),
+      'public/categoryFilterHelpers': path.resolve(__dirname, 'src/public/categoryFilterHelpers.js'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Extracts filter state logic into reusable `src/public/categoryFilterHelpers.js` — pure functions for chip building, URL serialization/deserialization, filter removal, and XSS sanitization
- Adds quick view size selector dropdown (AC: "size select" in quick view modal)
- Consolidates Category Page to use `categorySearch.web.searchProducts` (proper faceted multi-value arrays) instead of `searchService.web.searchProducts`
- 64 new tests for helper module + 2 new page tests = 6,909 total tests passing

## Changes
| File | What |
|------|------|
| `src/public/categoryFilterHelpers.js` | **New** — pure filter utilities (buildFilterChips, removeFilter, serializeFiltersToUrl, deserializeFiltersFromUrl, sanitizeFilterInput, formatFeatureLabel) |
| `src/pages/Category Page.js` | Refactored to import helpers, added QV size select, switched to categorySearch.web |
| `tests/categoryFilterHelpers.test.js` | **New** — 64 tests: sanitization, chips, filter removal, URL roundtrip, edge cases |
| `tests/categoryPage.test.js` | 2 new tests: QV size select show/hide |
| `vitest.config.js` | Added categoryFilterHelpers alias |

## Bead
`cf-4com` — Category page filtering UX

## Test plan
- [x] 64 new tests for categoryFilterHelpers (sanitization, chips, URL, edge cases)
- [x] 2 new tests for quick view size selector
- [x] All 6,909 tests passing (180 files, 0 failures)
- [ ] Manual: verify filter chips render correctly after refactor
- [ ] Manual: verify quick view modal shows size dropdown for products with size option

🤖 Generated with [Claude Code](https://claude.com/claude-code)