### PR TITLE
Retrofit empty state SVGs to 8-point quality bar (cf-37uy)

### DIFF
--- a/src/public/emptyStateIllustrations.js
+++ b/src/public/emptyStateIllustrations.js
@@ -334,6 +334,10 @@ export const ILLUSTRATION_SVGS = {
       <ellipse cx="120" cy="38" rx="45" ry="18" fill="${espresso}" opacity="0.4"/>
       <ellipse cx="175" cy="48" rx="50" ry="18" fill="${espressoLight}" opacity="0.42"/>
       <ellipse cx="155" cy="35" rx="40" ry="15" fill="${espresso}" opacity="0.35"/>
+      <line x1="30" y1="25" x2="35" y2="20" stroke="${espresso}" stroke-width="0.8" opacity="0.2"/>
+      <line x1="35" y1="20" x2="40" y2="25" stroke="${espresso}" stroke-width="0.8" opacity="0.2"/>
+      <line x1="248" y1="22" x2="252" y2="18" stroke="${espresso}" stroke-width="0.8" opacity="0.2"/>
+      <line x1="252" y1="18" x2="256" y2="22" stroke="${espresso}" stroke-width="0.8" opacity="0.2"/>
     </g>
     <g id="midground" opacity="0.75">
       <path d="M140 58 L143 78 L137 78 L141 98" stroke="${sunsetCoral}" stroke-width="1.5" fill="none" opacity="0.6"/>

--- a/tests/emptyStateIllustrations.test.js
+++ b/tests/emptyStateIllustrations.test.js
@@ -364,14 +364,19 @@ describe('Empty State Illustrations', () => {
 
   describe('Quality bar — detail elements', () => {
     REQUIRED_KEYS.forEach(key => {
-      it(`${key}: has birds (V-shaped line pairs) or wildflowers (small circles)`, () => {
+      it(`${key}: has bird V-shapes (espresso-stroked line pairs) or wildflower stems (success-stroked paths)`, () => {
         const svg = ILLUSTRATION_SVGS[key];
-        // Birds = V-shaped line pairs with subtle opacity
-        const hasBirds = /stroke-width="[01][^"]*"[^>]*opacity="0\.[2-3]/.test(svg);
-        // Wildflowers = small circles r < 3 (at least 2 per scene)
-        const hasSmallCircles = (svg.match(/<circle[^>]*r="[1-3](\.\d)?"/g) || []).length >= 2;
-        expect(hasBirds || hasSmallCircles,
-          `${key} lacks detail elements (needs birds or wildflowers)`).toBe(true);
+        const espressoHex = colors.espresso.toLowerCase();
+        const successHex = colors.success.toLowerCase();
+        const svgLower = svg.toLowerCase();
+        // Birds = V-shaped line pairs with espresso stroke (2 lines per V)
+        const birdLineRe = new RegExp(`<line[^>]*stroke="${espressoHex}"`, 'g');
+        const birdLineCount = (svgLower.match(birdLineRe) || []).length;
+        const hasBirds = birdLineCount >= 2;
+        // Wildflower stems = thin paths with success/green stroke
+        const hasWildflowerStems = svgLower.includes(`stroke="${successHex}"`);
+        expect(hasBirds || hasWildflowerStems,
+          `${key} lacks detail elements (needs espresso bird lines or success wildflower stems)`).toBe(true);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Upgraded all 8 empty state SVGs (`emptyStateIllustrations.js`) to match the comfort illustration quality standard
- Added watercolor filter (`feTurbulence` + `feDisplacementMap`), paper grain overlay (`fractalNoise`), 6-stop sky gradients, atmospheric depth layers (background/midground/foreground groups), detail elements (birds, wildflowers), and accessibility attributes (`role="img"`, `<title>`, `aria-labelledby`)
- TDD: wrote 91 quality bar tests first (modeled on `comfortIllustrations.test.js`), verified all fail, then implemented to pass
- Fixed review issues: replaced L-command jagged ridgelines with Q bezier curves for rolling Blue Ridge profile, removed always-true test fallback, tightened detail elements test to check for specific bird V-shapes (espresso-stroked line pairs) or wildflower stems (success-stroked paths)

## Test plan
- [x] All 179 empty state illustration tests pass (91 new quality bar + 88 existing)
- [x] Full suite: 7296 pass, 1 pre-existing failure in `deliveryScheduling.test.js` (unrelated)
- [x] Visual verification: rendered all 8 SVGs via Puppeteer, compared against `design.jpeg` — soft rolling ridgelines, watercolor texture, atmospheric depth, detail elements all match Blue Ridge aesthetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)