### PR TITLE
fix: booking window test timezone bug (hq-yjj4)

### DIFF
--- a/tests/deliveryScheduling.test.js
+++ b/tests/deliveryScheduling.test.js
@@ -197,7 +197,9 @@ describe('scheduleDelivery', () => {
     while (![3, 4, 5, 6].includes(farFuture.getDay())) {
       farFuture.setDate(farFuture.getDate() + 1);
     }
-    const dateStr = farFuture.toISOString().split('T')[0];
+    // Format as local date (not UTC via toISOString) to match implementation's
+    // new Date(date + 'T12:00:00') parsing which interprets as local time
+    const dateStr = `${farFuture.getFullYear()}-${String(farFuture.getMonth() + 1).padStart(2, '0')}-${String(farFuture.getDate()).padStart(2, '0')}`;
     const result = await scheduleDelivery({
       orderId: 'order-far',
       date: dateStr,


### PR DESCRIPTION
## Summary
- Fixed timezone bug in `deliveryScheduling.test.js` line 200 where `toISOString()` (UTC) was used to serialize a date validated with `getDay()` (local time)
- In US timezones, a Saturday local date becomes Sunday in UTC, causing the day-of-week validation to fire instead of the booking window validation
- Replaced `toISOString().split('T')[0]` with local date formatting to match the implementation's `new Date(date + 'T12:00:00')` parsing

## Root cause
The implementation parses dates as local time (`new Date(dateStr + 'T12:00:00')` — no `Z` suffix). The test used `toISOString()` which outputs UTC. When the local/UTC date boundary differs (e.g., Saturday 7pm MST = Sunday 2am UTC), the serialized date is a different day of the week than what `getDay()` validated.

## Test plan
- [x] All 44 deliveryScheduling tests pass (was 43/44)
- [x] Full suite: 7460/7460 pass (was 7459/7460)
- [x] Verified fix with debug output confirming the UTC/local date shift

Closes: hq-yjj4

🤖 Generated with [Claude Code](https://claude.com/claude-code)