### PR TITLE
feat(cf-7h85): blog sitemap + Pinterest Rich Pins meta injection

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -6,6 +6,7 @@ import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
 import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement } from 'backend/emailAutomation.web';
+import { getAllBlogPosts } from 'backend/blogContent';
 import wixData from 'wix-data';
 import { colors } from 'public/sharedTokens';
 
@@ -213,6 +214,54 @@ export async function get_productSitemap() {
     console.error('HTTP function error (productSitemap):', err);
     return serverError({
       body: 'Error generating sitemap',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+}
+
+// Dynamic blog sitemap for SEO
+// URL: GET https://www.carolinafutons.com/_functions/blogSitemap
+// Submit alongside productSitemap to Google Search Console
+export async function get_blogSitemap() {
+  try {
+    const SITE_URL = 'https://www.carolinafutons.com';
+    const blogPosts = getAllBlogPosts();
+
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+    xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
+
+    // Blog index page
+    xml += '  <url>\n';
+    xml += `    <loc>${escapeXml(SITE_URL + '/blog')}</loc>\n`;
+    xml += '    <changefreq>weekly</changefreq>\n';
+    xml += '    <priority>0.7</priority>\n';
+    xml += '  </url>\n';
+
+    // Individual blog posts
+    for (const post of blogPosts) {
+      xml += '  <url>\n';
+      xml += `    <loc>${escapeXml(SITE_URL + '/blog/' + post.slug)}</loc>\n`;
+      if (post.publishDate) {
+        xml += `    <lastmod>${escapeXml(post.publishDate)}</lastmod>\n`;
+      }
+      xml += '    <changefreq>monthly</changefreq>\n';
+      xml += '    <priority>0.6</priority>\n';
+      xml += '  </url>\n';
+    }
+
+    xml += '</urlset>';
+
+    return ok({
+      body: xml,
+      headers: {
+        'Content-Type': 'application/xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  } catch (err) {
+    console.error('HTTP function error (blogSitemap):', err);
+    return serverError({
+      body: 'Error generating blog sitemap',
       headers: { 'Content-Type': 'text/plain' },
     });
   }
@@ -565,9 +614,11 @@ export function get_robots() {
     'Disallow: /account',
     'Disallow: /search-results',
     'Allow: /_functions/productSitemap',
+    'Allow: /_functions/blogSitemap',
     'Disallow: /_functions/',
     '',
     'Sitemap: https://www.carolinafutons.com/_functions/productSitemap',
+    'Sitemap: https://www.carolinafutons.com/_functions/blogSitemap',
   ].join('\n');
 
   return ok({

--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -91,6 +91,7 @@ async function initProductPage() {
       { name: 'alsoBought', init: loadAlsoBought },
       { name: 'productSchema', init: () => injectProductSchema($w, state) },
       { name: 'productMeta', init: () => injectProductMeta(state) },
+      { name: 'pinterestMeta', init: () => injectPinterestMeta(state) },
       { name: 'imageGallery', init: () => initImageGallery($w, state) },
       { name: 'arViewer', init: () => initProductARViewer($w, state) },
       { name: 'breadcrumbs', init: () => initBreadcrumbs($w, state) },
@@ -172,6 +173,18 @@ async function injectProductMeta(state) {
     await injectMeta(state.product);
   } catch (e) {
     console.error('[ProductPage] Failed to set meta:', e?.message || e);
+  }
+}
+
+// ── Pinterest Rich Pins Meta ──────────────────────────────────────────
+
+async function injectPinterestMeta(state) {
+  try {
+    if (!state.product) return;
+    const { injectPinterestMeta: injectPins } = await import('public/product/productSchema.js');
+    await injectPins(state.product);
+  } catch (e) {
+    console.error('[ProductPage] Failed to set Pinterest meta:', e?.message || e);
   }
 }
 

--- a/src/public/product/productSchema.js
+++ b/src/public/product/productSchema.js
@@ -3,6 +3,7 @@
 // and product category/brand detection for alt text generation.
 
 import { getProductSchema, getBreadcrumbSchema, getProductOgTags, getProductFaqSchema, getPageTitle, getPageMetaDescription, getCanonicalUrl } from 'backend/seoHelpers.web';
+import { getProductPinData } from 'backend/pinterestRichPins.web';
 
 /**
  * Inject JSON-LD product schema, FAQ schema, and OG tags.
@@ -99,6 +100,53 @@ export async function injectProductMeta(product) {
     }
   } catch (e) {
     // Meta tag injection is non-critical
+  }
+}
+
+/**
+ * Inject Pinterest Rich Pin meta tags via wix-seo-frontend.
+ * Adds Pinterest-specific product metadata (pinterest:description,
+ * pinterest-rich-pin, product:retailer_item_id, sale price) that
+ * complement the standard OG tags already set by injectProductMeta.
+ */
+export async function injectPinterestMeta(product) {
+  try {
+    if (!product) return;
+
+    const { head } = await import('wix-seo-frontend');
+
+    const pinResult = await getProductPinData({
+      name: product.name,
+      slug: product.slug,
+      description: product.description,
+      image: product.mainMedia,
+      price: product.price,
+      salePrice: product.discountedPrice || undefined,
+      inStock: product.inStock !== false,
+      brand: detectProductBrand(product) || undefined,
+      category: detectProductCategory(product) || undefined,
+      sku: product.sku || product._id,
+    });
+
+    if (!pinResult.success || !pinResult.meta) return;
+
+    // Set Pinterest-specific tags that aren't covered by standard OG injection
+    const pinterestTags = [
+      'pinterest:description',
+      'pinterest-rich-pin',
+      'product:retailer_item_id',
+      'product:category',
+      'product:sale_price:amount',
+      'product:sale_price:currency',
+    ];
+
+    for (const tag of pinterestTags) {
+      if (pinResult.meta[tag]) {
+        head.setMetaTag(tag, pinResult.meta[tag]);
+      }
+    }
+  } catch (e) {
+    // Pinterest meta injection is non-critical
   }
 }
 

--- a/tests/httpFunctions.test.js
+++ b/tests/httpFunctions.test.js
@@ -5,6 +5,7 @@ import { __setHandler } from './__mocks__/wix-fetch.js';
 import {
   get_health,
   get_productSitemap,
+  get_blogSitemap,
   get_facebookCatalogFeed,
   get_pinterestProductFeed,
   get_checkWishlistAlerts,
@@ -127,6 +128,59 @@ describe('get_productSitemap', () => {
     expect(result.status).toBe(200);
     // Should still have static pages
     expect(result.body).toContain('<loc>https://www.carolinafutons.com/</loc>');
+  });
+});
+
+// ── get_blogSitemap ─────────────────────────────────────────────────
+
+describe('get_blogSitemap', () => {
+  it('returns XML with sitemap namespace', async () => {
+    const result = await get_blogSitemap();
+    expect(result.status).toBe(200);
+    expect(result.body).toContain('<?xml version="1.0"');
+    expect(result.body).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"');
+  });
+
+  it('includes blog index page', async () => {
+    const result = await get_blogSitemap();
+    expect(result.body).toContain('<loc>https://www.carolinafutons.com/blog</loc>');
+  });
+
+  it('includes all pillar blog post URLs', async () => {
+    const result = await get_blogSitemap();
+    expect(result.body).toContain('/blog/best-futons-for-everyday-sleeping</loc>');
+    expect(result.body).toContain('/blog/futon-frame-buying-guide</loc>');
+    expect(result.body).toContain('/blog/how-to-choose-futon-mattress</loc>');
+    expect(result.body).toContain('/blog/murphy-bed-vs-futon</loc>');
+    expect(result.body).toContain('/blog/futon-care-guide</loc>');
+    expect(result.body).toContain('/blog/futon-vs-sofa-bed</loc>');
+    expect(result.body).toContain('/blog/small-space-furniture-guide</loc>');
+    expect(result.body).toContain('/blog/platform-bed-guide</loc>');
+  });
+
+  it('includes lastmod from publishDate', async () => {
+    const result = await get_blogSitemap();
+    expect(result.body).toContain('<lastmod>2026-02-20</lastmod>');
+  });
+
+  it('sets XML content type with 1-hour cache', async () => {
+    const result = await get_blogSitemap();
+    expect(result.headers['Content-Type']).toContain('application/xml');
+    expect(result.headers['Cache-Control']).toContain('max-age=3600');
+  });
+
+  it('sets blog posts at priority 0.6 and blog index at 0.7', async () => {
+    const result = await get_blogSitemap();
+    // Blog index should be higher priority
+    const indexMatch = result.body.match(/<url>\s*<loc>[^<]*\/blog<\/loc>[\s\S]*?<priority>([\d.]+)<\/priority>/);
+    expect(indexMatch).toBeTruthy();
+    expect(indexMatch[1]).toBe('0.7');
+  });
+
+  it('escapes XML special characters in blog URLs', async () => {
+    const result = await get_blogSitemap();
+    // All URLs should be properly escaped — no raw & or < in loc elements
+    expect(result.body).not.toMatch(/<loc>[^<]*[<>][^<]*<\/loc>/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `get_blogSitemap` HTTP function for SEO (XML sitemap with all pillar blog posts)
- Adds `injectPinterestMeta` to Product Page for Pinterest Rich Pin support
- Updates `robots.txt` to allow and reference blog sitemap

## Test plan
- [x] `tests/httpFunctions.test.js` — blog sitemap XML, escaping, content type
- [ ] Verify no regressions: `npx vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)