### PR TITLE
Wire 18 BUILD-SPEC element IDs in masterPage + FooterSection

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -47,6 +47,9 @@ $w.onReady(async function () {
   initEnhancedNavigation();
   initAnnouncementBar();
   initSearch();
+  initCartIcon();
+  initCartBadge();
+  initSiteLogo();
   initSideCartAutoOpen();
   initFooter($w);
   initMountainSkylineHeader();
@@ -293,6 +296,64 @@ function openSideCart(cart) {
         try { highlight.hide('fade', { duration: 300 }); } catch (e) {}
       }, 3000);
     }
+  } catch (e) {}
+}
+
+// ── Cart Icon & Badge ────────────────────────────────────────────────
+// Wires cart icon click → open side cart, and badge with item count
+
+function initCartIcon() {
+  try {
+    const cartIcon = $w('#cartIcon');
+    if (!cartIcon) return;
+
+    try { cartIcon.accessibility.ariaLabel = 'Shopping cart'; } catch (e) {}
+
+    cartIcon.onClick(() => {
+      try {
+        $w('#sideCartPanel').show('slide', { direction: 'right', duration: 300 });
+      } catch (e) {}
+    });
+  } catch (e) {}
+}
+
+function initCartBadge() {
+  async function updateBadge() {
+    try {
+      const cart = await getCurrentCart();
+      const count = cart
+        ? cart.lineItems.reduce((sum, item) => sum + item.quantity, 0)
+        : 0;
+
+      const badge = $w('#cartBadge');
+      if (!badge) return;
+
+      if (count > 0) {
+        badge.text = String(count);
+        badge.show();
+      } else {
+        badge.hide();
+      }
+    } catch (e) {}
+  }
+
+  updateBadge();
+  onCartChanged(() => updateBadge());
+}
+
+// ── Site Logo ───────────────────────────────────────────────────────
+// Logo click → navigate to homepage
+
+function initSiteLogo() {
+  try {
+    const logo = $w('#siteLogo');
+    if (!logo) return;
+
+    try { logo.accessibility.ariaLabel = 'Carolina Futons - Go to homepage'; } catch (e) {}
+
+    logo.onClick(() => {
+      wixLocationFrontend.to('/');
+    });
   } catch (e) {}
 }
 

--- a/src/public/FooterSection.js
+++ b/src/public/FooterSection.js
@@ -83,17 +83,23 @@ export function initFooterColumns($w) {
       }
     } catch (e) {}
 
-    // Column 4: Store Info
+    // Column 4: Store Info (wire both legacy #footerStore* and BUILD-SPEC #footer* IDs)
     try {
       const info = getStoreInfo();
+      const phoneLabel = `Call ${info.name} at ${info.phone}`;
+      const hoursText = info.hours.map(h => `${h.days}: ${h.time}`).join('\n');
+
       try { $w('#footerStoreName').text = info.name; } catch (e) {}
       try { $w('#footerStoreAddress').text = info.address; } catch (e) {}
       try { $w('#footerStorePhone').text = info.phone; } catch (e) {}
-      try { $w('#footerStorePhone').accessibility.ariaLabel = `Call ${info.name} at ${info.phone}`; } catch (e) {}
-      try {
-        const hoursText = info.hours.map(h => `${h.days}: ${h.time}`).join('\n');
-        $w('#footerStoreHours').text = hoursText;
-      } catch (e) {}
+      try { $w('#footerStorePhone').accessibility.ariaLabel = phoneLabel; } catch (e) {}
+      try { $w('#footerStoreHours').text = hoursText; } catch (e) {}
+
+      // BUILD-SPEC element IDs
+      try { $w('#footerPhone').text = info.phone; } catch (e) {}
+      try { $w('#footerPhone').accessibility.ariaLabel = phoneLabel; } catch (e) {}
+      try { $w('#footerAddress').text = info.address; } catch (e) {}
+      try { $w('#footerHours').text = hoursText; } catch (e) {}
     } catch (e) {}
   } catch (e) {}
 }
@@ -152,17 +158,40 @@ export function initFooterNewsletter($w) {
  */
 export function initFooterSocial($w) {
   try {
-    const socialRepeater = $w('#footerSocialRepeater');
-    if (!socialRepeater) return;
-
     const links = getFooterSocialLinks();
-    socialRepeater.data = links.map((l, i) => ({ ...l, _id: `social-${i}` }));
-    socialRepeater.onItemReady(($item, itemData) => {
-      try { $item('#socialIcon').text = itemData.platform; } catch (e) {}
-      try { $item('#socialIcon').accessibility.ariaLabel = itemData.ariaLabel; } catch (e) {}
+
+    // Repeater-based social icons (legacy pattern)
+    try {
+      const socialRepeater = $w('#footerSocialRepeater');
+      if (socialRepeater) {
+        socialRepeater.data = links.map((l, i) => ({ ...l, _id: `social-${i}` }));
+        socialRepeater.onItemReady(($item, itemData) => {
+          try { $item('#socialIcon').text = itemData.platform; } catch (e) {}
+          try { $item('#socialIcon').accessibility.ariaLabel = itemData.ariaLabel; } catch (e) {}
+          try {
+            $item('#socialIcon').onClick(() => {
+              if (typeof window !== 'undefined') window.open(itemData.url, '_blank');
+            });
+          } catch (e) {}
+        });
+      }
+    } catch (e) {}
+
+    // Individual BUILD-SPEC social button elements
+    const socialMap = {
+      '#socialFacebook': links.find(l => l.platform === 'facebook'),
+      '#socialInstagram': links.find(l => l.platform === 'instagram'),
+      '#socialPinterest': links.find(l => l.platform === 'pinterest'),
+    };
+
+    Object.entries(socialMap).forEach(([selector, linkData]) => {
+      if (!linkData) return;
       try {
-        $item('#socialIcon').onClick(() => {
-          if (typeof window !== 'undefined') window.open(itemData.url, '_blank');
+        const el = $w(selector);
+        if (!el) return;
+        try { el.accessibility.ariaLabel = linkData.ariaLabel; } catch (e) {}
+        el.onClick(() => {
+          if (typeof window !== 'undefined') window.open(linkData.url, '_blank');
         });
       } catch (e) {}
     });
@@ -311,11 +340,30 @@ export function initMountainDivider($w) {
 }
 
 /**
+ * Initialize footer logo with navigation and ARIA.
+ * @param {Function} $w - Wix selector function
+ */
+export function initFooterLogo($w) {
+  try {
+    const logo = $w('#footerLogo');
+    if (!logo) return;
+
+    try { logo.alt = 'Carolina Futons'; } catch (e) {}
+    try { logo.accessibility.ariaLabel = 'Carolina Futons - Go to homepage'; } catch (e) {}
+
+    logo.onClick(() => {
+      import('wix-location-frontend').then(({ to }) => to('/'));
+    });
+  } catch (e) {}
+}
+
+/**
  * Initialize entire footer — orchestrates all subsections.
  * @param {Function} $w - Wix selector function
  */
 export function initFooter($w) {
   initMountainDivider($w);
+  initFooterLogo($w);
   initFooterColumns($w);
   initFooterNewsletter($w);
   initFooterSocial($w);

--- a/tests/footerSection.test.js
+++ b/tests/footerSection.test.js
@@ -16,6 +16,7 @@ import {
   initFooterPayment,
   initFooterCopyright,
   initFooterAria,
+  initFooterLogo,
   initFooter,
 } from '../src/public/FooterSection.js';
 
@@ -435,6 +436,88 @@ describe('initFooterAria', () => {
   it('survives missing footer element', () => {
     const broken$w = () => null;
     expect(() => initFooterAria(broken$w)).not.toThrow();
+  });
+});
+
+// ── initFooterLogo (cf-0z2w) ─────────────────────────────────────────
+
+describe('initFooterLogo', () => {
+  it('sets ariaLabel on #footerLogo', () => {
+    initFooterLogo($w);
+    expect($w('#footerLogo').accessibility.ariaLabel).toBe('Carolina Futons - Go to homepage');
+  });
+
+  it('wires onClick on #footerLogo to navigate home', () => {
+    initFooterLogo($w);
+    expect($w('#footerLogo').onClick).toHaveBeenCalled();
+  });
+
+  it('sets alt text on #footerLogo', () => {
+    initFooterLogo($w);
+    expect($w('#footerLogo').alt).toBe('Carolina Futons');
+  });
+
+  it('survives missing footer logo element', () => {
+    const broken$w = () => null;
+    expect(() => initFooterLogo(broken$w)).not.toThrow();
+  });
+});
+
+// ── BUILD-SPEC footer contact IDs (cf-0z2w) ─────────────────────────
+
+describe('initFooterColumns — BUILD-SPEC contact IDs', () => {
+  it('populates #footerPhone with phone number', () => {
+    initFooterColumns($w);
+    expect($w('#footerPhone').text).toMatch(/\d/);
+  });
+
+  it('sets ariaLabel on #footerPhone', () => {
+    initFooterColumns($w);
+    expect($w('#footerPhone').accessibility.ariaLabel).toContain('Call');
+  });
+
+  it('populates #footerAddress with address', () => {
+    initFooterColumns($w);
+    expect($w('#footerAddress').text).toContain('Hendersonville');
+  });
+
+  it('populates #footerHours with hours', () => {
+    initFooterColumns($w);
+    expect($w('#footerHours').text).toContain('Wednesday');
+  });
+});
+
+// ── Individual social buttons (cf-0z2w) ──────────────────────────────
+
+describe('initFooterSocial — individual social buttons', () => {
+  it('wires onClick on #socialFacebook', () => {
+    initFooterSocial($w);
+    expect($w('#socialFacebook').onClick).toHaveBeenCalled();
+  });
+
+  it('sets ariaLabel on #socialFacebook', () => {
+    initFooterSocial($w);
+    expect($w('#socialFacebook').accessibility.ariaLabel).toContain('Facebook');
+  });
+
+  it('wires onClick on #socialInstagram', () => {
+    initFooterSocial($w);
+    expect($w('#socialInstagram').onClick).toHaveBeenCalled();
+  });
+
+  it('sets ariaLabel on #socialInstagram', () => {
+    initFooterSocial($w);
+    expect($w('#socialInstagram').accessibility.ariaLabel).toContain('Instagram');
+  });
+
+  it('wires onClick on #socialPinterest', () => {
+    initFooterSocial($w);
+    expect($w('#socialPinterest').onClick).toHaveBeenCalled();
+  });
+
+  it('sets ariaLabel on #socialPinterest', () => {
+    initFooterSocial($w);
+    expect($w('#socialPinterest').accessibility.ariaLabel).toContain('Pinterest');
   });
 });
 

--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -73,15 +73,19 @@ vi.mock('backend/contactSubmissions.web', () => ({
 vi.mock('backend/coreWebVitals.web', () => ({
   reportMetrics: vi.fn().mockResolvedValue({}),
 }));
+const mockWixLocationTo = vi.fn();
 vi.mock('wix-location-frontend', () => ({
-  default: { path: [], to: vi.fn() },
+  default: { path: [], to: mockWixLocationTo },
   path: [],
-  to: vi.fn(),
+  to: mockWixLocationTo,
 }));
 vi.mock('public/cartService', () => ({
   getCurrentCart: vi.fn().mockResolvedValue({ lineItems: [] }),
   onCartChanged: vi.fn(),
+  getShippingProgress: vi.fn(() => ({ remaining: 999, progressPct: 0, qualifies: false })),
 }));
+
+import { getCurrentCart, onCartChanged } from 'public/cartService';
 const { mockIsMobile, mockGetViewport } = vi.hoisted(() => ({
   mockIsMobile: vi.fn(() => false),
   mockGetViewport: vi.fn(() => 'desktop'),
@@ -1059,6 +1063,84 @@ describe('masterPage.js', () => {
     it('wires dismiss button with click handler', async () => {
       await onReadyHandler();
       expect(getEl('#announcementDismiss').onClick).toHaveBeenCalled();
+    });
+  });
+
+  // ── Cart Icon & Badge (cf-0z2w) ──────────────────────────────────
+
+  describe('cart icon', () => {
+    it('wires onClick on #cartIcon', async () => {
+      await onReadyHandler();
+      expect(getEl('#cartIcon').onClick).toHaveBeenCalled();
+    });
+
+    it('sets ariaLabel on #cartIcon', async () => {
+      await onReadyHandler();
+      expect(getEl('#cartIcon').accessibility.ariaLabel).toBe('Shopping cart');
+    });
+
+    it('click opens side cart panel', async () => {
+      await onReadyHandler();
+      const clickHandler = getEl('#cartIcon').onClick.mock.calls[0][0];
+      clickHandler();
+      expect(getEl('#sideCartPanel').show).toHaveBeenCalledWith(
+        'slide',
+        expect.objectContaining({ direction: 'right' })
+      );
+    });
+  });
+
+  describe('cart badge', () => {
+    it('hides #cartBadge when cart is empty', async () => {
+      getCurrentCart.mockResolvedValueOnce({ lineItems: [] });
+      elements.clear();
+      await onReadyHandler();
+      // Allow async cart fetch to resolve
+      await vi.waitFor(() => {
+        expect(getEl('#cartBadge').hide).toHaveBeenCalled();
+      });
+    });
+
+    it('shows #cartBadge with count when cart has items', async () => {
+      getCurrentCart.mockResolvedValueOnce({
+        lineItems: [
+          { _id: '1', quantity: 2 },
+          { _id: '2', quantity: 1 },
+        ],
+      });
+      elements.clear();
+      await onReadyHandler();
+      await vi.waitFor(() => {
+        expect(getEl('#cartBadge').text).toBe('3');
+        expect(getEl('#cartBadge').show).toHaveBeenCalled();
+      });
+    });
+
+    it('updates badge on cart change via onCartChanged callback', async () => {
+      await onReadyHandler();
+      // onCartChanged should have been called with a handler
+      expect(onCartChanged).toHaveBeenCalled();
+    });
+  });
+
+  // ── Site Logo (cf-0z2w) ──────────────────────────────────────────
+
+  describe('site logo', () => {
+    it('wires onClick on #siteLogo', async () => {
+      await onReadyHandler();
+      expect(getEl('#siteLogo').onClick).toHaveBeenCalled();
+    });
+
+    it('sets ariaLabel on #siteLogo', async () => {
+      await onReadyHandler();
+      expect(getEl('#siteLogo').accessibility.ariaLabel).toBe('Carolina Futons - Go to homepage');
+    });
+
+    it('click navigates to homepage', async () => {
+      await onReadyHandler();
+      const clickHandler = getEl('#siteLogo').onClick.mock.calls[0][0];
+      clickHandler();
+      expect(mockWixLocationTo).toHaveBeenCalledWith('/');
     });
   });
 });


### PR DESCRIPTION
## Summary
- **masterPage.js**: Wire `#cartIcon` (click → open side cart), `#cartBadge` (show/hide count on load + cart change), `#siteLogo` (click → home, ARIA)
- **FooterSection.js**: Wire `#footerLogo` (alt, ARIA, click → home), BUILD-SPEC contact IDs (`#footerPhone`, `#footerAddress`, `#footerHours`) alongside legacy `#footerStore*` IDs, individual social buttons (`#socialFacebook`, `#socialInstagram`, `#socialPinterest`) alongside existing repeater
- **TDD**: 22 new tests covering all wired elements, error states, and ARIA attributes

Bead: cf-0z2w

## Element ID Coverage (18 BUILD-SPEC IDs)
| Group | IDs | Status |
|-------|-----|--------|
| Cart icon/badge | `#cartIcon`, `#cartBadge` | New in masterPage.js |
| Announcement bar | `#announcementBar` | Already wired via navigationHelpers |
| Site logo | `#siteLogo` | New in masterPage.js |
| Footer newsletter | `#footerEmailInput`, `#footerEmailSubmit`, `#footerEmailError`, `#footerEmailSuccess` | Already wired via FooterSection |
| Footer contact | `#footerPhone`, `#footerAddress`, `#footerHours`, `#footerLogo` | New in FooterSection.js |
| Social buttons | `#socialFacebook`, `#socialInstagram`, `#socialPinterest` | New in FooterSection.js |
| Mobile menu | `#mobileMenuButton`, `#mobileMenuOverlay`, `#mobileMenuClose` | Already wired via navigationHelpers |

## Test plan
- [x] 8 new masterPage integration tests (cart icon, cart badge, site logo)
- [x] 14 new FooterSection unit tests (logo, contact IDs, social buttons)
- [x] All 120 masterPage tests pass
- [x] All 60 FooterSection tests pass
- [x] Full suite: 7593/7594 pass (1 pre-existing failure in homePageHero.test.js unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)