### PR TITLE
feat: add Pinterest catalog sync validation, board mapping, pin conte…

### DIFF
--- a/src/backend/pinterestCatalogSync.web.js
+++ b/src/backend/pinterestCatalogSync.web.js
@@ -1,0 +1,380 @@
+/**
+ * @module pinterestCatalogSync
+ * @description Pinterest catalog validation, board mapping, and pin content generation.
+ * Validates product data quality for the Pinterest catalog feed, maps products to
+ * Pinterest boards per the social media strategy, and generates optimized pin content.
+ *
+ * Builds on pinterestRichPins.web.js (meta tags) and http-functions.js (feed endpoint).
+ *
+ * @requires wix-web-module
+ * @requires wix-data
+ */
+import { Permissions, webMethod } from 'wix-web-module';
+import wixData from 'wix-data';
+import { sanitize } from 'backend/utils/sanitize';
+
+const SITE_URL = 'https://www.carolinafutons.com';
+const SITE_NAME = 'Carolina Futons';
+const FEED_URL = `${SITE_URL}/_functions/pinterestProductFeed`;
+const MAX_TITLE_LEN = 150;
+const MAX_DESC_LEN = 500;
+
+// ── Board Structure (per SOCIAL-MEDIA-STRATEGY.md) ──────────────────
+
+const BOARDS = [
+  { name: 'Futon Living Rooms', contentType: 'Styled futon setups, customer photos', pinFrequency: '3-4/week' },
+  { name: 'Small Space Solutions', contentType: 'Studio/apartment layouts with futons', pinFrequency: '2-3/week' },
+  { name: 'Murphy & Cabinet Beds', contentType: 'Murphy bed transformations, before/after', pinFrequency: '2-3/week' },
+  { name: 'Platform Bed Inspiration', contentType: 'Platform bed room setups', pinFrequency: '2-3/week' },
+  { name: 'Handcrafted & Unfinished', contentType: 'DIY finish ideas, wood craftsmanship', pinFrequency: '1-2/week' },
+  { name: 'Sale & Clearance', contentType: 'Current deals, limited-time offers', pinFrequency: '2-3/week' },
+  { name: 'Customer Showcase', contentType: 'UGC repins from customers', pinFrequency: '1-2/week' },
+];
+
+// Collection → board mapping rules (first match wins)
+const BOARD_RULES = [
+  { match: c => c.includes('sales') || c.includes('sale') || c.includes('clearance'), board: 'Sale & Clearance', needsDiscount: true },
+  { match: c => c.includes('murphy') || c.includes('cabinet-bed'), board: 'Murphy & Cabinet Beds' },
+  { match: c => c.includes('platform'), board: 'Platform Bed Inspiration' },
+  { match: c => c.includes('unfinished'), board: 'Handcrafted & Unfinished' },
+  { match: c => c.includes('mattress'), board: 'Small Space Solutions' },
+  { match: c => c.includes('casegood') || c.includes('accessor'), board: 'Small Space Solutions' },
+  { match: c => c.includes('futon') || c.includes('wall-hugger'), board: 'Futon Living Rooms' },
+];
+
+// Category → hashtag mapping
+const CATEGORY_HASHTAGS = {
+  'futon-frames': ['#FutonLiving', '#FutonFrame'],
+  'wall-huggers': ['#FutonLiving', '#WallHugger'],
+  'mattresses': ['#FutonMattress', '#SmallSpaceLiving'],
+  'murphy-cabinet-beds': ['#MurphyBed', '#SpaceSaving'],
+  'platform-beds': ['#PlatformBed', '#BedroomDesign'],
+  'unfinished-wood': ['#DIYFurniture', '#UnfinishedWood'],
+  'casegoods-accessories': ['#FurnitureAccessories', '#HomeDecor'],
+  'sales': ['#FurnitureSale', '#DealAlert'],
+};
+
+const BASE_HASHTAGS = ['#CarolinaFutons', '#HandcraftedFurniture', '#NCFurniture'];
+
+// ── validateCatalogProduct ───────────────────────────────────────────
+
+/**
+ * Validate a single product meets Pinterest catalog requirements.
+ * Returns issues (blockers) and warnings (non-blocking quality concerns).
+ *
+ * @param {Object} product - Wix product object.
+ * @returns {Promise<{success: boolean, valid: boolean, issues: Array, warnings: Array, sanitizedName: string}>}
+ */
+export const validateCatalogProduct = webMethod(
+  Permissions.Anyone,
+  async (product) => {
+    try {
+      if (!product || typeof product !== 'object') {
+        return { success: false, error: 'Product object is required.', valid: false, issues: [], warnings: [] };
+      }
+
+      const issues = [];
+      const warnings = [];
+      const name = sanitize(product.name || '', MAX_TITLE_LEN);
+
+      // Required fields — issues (blockers)
+      if (!name) {
+        issues.push({ field: 'name', type: 'required', message: 'Product name is required.' });
+      }
+
+      if (!product.slug) {
+        issues.push({ field: 'slug', type: 'required', message: 'Product slug is required for URL generation.' });
+      }
+
+      const price = Number(product.price);
+      if (!price || price <= 0) {
+        issues.push({ field: 'price', type: 'required', message: 'Product price must be a positive number.' });
+      }
+
+      // Optional fields — warnings (quality concerns)
+      if (!product.description) {
+        warnings.push({ field: 'description', type: 'missing', message: 'Missing description — pin quality reduced.' });
+      } else if (product.description.length > MAX_DESC_LEN) {
+        warnings.push({ field: 'description', type: 'length', message: `Description exceeds ${MAX_DESC_LEN} chars — will be truncated.` });
+      }
+
+      if (!product.mainMedia) {
+        warnings.push({ field: 'mainMedia', type: 'missing', message: 'Missing product image — default image will be used.' });
+      } else if (typeof product.mainMedia === 'string' && !product.mainMedia.startsWith('http')) {
+        warnings.push({ field: 'mainMedia', type: 'format', message: 'Image URL should be absolute (https://).' });
+      }
+
+      if (product.name && product.name.length > MAX_TITLE_LEN) {
+        warnings.push({ field: 'name', type: 'length', message: `Title exceeds ${MAX_TITLE_LEN} chars — may be truncated on Pinterest.` });
+      }
+
+      return {
+        success: true,
+        valid: issues.length === 0,
+        issues,
+        warnings,
+        sanitizedName: name,
+      };
+    } catch (err) {
+      console.error('[pinterestCatalogSync] validateCatalogProduct error:', err);
+      return { success: false, error: 'Validation failed.', valid: false, issues: [], warnings: [] };
+    }
+  }
+);
+
+// ── auditCatalog ─────────────────────────────────────────────────────
+
+/**
+ * Audit all products in the catalog for Pinterest feed readiness.
+ * Queries Stores/Products and validates each one.
+ *
+ * @returns {Promise<{success: boolean, totalProducts: number, validCount: number, invalidCount: number, warningCount: number, issues: Array}>}
+ */
+export const auditCatalog = webMethod(
+  Permissions.Admin,
+  async () => {
+    try {
+      const PAGE_SIZE = 1000;
+      let allProducts = [];
+      let skip = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const result = await wixData.query('Stores/Products')
+          .limit(PAGE_SIZE)
+          .skip(skip)
+          .find();
+        allProducts = allProducts.concat(result.items);
+        skip += PAGE_SIZE;
+        hasMore = result.items.length === PAGE_SIZE;
+      }
+
+      let validCount = 0;
+      let invalidCount = 0;
+      let warningCount = 0;
+      const issues = [];
+
+      for (const product of allProducts) {
+        const validation = await validateCatalogProduct(product);
+
+        if (validation.valid) {
+          validCount++;
+        } else {
+          invalidCount++;
+          for (const issue of validation.issues) {
+            issues.push({
+              productId: product._id,
+              productName: sanitize(product.name || '', 100),
+              ...issue,
+            });
+          }
+        }
+
+        warningCount += (validation.warnings || []).length;
+      }
+
+      return {
+        success: true,
+        totalProducts: allProducts.length,
+        validCount,
+        invalidCount,
+        warningCount,
+        issues,
+      };
+    } catch (err) {
+      console.error('[pinterestCatalogSync] auditCatalog error:', err);
+      return {
+        success: false,
+        error: 'Catalog audit failed.',
+        totalProducts: 0,
+        validCount: 0,
+        invalidCount: 0,
+        warningCount: 0,
+        issues: [],
+      };
+    }
+  }
+);
+
+// ── getCatalogSyncStatus ─────────────────────────────────────────────
+
+/**
+ * Get Pinterest catalog feed health status.
+ * Returns feed URL, product count, and health score.
+ *
+ * @returns {Promise<{success: boolean, feedUrl: string, feedFormat: string, productCount: number, healthScore: number}>}
+ */
+export const getCatalogSyncStatus = webMethod(
+  Permissions.Admin,
+  async () => {
+    try {
+      const audit = await auditCatalog();
+
+      const healthScore = audit.totalProducts > 0
+        ? Math.round((audit.validCount / audit.totalProducts) * 100)
+        : 0;
+
+      return {
+        success: true,
+        feedUrl: FEED_URL,
+        feedFormat: 'TSV',
+        productCount: audit.totalProducts,
+        validCount: audit.validCount,
+        invalidCount: audit.invalidCount,
+        warningCount: audit.warningCount,
+        healthScore,
+        issues: audit.issues,
+      };
+    } catch (err) {
+      console.error('[pinterestCatalogSync] getCatalogSyncStatus error:', err);
+      return {
+        success: false,
+        error: 'Failed to get catalog sync status.',
+        feedUrl: FEED_URL,
+        feedFormat: 'TSV',
+        productCount: 0,
+        healthScore: 0,
+      };
+    }
+  }
+);
+
+// ── mapProductToBoard ────────────────────────────────────────────────
+
+/**
+ * Map a product to the appropriate Pinterest board based on its collections.
+ * Uses the board structure from SOCIAL-MEDIA-STRATEGY.md.
+ *
+ * @param {Object} product - Product with collections array.
+ * @returns {Promise<{success: boolean, board: string}>}
+ */
+export const mapProductToBoard = webMethod(
+  Permissions.Anyone,
+  async (product) => {
+    try {
+      if (!product || typeof product !== 'object') {
+        return { success: false, error: 'Product object is required.', board: null };
+      }
+
+      const collections = (product.collections || []).map(c =>
+        (typeof c === 'string' ? c : c.id || '').toLowerCase()
+      );
+
+      // Check for sale items first (needs discountedPrice)
+      if (product.discountedPrice && collections.some(c => c.includes('sale') || c.includes('clearance'))) {
+        return { success: true, board: 'Sale & Clearance' };
+      }
+
+      // Match against board rules
+      for (const rule of BOARD_RULES) {
+        if (rule.needsDiscount) continue; // Skip sale rule — already handled above
+        if (collections.some(rule.match)) {
+          return { success: true, board: rule.board };
+        }
+      }
+
+      // Default board
+      return { success: true, board: 'Futon Living Rooms' };
+    } catch (err) {
+      console.error('[pinterestCatalogSync] mapProductToBoard error:', err);
+      return { success: false, error: 'Board mapping failed.', board: null };
+    }
+  }
+);
+
+// ── generatePinContent ───────────────────────────────────────────────
+
+/**
+ * Generate optimized pin content for a product.
+ * Includes title, description with price, hashtags, and UTM-tagged link.
+ *
+ * @param {Object} product - Wix product object.
+ * @returns {Promise<{success: boolean, title: string, description: string, hashtags: string[], link: string}>}
+ */
+export const generatePinContent = webMethod(
+  Permissions.Anyone,
+  async (product) => {
+    try {
+      if (!product || !product.name) {
+        return { success: false, error: 'Product with name is required.', title: '', description: '', hashtags: [], link: '' };
+      }
+
+      const name = sanitize(product.name, MAX_TITLE_LEN);
+      const slug = sanitize(product.slug || '', 100);
+      const rawDesc = sanitize(product.description || '', 300);
+      const price = Number(product.price) || 0;
+      const salePrice = product.discountedPrice ? Number(product.discountedPrice) : null;
+      const collections = (product.collections || []).map(c =>
+        (typeof c === 'string' ? c : c.id || '').toLowerCase()
+      );
+
+      // Title
+      const title = name;
+
+      // Price display
+      const displayPrice = salePrice && salePrice < price
+        ? `$${salePrice.toFixed(2)} (was $${price.toFixed(2)})`
+        : `$${price.toFixed(2)}`;
+
+      // Description — keyword-rich, includes price, brand
+      const descParts = [
+        `${name} — ${displayPrice} at ${SITE_NAME}.`,
+      ];
+      if (rawDesc) {
+        descParts.push(rawDesc);
+      }
+      descParts.push(`Shop handcrafted furniture made in the USA.`);
+
+      let description = descParts.join(' ');
+      if (description.length > MAX_DESC_LEN) {
+        description = description.slice(0, MAX_DESC_LEN - 3) + '...';
+      }
+
+      // Hashtags — category-specific + base
+      const hashtags = [...BASE_HASHTAGS];
+      for (const col of collections) {
+        const catTags = CATEGORY_HASHTAGS[col];
+        if (catTags) {
+          for (const tag of catTags) {
+            if (!hashtags.includes(tag)) {
+              hashtags.push(tag);
+            }
+          }
+        }
+      }
+
+      // UTM-tagged link (per SOCIAL-MEDIA-STRATEGY.md)
+      const link = slug
+        ? `${SITE_URL}/product-page/${slug}?utm_source=pinterest&utm_medium=social&utm_campaign=product`
+        : `${SITE_URL}?utm_source=pinterest&utm_medium=social&utm_campaign=product`;
+
+      return {
+        success: true,
+        title,
+        description,
+        hashtags,
+        link,
+      };
+    } catch (err) {
+      console.error('[pinterestCatalogSync] generatePinContent error:', err);
+      return { success: false, error: 'Pin content generation failed.', title: '', description: '', hashtags: [], link: '' };
+    }
+  }
+);
+
+// ── getBoardStructure ────────────────────────────────────────────────
+
+/**
+ * Return the configured Pinterest board structure.
+ *
+ * @returns {Promise<{success: boolean, boards: Array}>}
+ */
+export const getBoardStructure = webMethod(
+  Permissions.Anyone,
+  async () => {
+    return {
+      success: true,
+      boards: BOARDS.map(b => ({ ...b })),
+    };
+  }
+);

--- a/tests/pinterestCatalogSync.test.js
+++ b/tests/pinterestCatalogSync.test.js
@@ -1,0 +1,420 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __reset as resetData, __seed as seedData } from './__mocks__/wix-data.js';
+import {
+  validateCatalogProduct,
+  auditCatalog,
+  getCatalogSyncStatus,
+  mapProductToBoard,
+  generatePinContent,
+  getBoardStructure,
+} from '../src/backend/pinterestCatalogSync.web.js';
+
+beforeEach(() => {
+  resetData();
+});
+
+// ── Helper fixtures ──────────────────────────────────────────────────
+
+const validProduct = {
+  _id: 'prod-001',
+  name: 'Eureka Futon Frame',
+  slug: 'eureka-futon-frame',
+  description: 'Solid hardwood futon frame with wall hugger design.',
+  price: 599.99,
+  inStock: true,
+  mainMedia: 'https://www.carolinafutons.com/images/eureka.jpg',
+  collections: ['futon-frames'],
+  sku: 'NDF-EUREKA-001',
+};
+
+const minimalProduct = {
+  _id: 'prod-002',
+  name: 'Basic Frame',
+  slug: 'basic-frame',
+  price: 199,
+};
+
+// ── validateCatalogProduct ───────────────────────────────────────────
+
+describe('validateCatalogProduct', () => {
+  it('validates a complete product with no issues', async () => {
+    const result = await validateCatalogProduct(validProduct);
+    expect(result.success).toBe(true);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('detects missing product name', async () => {
+    const result = await validateCatalogProduct({ ...validProduct, name: '' });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ field: 'name' }));
+  });
+
+  it('detects missing slug', async () => {
+    const result = await validateCatalogProduct({ ...validProduct, slug: '' });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ field: 'slug' }));
+  });
+
+  it('detects missing or zero price', async () => {
+    const result = await validateCatalogProduct({ ...validProduct, price: 0 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ field: 'price' }));
+  });
+
+  it('detects negative price', async () => {
+    const result = await validateCatalogProduct({ ...validProduct, price: -50 });
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual(expect.objectContaining({ field: 'price' }));
+  });
+
+  it('warns on missing description', async () => {
+    const result = await validateCatalogProduct({ ...validProduct, description: '' });
+    expect(result.valid).toBe(true); // warning, not error
+    expect(result.warnings).toContainEqual(expect.objectContaining({ field: 'description' }));
+  });
+
+  it('warns on missing image', async () => {
+    const result = await validateCatalogProduct({ ...validProduct, mainMedia: '' });
+    expect(result.valid).toBe(true); // warning, not error — default image fallback
+    expect(result.warnings).toContainEqual(expect.objectContaining({ field: 'mainMedia' }));
+  });
+
+  it('warns on description exceeding 500 chars', async () => {
+    const longDesc = 'A'.repeat(501);
+    const result = await validateCatalogProduct({ ...validProduct, description: longDesc });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ field: 'description', type: 'length' })
+    );
+  });
+
+  it('warns on title exceeding 150 chars', async () => {
+    const longName = 'X'.repeat(151);
+    const result = await validateCatalogProduct({ ...validProduct, name: longName });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ field: 'name', type: 'length' })
+    );
+  });
+
+  it('returns error for null input', async () => {
+    const result = await validateCatalogProduct(null);
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns error for non-object input', async () => {
+    const result = await validateCatalogProduct('not-an-object');
+    expect(result.success).toBe(false);
+  });
+
+  it('detects non-absolute image URL', async () => {
+    const result = await validateCatalogProduct({
+      ...validProduct,
+      mainMedia: '/relative/path.jpg',
+    });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ field: 'mainMedia', type: 'format' })
+    );
+  });
+
+  it('sanitizes XSS in product fields', async () => {
+    const result = await validateCatalogProduct({
+      ...validProduct,
+      name: '<script>alert(1)</script>Clean Frame',
+    });
+    expect(result.success).toBe(true);
+    // Sanitized name should not contain script tags
+    expect(result.sanitizedName).not.toContain('<script>');
+  });
+});
+
+// ── auditCatalog ─────────────────────────────────────────────────────
+
+describe('auditCatalog', () => {
+  it('audits all products in the catalog', async () => {
+    seedData('Stores/Products', [
+      validProduct,
+      { _id: 'prod-bad', name: '', slug: '', price: 0 },
+      minimalProduct,
+    ]);
+
+    const result = await auditCatalog();
+    expect(result.success).toBe(true);
+    expect(result.totalProducts).toBe(3);
+    expect(result.validCount).toBeGreaterThanOrEqual(1);
+    expect(result.invalidCount).toBeGreaterThanOrEqual(1);
+    expect(result.issues).toBeInstanceOf(Array);
+  });
+
+  it('returns empty audit for empty catalog', async () => {
+    seedData('Stores/Products', []);
+
+    const result = await auditCatalog();
+    expect(result.success).toBe(true);
+    expect(result.totalProducts).toBe(0);
+    expect(result.validCount).toBe(0);
+    expect(result.invalidCount).toBe(0);
+  });
+
+  it('includes product ID in issue reports', async () => {
+    seedData('Stores/Products', [
+      { _id: 'bad-prod', name: '', slug: 'test', price: 99 },
+    ]);
+
+    const result = await auditCatalog();
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issues[0].productId).toBe('bad-prod');
+  });
+
+  it('tracks warning count separately from errors', async () => {
+    seedData('Stores/Products', [minimalProduct]); // valid but missing desc/image
+
+    const result = await auditCatalog();
+    expect(result.warningCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles wix-data query errors gracefully', async () => {
+    // Empty store with no seed — should still succeed with 0 products
+    const result = await auditCatalog();
+    expect(result.success).toBe(true);
+    expect(result.totalProducts).toBe(0);
+  });
+});
+
+// ── getCatalogSyncStatus ─────────────────────────────────────────────
+
+describe('getCatalogSyncStatus', () => {
+  it('returns feed configuration status', async () => {
+    seedData('Stores/Products', [validProduct, minimalProduct]);
+
+    const result = await getCatalogSyncStatus();
+    expect(result.success).toBe(true);
+    expect(result.feedUrl).toContain('pinterestProductFeed');
+    expect(result.productCount).toBe(2);
+    expect(result.feedFormat).toBe('TSV');
+  });
+
+  it('includes health score based on product validity', async () => {
+    seedData('Stores/Products', [validProduct]);
+
+    const result = await getCatalogSyncStatus();
+    expect(result.healthScore).toBeDefined();
+    expect(result.healthScore).toBeGreaterThanOrEqual(0);
+    expect(result.healthScore).toBeLessThanOrEqual(100);
+  });
+
+  it('returns zero product count for empty catalog', async () => {
+    seedData('Stores/Products', []);
+
+    const result = await getCatalogSyncStatus();
+    expect(result.productCount).toBe(0);
+    expect(result.healthScore).toBe(0);
+  });
+});
+
+// ── mapProductToBoard ────────────────────────────────────────────────
+
+describe('mapProductToBoard', () => {
+  it('maps futon frames to Futon Living Rooms board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['futon-frames'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.board).toBe('Futon Living Rooms');
+  });
+
+  it('maps murphy beds to Murphy & Cabinet Beds board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      name: 'Daisy Murphy Cabinet Bed',
+      collections: ['murphy-cabinet-beds'],
+    });
+    expect(result.board).toBe('Murphy & Cabinet Beds');
+  });
+
+  it('maps platform beds to Platform Bed Inspiration board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['platform-beds'],
+    });
+    expect(result.board).toBe('Platform Bed Inspiration');
+  });
+
+  it('maps mattresses to Small Space Solutions board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['mattresses'],
+    });
+    expect(result.board).toBe('Small Space Solutions');
+  });
+
+  it('maps wall huggers to Futon Living Rooms board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['wall-huggers'],
+    });
+    expect(result.board).toBe('Futon Living Rooms');
+  });
+
+  it('maps unfinished wood to Handcrafted & Unfinished board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['unfinished-wood'],
+    });
+    expect(result.board).toBe('Handcrafted & Unfinished');
+  });
+
+  it('maps accessories to Small Space Solutions board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['casegoods-accessories'],
+    });
+    expect(result.board).toBe('Small Space Solutions');
+  });
+
+  it('defaults to Futon Living Rooms for unknown collections', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: ['unknown-collection'],
+    });
+    expect(result.board).toBe('Futon Living Rooms');
+  });
+
+  it('handles products with no collections', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      collections: [],
+    });
+    expect(result.success).toBe(true);
+    expect(result.board).toBe('Futon Living Rooms');
+  });
+
+  it('returns error for null input', async () => {
+    const result = await mapProductToBoard(null);
+    expect(result.success).toBe(false);
+  });
+
+  it('maps sale items to Sale & Clearance board', async () => {
+    const result = await mapProductToBoard({
+      ...validProduct,
+      discountedPrice: 399.99,
+      collections: ['sales', 'futon-frames'],
+    });
+    expect(result.board).toBe('Sale & Clearance');
+  });
+});
+
+// ── generatePinContent ───────────────────────────────────────────────
+
+describe('generatePinContent', () => {
+  it('generates pin title, description, hashtags, and link', async () => {
+    const result = await generatePinContent(validProduct);
+    expect(result.success).toBe(true);
+    expect(result.title).toBeTruthy();
+    expect(result.description).toBeTruthy();
+    expect(result.hashtags).toBeInstanceOf(Array);
+    expect(result.hashtags.length).toBeGreaterThan(0);
+    expect(result.link).toContain('carolinafutons.com');
+  });
+
+  it('includes UTM parameters in link', async () => {
+    const result = await generatePinContent(validProduct);
+    expect(result.link).toContain('utm_source=pinterest');
+    expect(result.link).toContain('utm_medium=social');
+  });
+
+  it('includes price in description', async () => {
+    const result = await generatePinContent(validProduct);
+    expect(result.description).toContain('$599.99');
+  });
+
+  it('includes product category hashtags', async () => {
+    const result = await generatePinContent({
+      ...validProduct,
+      collections: ['futon-frames'],
+    });
+    expect(result.hashtags).toContain('#FutonLiving');
+  });
+
+  it('always includes brand hashtags', async () => {
+    const result = await generatePinContent(validProduct);
+    expect(result.hashtags).toContain('#CarolinaFutons');
+    expect(result.hashtags).toContain('#HandcraftedFurniture');
+  });
+
+  it('formats pin description with keyword-rich text', async () => {
+    const result = await generatePinContent(validProduct);
+    // Should mention the product name
+    expect(result.description).toContain('Eureka Futon Frame');
+  });
+
+  it('returns error for null input', async () => {
+    const result = await generatePinContent(null);
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error for product without name', async () => {
+    const result = await generatePinContent({ slug: 'test', price: 99 });
+    expect(result.success).toBe(false);
+  });
+
+  it('handles sale price in description', async () => {
+    const result = await generatePinContent({
+      ...validProduct,
+      discountedPrice: 449.99,
+    });
+    expect(result.description).toContain('$449.99');
+  });
+
+  it('sanitizes XSS in product name for pin content', async () => {
+    const result = await generatePinContent({
+      ...validProduct,
+      name: '<script>alert(1)</script>Bad Frame',
+    });
+    expect(result.title).not.toContain('<script>');
+    expect(result.description).not.toContain('<script>');
+  });
+
+  it('limits description length for Pinterest', async () => {
+    const result = await generatePinContent({
+      ...validProduct,
+      description: 'X'.repeat(1000),
+    });
+    // Pinterest descriptions should be ≤500 chars
+    expect(result.description.length).toBeLessThanOrEqual(500);
+  });
+});
+
+// ── getBoardStructure ────────────────────────────────────────────────
+
+describe('getBoardStructure', () => {
+  it('returns all configured boards', async () => {
+    const result = await getBoardStructure();
+    expect(result.success).toBe(true);
+    expect(result.boards).toBeInstanceOf(Array);
+    expect(result.boards.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('each board has name, contentType, and pinFrequency', async () => {
+    const result = await getBoardStructure();
+    for (const board of result.boards) {
+      expect(board.name).toBeTruthy();
+      expect(board.contentType).toBeTruthy();
+      expect(board.pinFrequency).toBeTruthy();
+    }
+  });
+
+  it('includes Futon Living Rooms board', async () => {
+    const result = await getBoardStructure();
+    const board = result.boards.find(b => b.name === 'Futon Living Rooms');
+    expect(board).toBeDefined();
+    expect(board.pinFrequency).toContain('3-4');
+  });
+
+  it('includes Customer Showcase board', async () => {
+    const result = await getBoardStructure();
+    const board = result.boards.find(b => b.name === 'Customer Showcase');
+    expect(board).toBeDefined();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -62,6 +62,7 @@ export default defineConfig({
       'backend/bundleAnalytics.web': path.resolve(__dirname, 'src/backend/bundleAnalytics.web.js'),
       'backend/seoContentHub.web': path.resolve(__dirname, 'src/backend/seoContentHub.web.js'),
       'backend/pinterestRichPins.web': path.resolve(__dirname, 'src/backend/pinterestRichPins.web.js'),
+      'backend/pinterestCatalogSync.web': path.resolve(__dirname, 'src/backend/pinterestCatalogSync.web.js'),
       'backend/photoReviews.web': path.resolve(__dirname, 'src/backend/photoReviews.web.js'),
       'backend/sustainability.web': path.resolve(__dirname, 'src/backend/sustainability.web.js'),
       'backend/roomPlanner.web': path.resolve(__dirname, 'src/backend/roomPlanner.web.js'),


### PR DESCRIPTION
…nt (cf-hwi9)

New backend module pinterestCatalogSync.web.js adds:
- validateCatalogProduct: validate products meet Pinterest catalog requirements
- auditCatalog: batch validate all products for feed readiness
- getCatalogSyncStatus: feed health check with product count and health score
- mapProductToBoard: map products to Pinterest boards per social strategy
- generatePinContent: generate optimized pin descriptions, hashtags, UTM links
- getBoardStructure: return configured board structure

47 new tests covering validation, catalog audit, board mapping, pin content generation, edge cases, XSS sanitization, and error handling.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Executed-By: cfutons/polecats/squire
Rig: cfutons
Role: polecats