### PR TITLE
cf-v3gu: Reviews system tests (35 IDs) + fix item star rendering

### DIFF
--- a/src/public/ProductReviews.js
+++ b/src/public/ProductReviews.js
@@ -132,12 +132,8 @@ function renderReviews($w, reviewsResult) {
       try { $item('#reviewDate').text = itemData.date; } catch (e) {}
       try { $item('#reviewTitle').text = itemData.title || ''; } catch (e) {}
       try { $item('#reviewBody').text = itemData.body; } catch (e) {}
-      try {
-        renderStars({ [sel => sel]: null, ...createItemStarHelper($item) }, '#reviewStars', itemData.rating);
-      } catch (e) {
-        // Fallback: set star text directly
-        try { $item('#reviewStars').text = '★'.repeat(itemData.rating) + '☆'.repeat(5 - itemData.rating); } catch (e2) {}
-      }
+      // $item is a scoped selector — works like $w for the repeater row
+      renderStars($item, '#reviewStars', itemData.rating);
 
       // Verified purchase badge
       try {
@@ -169,12 +165,6 @@ function renderReviews($w, reviewsResult) {
 
     repeater.data = reviewsResult.reviews.map((r, i) => ({ ...r, _id: r._id || `rev-${i}` }));
   } catch (e) {}
-}
-
-function createItemStarHelper($item) {
-  return new Proxy({}, {
-    get: (_, prop) => (sel) => $item(sel),
-  });
 }
 
 // ── Sort Dropdown ─────────────────────────────────────────────────────

--- a/tests/productReviews.test.js
+++ b/tests/productReviews.test.js
@@ -150,6 +150,570 @@ describe('ProductReviews', () => {
     expect($w('#reviewsEmptyState').show).toHaveBeenCalled();
   });
 
+  it('hides empty state when reviews exist', async () => {
+    await initProductReviews($w, state);
+    expect($w('#reviewsEmptyState').hide).toHaveBeenCalled();
+  });
+
+  it('collapses repeater when no reviews', async () => {
+    const { getProductReviews } = await import('backend/reviewsService.web');
+    getProductReviews.mockResolvedValueOnce({ reviews: [], total: 0, page: 0, pageSize: 10 });
+
+    await initProductReviews($w, state);
+    expect($w('#reviewsRepeater').collapse).toHaveBeenCalled();
+  });
+
+  // ── Rating Breakdown Bars (#ratingBar1-5, #ratingCount1-5) ──────────
+
+  it('sets rating breakdown bar values as percentages', async () => {
+    await initProductReviews($w, state);
+    // breakdown: { 5: 6, 4: 3, 3: 2, 2: 1, 1: 0 }, total: 12
+    expect($w('#ratingBar5').value).toBe(50);  // 6/12 = 50%
+    expect($w('#ratingBar4').value).toBe(25);  // 3/12 = 25%
+    expect($w('#ratingBar3').value).toBe(17);  // 2/12 = 16.67 → 17%
+    expect($w('#ratingBar2').value).toBe(8);   // 1/12 = 8.33 → 8%
+    expect($w('#ratingBar1').value).toBe(0);   // 0/12 = 0%
+  });
+
+  it('sets rating breakdown count text', async () => {
+    await initProductReviews($w, state);
+    expect($w('#ratingCount5').text).toBe('6');
+    expect($w('#ratingCount4').text).toBe('3');
+    expect($w('#ratingCount3').text).toBe('2');
+    expect($w('#ratingCount2').text).toBe('1');
+    expect($w('#ratingCount1').text).toBe('0');
+  });
+
+  it('sets all rating bars to 0 when no reviews', async () => {
+    const { getAggregateRating } = await import('backend/reviewsService.web');
+    getAggregateRating.mockResolvedValueOnce({ average: 0, total: 0, breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } });
+
+    await initProductReviews($w, state);
+    for (let star = 1; star <= 5; star++) {
+      expect($w(`#ratingBar${star}`).value).toBe(0);
+    }
+  });
+
+  it('shows dash for average when no reviews', async () => {
+    const { getAggregateRating } = await import('backend/reviewsService.web');
+    getAggregateRating.mockResolvedValueOnce({ average: 0, total: 0, breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } });
+
+    await initProductReviews($w, state);
+    expect($w('#reviewsAverage').text).toBe('—');
+  });
+
+  it('shows "No reviews yet" text when total is 0', async () => {
+    const { getAggregateRating } = await import('backend/reviewsService.web');
+    getAggregateRating.mockResolvedValueOnce({ average: 0, total: 0, breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } });
+
+    await initProductReviews($w, state);
+    expect($w('#reviewsCount').text).toBe('No reviews yet');
+  });
+
+  // ── Repeater Item Bindings ──────────────────────────────────────────
+
+  describe('repeater item bindings', () => {
+    let $item;
+    let renderHandler;
+
+    beforeEach(async () => {
+      await initProductReviews($w, state);
+      const repeater = $w('#reviewsRepeater');
+      // renderReviews sets onItemReady first
+      renderHandler = repeater.onItemReady.mock.calls[0][0];
+      $item = create$w();
+    });
+
+    it('binds #reviewAuthor text', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      expect($item('#reviewAuthor').text).toBe('Sarah M.');
+    });
+
+    it('binds #reviewDate text', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      expect($item('#reviewDate').text).toBe('January 15, 2026');
+    });
+
+    it('binds #reviewTitle text', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      expect($item('#reviewTitle').text).toBe('Great');
+    });
+
+    it('binds empty title as empty string', () => {
+      renderHandler($item, { ...mockReviews.reviews[0], title: null });
+      expect($item('#reviewTitle').text).toBe('');
+    });
+
+    it('binds #reviewBody text', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      expect($item('#reviewBody').text).toBe('Solid build.');
+    });
+
+    it('renders #reviewStars for item rating', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      // rating 5 → ★★★★★
+      expect($item('#reviewStars').text).toMatch(/[★½☆]{5}/);
+    });
+
+    it('shows #reviewVerified for verified purchase', () => {
+      renderHandler($item, mockReviews.reviews[0]); // verifiedPurchase: true
+      expect($item('#reviewVerified').show).toHaveBeenCalled();
+    });
+
+    it('hides #reviewVerified for non-verified purchase', () => {
+      renderHandler($item, mockReviews.reviews[1]); // verifiedPurchase: false
+      expect($item('#reviewVerified').hide).toHaveBeenCalled();
+    });
+
+    it('sets verified purchase ARIA label', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      expect($item('#reviewVerified').accessibility.ariaLabel).toBe('Verified purchase');
+    });
+
+    it('shows #reviewPhotos when photos exist', () => {
+      renderHandler($item, mockReviews.reviews[1]); // has photos: ['photo.jpg']
+      expect($item('#reviewPhotos').show).toHaveBeenCalled();
+    });
+
+    it('hides #reviewPhotos when no photos', () => {
+      renderHandler($item, mockReviews.reviews[0]); // photos: []
+      expect($item('#reviewPhotos').hide).toHaveBeenCalled();
+    });
+
+    it('sets #reviewHelpfulCount text with count', () => {
+      renderHandler($item, mockReviews.reviews[0]); // helpful: 3
+      expect($item('#reviewHelpfulCount').text).toBe('Helpful (3)');
+    });
+
+    it('sets #reviewHelpfulCount to "Helpful" when count is 0', () => {
+      renderHandler($item, { ...mockReviews.reviews[0], helpful: 0 });
+      expect($item('#reviewHelpfulCount').text).toBe('Helpful');
+    });
+
+    it('stores review ID on #reviewHelpfulBtn label', () => {
+      renderHandler($item, mockReviews.reviews[0]);
+      expect($item('#reviewHelpfulBtn').label).toBe('rev-1');
+    });
+  });
+
+  // ── Helpful Voting ──────────────────────────────────────────────────
+
+  describe('helpful voting', () => {
+    it('calls markHelpful on button click', async () => {
+      const { markHelpful } = await import('backend/reviewsService.web');
+      await initProductReviews($w, state);
+
+      const repeater = $w('#reviewsRepeater');
+      // initHelpfulVoting sets onItemReady second time
+      const helpfulHandler = repeater.onItemReady.mock.calls[1][0];
+      const $item = create$w();
+      helpfulHandler($item, mockReviews.reviews[0]);
+
+      const clickHandler = $item('#reviewHelpfulBtn').onClick.mock.calls[0][0];
+      await clickHandler();
+
+      expect(markHelpful).toHaveBeenCalledWith('rev-1');
+    });
+
+    it('disables helpful button after click', async () => {
+      await initProductReviews($w, state);
+
+      const repeater = $w('#reviewsRepeater');
+      const helpfulHandler = repeater.onItemReady.mock.calls[1][0];
+      const $item = create$w();
+      helpfulHandler($item, mockReviews.reviews[0]);
+
+      const clickHandler = $item('#reviewHelpfulBtn').onClick.mock.calls[0][0];
+      await clickHandler();
+
+      expect($item('#reviewHelpfulBtn').disable).toHaveBeenCalled();
+    });
+
+    it('updates helpful count text after successful vote', async () => {
+      await initProductReviews($w, state);
+
+      const repeater = $w('#reviewsRepeater');
+      const helpfulHandler = repeater.onItemReady.mock.calls[1][0];
+      const $item = create$w();
+      helpfulHandler($item, mockReviews.reviews[0]);
+
+      const clickHandler = $item('#reviewHelpfulBtn').onClick.mock.calls[0][0];
+      await clickHandler();
+
+      expect($item('#reviewHelpfulCount').text).toBe('Helpful (4)');
+    });
+
+    it('sets ARIA label on helpful button', async () => {
+      await initProductReviews($w, state);
+
+      const repeater = $w('#reviewsRepeater');
+      const helpfulHandler = repeater.onItemReady.mock.calls[1][0];
+      const $item = create$w();
+      helpfulHandler($item, mockReviews.reviews[0]);
+
+      expect($item('#reviewHelpfulBtn').accessibility.ariaLabel).toBe('Mark review by Sarah M. as helpful');
+    });
+
+    it('re-enables helpful button on backend error', async () => {
+      const { markHelpful } = await import('backend/reviewsService.web');
+      markHelpful.mockRejectedValueOnce(new Error('Network error'));
+
+      await initProductReviews($w, state);
+
+      const repeater = $w('#reviewsRepeater');
+      const helpfulHandler = repeater.onItemReady.mock.calls[1][0];
+      const $item = create$w();
+      helpfulHandler($item, mockReviews.reviews[0]);
+
+      const clickHandler = $item('#reviewHelpfulBtn').onClick.mock.calls[0][0];
+      await clickHandler();
+
+      expect($item('#reviewHelpfulBtn').enable).toHaveBeenCalled();
+    });
+  });
+
+  // ── Pagination (#reviewsPageInfo, next/prev behavior) ──────────────
+
+  describe('pagination', () => {
+    it('renders page info text', async () => {
+      await initProductReviews($w, state);
+      // total: 2, pageSize: 10 → 1 page
+      expect($w('#reviewsPageInfo').text).toBe('Page 1 of 1');
+    });
+
+    it('renders multi-page info', async () => {
+      const { getProductReviews } = await import('backend/reviewsService.web');
+      getProductReviews.mockResolvedValueOnce({ reviews: mockReviews.reviews, total: 25, page: 0, pageSize: 10 });
+
+      await initProductReviews($w, state);
+      expect($w('#reviewsPageInfo').text).toBe('Page 1 of 3');
+    });
+
+    it('disables next button on last page', async () => {
+      // total: 2, pageSize: 10 → only 1 page, next should be disabled
+      await initProductReviews($w, state);
+      expect($w('#reviewsNextBtn').disable).toHaveBeenCalled();
+    });
+
+    it('enables next button when more pages exist', async () => {
+      const { getProductReviews } = await import('backend/reviewsService.web');
+      getProductReviews.mockResolvedValueOnce({ reviews: mockReviews.reviews, total: 25, page: 0, pageSize: 10 });
+
+      await initProductReviews($w, state);
+      expect($w('#reviewsNextBtn').enable).toHaveBeenCalled();
+    });
+
+    it('updates page info after next click', async () => {
+      const { getProductReviews } = await import('backend/reviewsService.web');
+      getProductReviews.mockResolvedValueOnce({ reviews: mockReviews.reviews, total: 25, page: 0, pageSize: 10 });
+
+      await initProductReviews($w, state);
+
+      getProductReviews.mockResolvedValueOnce({ reviews: mockReviews.reviews, total: 25, page: 1, pageSize: 10 });
+      const nextHandler = $w('#reviewsNextBtn').onClick.mock.calls[0][0];
+      await nextHandler();
+
+      expect($w('#reviewsPageInfo').text).toBe('Page 2 of 3');
+    });
+
+    it('enables prev button after navigating forward', async () => {
+      const { getProductReviews } = await import('backend/reviewsService.web');
+      getProductReviews.mockResolvedValueOnce({ reviews: mockReviews.reviews, total: 25, page: 0, pageSize: 10 });
+
+      await initProductReviews($w, state);
+
+      getProductReviews.mockResolvedValueOnce({ reviews: mockReviews.reviews, total: 25, page: 1, pageSize: 10 });
+      const nextHandler = $w('#reviewsNextBtn').onClick.mock.calls[0][0];
+      await nextHandler();
+
+      expect($w('#reviewsPrevBtn').enable).toHaveBeenCalled();
+    });
+
+    it('renders empty page info when no reviews', async () => {
+      const { getProductReviews, getAggregateRating } = await import('backend/reviewsService.web');
+      getProductReviews.mockResolvedValueOnce({ reviews: [], total: 0, page: 0, pageSize: 10 });
+      getAggregateRating.mockResolvedValueOnce({ average: 0, total: 0, breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 } });
+
+      await initProductReviews($w, state);
+      expect($w('#reviewsPageInfo').text).toBe('');
+    });
+
+    it('sets ARIA labels on pagination buttons', async () => {
+      await initProductReviews($w, state);
+      expect($w('#reviewsNextBtn').accessibility.ariaLabel).toBe('Next page of reviews');
+      expect($w('#reviewsPrevBtn').accessibility.ariaLabel).toBe('Previous page of reviews');
+    });
+  });
+
+  // ── Sort Dropdown ───────────────────────────────────────────────────
+
+  describe('sort dropdown', () => {
+    it('has correct sort options', async () => {
+      await initProductReviews($w, state);
+      const opts = $w('#reviewsSortDropdown').options;
+      expect(opts).toEqual([
+        { label: 'Newest', value: 'newest' },
+        { label: 'Highest Rated', value: 'highest' },
+        { label: 'Lowest Rated', value: 'lowest' },
+        { label: 'Most Helpful', value: 'helpful' },
+      ]);
+    });
+
+    it('defaults to newest sort', async () => {
+      await initProductReviews($w, state);
+      expect($w('#reviewsSortDropdown').value).toBe('newest');
+    });
+
+    it('reloads reviews on sort change', async () => {
+      const { getProductReviews } = await import('backend/reviewsService.web');
+      await initProductReviews($w, state);
+
+      $w('#reviewsSortDropdown').value = 'highest';
+      const handler = $w('#reviewsSortDropdown').onChange.mock.calls[0][0];
+      await handler();
+
+      expect(getProductReviews).toHaveBeenCalledWith(
+        state.product._id,
+        expect.objectContaining({ sort: 'highest', page: 0 })
+      );
+    });
+
+    it('resets page to 0 on sort change', async () => {
+      const { getProductReviews } = await import('backend/reviewsService.web');
+      getProductReviews.mockResolvedValue({ reviews: mockReviews.reviews, total: 25, page: 0, pageSize: 10 });
+
+      await initProductReviews($w, state);
+
+      // Navigate to page 1
+      const nextHandler = $w('#reviewsNextBtn').onClick.mock.calls[0][0];
+      await nextHandler();
+
+      // Change sort
+      $w('#reviewsSortDropdown').value = 'lowest';
+      const sortHandler = $w('#reviewsSortDropdown').onChange.mock.calls[0][0];
+      await sortHandler();
+
+      expect(getProductReviews).toHaveBeenLastCalledWith(
+        state.product._id,
+        expect.objectContaining({ sort: 'lowest', page: 0 })
+      );
+    });
+
+    it('sets ARIA label on sort dropdown', async () => {
+      await initProductReviews($w, state);
+      expect($w('#reviewsSortDropdown').accessibility.ariaLabel).toBe('Sort reviews');
+    });
+  });
+
+  // ── Review Form (#reviewForm, inputs, submit, errors, success) ──────
+
+  describe('review form', () => {
+    it('shows error when no rating selected', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '';
+      $w('#reviewBodyInput').value = 'This is a long enough review body text.';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').text).toBe('Please select a star rating.');
+      expect($w('#reviewFormError').show).toHaveBeenCalled();
+    });
+
+    it('shows error when rating is 0', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '0';
+      $w('#reviewBodyInput').value = 'This is a long enough review body text.';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').text).toBe('Please select a star rating.');
+    });
+
+    it('shows error when rating exceeds 5', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '6';
+      $w('#reviewBodyInput').value = 'This is a long enough review body text.';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').text).toBe('Please select a star rating.');
+    });
+
+    it('shows error when body too short', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Short';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').text).toBe('Review must be at least 10 characters.');
+    });
+
+    it('submits review with valid data', async () => {
+      const { submitReview } = await import('backend/reviewsService.web');
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '5';
+      $w('#reviewTitleInput').value = 'Amazing product';
+      $w('#reviewBodyInput').value = 'This futon is absolutely wonderful!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect(submitReview).toHaveBeenCalledWith({
+        productId: state.product._id,
+        rating: 5,
+        title: 'Amazing product',
+        body: 'This futon is absolutely wonderful!',
+        photos: [],
+      });
+    });
+
+    it('disables submit button during submission', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewSubmitBtn').disable).toHaveBeenCalled();
+    });
+
+    it('shows #reviewFormSuccess on successful submit', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormSuccess').show).toHaveBeenCalled();
+    });
+
+    it('collapses #reviewForm on successful submit', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewForm').collapse).toHaveBeenCalled();
+    });
+
+    it('shows #reviewFormError on backend failure', async () => {
+      const { submitReview } = await import('backend/reviewsService.web');
+      submitReview.mockResolvedValueOnce({ success: false, error: 'Duplicate review' });
+
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').text).toBe('Duplicate review');
+      expect($w('#reviewSubmitBtn').enable).toHaveBeenCalled();
+    });
+
+    it('shows generic error on exception', async () => {
+      const { submitReview } = await import('backend/reviewsService.web');
+      submitReview.mockRejectedValueOnce(new Error('Network error'));
+
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').text).toBe('Something went wrong. Please try again.');
+      expect($w('#reviewSubmitBtn').enable).toHaveBeenCalled();
+    });
+
+    it('re-enables submit button on backend failure', async () => {
+      const { submitReview } = await import('backend/reviewsService.web');
+      submitReview.mockResolvedValueOnce({ success: false, error: 'Error' });
+
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewSubmitBtn').enable).toHaveBeenCalled();
+    });
+
+    it('hides error before submitting', async () => {
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '4';
+      $w('#reviewBodyInput').value = 'Great product, very comfortable!';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect($w('#reviewFormError').hide).toHaveBeenCalled();
+    });
+
+    it('trims whitespace from title and body', async () => {
+      const { submitReview } = await import('backend/reviewsService.web');
+      await initProductReviews($w, state);
+
+      $w('#reviewRatingInput').value = '3';
+      $w('#reviewTitleInput').value = '  Padded Title  ';
+      $w('#reviewBodyInput').value = '  This is long enough review text  ';
+
+      const handler = $w('#reviewSubmitBtn').onClick.mock.calls[0][0];
+      await handler();
+
+      expect(submitReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Padded Title',
+          body: 'This is long enough review text',
+        })
+      );
+    });
+
+    it('sets ARIA label on submit button', async () => {
+      await initProductReviews($w, state);
+      expect($w('#reviewSubmitBtn').accessibility.ariaLabel).toBe('Submit your review');
+    });
+  });
+
+  // ── Error Handling ──────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('collapses section on backend error', async () => {
+      const { getAggregateRating } = await import('backend/reviewsService.web');
+      getAggregateRating.mockRejectedValueOnce(new Error('DB down'));
+
+      await initProductReviews($w, state);
+      expect($w('#reviewsSection').collapse).toHaveBeenCalled();
+    });
+
+    it('handles missing product gracefully', async () => {
+      state.product = null;
+      await expect(initProductReviews($w, state)).resolves.not.toThrow();
+    });
+  });
+
   // ── SPA state-bleed regression tests ────────────────────────────────
 
   it('resets sort to newest on each init (SPA navigation)', async () => {


### PR DESCRIPTION
## Summary
- Add 55 new tests covering all 35 review element IDs (was 15 tests, now 70)
- Fix bug: item-level star rendering in repeater rows used broken Proxy+spread pattern that silently failed — stars never rendered for individual reviews
- Replaced with direct `$item` pass-through since it's already a scoped Wix Velo selector

## Test Coverage Added
- **Rating breakdown**: `#ratingBar1-5`, `#ratingCount1-5` (percentages, counts, zero-state)
- **Repeater bindings**: `#reviewAuthor`, `#reviewDate`, `#reviewStars`, `#reviewTitle`, `#reviewBody`, `#reviewVerified`, `#reviewPhotos`, `#reviewHelpfulBtn`, `#reviewHelpfulCount`
- **Helpful voting**: backend call, disable/enable, error recovery, ARIA labels
- **Pagination**: `#reviewsPageInfo` text, multi-page nav, next/prev enable/disable
- **Sort dropdown**: options validation, ARIA, page reset on sort change
- **Review form**: validation (rating bounds, body length), trimming, success/error flows, `#reviewFormSuccess`, `#reviewForm` collapse, `#reviewFormError`
- **Edge cases**: zero reviews (dash average, "No reviews yet"), backend errors, missing product
- **Accessibility**: ARIA labels on pagination, sort, submit, helpful buttons

## Bug Fixed
`renderStars()` was called with `{ [sel => sel]: null, ...Proxy }` — the Proxy spread produced `{}`, making the object non-callable. `renderStars` caught the TypeError internally (silent catch), so the outer fallback never triggered. Individual review stars were always empty.

## Test plan
- [x] All 70 review tests pass
- [x] Full suite: 7,626 tests pass across 197 files
- [ ] Visual verification: review stars render in repeater rows on product page

🤖 Generated with [Claude Code](https://claude.com/claude-code)