### PR TITLE
Fix missing initFeelAndComfort import + cf-qxct audit

### DIFF
--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -27,6 +27,7 @@ import { initProductSocialProof } from 'public/socialProofToast';
 import { validateEmail } from 'public/validators.js';
 import { initProductARViewer } from 'public/ProductARViewer.js';
 import { initLifestyleGallery } from 'public/LifestyleGallery.js';
+import { initFeelAndComfort } from 'public/FeelAndComfort.js';
 import { applyProductPageTokens } from 'public/ProductPagePolish.js';
 
 const state = {


### PR DESCRIPTION
## Summary
- **Fix**: Add missing `initFeelAndComfort` import from `public/FeelAndComfort.js` in Product Page.js. The function was referenced in `secondaryInits` (line 132) but never imported, causing a silent `ReferenceError` caught by try/catch on every page load.

## cf-qxct Audit Finding: All 176 BUILD-SPEC IDs Already Wired

Comprehensive audit of all Product Page component modules reveals **all 176 BUILD-SPEC element IDs are already wired**:

| Component Module | IDs Wired | Status |
|-----------------|-----------|--------|
| Product Page.js (orchestrator) | ~40 | All spec IDs present |
| ProductGallery.js | 7 | Gallery, badge, video |
| ProductOptions.js | 30 | Variants, swatch selector, swatch gallery |
| ProductDetails.js | 40 | Breadcrumbs, accordion, social share, delivery, swatch request |
| ProductReviews.js | 43 | Reviews section + form + photo upload |
| ProductFinancing.js | 19 | Financing section + modal |
| AddToCart.js | 27 | Quantity, sticky bar, bundle, stock urgency, back-in-stock, wishlist |

22 spec IDs use dynamic template literals (`$w(\`#infoHeader${section}\`)`, `$w(\`#ratingBar${star}\`)`) — all verified present.

**Recommendation**: Close cf-qxct as already complete.

Bead: cf-qxct

## Test plan
- [x] productPage.test.js: 19/19 pass (initFeelAndComfort no longer throws)
- [x] Full suite: 197 files, 7571 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)