### PR TITLE
feat(cf-0g2l): Post-purchase care sequence — day 3/7/30 redesign

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -62,8 +62,8 @@ const SEQUENCES = {
   },
   post_purchase: {
     steps: [
-      { step: 1, templateId: 'post_purchase_1', delayHours: 0, description: 'Thank you + tracking' },
-      { step: 2, templateId: 'post_purchase_2', delayHours: 168, description: 'Assembly tips + review request' },
+      { step: 1, templateId: 'post_purchase_1', delayHours: 72, description: 'Assembly follow-up — How\'s setup going?' },
+      { step: 2, templateId: 'post_purchase_2', delayHours: 168, description: 'Review solicitation — Enjoying your furniture?' },
       { step: 3, templateId: 'post_purchase_3', delayHours: 720, description: 'Care guide + accessory upsell' },
     ],
   },
@@ -248,6 +248,10 @@ export const triggerPostPurchaseSequence = webMethod(
         .filter(Boolean)
         .join(', ');
 
+      const SITE_URL = 'https://www.carolinafutons.com';
+      const assemblyGuideUrl = `${SITE_URL}/getting-it-home#assembly`;
+      const reviewUrl = `${SITE_URL}/product-page/${cleanOrderNumber}#reviews`;
+
       const now = new Date();
       let queued = 0;
 
@@ -264,6 +268,8 @@ export const triggerPostPurchaseSequence = webMethod(
             total: String(total),
             productNames,
             email: cleanEmail,
+            assemblyGuideUrl,
+            reviewUrl,
           },
           sequenceType: 'post_purchase',
           sequenceStep: step.step,

--- a/src/backend/emailTemplates.web.js
+++ b/src/backend/emailTemplates.web.js
@@ -87,25 +87,25 @@ const TEMPLATE_REGISTRY = {
     category: 'recovery',
   },
 
-  // Post-Purchase Follow-up
+  // Post-Purchase Care Sequence (Day 3/7/30)
   post_purchase_1: {
     id: 'post_purchase_1',
-    name: 'Post-Purchase — Thank You + Tracking',
+    name: 'Post-Purchase — Assembly Follow-Up',
     sequence: 'post_purchase',
     step: 1,
-    subjectLine: 'Thank you for your order, {firstName}!',
-    previewText: 'Your order is confirmed. Here\'s what happens next.',
-    variables: ['firstName', 'orderNumber', 'total', 'productNames', 'email'],
+    subjectLine: 'How\'s setup going, {firstName}? Need help with assembly?',
+    previewText: 'Quick-start guide and video walkthrough for easy setup. We\'re here to help.',
+    variables: ['firstName', 'orderNumber', 'total', 'productNames', 'assemblyGuideUrl', 'email'],
     category: 'transactional',
   },
   post_purchase_2: {
     id: 'post_purchase_2',
-    name: 'Post-Purchase — Assembly Tips + Review Request',
+    name: 'Post-Purchase — Review Solicitation',
     sequence: 'post_purchase',
     step: 2,
-    subjectLine: 'Assembly tips for your new furniture',
-    previewText: 'Quick-start guide and video walkthrough for easy setup.',
-    variables: ['firstName', 'orderNumber', 'productNames', 'email'],
+    subjectLine: 'Enjoying your new furniture, {firstName}? Leave a review!',
+    previewText: 'Your feedback helps other customers find the perfect piece.',
+    variables: ['firstName', 'orderNumber', 'productNames', 'reviewUrl', 'email'],
     category: 'transactional',
   },
   post_purchase_3: {

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -5,7 +5,8 @@ import { generateFeed } from 'backend/googleMerchantFeed.web';
 import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
-import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement } from 'backend/emailAutomation.web';
+import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence } from 'backend/emailAutomation.web';
+import { getAssemblyFollowUpData } from 'backend/postPurchaseCare.web';
 import { getAllBlogPosts } from 'backend/blogContent';
 import wixData from 'wix-data';
 import { colors } from 'public/sharedTokens';
@@ -704,6 +705,49 @@ export async function get_triggerReengagementCron(request) {
     });
   } catch (err) {
     console.error('HTTP function error (triggerReengagementCron):', err);
+    return serverError({
+      body: JSON.stringify({ error: 'Internal server error' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// ── Post-Purchase Care Cron ────────────────────────────────────────────
+// URL: GET https://www.carolinafutons.com/_functions/processPostPurchaseCareCron
+// Schedule daily via Wix Automations or external cron.
+// Pass ?key=<secret> for auth (ALERT_CRON_KEY in Secrets Manager).
+// Processes pending post-purchase care sequences (assembly follow-ups, review solicitations).
+export async function get_processPostPurchaseCareCron(request) {
+  try {
+    const { getSecret } = await import('wix-secrets-backend');
+    const cronKey = await getSecret('ALERT_CRON_KEY');
+    const requestKey = request.query?.key;
+
+    if (!cronKey || !requestKey || !timingSafeEqual(requestKey, cronKey)) {
+      return forbidden({
+        body: JSON.stringify({ error: 'Unauthorized' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Process the email queue (handles all sequences including post-purchase)
+    const result = await processEmailQueue();
+
+    return ok({
+      body: JSON.stringify({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+        sent: result.sent || 0,
+        failed: result.failed || 0,
+        cancelled: result.cancelled || 0,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (err) {
+    console.error('HTTP function error (processPostPurchaseCareCron):', err);
     return serverError({
       body: JSON.stringify({ error: 'Internal server error' }),
       headers: { 'Content-Type': 'application/json' },

--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -333,6 +333,104 @@ export const logUpsellConversion = webMethod(
   }
 );
 
+// ── Day 3/7 Post-Purchase Care Helpers ────────────────────────────────
+
+const SITE_URL = 'https://www.carolinafutons.com';
+const SUPPORT_PHONE = '(828) 252-9449';
+const SUPPORT_EMAIL = 'support@carolinafutons.com';
+
+/**
+ * Get assembly follow-up data for Day 3 email (72h post-purchase).
+ * Returns assembly guides relevant to the ordered products plus support info.
+ *
+ * @param {string} orderId - The order ID.
+ * @param {string[]} productCategories - Categories of products in the order.
+ * @returns {Promise<{success: boolean, guides: Array, supportPhone: string, supportEmail: string, error?: string}>}
+ */
+export const getAssemblyFollowUpData = webMethod(
+  Permissions.Anyone,
+  async (orderId, productCategories) => {
+    try {
+      const cleanOrderId = validateId(orderId);
+      if (!cleanOrderId) {
+        return { success: false, error: 'Valid order ID is required.', guides: [], supportPhone: '', supportEmail: '' };
+      }
+
+      if (!Array.isArray(productCategories) || productCategories.length === 0) {
+        return { success: false, error: 'Product categories are required.', guides: [], supportPhone: '', supportEmail: '' };
+      }
+
+      const categories = productCategories
+        .slice(0, 10)
+        .map(c => sanitize(c, 100))
+        .filter(Boolean);
+
+      if (categories.length === 0) {
+        return { success: true, guides: [], supportPhone: SUPPORT_PHONE, supportEmail: SUPPORT_EMAIL };
+      }
+
+      const result = await wixData.query('ProductCareGuides')
+        .hasSome('productCategory', categories)
+        .eq('guideType', 'assembly')
+        .eq('active', true)
+        .ascending('priority')
+        .limit(20)
+        .find();
+
+      const guides = result.items.map(item => ({
+        _id: item._id,
+        productCategory: item.productCategory,
+        title: item.title,
+        summary: item.summary,
+        content: item.content,
+        steps: parseSteps(item.steps),
+        videoUrl: item.videoUrl || '',
+        imageUrl: item.imageUrl || '',
+      }));
+
+      return { success: true, guides, supportPhone: SUPPORT_PHONE, supportEmail: SUPPORT_EMAIL };
+    } catch (err) {
+      console.error('[postPurchaseCare] Error getting assembly follow-up data:', err);
+      return { success: false, error: 'Failed to load assembly data.', guides: [], supportPhone: '', supportEmail: '' };
+    }
+  }
+);
+
+/**
+ * Get review solicitation data for Day 7 email (168h post-purchase).
+ * Returns review URLs and product info for the email template.
+ *
+ * @param {string} orderId - The order ID.
+ * @param {string} customerName - Customer first name.
+ * @param {Array<{name: string, productId: string}>} products - Products from the order.
+ * @returns {Promise<{success: boolean, reviewUrl: string, customerName: string, products: Array, error?: string}>}
+ */
+export const getReviewSolicitationData = webMethod(
+  Permissions.Anyone,
+  async (orderId, customerName, products) => {
+    try {
+      const cleanOrderId = validateId(orderId);
+      if (!cleanOrderId) {
+        return { success: false, error: 'Valid order ID is required.', reviewUrl: '', customerName: '', products: [] };
+      }
+
+      const cleanName = sanitize(customerName || '', 200);
+      const reviewUrl = `${SITE_URL}/product-page/${cleanOrderId}#reviews`;
+
+      const productList = (products || []).slice(0, 20).map(p => ({
+        name: sanitize(p.name || '', 200),
+        productId: sanitize(p.productId || '', 50),
+        reviewUrl: p.productId ? `${SITE_URL}/product-page/${sanitize(p.productId, 50)}#reviews` : reviewUrl,
+      }));
+
+      return { success: true, reviewUrl, customerName: cleanName, products: productList };
+    } catch (err) {
+      console.error('[postPurchaseCare] Error getting review solicitation data:', err);
+      return { success: false, error: 'Failed to load review data.', reviewUrl: '', customerName: '', products: [] };
+    }
+  }
+);
+
 // ── Internal helpers ──────────────────────────────────────────────────
 
 function parseSteps(stepsJson) {

--- a/tests/emailAutomation.test.js
+++ b/tests/emailAutomation.test.js
@@ -43,11 +43,17 @@ describe('sequence definitions', () => {
     expect(_SEQUENCES.cart_recovery.steps[2].delayHours).toBe(72);
   });
 
-  it('has post_purchase sequence with 3 steps', () => {
+  it('has post_purchase sequence with day 3/7/30 timing', () => {
     expect(_SEQUENCES.post_purchase.steps).toHaveLength(3);
-    expect(_SEQUENCES.post_purchase.steps[0].delayHours).toBe(0);
-    expect(_SEQUENCES.post_purchase.steps[1].delayHours).toBe(168);
-    expect(_SEQUENCES.post_purchase.steps[2].delayHours).toBe(720);
+    expect(_SEQUENCES.post_purchase.steps[0].delayHours).toBe(72);   // Day 3: Assembly follow-up
+    expect(_SEQUENCES.post_purchase.steps[1].delayHours).toBe(168);  // Day 7: Review solicitation
+    expect(_SEQUENCES.post_purchase.steps[2].delayHours).toBe(720);  // Day 30: Care guide + upsell
+  });
+
+  it('has post_purchase step descriptions matching day 3/7/30 redesign', () => {
+    expect(_SEQUENCES.post_purchase.steps[0].description).toContain('Assembly follow-up');
+    expect(_SEQUENCES.post_purchase.steps[1].description).toContain('Review solicitation');
+    expect(_SEQUENCES.post_purchase.steps[2].description).toContain('Care guide');
   });
 
   it('has reengagement sequence with 1 step', () => {
@@ -260,10 +266,11 @@ describe('triggerPostPurchaseSequence', () => {
     expect(insertedItems[0].variables.productNames).toBe('');
   });
 
-  it('schedules post-purchase at correct delays', async () => {
+  it('schedules post-purchase at day 3/7/30 delays', async () => {
     let insertedItems = [];
     __onInsert((collection, item) => { insertedItems.push(item); });
 
+    const before = Date.now();
     await triggerPostPurchaseSequence(
       'contact-1', 'buyer@test.com', 'Bob', 'ORD-001', 100, []
     );
@@ -272,11 +279,33 @@ describe('triggerPostPurchaseSequence', () => {
     const step2Time = new Date(insertedItems[1].scheduledFor).getTime();
     const step3Time = new Date(insertedItems[2].scheduledFor).getTime();
 
-    // Step 2: 168h (1 week) after step 1
-    expect(step2Time - step1Time).toBeGreaterThanOrEqual(168 * 60 * 60 * 1000 - 1000);
+    // Step 1: 72h (day 3) after queue time
+    expect(step1Time - before).toBeGreaterThanOrEqual(72 * 60 * 60 * 1000 - 1000);
 
-    // Step 3: 720h (30 days) after step 1
-    expect(step3Time - step1Time).toBeGreaterThanOrEqual(720 * 60 * 60 * 1000 - 1000);
+    // Step 2: 168h (day 7) after queue time
+    expect(step2Time - before).toBeGreaterThanOrEqual(168 * 60 * 60 * 1000 - 1000);
+
+    // Step 3: 720h (day 30) after queue time
+    expect(step3Time - before).toBeGreaterThanOrEqual(720 * 60 * 60 * 1000 - 1000);
+  });
+
+  it('includes assemblyGuideUrl and reviewUrl in post-purchase variables', async () => {
+    let insertedItems = [];
+    __onInsert((collection, item) => { insertedItems.push(item); });
+
+    await triggerPostPurchaseSequence(
+      'contact-1', 'buyer@test.com', 'Bob', 'ORD-001', 899, [
+        { name: 'Eureka Frame', quantity: 1, price: 599 },
+      ]
+    );
+
+    // All steps should have assemblyGuideUrl and reviewUrl
+    for (const item of insertedItems) {
+      expect(item.variables).toHaveProperty('assemblyGuideUrl');
+      expect(item.variables).toHaveProperty('reviewUrl');
+      expect(item.variables.assemblyGuideUrl).toBeTruthy();
+      expect(item.variables.reviewUrl).toBeTruthy();
+    }
   });
 });
 

--- a/tests/emailTemplates.test.js
+++ b/tests/emailTemplates.test.js
@@ -30,9 +30,23 @@ describe('_TEMPLATE_REGISTRY', () => {
     expect(cart).toHaveLength(3);
   });
 
-  it('contains post-purchase templates (3 steps)', () => {
+  it('contains post-purchase templates (3 steps) with day 3/7/30 focus', () => {
     const pp = Object.values(_TEMPLATE_REGISTRY).filter(t => t.sequence === 'post_purchase');
     expect(pp).toHaveLength(3);
+    const sorted = pp.sort((a, b) => a.step - b.step);
+
+    // Step 1 (Day 3): Assembly follow-up
+    expect(sorted[0].name).toContain('Assembly');
+    expect(sorted[0].subjectLine).toMatch(/assembly|setup/i);
+    expect(sorted[0].variables).toContain('assemblyGuideUrl');
+
+    // Step 2 (Day 7): Review solicitation
+    expect(sorted[1].name).toContain('Review');
+    expect(sorted[1].subjectLine).toMatch(/review|enjoying/i);
+    expect(sorted[1].variables).toContain('reviewUrl');
+
+    // Step 3 (Day 30): Care guide + upsell (unchanged)
+    expect(sorted[2].name).toContain('Care');
   });
 
   it('contains promotional templates', () => {
@@ -137,7 +151,8 @@ describe('getTemplateIndex', () => {
 describe('resolveSubjectLine', () => {
   it('substitutes variables in subject line', async () => {
     const subject = await resolveSubjectLine('post_purchase_1', { firstName: 'Jane' });
-    expect(subject).toBe('Thank you for your order, Jane!');
+    expect(subject).toContain('Jane');
+    expect(subject).toMatch(/setup|assembly/i);
   });
 
   it('substitutes multiple variables', async () => {

--- a/tests/postPurchaseCare.test.js
+++ b/tests/postPurchaseCare.test.js
@@ -7,6 +7,8 @@ import {
   getUpsellRecommendations,
   trackGuideEngagement,
   logUpsellConversion,
+  getAssemblyFollowUpData,
+  getReviewSolicitationData,
 } from '../src/backend/postPurchaseCare.web.js';
 
 beforeEach(() => {
@@ -337,5 +339,118 @@ describe('logUpsellConversion', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+});
+
+// ── getAssemblyFollowUpData ───────────────────────────────────────────
+
+describe('getAssemblyFollowUpData', () => {
+  it('returns assembly guides and support info for an order', async () => {
+    __seed('ProductCareGuides', [
+      { _id: 'g-1', productCategory: 'futon-frames', guideType: 'assembly', title: 'Frame Assembly Guide', summary: 'How to assemble', content: 'Step by step...', steps: '["Unbox","Attach legs","Secure bolts"]', videoUrl: 'https://example.com/video', priority: 1, active: true },
+    ]);
+
+    const result = await getAssemblyFollowUpData('order-123', ['futon-frames']);
+    expect(result.success).toBe(true);
+    expect(result.guides).toHaveLength(1);
+    expect(result.guides[0].title).toBe('Frame Assembly Guide');
+    expect(result.guides[0].videoUrl).toBeTruthy();
+    expect(result.supportPhone).toBeTruthy();
+    expect(result.supportEmail).toBeTruthy();
+  });
+
+  it('returns guides across multiple product categories', async () => {
+    __seed('ProductCareGuides', [
+      { _id: 'g-1', productCategory: 'futon-frames', guideType: 'assembly', title: 'Frame Assembly', summary: 'Assemble frame', content: 'Steps...', steps: '[]', priority: 1, active: true },
+      { _id: 'g-2', productCategory: 'mattresses', guideType: 'assembly', title: 'Mattress Setup', summary: 'Setup mattress', content: 'Steps...', steps: '[]', priority: 1, active: true },
+    ]);
+
+    const result = await getAssemblyFollowUpData('order-456', ['futon-frames', 'mattresses']);
+    expect(result.success).toBe(true);
+    expect(result.guides).toHaveLength(2);
+  });
+
+  it('returns empty guides when no assembly guides exist for categories', async () => {
+    __seed('ProductCareGuides', [
+      { _id: 'g-1', productCategory: 'covers', guideType: 'fabric_care', title: 'Cover Care', summary: 'Care', content: 'Tips', steps: '[]', priority: 1, active: true },
+    ]);
+
+    const result = await getAssemblyFollowUpData('order-789', ['covers']);
+    expect(result.success).toBe(true);
+    expect(result.guides).toHaveLength(0);
+    expect(result.supportPhone).toBeTruthy();
+  });
+
+  it('requires valid order ID', async () => {
+    const result = await getAssemblyFollowUpData('', ['futon-frames']);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('order ID');
+  });
+
+  it('requires product categories', async () => {
+    const result = await getAssemblyFollowUpData('order-123', []);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('categories');
+  });
+
+  it('handles null categories', async () => {
+    const result = await getAssemblyFollowUpData('order-123', null);
+    expect(result.success).toBe(false);
+  });
+
+  it('sanitizes input', async () => {
+    __seed('ProductCareGuides', []);
+    const result = await getAssemblyFollowUpData('order-123', ['<script>alert(1)</script>']);
+    expect(result.success).toBe(true);
+    expect(result.guides).toHaveLength(0);
+  });
+});
+
+// ── getReviewSolicitationData ─────────────────────────────────────────
+
+describe('getReviewSolicitationData', () => {
+  it('returns review data for an order', async () => {
+    const result = await getReviewSolicitationData('order-123', 'Bob', [
+      { name: 'Eureka Frame', productId: 'prod-1' },
+      { name: 'Moonshadow Mattress', productId: 'prod-2' },
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.reviewUrl).toBeTruthy();
+    expect(result.customerName).toBe('Bob');
+    expect(result.products).toHaveLength(2);
+    expect(result.products[0].name).toBe('Eureka Frame');
+    expect(result.products[0].reviewUrl).toBeTruthy();
+  });
+
+  it('generates product-specific review URLs', async () => {
+    const result = await getReviewSolicitationData('order-456', 'Alice', [
+      { name: 'Eureka Frame', productId: 'prod-1' },
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.products[0].reviewUrl).toContain('prod-1');
+  });
+
+  it('requires valid order ID', async () => {
+    const result = await getReviewSolicitationData('', 'Bob', []);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('order ID');
+  });
+
+  it('handles empty product list', async () => {
+    const result = await getReviewSolicitationData('order-123', 'Bob', []);
+    expect(result.success).toBe(true);
+    expect(result.products).toHaveLength(0);
+  });
+
+  it('handles null product list', async () => {
+    const result = await getReviewSolicitationData('order-123', 'Bob', null);
+    expect(result.success).toBe(true);
+    expect(result.products).toHaveLength(0);
+  });
+
+  it('sanitizes customer name', async () => {
+    const result = await getReviewSolicitationData('order-123', '<script>alert(1)</script>Bob', []);
+    expect(result.success).toBe(true);
+    expect(result.customerName).not.toContain('<script>');
   });
 });


### PR DESCRIPTION
## Summary
- Redesign post-purchase email timing: immediate/7d/30d → day 3 (assembly follow-up) / day 7 (review solicitation) / day 30 (care guide + upsell)
- Add `assemblyGuideUrl` and `reviewUrl` variables to post-purchase email templates
- Add `getAssemblyFollowUpData()` and `getReviewSolicitationData()` helpers to `postPurchaseCare.web.js`
- Add `processPostPurchaseCareCron` HTTP endpoint for scheduled processing
- Update template metadata (names, subject lines, preview text) for day 3/7/30 content focus

## Files Changed
- `src/backend/emailAutomation.web.js` — sequence timing + new variables
- `src/backend/emailTemplates.web.js` — template metadata
- `src/backend/postPurchaseCare.web.js` — new helper functions
- `src/backend/http-functions.js` — new cron endpoint
- `tests/emailAutomation.test.js` — updated timing assertions + new variable tests
- `tests/emailTemplates.test.js` — updated template metadata tests
- `tests/postPurchaseCare.test.js` — tests for new helpers

## Test plan
- [x] 206 test files, 8034 tests — all green
- [x] emailAutomation: 78 tests (updated timing + new variable assertions)
- [x] emailTemplates: 32 tests (updated metadata assertions)
- [x] postPurchaseCare: 44 tests (13 new for getAssemblyFollowUpData + getReviewSolicitationData)
- [ ] Verify emails send at correct day 3/7/30 intervals in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)