### PR TITLE
feat(cf-lugx): sustainability showcase page

### DIFF
--- a/src/pages/Sustainability.js
+++ b/src/pages/Sustainability.js
@@ -1,0 +1,174 @@
+// Sustainability.js - Sustainability Showcase Page
+// Eco-friendly materials, certifications, carbon offset,
+// and trade-in program with local SEO signals
+import { getBusinessSchema } from 'backend/seoHelpers.web';
+import { trackEvent } from 'public/engagementTracker';
+import { initBackToTop } from 'public/mobileHelpers';
+import { makeClickable } from 'public/a11yHelpers.js';
+import {
+  getSustainabilityPageContent,
+  getMaterialHighlights,
+  getCertificationsList,
+  getBadgeDefinitions,
+  getConditionOptions,
+  getTradeInSteps,
+  formatCarbonData,
+  estimateCreditRange,
+} from 'public/sustainabilityHelpers.js';
+
+$w.onReady(async function () {
+  initBackToTop($w);
+  initHero();
+  initMaterials();
+  initCertifications();
+  initBadgesShowcase();
+  initCarbonOffset();
+  initTradeIn();
+  initTradeInSteps();
+  await injectSchema();
+  trackEvent('page_view', { page: 'sustainability' });
+});
+
+// ── Hero Section ────────────────────────────────────────────────────
+
+function initHero() {
+  try {
+    const content = getSustainabilityPageContent();
+    try { $w('#sustainHeroHeading').text = content.hero.heading; } catch (e) {}
+    try { $w('#sustainHeroSubheading').text = content.hero.subheading; } catch (e) {}
+    try { $w('#sustainHeroIntro').text = content.hero.intro; } catch (e) {}
+  } catch (e) {}
+}
+
+// ── Materials Section ───────────────────────────────────────────────
+
+function initMaterials() {
+  try {
+    const repeater = $w('#materialsRepeater');
+    if (!repeater) return;
+
+    const content = getSustainabilityPageContent();
+    try { $w('#materialsHeading').text = content.materials.heading; } catch (e) {}
+    try { $w('#materialsDescription').text = content.materials.description; } catch (e) {}
+
+    const highlights = getMaterialHighlights();
+    try { repeater.accessibility.ariaLabel = 'Sustainably sourced materials'; } catch (e) {}
+    repeater.onItemReady(($item, itemData) => {
+      try { $item('#materialTitle').text = itemData.title; } catch (e) {}
+      try { $item('#materialDesc').text = itemData.description; } catch (e) {}
+    });
+    repeater.data = highlights.map((h, i) => ({ ...h, _id: `material-${i}` }));
+  } catch (e) {}
+}
+
+// ── Certifications Section ──────────────────────────────────────────
+
+function initCertifications() {
+  try {
+    const repeater = $w('#certificationsRepeater');
+    if (!repeater) return;
+
+    const content = getSustainabilityPageContent();
+    try { $w('#certificationsHeading').text = content.certifications.heading; } catch (e) {}
+
+    const certs = getCertificationsList();
+    try { repeater.accessibility.ariaLabel = 'Environmental certifications'; } catch (e) {}
+    repeater.onItemReady(($item, itemData) => {
+      try { $item('#certName').text = itemData.name; } catch (e) {}
+      try { $item('#certDesc').text = itemData.description; } catch (e) {}
+    });
+    repeater.data = certs.map((c, i) => ({ ...c, _id: `cert-${i}` }));
+  } catch (e) {}
+}
+
+// ── Badges Showcase ─────────────────────────────────────────────────
+
+function initBadgesShowcase() {
+  try {
+    const repeater = $w('#badgesRepeater');
+    if (!repeater) return;
+
+    const badges = getBadgeDefinitions();
+    try { repeater.accessibility.ariaLabel = 'Sustainability badges'; } catch (e) {}
+    repeater.onItemReady(($item, itemData) => {
+      try { $item('#badgeLabel').text = itemData.label; } catch (e) {}
+      try { $item('#badgeDesc').text = itemData.description; } catch (e) {}
+    });
+    repeater.data = badges.map((b, i) => ({ ...b, _id: `badge-${i}` }));
+  } catch (e) {}
+}
+
+// ── Carbon Offset Section ───────────────────────────────────────────
+
+function initCarbonOffset() {
+  try {
+    const section = $w('#carbonOffsetSection');
+    if (!section) return;
+
+    try { $w('#carbonHeading').text = 'Carbon Offset at Checkout'; } catch (e) {}
+    try {
+      $w('#carbonDescription').text = 'Add a small contribution at checkout to offset the carbon footprint of your purchase. We partner with verified reforestation programs.';
+    } catch (e) {}
+  } catch (e) {}
+}
+
+// ── Trade-In Section ────────────────────────────────────────────────
+
+function initTradeIn() {
+  try {
+    const content = getSustainabilityPageContent();
+    try { $w('#tradeInHeading').text = content.tradeIn.heading; } catch (e) {}
+    try { $w('#tradeInDescription').text = content.tradeIn.description; } catch (e) {}
+
+    // Condition dropdown
+    const dropdown = $w('#tradeInCondition');
+    if (dropdown) {
+      const options = getConditionOptions();
+      try {
+        dropdown.options = options.map(o => ({ value: o.value, label: o.label }));
+      } catch (e) {}
+
+      // Show credit estimate on selection
+      try {
+        dropdown.onChange(() => {
+          const selected = dropdown.value;
+          const range = estimateCreditRange(selected);
+          if (range) {
+            try {
+              $w('#tradeInEstimate').text = `Estimated credit: $${range.min}–$${range.max}`;
+            } catch (e) {}
+          }
+        });
+      } catch (e) {}
+    }
+  } catch (e) {}
+}
+
+// ── Trade-In Steps ──────────────────────────────────────────────────
+
+function initTradeInSteps() {
+  try {
+    const repeater = $w('#tradeInStepsRepeater');
+    if (!repeater) return;
+
+    const steps = getTradeInSteps();
+    try { repeater.accessibility.ariaLabel = 'Trade-in process steps'; } catch (e) {}
+    repeater.onItemReady(($item, itemData) => {
+      try { $item('#stepNumber').text = String(itemData.number); } catch (e) {}
+      try { $item('#stepTitle').text = itemData.title; } catch (e) {}
+      try { $item('#stepDesc').text = itemData.description; } catch (e) {}
+    });
+    repeater.data = steps.map((s, i) => ({ ...s, _id: `step-${i}` }));
+  } catch (e) {}
+}
+
+// ── SEO Schema ──────────────────────────────────────────────────────
+
+async function injectSchema() {
+  try {
+    const schema = await getBusinessSchema();
+    if (schema) {
+      $w('#sustainSchemaHtml').postMessage(schema);
+    }
+  } catch (e) {}
+}

--- a/src/public/sustainabilityHelpers.js
+++ b/src/public/sustainabilityHelpers.js
@@ -1,0 +1,186 @@
+/**
+ * @module sustainabilityHelpers
+ * @description Frontend helpers for the Sustainability showcase page.
+ * Static content, formatting, and display utilities for eco-friendly
+ * materials, certifications, carbon offset, and trade-in program.
+ */
+
+// Credit ranges matching backend sustainability.web.js
+const CREDIT_RANGES = {
+  excellent: { min: 100, max: 200 },
+  good: { min: 75, max: 150 },
+  fair: { min: 50, max: 100 },
+  poor: { min: 25, max: 50 },
+};
+
+/**
+ * Get static content for sustainability page sections.
+ * @returns {{ hero: Object, materials: Object, certifications: Object, tradeIn: Object }}
+ */
+export function getSustainabilityPageContent() {
+  return {
+    hero: {
+      heading: 'Furniture That Cares for the Planet',
+      subheading: 'Our Sustainability Promise',
+      intro: 'At Carolina Futons, sustainability isn\'t a buzzword — it\'s how we build. From responsibly sourced wood to eco-friendly finishes, every piece is crafted to last decades, not seasons.',
+    },
+    materials: {
+      heading: 'Responsibly Sourced Materials',
+      description: 'We partner with suppliers who share our commitment to the environment, choosing materials that are renewable, durable, and low-impact.',
+    },
+    certifications: {
+      heading: 'Certifications & Standards',
+      description: 'Our products meet rigorous third-party environmental and safety standards.',
+    },
+    tradeIn: {
+      heading: 'Trade-In Program',
+      description: 'Give your old futon a second life. Trade in your used furniture for store credit toward a new piece — we\'ll handle the pickup and responsible recycling.',
+    },
+  };
+}
+
+/**
+ * Get material sourcing highlights for display.
+ * @returns {Array<{ title: string, description: string, icon: string }>}
+ */
+export function getMaterialHighlights() {
+  return [
+    {
+      title: 'Sustainably Sourced Wood',
+      description: 'Our frames use plantation-grown rubberwood and responsibly harvested hardwoods — never old-growth timber.',
+      icon: 'tree',
+    },
+    {
+      title: 'Eco-Friendly Finishes',
+      description: 'Water-based stains and low-VOC finishes protect indoor air quality and reduce environmental impact.',
+      icon: 'droplet',
+    },
+    {
+      title: 'Natural Fabrics',
+      description: 'Organic cotton, linen, and recycled polyester covers that are better for you and the planet.',
+      icon: 'fabric',
+    },
+    {
+      title: 'Durable by Design',
+      description: 'Built to last 15–20 years of daily use, reducing waste from disposable furniture.',
+      icon: 'shield',
+    },
+  ];
+}
+
+/**
+ * Get certifications list for display.
+ * @returns {Array<{ name: string, description: string, icon: string }>}
+ */
+export function getCertificationsList() {
+  return [
+    {
+      name: 'FSC Certified',
+      description: 'Forest Stewardship Council certification ensures wood comes from responsibly managed forests.',
+      icon: 'certificate',
+    },
+    {
+      name: 'GREENGUARD Gold',
+      description: 'Meets strict chemical emissions limits for healthier indoor air quality.',
+      icon: 'shield-check',
+    },
+    {
+      name: 'CertiPUR-US',
+      description: 'Foam meets rigorous standards for content, emissions, and durability — no harmful chemicals.',
+      icon: 'check-circle',
+    },
+  ];
+}
+
+/**
+ * Get badge definitions for sustainability showcase.
+ * Mirrors backend BADGE_DEFS from sustainability.web.js.
+ * @returns {Array<{ slug: string, label: string, icon: string, description: string }>}
+ */
+export function getBadgeDefinitions() {
+  return [
+    { slug: 'eco-material', label: 'Eco-Friendly Materials', icon: 'leaf', description: 'Made from sustainably sourced materials' },
+    { slug: 'long-lasting', label: 'Built to Last', icon: 'shield', description: 'Designed for 15+ years of daily use' },
+    { slug: 'recyclable', label: 'Recyclable', icon: 'recycle', description: 'Materials can be recycled at end of life' },
+    { slug: 'low-carbon', label: 'Low Carbon', icon: 'globe', description: 'Below-average carbon footprint for its category' },
+    { slug: 'certified', label: 'Certified Sustainable', icon: 'badge', description: 'Third-party sustainability certification' },
+    { slug: 'trade-in-eligible', label: 'Trade-In Eligible', icon: 'refresh', description: 'Eligible for our trade-in credit program' },
+  ];
+}
+
+/**
+ * Get trade-in condition options for the form dropdown.
+ * @returns {Array<{ value: string, label: string, creditRange: { min: number, max: number } }>}
+ */
+export function getConditionOptions() {
+  return [
+    { value: 'excellent', label: 'Excellent — Like new, minimal wear', creditRange: CREDIT_RANGES.excellent },
+    { value: 'good', label: 'Good — Normal wear, fully functional', creditRange: CREDIT_RANGES.good },
+    { value: 'fair', label: 'Fair — Visible wear, still usable', creditRange: CREDIT_RANGES.fair },
+    { value: 'poor', label: 'Poor — Heavy wear, needs repair', creditRange: CREDIT_RANGES.poor },
+  ];
+}
+
+/**
+ * Format carbon offset data for human-readable display.
+ * @param {Object|null} data - Carbon offset data from calculateCarbonOffset.
+ * @returns {{ carbonText: string, costText: string, treesText: string }|null}
+ */
+export function formatCarbonData(data) {
+  if (!data) return null;
+
+  return {
+    carbonText: `${data.totalCarbonKg} kg CO₂`,
+    costText: `$${data.offsetCost.toFixed(2)}`,
+    treesText: `${data.treesEquivalent} trees per year`,
+  };
+}
+
+/**
+ * Format trade-in request status to human-readable label.
+ * @param {string|null|undefined} status
+ * @returns {string}
+ */
+export function formatTradeInStatus(status) {
+  if (!status) return '';
+
+  const labels = {
+    submitted: 'Submitted — Pending Review',
+    reviewing: 'Under Review',
+    approved: 'Approved — Ready to Ship',
+    shipped: 'Shipped — In Transit',
+    received: 'Received — Being Inspected',
+    credited: 'Credit Issued to Your Account',
+    rejected: 'Not Eligible for Trade-In',
+  };
+
+  return labels[status] || status;
+}
+
+/**
+ * Get the trade-in process steps for display.
+ * @returns {Array<{ number: number, title: string, description: string }>}
+ */
+export function getTradeInSteps() {
+  return [
+    { number: 1, title: 'Submit Your Item', description: 'Tell us about your furniture — type, condition, and photos. We\'ll give you an instant credit estimate.' },
+    { number: 2, title: 'We Pick It Up', description: 'Once approved, we\'ll schedule a free pickup from your home at a time that works for you.' },
+    { number: 3, title: 'Get Store Credit', description: 'Your credit is applied to your account within 48 hours of receiving your item. Use it on anything in store.' },
+  ];
+}
+
+/**
+ * Estimate credit range for a given condition.
+ * @param {string|null} condition - 'excellent'|'good'|'fair'|'poor'
+ * @returns {{ min: number, max: number, estimated: number }|null}
+ */
+export function estimateCreditRange(condition) {
+  if (!condition || !CREDIT_RANGES[condition]) return null;
+
+  const range = CREDIT_RANGES[condition];
+  return {
+    min: range.min,
+    max: range.max,
+    estimated: Math.round((range.min + range.max) / 2),
+  };
+}

--- a/tests/sustainabilityHelpers.test.js
+++ b/tests/sustainabilityHelpers.test.js
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  getSustainabilityPageContent,
+  getMaterialHighlights,
+  getCertificationsList,
+  getBadgeDefinitions,
+  getConditionOptions,
+  formatCarbonData,
+  formatTradeInStatus,
+  getTradeInSteps,
+  estimateCreditRange,
+} from '../src/public/sustainabilityHelpers.js';
+
+// ── getSustainabilityPageContent ──────────────────────────────────────
+
+describe('getSustainabilityPageContent', () => {
+  it('returns object with hero section content', () => {
+    const content = getSustainabilityPageContent();
+    expect(content).toHaveProperty('hero');
+    expect(content.hero).toHaveProperty('heading');
+    expect(content.hero).toHaveProperty('subheading');
+    expect(content.hero).toHaveProperty('intro');
+    expect(typeof content.hero.heading).toBe('string');
+    expect(content.hero.heading.length).toBeGreaterThan(0);
+  });
+
+  it('hero content references sustainability or eco-friendly messaging', () => {
+    const content = getSustainabilityPageContent();
+    const combined = `${content.hero.heading} ${content.hero.subheading} ${content.hero.intro}`.toLowerCase();
+    expect(combined).toMatch(/sustain|eco|green|planet|environment/);
+  });
+
+  it('returns sections for materials, certifications, tradeIn', () => {
+    const content = getSustainabilityPageContent();
+    expect(content).toHaveProperty('materials');
+    expect(content).toHaveProperty('certifications');
+    expect(content).toHaveProperty('tradeIn');
+    expect(content.materials).toHaveProperty('heading');
+    expect(content.certifications).toHaveProperty('heading');
+    expect(content.tradeIn).toHaveProperty('heading');
+  });
+
+  it('trade-in section includes a call-to-action description', () => {
+    const content = getSustainabilityPageContent();
+    expect(content.tradeIn).toHaveProperty('description');
+    expect(content.tradeIn.description.length).toBeGreaterThan(10);
+  });
+});
+
+// ── getMaterialHighlights ─────────────────────────────────────────────
+
+describe('getMaterialHighlights', () => {
+  it('returns array of material highlights', () => {
+    const highlights = getMaterialHighlights();
+    expect(Array.isArray(highlights)).toBe(true);
+    expect(highlights.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('each highlight has title, description, and icon', () => {
+    const highlights = getMaterialHighlights();
+    for (const h of highlights) {
+      expect(h).toHaveProperty('title');
+      expect(h).toHaveProperty('description');
+      expect(h).toHaveProperty('icon');
+      expect(typeof h.title).toBe('string');
+      expect(typeof h.description).toBe('string');
+      expect(typeof h.icon).toBe('string');
+      expect(h.title.length).toBeGreaterThan(0);
+      expect(h.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes wood sourcing highlight', () => {
+    const highlights = getMaterialHighlights();
+    const wood = highlights.find(h =>
+      h.title.toLowerCase().includes('wood') || h.description.toLowerCase().includes('wood')
+    );
+    expect(wood).toBeTruthy();
+  });
+});
+
+// ── getCertificationsList ─────────────────────────────────────────────
+
+describe('getCertificationsList', () => {
+  it('returns array of certifications', () => {
+    const certs = getCertificationsList();
+    expect(Array.isArray(certs)).toBe(true);
+    expect(certs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('each certification has name, description, and icon', () => {
+    const certs = getCertificationsList();
+    for (const cert of certs) {
+      expect(cert).toHaveProperty('name');
+      expect(cert).toHaveProperty('description');
+      expect(cert).toHaveProperty('icon');
+      expect(typeof cert.name).toBe('string');
+      expect(cert.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes FSC or GREENGUARD certification', () => {
+    const certs = getCertificationsList();
+    const known = certs.find(c =>
+      c.name.match(/FSC|GREENGUARD|CertiPUR/i)
+    );
+    expect(known).toBeTruthy();
+  });
+});
+
+// ── getBadgeDefinitions ───────────────────────────────────────────────
+
+describe('getBadgeDefinitions', () => {
+  it('returns array of badge definitions', () => {
+    const badges = getBadgeDefinitions();
+    expect(Array.isArray(badges)).toBe(true);
+    expect(badges.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('each badge has slug, label, icon, and description', () => {
+    const badges = getBadgeDefinitions();
+    for (const badge of badges) {
+      expect(badge).toHaveProperty('slug');
+      expect(badge).toHaveProperty('label');
+      expect(badge).toHaveProperty('icon');
+      expect(badge).toHaveProperty('description');
+      expect(typeof badge.slug).toBe('string');
+      expect(typeof badge.label).toBe('string');
+      expect(badge.slug.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes eco-material and long-lasting badges', () => {
+    const badges = getBadgeDefinitions();
+    const slugs = badges.map(b => b.slug);
+    expect(slugs).toContain('eco-material');
+    expect(slugs).toContain('long-lasting');
+  });
+
+  it('includes trade-in-eligible badge', () => {
+    const badges = getBadgeDefinitions();
+    const slugs = badges.map(b => b.slug);
+    expect(slugs).toContain('trade-in-eligible');
+  });
+});
+
+// ── getConditionOptions ───────────────────────────────────────────────
+
+describe('getConditionOptions', () => {
+  it('returns array of condition options', () => {
+    const options = getConditionOptions();
+    expect(Array.isArray(options)).toBe(true);
+    expect(options).toHaveLength(4);
+  });
+
+  it('each option has value, label, and creditRange', () => {
+    const options = getConditionOptions();
+    for (const opt of options) {
+      expect(opt).toHaveProperty('value');
+      expect(opt).toHaveProperty('label');
+      expect(opt).toHaveProperty('creditRange');
+      expect(opt.creditRange).toHaveProperty('min');
+      expect(opt.creditRange).toHaveProperty('max');
+      expect(typeof opt.creditRange.min).toBe('number');
+      expect(typeof opt.creditRange.max).toBe('number');
+      expect(opt.creditRange.max).toBeGreaterThanOrEqual(opt.creditRange.min);
+    }
+  });
+
+  it('condition values are excellent, good, fair, poor', () => {
+    const options = getConditionOptions();
+    const values = options.map(o => o.value);
+    expect(values).toContain('excellent');
+    expect(values).toContain('good');
+    expect(values).toContain('fair');
+    expect(values).toContain('poor');
+  });
+
+  it('excellent has highest credit range', () => {
+    const options = getConditionOptions();
+    const excellent = options.find(o => o.value === 'excellent');
+    const poor = options.find(o => o.value === 'poor');
+    expect(excellent.creditRange.max).toBeGreaterThan(poor.creditRange.max);
+  });
+});
+
+// ── formatCarbonData ──────────────────────────────────────────────────
+
+describe('formatCarbonData', () => {
+  it('formats carbon offset data for display', () => {
+    const result = formatCarbonData({
+      totalCarbonKg: 45.3,
+      offsetCost: 1.00,
+      treesEquivalent: 2.1,
+      productsMatched: 2,
+      productsRequested: 2,
+    });
+
+    expect(result).toHaveProperty('carbonText');
+    expect(result).toHaveProperty('costText');
+    expect(result).toHaveProperty('treesText');
+    expect(typeof result.carbonText).toBe('string');
+    expect(typeof result.costText).toBe('string');
+    expect(typeof result.treesText).toBe('string');
+  });
+
+  it('includes kg in carbon text', () => {
+    const result = formatCarbonData({ totalCarbonKg: 45.3, offsetCost: 1, treesEquivalent: 2.1 });
+    expect(result.carbonText).toMatch(/45\.3/);
+    expect(result.carbonText).toMatch(/kg/i);
+  });
+
+  it('formats cost as dollar amount', () => {
+    const result = formatCarbonData({ totalCarbonKg: 100, offsetCost: 2.50, treesEquivalent: 4.6 });
+    expect(result.costText).toMatch(/\$2\.50/);
+  });
+
+  it('handles zero carbon gracefully', () => {
+    const result = formatCarbonData({ totalCarbonKg: 0, offsetCost: 0, treesEquivalent: 0 });
+    expect(result.carbonText).toBeDefined();
+    expect(result.costText).toBeDefined();
+    expect(result.treesText).toBeDefined();
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(formatCarbonData(null)).toBeNull();
+    expect(formatCarbonData(undefined)).toBeNull();
+  });
+});
+
+// ── formatTradeInStatus ───────────────────────────────────────────────
+
+describe('formatTradeInStatus', () => {
+  it('returns human-readable label for each status', () => {
+    const statuses = ['submitted', 'reviewing', 'approved', 'shipped', 'received', 'credited', 'rejected'];
+    for (const status of statuses) {
+      const result = formatTradeInStatus(status);
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('submitted status indicates pending review', () => {
+    const result = formatTradeInStatus('submitted');
+    expect(result.toLowerCase()).toMatch(/submitted|pending|received/);
+  });
+
+  it('credited status indicates credit issued', () => {
+    const result = formatTradeInStatus('credited');
+    expect(result.toLowerCase()).toMatch(/credit|issued|applied/);
+  });
+
+  it('returns the raw status for unknown values', () => {
+    const result = formatTradeInStatus('unknown_status');
+    expect(result).toBe('unknown_status');
+  });
+
+  it('handles empty/null input', () => {
+    expect(formatTradeInStatus('')).toBe('');
+    expect(formatTradeInStatus(null)).toBe('');
+    expect(formatTradeInStatus(undefined)).toBe('');
+  });
+});
+
+// ── getTradeInSteps ───────────────────────────────────────────────────
+
+describe('getTradeInSteps', () => {
+  it('returns array of trade-in process steps', () => {
+    const steps = getTradeInSteps();
+    expect(Array.isArray(steps)).toBe(true);
+    expect(steps.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('each step has number, title, and description', () => {
+    const steps = getTradeInSteps();
+    for (const step of steps) {
+      expect(step).toHaveProperty('number');
+      expect(step).toHaveProperty('title');
+      expect(step).toHaveProperty('description');
+      expect(typeof step.number).toBe('number');
+      expect(typeof step.title).toBe('string');
+      expect(step.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('steps are numbered sequentially starting from 1', () => {
+    const steps = getTradeInSteps();
+    steps.forEach((step, i) => {
+      expect(step.number).toBe(i + 1);
+    });
+  });
+});
+
+// ── estimateCreditRange ───────────────────────────────────────────────
+
+describe('estimateCreditRange', () => {
+  it('returns credit range for valid condition', () => {
+    const result = estimateCreditRange('excellent');
+    expect(result).toHaveProperty('min');
+    expect(result).toHaveProperty('max');
+    expect(result).toHaveProperty('estimated');
+    expect(result.min).toBeGreaterThan(0);
+    expect(result.max).toBeGreaterThan(result.min);
+    expect(result.estimated).toBe(Math.round((result.min + result.max) / 2));
+  });
+
+  it('returns progressively lower ranges for worse conditions', () => {
+    const excellent = estimateCreditRange('excellent');
+    const good = estimateCreditRange('good');
+    const fair = estimateCreditRange('fair');
+    const poor = estimateCreditRange('poor');
+
+    expect(excellent.max).toBeGreaterThan(good.max);
+    expect(good.max).toBeGreaterThan(fair.max);
+    expect(fair.max).toBeGreaterThan(poor.max);
+  });
+
+  it('returns null for invalid condition', () => {
+    expect(estimateCreditRange('broken')).toBeNull();
+    expect(estimateCreditRange('')).toBeNull();
+    expect(estimateCreditRange(null)).toBeNull();
+  });
+});

--- a/tests/sustainabilityPage.test.js
+++ b/tests/sustainabilityPage.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '',
+    src: '',
+    alt: '',
+    value: '',
+    label: '',
+    html: '',
+    data: [],
+    style: { color: '', backgroundColor: '', fontWeight: '' },
+    accessibility: { ariaLabel: '', ariaLive: undefined, role: undefined },
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(),
+    expand: vi.fn(),
+    onClick: vi.fn(),
+    onMouseIn: vi.fn(),
+    onMouseOut: vi.fn(),
+    onItemReady: vi.fn(),
+    postMessage: vi.fn(),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Mock Backend ────────────────────────────────────────────────────
+
+vi.mock('backend/seoHelpers.web', () => ({
+  getBusinessSchema: vi.fn().mockResolvedValue('{"@type":"LocalBusiness"}'),
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  initBackToTop: vi.fn(),
+}));
+
+vi.mock('public/a11yHelpers.js', () => ({
+  makeClickable: vi.fn(),
+  announce: vi.fn(),
+}));
+
+vi.mock('public/sustainabilityHelpers.js', async () => {
+  const actual = await vi.importActual('../src/public/sustainabilityHelpers.js');
+  return actual;
+});
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('Sustainability Page', () => {
+  beforeEach(() => {
+    elements.clear();
+    onReadyHandler = null;
+    vi.resetModules();
+  });
+
+  it('registers $w.onReady handler', async () => {
+    await import('../src/pages/Sustainability.js');
+    expect(onReadyHandler).toBeTypeOf('function');
+  });
+
+  it('onReady calls initBackToTop', async () => {
+    const { initBackToTop } = await import('public/mobileHelpers');
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    expect(initBackToTop).toHaveBeenCalled();
+  });
+
+  it('onReady tracks page_view event', async () => {
+    const { trackEvent } = await import('public/engagementTracker');
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    expect(trackEvent).toHaveBeenCalledWith('page_view', expect.objectContaining({ page: 'sustainability' }));
+  });
+
+  it('populates hero section text elements', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    // Hero elements should have been populated with sustainability content
+    const heading = getEl('#sustainHeroHeading');
+    expect(heading.text.length).toBeGreaterThan(0);
+  });
+
+  it('sets up materials repeater with data', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    const repeater = getEl('#materialsRepeater');
+    expect(repeater.onItemReady).toHaveBeenCalled();
+    expect(repeater.data.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('sets up certifications repeater', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    const repeater = getEl('#certificationsRepeater');
+    expect(repeater.onItemReady).toHaveBeenCalled();
+    expect(repeater.data.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('sets up badges repeater', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    const repeater = getEl('#badgesRepeater');
+    expect(repeater.onItemReady).toHaveBeenCalled();
+    expect(repeater.data.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('sets up trade-in steps repeater', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    const repeater = getEl('#tradeInStepsRepeater');
+    expect(repeater.onItemReady).toHaveBeenCalled();
+    expect(repeater.data.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('sets up condition dropdown for trade-in form', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    const dropdown = getEl('#tradeInCondition');
+    // Options should be set
+    expect(dropdown.options || dropdown.data).toBeDefined();
+  });
+
+  it('injects SEO schema', async () => {
+    const { getBusinessSchema } = await import('backend/seoHelpers.web');
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    expect(getBusinessSchema).toHaveBeenCalled();
+  });
+
+  it('sets aria labels on repeaters for accessibility', async () => {
+    await import('../src/pages/Sustainability.js');
+    await onReadyHandler();
+    const materialsRepeater = getEl('#materialsRepeater');
+    expect(materialsRepeater.accessibility.ariaLabel).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- New `Sustainability.js` page with hero, materials sourcing, certifications, badges showcase, carbon offset, and trade-in program sections
- New `sustainabilityHelpers.js` public module with static content, badge definitions, carbon data formatting, trade-in steps, and credit estimation
- Follows `About.js` pattern: repeaters, aria labels, try/catch, engagement tracking, SEO schema injection
- Backend already exists (`sustainability.web.js`) — this adds the frontend showcase

## Test plan
- [x] 34 sustainabilityHelpers tests (content, formatting, edge cases, null handling)
- [x] 11 sustainabilityPage tests (init, repeaters, a11y, tracking, SEO)
- [x] Full suite: 217 files, 8434 tests — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)