### PR TITLE
feat(cf-rnbe): nightly full integration testing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,93 @@ jobs:
             node --check "$f" 2>&1 || failed=1
           done
           exit $failed
+
+  nightly-integration:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run full integration test suite
+        id: integration
+        run: |
+          mkdir -p test-results
+          npx vitest run --reporter=verbose --reporter=junit \
+            --outputFile.junit=test-results/junit.xml 2>&1 | tee test-results/full-output.txt
+        continue-on-error: true
+
+      - name: Generate coverage report
+        if: always()
+        run: |
+          npx vitest run --coverage --reporter=json \
+            --outputFile=test-results/coverage.json || true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-test-results
+          path: test-results/
+          retention-days: 30
+
+      - name: Check for failures and create issue
+        if: steps.integration.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let output = '';
+            try {
+              output = fs.readFileSync('test-results/full-output.txt', 'utf8');
+            } catch (e) {
+              output = 'Could not read test output.';
+            }
+
+            const failedLines = output.split('\n')
+              .filter(l => l.includes('FAIL') || l.includes('×'))
+              .slice(0, 30)
+              .join('\n');
+
+            const runUrl = [
+              process.env.GITHUB_SERVER_URL,
+              process.env.GITHUB_REPOSITORY,
+              'actions/runs',
+              process.env.GITHUB_RUN_ID,
+            ].join('/');
+
+            const today = new Date().toISOString().split('T')[0];
+
+            const body = [
+              '## Nightly Integration Test Failure',
+              '',
+              '**Date:** ' + today,
+              '**Run:** ' + runUrl,
+              '',
+              '### Failed Tests',
+              '```',
+              failedLines || 'See full output in artifacts.',
+              '```',
+              '',
+              '### Full Output',
+              'Download the `nightly-test-results` artifact from the workflow run for complete details.',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Nightly integration tests failed — ' + today,
+              body,
+              labels: ['bug', 'ci-nightly'],
+            });
+
+      - name: Fail workflow if tests failed
+        if: steps.integration.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds dedicated `nightly-integration` job to GitHub Actions CI workflow
- Runs full vitest suite with verbose reporter + JUnit XML output on nightly schedule (6am UTC)
- Uploads test results as artifacts (30-day retention) for debugging
- Auto-creates GitHub issue with failed test summary when nightly tests fail
- Existing PR/push `test` and `lint` jobs unchanged

## Test plan
- [x] Full test suite passes locally (219 files, 8549 tests)
- [ ] Verify nightly cron triggers correctly (next run at 6am UTC)
- [ ] Verify issue creation on failure (can test by temporarily breaking a test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)