### PR TITLE
docs(cf-b17): JSDoc audit batch 1 — 13 worst offenders

### DIFF
--- a/src/backend/buyingGuides.web.js
+++ b/src/backend/buyingGuides.web.js
@@ -606,6 +606,16 @@ const GUIDE_SLUGS = Object.keys(GUIDES);
 
 // ── getBuyingGuide ──────────────────────────────────────────────────
 
+/**
+ * Retrieves a single buying guide by category slug, with related product
+ * sidebar pulled from Stores/Products. Returns a "coming soon" stub for
+ * categories that don't yet have a full guide defined.
+ *
+ * @param {string} slug - URL-safe category identifier (e.g. "futon-frames").
+ * @returns {Promise<{success: boolean, guide?: Object, error?: string}>}
+ *   guide includes sections, FAQs, comparison table, and up to 6 related products.
+ * @permission Permissions.Anyone
+ */
 export const getBuyingGuide = webMethod(
   Permissions.Anyone,
   async (slug) => {
@@ -666,6 +676,14 @@ export const getBuyingGuide = webMethod(
 
 // ── getAllBuyingGuides ───────────────────────────────────────────────
 
+/**
+ * Returns summary metadata for every available buying guide. Used on the
+ * buying guides index page to render cards with title, hero image, and
+ * category label.
+ *
+ * @returns {Promise<{success: boolean, guides?: Array<Object>, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getAllBuyingGuides = webMethod(
   Permissions.Anyone,
   async () => {
@@ -693,6 +711,13 @@ export const getAllBuyingGuides = webMethod(
 
 // ── getBuyingGuideSlugs ─────────────────────────────────────────────
 
+/**
+ * Returns the list of valid buying guide slugs. Used by the router to
+ * pre-register dynamic routes and by sitemaps to enumerate guide URLs.
+ *
+ * @returns {Promise<{success: boolean, slugs: string[]}>}
+ * @permission Permissions.Anyone
+ */
 export const getBuyingGuideSlugs = webMethod(
   Permissions.Anyone,
   async () => {
@@ -702,6 +727,15 @@ export const getBuyingGuideSlugs = webMethod(
 
 // ── getBuyingGuideSchema ────────────────────────────────────────────
 
+/**
+ * Generates JSON-LD structured data for a buying guide — both Article
+ * and FAQPage schemas — so Google can render rich results in search.
+ *
+ * @param {string} slug - Category slug identifying the guide.
+ * @returns {Promise<{success: boolean, articleSchema?: string, faqSchema?: string, error?: string}>}
+ *   Schemas are returned as JSON strings ready for injection into a script tag.
+ * @permission Permissions.Anyone
+ */
 export const getBuyingGuideSchema = webMethod(
   Permissions.Anyone,
   async (slug) => {
@@ -758,6 +792,15 @@ export const getBuyingGuideSchema = webMethod(
 
 // ── getGuideComparisonTable ─────────────────────────────────────────
 
+/**
+ * Extracts just the comparison table from a buying guide. Useful when
+ * the full guide is already cached on the client but the table needs
+ * to be rendered in an isolated component (e.g. a product-compare widget).
+ *
+ * @param {string} slug - Category slug identifying the guide.
+ * @returns {Promise<{success: boolean, table?: Object|null, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getGuideComparisonTable = webMethod(
   Permissions.Anyone,
   async (slug) => {
@@ -783,6 +826,15 @@ export const getGuideComparisonTable = webMethod(
 
 // ── getGuideFaqs ────────────────────────────────────────────────────
 
+/**
+ * Extracts just the FAQ list from a buying guide. Rendered in an
+ * accordion on the guide page and also used to build the FAQPage
+ * structured data independently of the full guide payload.
+ *
+ * @param {string} slug - Category slug identifying the guide.
+ * @returns {Promise<{success: boolean, faqs?: Array<{question: string, answer: string}>|null, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getGuideFaqs = webMethod(
   Permissions.Anyone,
   async (slug) => {
@@ -806,6 +858,15 @@ export const getGuideFaqs = webMethod(
 
 // ── getSocialShareLinks ─────────────────────────────────────────────
 
+/**
+ * Builds pre-formatted share URLs for Facebook, Twitter/X, Pinterest,
+ * and email for a given buying guide. The frontend renders these as
+ * share buttons at the top and bottom of each guide page.
+ *
+ * @param {string} slug - Category slug identifying the guide.
+ * @returns {Promise<{success: boolean, links?: {facebook: string, twitter: string, pinterest: string, email: string, url: string}|null, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getSocialShareLinks = webMethod(
   Permissions.Anyone,
   async (slug) => {

--- a/src/backend/categorySearch.web.js
+++ b/src/backend/categorySearch.web.js
@@ -51,6 +51,36 @@ const SORT_OPTIONS = {
 
 // ── searchProducts ──────────────────────────────────────────────────
 
+/**
+ * Full-text product search with multi-faceted filtering. Supports category,
+ * text query, price range, materials, colors, feature tags, brands,
+ * dimension ranges, stock status, and sort order. All string inputs are
+ * sanitized. Pagination is capped at 100 items per page.
+ *
+ * Queries CMS: Stores/Products
+ *
+ * @param {Object} [params={}] - Search and filter parameters.
+ * @param {string}   [params.category]     - Collection slug to filter by.
+ * @param {string}   [params.searchQuery]  - Free-text search (matched against product name).
+ * @param {number}   [params.priceMin]     - Minimum price (inclusive).
+ * @param {number}   [params.priceMax]     - Maximum price (inclusive).
+ * @param {string[]} [params.materials]    - Material values to include (multi-select OR).
+ * @param {string[]} [params.colors]       - Color values to include.
+ * @param {string[]} [params.featureTags]  - Feature tag values to include.
+ * @param {string[]} [params.brands]       - Brand names to include.
+ * @param {number}   [params.widthMin]     - Minimum width in inches.
+ * @param {number}   [params.widthMax]     - Maximum width in inches.
+ * @param {number}   [params.depthMin]     - Minimum depth in inches.
+ * @param {number}   [params.depthMax]     - Maximum depth in inches.
+ * @param {number}   [params.heightMin]    - Minimum height in inches.
+ * @param {number}   [params.heightMax]    - Maximum height in inches.
+ * @param {boolean}  [params.inStockOnly]  - When true, exclude out-of-stock items.
+ * @param {string}   [params.sort='bestselling'] - Sort key (see SORT_OPTIONS).
+ * @param {number}   [params.limit=50]     - Page size (max 100).
+ * @param {number}   [params.skip=0]       - Offset for pagination.
+ * @returns {Promise<{items: Object[], totalCount: number, hasMore: boolean}>}
+ * @permission Permissions.Anyone
+ */
 export const searchProducts = webMethod(
   Permissions.Anyone,
   async (params = {}) => {
@@ -196,6 +226,17 @@ export const searchProducts = webMethod(
 
 // ── getFilteredProductCount ─────────────────────────────────────────
 
+/**
+ * Returns just the matching product count for a given filter combination.
+ * Used by the UI to show "X products found" badges on filter chips before
+ * the user commits to a full search.
+ *
+ * Queries CMS: Stores/Products
+ *
+ * @param {Object} [params={}] - Same filter shape as searchProducts (minus sort/pagination).
+ * @returns {Promise<{count: number}>}
+ * @permission Permissions.Anyone
+ */
 export const getFilteredProductCount = webMethod(
   Permissions.Anyone,
   async (params = {}) => {
@@ -254,6 +295,18 @@ export const getFilteredProductCount = webMethod(
 
 // ── getFacetMetadata ────────────────────────────────────────────────
 
+/**
+ * Builds available filter facets for a category (or all products). Scans
+ * up to 100 products and extracts distinct materials, colors, feature tags,
+ * brands, price range, and dimension ranges. Results are cached for 5 min
+ * to avoid redundant queries on every page load.
+ *
+ * Queries CMS: Stores/Products
+ *
+ * @param {string} [category] - Optional collection slug. Omit for site-wide facets.
+ * @returns {Promise<{totalProducts: number, priceRange: {min: number, max: number}, materials: string[], colors: string[], featureTags: string[], brands: string[], dimensionRange: Object}>}
+ * @permission Permissions.Anyone
+ */
 export const getFacetMetadata = webMethod(
   Permissions.Anyone,
   async (category) => {
@@ -362,6 +415,18 @@ export const getFacetMetadata = webMethod(
 
 // ── suggestFilterRelaxation ─────────────────────────────────────────
 
+/**
+ * When a search returns zero results, this function identifies which single
+ * filter removal would yield results. It tries dropping each active filter
+ * one at a time and returns suggestions sorted by the most results gained.
+ * Helps the user recover from over-filtered dead ends.
+ *
+ * Queries CMS: Stores/Products
+ *
+ * @param {Object} [params={}] - The current filter set that produced zero results.
+ * @returns {Promise<{suggestions: Array<{filter: string, label: string, resultCount: number}>}>}
+ * @permission Permissions.Anyone
+ */
 export const suggestFilterRelaxation = webMethod(
   Permissions.Anyone,
   async (params = {}) => {

--- a/src/backend/fulfillment.web.js
+++ b/src/backend/fulfillment.web.js
@@ -1,6 +1,24 @@
-// Order Fulfillment Backend Module
-// Manages the workflow from order received → label printed → shipped → delivered
-// Integrates with UPS shipping and Wix Stores orders
+/**
+ * @module fulfillment
+ * @description Order fulfillment backend — manages the lifecycle from
+ * "order paid" through "label printed" to "delivered". Creates UPS shipments,
+ * stores fulfillment records, and batch-updates tracking status.
+ *
+ * CMS collections:
+ * - Stores/Orders (read) — Wix-managed order data with billing/shipping info
+ * - Fulfillments (read/write) — Custom collection storing tracking numbers,
+ *   labels, carrier info, and delivery status per order
+ *
+ * Key responsibilities:
+ * - List paid-but-unfulfilled orders for the fulfillment dashboard
+ * - Create UPS shipments and persist tracking + label data
+ * - Poll UPS for tracking updates (single + batch)
+ * - Expose fulfillment history for admin reporting
+ *
+ * @requires backend/ups-shipping.web   - createShipment, trackShipment
+ * @requires backend/utils/sanitize     - Input sanitization and ID validation
+ * @requires wix-members-backend        - Admin role verification
+ */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
@@ -26,7 +44,16 @@ async function requireAdmin() {
 
 // ── Order Processing ────────────────────────────────────────────────
 
-// Get orders ready for fulfillment (paid, not yet shipped)
+/**
+ * Retrieve orders that are paid but not yet shipped, for the fulfillment
+ * dashboard. Results are sorted newest-first and capped at 200.
+ *
+ * Permission: SiteMember (further restricted to Admin role internally).
+ *
+ * @param {number} [limit=50] - Maximum orders to return (clamped 1-200)
+ * @returns {Promise<Array<{_id: string, number: string, createdDate: Date, buyerName: string, buyerEmail: string, shippingAddress: Object, lineItems: Array, subtotal: number, shipping: number, total: number, fulfillmentStatus: string, shippingMethod: string, buyerNote: string}>>}
+ *   Simplified order objects. Returns empty array on error.
+ */
 export const getPendingOrders = webMethod(
   Permissions.SiteMember,
   async (limit = 50) => {
@@ -68,7 +95,21 @@ export const getPendingOrders = webMethod(
   }
 );
 
-// Create UPS shipment for an order and save tracking info
+/**
+ * Create a UPS shipment for an order, generate labels, and persist the
+ * fulfillment record to the Fulfillments collection. This is the primary
+ * action on the fulfillment dashboard "Ship" button.
+ *
+ * Permission: SiteMember (further restricted to Admin role internally).
+ *
+ * @param {string} orderId - Wix Stores order ID
+ * @param {Object} packageDetails - Shipment configuration
+ * @param {string} [packageDetails.serviceCode='03'] - UPS service code (default Ground)
+ * @param {Array<{length: number, width: number, height: number, weight: number, description: string}>} [packageDetails.packages]
+ *   Package dimensions. Falls back to a single 48x30x12 default package.
+ * @param {number} [packageDetails.totalWeight=50] - Fallback weight when packages not specified
+ * @returns {Promise<{success: boolean, trackingNumber?: string, labels?: Array, shippingCost?: number, error?: string}>}
+ */
 export const fulfillOrder = webMethod(
   Permissions.SiteMember,
   async (orderId, packageDetails) => {
@@ -142,7 +183,15 @@ export const fulfillOrder = webMethod(
 
 // ── Tracking Updates ────────────────────────────────────────────────
 
-// Get tracking status for a fulfillment record (admin only — writes to CMS)
+/**
+ * Fetch the latest UPS tracking status for a single fulfillment record
+ * and persist the update to the Fulfillments collection.
+ *
+ * Permission: Admin — writes tracking state to CMS.
+ *
+ * @param {string} trackingNumber - UPS tracking number
+ * @returns {Promise<{success: boolean, trackingNumber?: string, status?: string, activities?: Array, error?: string}>}
+ */
 export const getTrackingUpdate = webMethod(
   Permissions.Admin,
   async (trackingNumber) => {

--- a/src/backend/inventoryAlerts.web.js
+++ b/src/backend/inventoryAlerts.web.js
@@ -59,6 +59,17 @@ async function requireAdmin() {
 
 // ── getStockStatus (public) ─────────────────────────────────────────
 
+/**
+ * Returns the customer-facing stock status for a single product. When
+ * quantity (QTY) is at or below the urgency threshold, the response
+ * includes a "Only X left!" message for the product page badge.
+ *
+ * Queries CMS: InventoryThresholds
+ *
+ * @param {string} productId - Wix Stores product ID.
+ * @returns {Promise<{success: boolean, showUrgency?: boolean, inStock?: boolean, message?: string, stockLevel?: number, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getStockStatus = webMethod(
   Permissions.Anyone,
   async (productId) => {
@@ -123,6 +134,17 @@ export const getStockStatus = webMethod(
 
 // ── getBatchStockStatus (public, for category pages) ────────────────
 
+/**
+ * Batch version of getStockStatus for category page grids. Accepts up
+ * to 50 product IDs and returns a map of productId to stock status,
+ * avoiding N+1 queries when rendering product cards.
+ *
+ * Queries CMS: InventoryThresholds
+ *
+ * @param {string[]} [productIds=[]] - Array of Wix Stores product IDs (max 50).
+ * @returns {Promise<{success: boolean, statuses?: Object.<string, {showUrgency: boolean, inStock: boolean, message: string, stockLevel: number}>, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getBatchStockStatus = webMethod(
   Permissions.Anyone,
   async (productIds = []) => {
@@ -184,6 +206,22 @@ export const getBatchStockStatus = webMethod(
 
 // ── syncInventory (admin — updates stock levels) ────────────────────
 
+/**
+ * Ingests stock level updates from an external inventory source (e.g.
+ * warehouse feed or manual CSV import). For each product, upserts its
+ * threshold config and creates a reorder alert in LowStockAlerts when
+ * QTY (quantity) drops below the reorder threshold. Processes up to
+ * 100 updates per call.
+ *
+ * SKU = Stock Keeping Unit, a unique product identifier from the warehouse.
+ *
+ * Queries/Writes CMS: InventoryThresholds, LowStockAlerts
+ *
+ * @param {Array<{productId: string, sku?: string, productName?: string, stock: number}>} [inventoryUpdates=[]]
+ *   Each entry maps a product to its current stock count.
+ * @returns {Promise<{success: boolean, synced?: number, alertsCreated?: number, error?: string}>}
+ * @permission Permissions.SiteMember (admin role enforced at runtime)
+ */
 export const syncInventory = webMethod(
   Permissions.SiteMember,
   async (inventoryUpdates = []) => {
@@ -288,6 +326,19 @@ export const syncInventory = webMethod(
 
 // ── getLowStockAlerts (admin dashboard) ─────────────────────────────
 
+/**
+ * Lists low-stock alerts for the admin dashboard, filtered by status.
+ * Newest alerts appear first. Used to populate the inventory alerts
+ * panel so admins can acknowledge and resolve stock issues.
+ *
+ * Queries CMS: LowStockAlerts
+ *
+ * @param {Object} [options={}]
+ * @param {string} [options.status='active'] - Filter: "active" | "acknowledged" | "resolved" | "all".
+ * @param {number} [options.limit=50] - Max alerts to return (capped at 100).
+ * @returns {Promise<{success: boolean, alerts?: Array<Object>, totalCount?: number, error?: string}>}
+ * @permission Permissions.SiteMember (admin role enforced at runtime)
+ */
 export const getLowStockAlerts = webMethod(
   Permissions.SiteMember,
   async (options = {}) => {
@@ -337,6 +388,17 @@ export const getLowStockAlerts = webMethod(
 
 // ── acknowledgeAlert (admin) ────────────────────────────────────────
 
+/**
+ * Marks an active low-stock alert as acknowledged, recording which admin
+ * took ownership. Prevents duplicate action — only "active" alerts can
+ * be acknowledged.
+ *
+ * Writes CMS: LowStockAlerts
+ *
+ * @param {string} alertId - The _id of the LowStockAlerts record.
+ * @returns {Promise<{success: boolean, status?: string, error?: string}>}
+ * @permission Permissions.SiteMember (admin role enforced at runtime)
+ */
 export const acknowledgeAlert = webMethod(
   Permissions.SiteMember,
   async (alertId) => {
@@ -370,6 +432,16 @@ export const acknowledgeAlert = webMethod(
 
 // ── resolveAlert (admin) ────────────────────────────────────────────
 
+/**
+ * Marks a low-stock alert as resolved (e.g. after restocking). Only
+ * non-resolved alerts can transition to resolved.
+ *
+ * Writes CMS: LowStockAlerts
+ *
+ * @param {string} alertId - The _id of the LowStockAlerts record.
+ * @returns {Promise<{success: boolean, status?: string, error?: string}>}
+ * @permission Permissions.SiteMember (admin role enforced at runtime)
+ */
 export const resolveAlert = webMethod(
   Permissions.SiteMember,
   async (alertId) => {
@@ -401,6 +473,21 @@ export const resolveAlert = webMethod(
 
 // ── updateThreshold (admin) ─────────────────────────────────────────
 
+/**
+ * Adjusts the urgency and/or reorder thresholds for a specific product.
+ * The product must already have a threshold config (created via syncInventory).
+ * Urgency threshold controls the "Only X left!" badge; reorder threshold
+ * triggers admin alerts.
+ *
+ * Writes CMS: InventoryThresholds
+ *
+ * @param {string} productId - Wix Stores product ID.
+ * @param {Object} [thresholds={}]
+ * @param {number} [thresholds.urgencyThreshold] - New urgency threshold (>= 0).
+ * @param {number} [thresholds.reorderThreshold] - New reorder threshold (>= 0).
+ * @returns {Promise<{success: boolean, urgencyThreshold?: number, reorderThreshold?: number, error?: string}>}
+ * @permission Permissions.SiteMember (admin role enforced at runtime)
+ */
 export const updateThreshold = webMethod(
   Permissions.SiteMember,
   async (productId, thresholds = {}) => {
@@ -445,6 +532,17 @@ export const updateThreshold = webMethod(
 
 // ── getLowStockSummary (admin dashboard) ────────────────────────────
 
+/**
+ * Aggregates inventory health across all tracked products into four
+ * buckets: out-of-stock, urgency-level, reorder-level, and healthy.
+ * Also counts active (unacknowledged) alerts. Powers the admin
+ * dashboard summary cards.
+ *
+ * Queries CMS: InventoryThresholds, LowStockAlerts
+ *
+ * @returns {Promise<{success: boolean, summary?: {totalProducts: number, outOfStock: number, urgencyLevel: number, reorderLevel: number, healthy: number, activeAlerts: number}, error?: string}>}
+ * @permission Permissions.SiteMember (admin role enforced at runtime)
+ */
 export const getLowStockSummary = webMethod(
   Permissions.SiteMember,
   async () => {

--- a/src/backend/liveChat.web.js
+++ b/src/backend/liveChat.web.js
@@ -104,6 +104,17 @@ const DEFAULT_CANNED_RESPONSES = [
 
 // ── getOfficeHoursStatus ────────────────────────────────────────────
 
+/**
+ * Determines whether the support team is currently online based on
+ * configurable office hours (EST). Checks the ChatConfig CMS collection
+ * for custom schedules, falling back to hardcoded defaults. The frontend
+ * uses this to toggle between live chat and the offline message form.
+ *
+ * Queries CMS: ChatConfig
+ *
+ * @returns {Promise<{isOnline: boolean, message: string, nextOpen?: string|null, closesAt?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getOfficeHoursStatus = webMethod(
   Permissions.Anyone,
   async () => {
@@ -170,6 +181,17 @@ export const getOfficeHoursStatus = webMethod(
 
 // ── getCannedResponses ──────────────────────────────────────────────
 
+/**
+ * Returns the list of canned (pre-written) responses available to the
+ * chat widget. Attempts to load custom responses from ChatConfig CMS;
+ * falls back to built-in defaults covering shipping, returns, assembly,
+ * fabrics, store hours, and warranty.
+ *
+ * Queries CMS: ChatConfig
+ *
+ * @returns {Promise<{success: boolean, responses: Array<{id: string, category: string, trigger: string, title: string, response: string}>}>}
+ * @permission Permissions.Anyone
+ */
 export const getCannedResponses = webMethod(
   Permissions.Anyone,
   async () => {
@@ -202,6 +224,16 @@ export const getCannedResponses = webMethod(
 
 // ── matchCannedResponse ─────────────────────────────────────────────
 
+/**
+ * Attempts to match a customer's chat message to a canned response by
+ * scanning for trigger keywords (e.g. "shipping", "return", "warranty").
+ * Also detects common pricing questions. Used for instant auto-replies
+ * before a human agent picks up the conversation.
+ *
+ * @param {string} userMessage - The customer's chat input text.
+ * @returns {Promise<{matched: boolean, response?: {id: string, category: string, title: string, response: string}}>}
+ * @permission Permissions.Anyone
+ */
 export const matchCannedResponse = webMethod(
   Permissions.Anyone,
   async (userMessage) => {
@@ -245,6 +277,21 @@ export const matchCannedResponse = webMethod(
 
 // ── createSupportTicket ─────────────────────────────────────────────
 
+/**
+ * Creates a support ticket from an after-hours chat message or contact
+ * form submission. Stored in the SupportTickets CMS collection for
+ * staff follow-up during business hours.
+ *
+ * Writes CMS: SupportTickets
+ *
+ * @param {Object} [ticketData={}]
+ * @param {string} [ticketData.name]    - Customer name (defaults to "Anonymous").
+ * @param {string} [ticketData.email]   - Customer email (validated if provided).
+ * @param {string}  ticketData.message  - The support message (required, max 5000 chars).
+ * @param {string} [ticketData.page]    - URL path where the chat was initiated.
+ * @returns {Promise<{success: boolean, ticketId?: string, message?: string, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const createSupportTicket = webMethod(
   Permissions.Anyone,
   async (ticketData = {}) => {
@@ -292,8 +339,20 @@ export const createSupportTicket = webMethod(
 );
 
 // ── getChatContext ───────────────────────────────────────────────────
-// Pre-populate chat with customer info from session
 
+/**
+ * Pre-populates the chat widget with the logged-in member's name, email,
+ * and up to 3 recent orders so support agents have immediate context.
+ * Uses the caller's authenticated session — never accepts arbitrary
+ * member IDs — to prevent information disclosure.
+ *
+ * Queries CMS: Members/PrivateMembersData, Stores/Orders
+ *
+ * @param {Object} [sessionInfo={}]
+ * @param {string} [sessionInfo.currentPage] - The page path the customer is viewing.
+ * @returns {Promise<{success: boolean, context: {page: string, userName: string, userEmail: string, isLoggedIn: boolean, recentOrders: Array<{number: string, date: Date, status: string}>}}>}
+ * @permission Permissions.SiteMember
+ */
 export const getChatContext = webMethod(
   Permissions.SiteMember,
   async (sessionInfo = {}) => {

--- a/src/backend/mediaGallery.web.js
+++ b/src/backend/mediaGallery.web.js
@@ -109,6 +109,23 @@ function buildStaticUrl(fileName, options = {}) {
 
 // ── getProductMedia (public) ────────────────────────────────────────
 
+/**
+ * Retrieves all media items for a single product. First checks the
+ * MediaSync cache (populated by syncProductMedia); if no cache exists,
+ * falls back to reading mediaItems directly from Stores/Products.
+ * Returns permanent static wixstatic.com URLs with optional resize params.
+ *
+ * Queries CMS: MediaSync, Stores/Products
+ *
+ * @param {string} productId - Wix Stores product ID.
+ * @param {Object} [options={}]
+ * @param {number} [options.width]   - Desired image width in pixels.
+ * @param {number} [options.height]  - Desired image height in pixels.
+ * @param {number} [options.quality] - JPEG quality (1-100).
+ * @param {number} [options.limit=20] - Max media items to return (capped at 50).
+ * @returns {Promise<{success: boolean, productId?: string, mediaCount?: number, items?: Array<Object>, lastSynced?: Date|null, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getProductMedia = webMethod(
   Permissions.Anyone,
   async (productId, options = {}) => {
@@ -191,6 +208,21 @@ export const getProductMedia = webMethod(
 
 // ── getBatchProductThumbnails (public, for category pages) ──────────
 
+/**
+ * Batch-fetches the primary thumbnail for up to 50 products at once.
+ * Used on category pages to populate product card images without N+1
+ * queries. Returns static URLs with configurable dimensions.
+ *
+ * Queries CMS: Stores/Products
+ *
+ * @param {string[]} [productIds=[]] - Array of product IDs (max 50).
+ * @param {Object}  [options={}]
+ * @param {number}  [options.width=400]   - Thumbnail width in pixels.
+ * @param {number}  [options.height=400]  - Thumbnail height in pixels.
+ * @param {number}  [options.quality=85]  - JPEG quality.
+ * @returns {Promise<{success: boolean, thumbnails?: Object.<string, {src: string, staticUrl: string, thumbnailUrl: string, altText: string}>, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getBatchProductThumbnails = webMethod(
   Permissions.Anyone,
   async (productIds = [], options = {}) => {
@@ -241,6 +273,17 @@ export const getBatchProductThumbnails = webMethod(
 
 // ── listMediaFolder (admin) ─────────────────────────────────────────
 
+/**
+ * Lists files inside a specific Wix Media Manager folder. Used by the
+ * admin media browser to view product photos organized by category
+ * (e.g. "/products/futon-frames").
+ *
+ * @param {string} folderPath - Media Manager folder path or ID.
+ * @param {Object} [options={}]
+ * @param {number} [options.limit=50] - Max files to return (capped at 100).
+ * @returns {Promise<{success: boolean, folder?: string, files?: Array<Object>, totalCount?: number, error?: string}>}
+ * @permission Permissions.Admin
+ */
 export const listMediaFolder = webMethod(
   Permissions.Admin,
   async (folderPath, options = {}) => {
@@ -290,6 +333,13 @@ export const listMediaFolder = webMethod(
 
 // ── listMediaFolders (admin) ────────────────────────────────────────
 
+/**
+ * Lists all top-level folders in the Wix Media Manager. Provides the
+ * folder tree for the admin media browser navigation sidebar.
+ *
+ * @returns {Promise<{success: boolean, folders?: Array<{folderId: string, folderName: string, parentFolderId: string}>, error?: string}>}
+ * @permission Permissions.Admin
+ */
 export const listMediaFolders = webMethod(
   Permissions.Admin,
   async () => {
@@ -313,6 +363,18 @@ export const listMediaFolders = webMethod(
 
 // ── syncProductMedia (admin — pulls from Media Manager to cache) ────
 
+/**
+ * Snapshots a single product's media items from Stores/Products into
+ * the MediaSync CMS collection. This cache avoids repeated product
+ * queries and stores pre-extracted file names for fast static URL
+ * generation.
+ *
+ * Queries/Writes CMS: Stores/Products, MediaSync
+ *
+ * @param {string} productId - Wix Stores product ID to sync.
+ * @returns {Promise<{success: boolean, productId?: string, mediaCount?: number, lastSynced?: Date, error?: string}>}
+ * @permission Permissions.Admin
+ */
 export const syncProductMedia = webMethod(
   Permissions.Admin,
   async (productId) => {
@@ -383,6 +445,18 @@ export const syncProductMedia = webMethod(
 
 // ── batchSyncMedia (admin — sync all products) ─────────────────────
 
+/**
+ * Syncs media for multiple products in one call. Iterates through
+ * Stores/Products and upserts each product's media into MediaSync.
+ * Intended for periodic bulk cache refresh.
+ *
+ * Queries/Writes CMS: Stores/Products, MediaSync
+ *
+ * @param {Object} [options={}]
+ * @param {number} [options.limit=50] - Max products to sync (capped at 200).
+ * @returns {Promise<{success: boolean, synced?: number, totalProducts?: number, error?: string}>}
+ * @permission Permissions.Admin
+ */
 export const batchSyncMedia = webMethod(
   Permissions.Admin,
   async (options = {}) => {
@@ -445,6 +519,19 @@ export const batchSyncMedia = webMethod(
 
 // ── getImageUrl (public utility) ────────────────────────────────────
 
+/**
+ * Converts a Wix internal image URL (wix:image://v1/...) to a permanent
+ * static wixstatic.com URL with optional resize transforms. Useful when
+ * the frontend has a raw Wix image reference and needs a displayable src.
+ *
+ * @param {string} wixImageUrl - A wix:image:// or wixstatic.com URL.
+ * @param {Object} [options={}]
+ * @param {number} [options.width]   - Desired width in pixels.
+ * @param {number} [options.height]  - Desired height in pixels.
+ * @param {number} [options.quality] - JPEG quality (1-100).
+ * @returns {Promise<{success: boolean, fileName?: string, staticUrl?: string, thumbnailUrl?: string, originalUrl?: string, error?: string}>}
+ * @permission Permissions.Anyone
+ */
 export const getImageUrl = webMethod(
   Permissions.Anyone,
   async (wixImageUrl, options = {}) => {

--- a/src/backend/shipping-rates-plugin.js
+++ b/src/backend/shipping-rates-plugin.js
@@ -1,12 +1,26 @@
-// Wix eCommerce Shipping Rates Service Plugin
-// This file hooks into Wix's checkout flow to display real-time UPS rates
-//
-// File location: must be registered as a shipping rates plugin in Wix
-// See: https://dev.wix.com/docs/develop-websites/articles/code-tutorials/
-//      wix-e-commerce-stores/e-commerce-shipping-rates-service-plugin
-//
-// IMPORTANT: The function name must be exactly "getShippingRates" and
-// must be exported. Wix calls this automatically during checkout.
+/**
+ * @module shipping-rates-plugin
+ * @description Wix eCommerce Shipping Rates SPI (Service Provider Interface).
+ * Hooks into the Wix checkout flow to return real-time UPS rates, local
+ * pickup/delivery options, white-glove delivery, and international shipping.
+ * Wix calls `getShippingRates` automatically during checkout — the function
+ * name and export are mandatory per the SPI contract.
+ *
+ * Key responsibilities:
+ * - Resolve package dimensions from product category via ups-shipping.web
+ * - Route international destinations to internationalShipping.web
+ * - Offer in-store pickup for Hendersonville-area ZIP prefixes
+ * - Offer local delivery + white-glove for NC/SC/GA/TN ZIP prefixes
+ * - Fall back to flat estimated rates when UPS API is unavailable
+ *
+ * No CMS collections — reads shipping config from sharedTokens.js.
+ *
+ * @requires backend/ups-shipping.web     - Live UPS rate lookup
+ * @requires backend/internationalShipping.web - Non-US rate lookup
+ * @requires public/sharedTokens.js       - Business address, shipping zones, thresholds
+ *
+ * @see https://dev.wix.com/docs/develop-websites/articles/code-tutorials/wix-e-commerce-stores/e-commerce-shipping-rates-service-plugin
+ */
 
 import { getUPSRates, getPackageDimensions } from 'backend/ups-shipping.web';
 import { getInternationalShippingRates } from 'backend/internationalShipping.web';
@@ -15,6 +29,20 @@ import { business, shippingConfig, internationalShippingConfig } from 'public/sh
 const { freeThreshold: FREE_SHIPPING_THRESHOLD, whiteGlove, zones } = shippingConfig;
 const { freeThreshold: WHITE_GLOVE_FREE_THRESHOLD, localPrice: WHITE_GLOVE_LOCAL_PRICE, regionalPrice: WHITE_GLOVE_REGIONAL_PRICE } = whiteGlove;
 
+/**
+ * Calculate available shipping rates for the current checkout.
+ * Wix calls this automatically — the function name is mandated by the SPI.
+ *
+ * Flow: build destination → size packages by category → check international →
+ * fetch UPS rates → append local pickup / delivery / white-glove options.
+ *
+ * @param {Object} options - Wix-provided checkout context
+ * @param {Array}  options.lineItems - Cart line items with name, sku, price, quantity, physicalProperties
+ * @param {Object} options.shippingDestination - Buyer address with contactDetails + address fields
+ * @param {Object} options.shippingOrigin - Store origin address (not used; we hardcode from sharedTokens)
+ * @returns {Promise<{shippingRates: Array<{code: string, title: string, logistics: Object, cost: Object}>}>}
+ *   Wix-formatted shipping rates array. Returns flat fallback rates on error.
+ */
 export const getShippingRates = async (options) => {
   const { lineItems, shippingDestination, shippingOrigin } = options;
 
@@ -199,7 +227,14 @@ export const getShippingRates = async (options) => {
   }
 };
 
-// Detect product category from line item data for package sizing
+/**
+ * Detect product category from line item data for package sizing.
+ * Uses name/SKU (Stock Keeping Unit) keyword matching because Wix checkout
+ * line items don't carry a structured category field.
+ *
+ * @param {Object} item - Wix line item with name and sku fields
+ * @returns {string} Category key matching PACKAGE_DEFAULTS in ups-shipping.web
+ */
 function detectCategory(item) {
   const name = (item.name || '').toLowerCase();
   const sku = (item.sku || '').toLowerCase();

--- a/src/backend/ups-shipping.web.js
+++ b/src/backend/ups-shipping.web.js
@@ -1,14 +1,32 @@
-// UPS Shipping Integration - Backend Web Module
-// Handles OAuth 2.0 auth, rate calculation, label generation, and tracking
-// Uses UPS REST API (OAuth 2.0 client credentials flow)
-//
-// SETUP REQUIRED:
-// 1. Create app at https://developer.ups.com/ → get Client ID + Client Secret
-// 2. In Wix Dashboard → Secrets Manager, add:
-//    - "UPS_CLIENT_ID" → your Client ID
-//    - "UPS_CLIENT_SECRET" → your Client Secret
-//    - "UPS_ACCOUNT_NUMBER" → your UPS account number
-// 3. For testing, set UPS_SANDBOX=true in secrets; remove for production
+/**
+ * @module ups-shipping
+ * @description UPS REST API integration for shipping rates, label generation,
+ * package tracking, and address validation. Authenticates via OAuth 2.0
+ * client-credentials flow with token caching.
+ *
+ * Key responsibilities:
+ * - Fetch live multi-service shipping rates (Shop endpoint)
+ * - Create shipments and generate PDF shipping labels (forward + return)
+ * - Track packages by tracking number
+ * - Validate destination addresses before shipment creation
+ * - Provide fallback estimated rates when UPS API is unavailable
+ * - Map product categories to default package dimensions for furniture
+ *
+ * No CMS collections — secrets stored in Wix Secrets Manager.
+ *
+ * @requires wix-secrets-backend - UPS_CLIENT_ID, UPS_CLIENT_SECRET, UPS_ACCOUNT_NUMBER
+ * @requires wix-fetch           - HTTP calls to UPS REST API
+ * @requires public/sharedTokens.js - Brand name, business address, shipping config
+ * @requires backend/utils/sanitize - Input sanitization for address fields
+ *
+ * SETUP REQUIRED:
+ * 1. Create app at https://developer.ups.com/ → get Client ID + Client Secret
+ * 2. In Wix Dashboard → Secrets Manager, add:
+ *    - "UPS_CLIENT_ID" → your Client ID
+ *    - "UPS_CLIENT_SECRET" → your Client Secret
+ *    - "UPS_ACCOUNT_NUMBER" → your UPS account number
+ * 3. For testing, set UPS_SANDBOX=true in secrets; remove for production
+ */
 
 import { Permissions, webMethod } from 'wix-web-module';
 import { getSecret } from 'wix-secrets-backend';
@@ -58,6 +76,13 @@ const FREE_SHIPPING_THRESHOLD = shippingConfig.freeThreshold;
 let cachedToken = null;
 let tokenExpiry = 0;
 
+/**
+ * Obtain a UPS OAuth 2.0 access token, returning a cached token when possible.
+ * Tokens are refreshed 5 minutes before expiry to avoid mid-request failures.
+ *
+ * @returns {Promise<string>} Bearer access token
+ * @throws {Error} If UPS OAuth endpoint rejects credentials
+ */
 async function getUPSToken() {
   // Return cached token if still valid (with 5-minute buffer)
   if (cachedToken && Date.now() < tokenExpiry - 300000) {
@@ -103,6 +128,10 @@ async function getUPSToken() {
   return cachedToken;
 }
 
+/**
+ * Resolve the UPS API base URL (sandbox vs production) from Wix Secrets.
+ * @returns {Promise<string>} Base URL for UPS REST endpoints
+ */
 async function getBaseUrl() {
   let sandbox = false;
   try {
@@ -115,8 +144,27 @@ async function getBaseUrl() {
 
 // ── Rate Calculation ────────────────────────────────────────────────
 
-// Get shipping rates for a destination address and package details
-// Called by the Wix Shipping Rates plugin and also directly from cart
+/**
+ * Fetch live UPS shipping rates for a destination and set of packages.
+ * Called by the shipping-rates-plugin SPI during checkout and by the cart
+ * page for rate estimates. Returns free-ground when order exceeds the
+ * free-shipping threshold.
+ *
+ * Permission: Anyone — rate quotes must work for anonymous shoppers.
+ *
+ * @param {Object} destinationAddress - Recipient address
+ * @param {string} destinationAddress.name - Recipient name
+ * @param {string} destinationAddress.addressLine1 - Street address
+ * @param {string} destinationAddress.city - City
+ * @param {string} destinationAddress.state - State/province code
+ * @param {string} destinationAddress.postalCode - ZIP/postal code
+ * @param {string} destinationAddress.country - ISO country code (default 'US')
+ * @param {Array<{length: number, width: number, height: number, weight: number, description: string}>} packages
+ *   Package dimensions in inches/lbs. Capped at 20 to prevent API amplification.
+ * @param {number} [orderSubtotal=0] - Cart subtotal for free-shipping eligibility
+ * @returns {Promise<Array<{code: string, title: string, cost: number, estimatedDelivery: string, currency: string}>>}
+ *   Sorted by cost ascending. Falls back to estimated flat rates on API error.
+ */
 export const getUPSRates = webMethod(
   Permissions.Anyone,
   async (destinationAddress, packages, orderSubtotal = 0) => {
@@ -246,7 +294,14 @@ export const getUPSRates = webMethod(
   }
 );
 
-// Fallback rates when API is unavailable
+/**
+ * Generate estimated flat-rate shipping prices when the UPS API is down.
+ * Uses 3-digit ZIP prefix to apply regional pricing tiers so customers
+ * still get a reasonable estimate during outages.
+ *
+ * @param {string|undefined} postalCode - Destination ZIP code
+ * @returns {Array<{code: string, title: string, cost: number, estimatedDelivery: string, isEstimate: boolean}>}
+ */
 function getFallbackRates(postalCode) {
   const prefix = postalCode ? parseInt(postalCode.substring(0, 3)) : 0;
   let groundRate = 49.99;
@@ -265,8 +320,28 @@ function getFallbackRates(postalCode) {
 
 // ── Shipment Creation & Label Generation ────────────────────────────
 
-// Create a shipment and generate a shipping label
-// Called from the order fulfillment dashboard
+/**
+ * Create a UPS shipment and generate a PDF shipping label.
+ * Supports both outbound and return (RMA) labels — when `orderData.returnLabel`
+ * is true, ShipTo/ShipFrom are swapped so the label routes back to Carolina Futons.
+ *
+ * Permission: Admin — only staff should generate labels and incur shipping charges.
+ *
+ * @param {Object} orderData - Shipment details
+ * @param {string} orderData.orderId - Wix order number (used in UPS transaction reference)
+ * @param {string} orderData.recipientName - Full name of the recipient
+ * @param {string} [orderData.recipientPhone] - Recipient phone number
+ * @param {string} orderData.addressLine1 - Street address line 1
+ * @param {string} [orderData.addressLine2] - Street address line 2
+ * @param {string} orderData.city - City
+ * @param {string} orderData.state - State/province code
+ * @param {string} orderData.postalCode - ZIP/postal code
+ * @param {string} [orderData.country='US'] - ISO country code
+ * @param {string} [orderData.serviceCode='03'] - UPS service code (default Ground)
+ * @param {boolean} [orderData.returnLabel=false] - If true, generate a return label
+ * @param {Array<{length: number, width: number, height: number, weight: number, description: string}>} orderData.packages
+ * @returns {Promise<{success: boolean, trackingNumber?: string, labels?: Array, totalCharge?: number, currency?: string, error?: string}>}
+ */
 export const createShipment = webMethod(
   Permissions.Admin,
   async (orderData) => {
@@ -433,7 +508,15 @@ export const createShipment = webMethod(
 
 // ── Shipment Tracking ───────────────────────────────────────────────
 
-// Track a package by tracking number
+/**
+ * Look up real-time tracking status and activity history for a UPS package.
+ * Sanitizes the tracking number to alphanumeric only (UPS format: 1Z + digits).
+ *
+ * Permission: Anyone — customers need to track their own packages.
+ *
+ * @param {string} trackingNumber - UPS tracking number (10-35 alphanumeric chars)
+ * @returns {Promise<{success: boolean, trackingNumber?: string, status?: string, statusCode?: string, estimatedDelivery?: string|null, activities?: Array<{status: string, location: string, date: string, time: string}>, error?: string}>}
+ */
 export const trackShipment = webMethod(
   Permissions.Anyone,
   async (trackingNumber) => {
@@ -511,7 +594,22 @@ export const trackShipment = webMethod(
 
 // ── Address Validation ──────────────────────────────────────────────
 
-// Validate a shipping address with UPS before creating shipment
+/**
+ * Validate a shipping address against UPS Address Validation (XAV) API.
+ * Returns whether the address is valid, ambiguous (with candidate suggestions),
+ * or invalid. Gracefully degrades — returns `unavailable: true` if the API is down,
+ * so checkout is never blocked by validation outages.
+ *
+ * Permission: Anyone — used during checkout address entry.
+ *
+ * @param {Object} address - Address to validate
+ * @param {string} address.addressLine1 - Street address
+ * @param {string} address.city - City
+ * @param {string} address.state - State/province code
+ * @param {string} address.postalCode - ZIP/postal code
+ * @param {string} [address.country='US'] - ISO country code
+ * @returns {Promise<{valid: boolean, ambiguous?: boolean, candidates: Array<{addressLine1: string, city: string, state: string, postalCode: string}>, unavailable?: boolean, error?: string}>}
+ */
 export const validateAddress = webMethod(
   Permissions.Anyone,
   async (address) => {
@@ -578,6 +676,16 @@ export const validateAddress = webMethod(
 
 // ── Helper: Get package dimensions from product category ────────────
 
+/**
+ * Look up default package dimensions for a furniture product category.
+ * The shipping-rates-plugin calls this to size packages when Wix line items
+ * lack physical dimension data.
+ *
+ * Permission: Anyone — called indirectly during checkout rate calculation.
+ *
+ * @param {string} category - Category key (e.g. 'futon-frame', 'murphy-bed', 'casegoods')
+ * @returns {{length: number, width: number, height: number, weight: number}} Dimensions in inches, weight in lbs
+ */
 export const getPackageDimensions = webMethod(
   Permissions.Anyone,
   (category) => {

--- a/src/public/AddToCart.js
+++ b/src/public/AddToCart.js
@@ -1,4 +1,13 @@
-// AddToCart.js - Quantity, cart, sticky bar, bundle, stock, wishlist
+/**
+ * @module AddToCart
+ * Product Page add-to-cart orchestration — quantity selector, cart button,
+ * sticky cart bar, bundle upsell, stock urgency badges, back-in-stock
+ * notifications, and wishlist toggling.
+ *
+ * Each exported `init*` function wires up a self-contained UI section and is
+ * called from the Product Page onReady lifecycle. All DOM access is wrapped
+ * in try/catch because elements may not exist on every product template.
+ */
 import { getProductVariants, addToCart, onCartChanged, clampQuantity, MIN_QUANTITY, MAX_QUANTITY } from 'public/cartService';
 import { getBundleSuggestion } from 'backend/productRecommendations.web';
 import { trackCartAdd } from 'public/engagementTracker';
@@ -7,8 +16,16 @@ import { formatCurrency, HEART_FILLED_SVG, HEART_OUTLINE_SVG } from 'public/prod
 import wixWindowFrontend from 'wix-window-frontend';
 import { validateEmail } from 'public/validators.js';
 
-// ── Quantity Selector ─────────────────────────────────────────────────
+// --- Quantity Selector ---
 
+/**
+ * Wire up the +/- quantity input so users can pick how many units to add.
+ * Clamps value between MIN_QUANTITY and MAX_QUANTITY from cartService.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {number} state.selectedQuantity - Mutated in-place as the user changes quantity
+ * @returns {void}
+ */
 export function initQuantitySelector($w, state) {
   try {
     const input = $w('#quantityInput');
@@ -31,8 +48,18 @@ export function initQuantitySelector($w, state) {
   } catch (e) {}
 }
 
-// ── Add to Cart Button ────────────────────────────────────────────────
+// --- Add to Cart Button ---
 
+/**
+ * Enhance the Add to Cart button with loading/success/error states,
+ * analytics tracking (GA4 + engagement), and a brief success toast.
+ * Also listens for cart changes to show a confirmation banner.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @param {number} state.selectedQuantity - Quantity chosen by user
+ * @returns {void}
+ */
 export function initAddToCartEnhancements($w, state) {
   try {
     const btn = $w('#addToCartButton');
@@ -60,12 +87,30 @@ export function initAddToCartEnhancements($w, state) {
   } catch (e) {}
 }
 
-// ── Sticky Cart Bar ───────────────────────────────────────────────────
+// --- Sticky Cart Bar ---
 
+/**
+ * Update the sticky bar's price label when a variant changes.
+ * Called from ProductOptions when the user picks a new size/finish.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} variant - Selected variant object from cartService
+ * @param {number} [variant.price] - Numeric price to format and display
+ * @returns {void}
+ */
 export function updateStickyPrice($w, variant) {
   try { if (variant?.price) $w('#stickyPrice').text = formatCurrency(variant.price); } catch (e) {}
 }
 
+/**
+ * Initialize the sticky cart bar that slides up from the bottom once the
+ * main Add to Cart button scrolls out of view. Mirrors the primary
+ * add-to-cart action so users always have a visible purchase CTA.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @param {number} state.selectedQuantity - Quantity chosen by user
+ * @returns {void}
+ */
 export function initStickyCartBar($w, state) {
   try {
     const bar = $w('#stickyCartBar');
@@ -101,8 +146,18 @@ export function initStickyCartBar($w, state) {
   } catch (e) {}
 }
 
-// ── Bundle Section ────────────────────────────────────────────────────
+// --- Bundle Upsell Section ---
 
+/**
+ * Fetch and display a "Complete the Set" bundle suggestion powered by the
+ * productRecommendations backend. Shows bundle image, savings, and an
+ * "Add Both to Cart" button. Collapses the section when no bundle exists.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @param {Object} [state.bundleProduct] - Populated with the suggested bundle product on success
+ * @returns {Promise<void>}
+ */
 export async function initBundleSection($w, state) {
   try {
     if (!state.product) return;
@@ -142,8 +197,18 @@ export async function initBundleSection($w, state) {
   } catch (err) { console.error('Error loading bundle section:', err); }
 }
 
-// ── Stock Urgency ─────────────────────────────────────────────────────
+// --- Stock Urgency & Popularity ---
 
+/**
+ * Show a low-stock urgency message when fewer than 5 units remain and a
+ * popularity badge when the product has recent sales. Adds a pulse
+ * animation at critically low inventory (2 or fewer) to drive urgency.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @param {number} [state.product.quantityInStock] - Current inventory count
+ * @returns {Promise<void>}
+ */
 export async function initStockUrgency($w, state) {
   try {
     if (!state.product) return;
@@ -171,8 +236,17 @@ export async function initStockUrgency($w, state) {
   } catch (e) {}
 }
 
-// ── Back-in-Stock Notification ────────────────────────────────────────
+// --- Back-in-Stock Notification ---
 
+/**
+ * Show an email signup form when the selected variant is out of stock.
+ * Logged-in members with the product in their wishlist see an auto-enrolled
+ * message instead. Submits to contactSubmissions backend for CRM capture.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {Promise<void>}
+ */
 export async function initBackInStockNotification($w, state) {
   try {
     const section = $w('#backInStockSection');
@@ -218,6 +292,15 @@ export async function initBackInStockNotification($w, state) {
   } catch (e) {}
 }
 
+/**
+ * Check whether the currently selected variant is out of stock and
+ * expand/collapse the back-in-stock section accordingly.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} section - The #backInStockSection Wix element
+ * @returns {Promise<void>}
+ * @private
+ */
 async function checkBackInStock($w, state, section) {
   try {
     const size = $w('#sizeDropdown')?.value;
@@ -236,8 +319,18 @@ async function checkBackInStock($w, state, section) {
   } catch (e) {}
 }
 
-// ── Wishlist ──────────────────────────────────────────────────────────
+// --- Wishlist ---
 
+/**
+ * Initialize the wishlist heart toggle. Checks if the current member already
+ * has this product wishlisted (fills the heart). On click, toggles the
+ * wishlist entry in the Wishlist collection and fires GA4 tracking.
+ * Prompts login for anonymous visitors.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {Promise<void>}
+ */
 export async function initWishlistButton($w, state) {
   try {
     const btn = $w('#wishlistBtn');
@@ -278,6 +371,13 @@ export async function initWishlistButton($w, state) {
   } catch (e) { console.error('[AddToCart] Wishlist operation failed:', e.message); try { $w('#wishlistBtn').hide(); } catch (e2) {} }
 }
 
+/**
+ * Swap the wishlist icon between filled/outline and update ARIA label.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {boolean} active - Whether the product is currently wishlisted
+ * @returns {void}
+ * @private
+ */
 function setWishlistActive($w, active) {
   try {
     const icon = $w('#wishlistIcon');

--- a/src/public/ProductDetails.js
+++ b/src/public/ProductDetails.js
@@ -1,4 +1,12 @@
-// ProductDetails.js - Breadcrumbs, info accordion, social share, delivery, SEO, swatch request
+/**
+ * @module ProductDetails
+ * Supplementary Product Page sections — breadcrumbs, info accordion,
+ * social sharing, delivery estimate with zip-code lookup, structured-data
+ * SEO injection, and the free swatch request flow.
+ *
+ * Each exported `init*` function wires up a self-contained section and is
+ * called from the Product Page onReady lifecycle.
+ */
 import { getProductSchema, getBreadcrumbSchema, getProductOgTags, getProductFaqSchema } from 'backend/seoHelpers.web';
 import { submitSwatchRequest } from 'backend/emailService.web';
 import { getCategoryFromCollections, addBusinessDays } from 'public/productPageUtils.js';
@@ -7,8 +15,16 @@ import { makeClickable } from 'public/a11yHelpers';
 import { colors } from 'public/designTokens.js';
 import { validateEmail } from 'public/validators.js';
 
-// ── Breadcrumbs ───────────────────────────────────────────────────────
+// --- Breadcrumbs ---
 
+/**
+ * Build a three-level breadcrumb trail (Home > Category > Product) with
+ * clickable navigation and inject BreadcrumbList structured data for SEO.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {Promise<void>}
+ */
 export async function initBreadcrumbs($w, state) {
   try {
     if (!state.product) return;
@@ -29,8 +45,15 @@ export async function initBreadcrumbs($w, state) {
   } catch (e) {}
 }
 
-// ── Product Info Accordion ────────────────────────────────────────────
+// --- Product Info Accordion ---
 
+/**
+ * Set up collapsible Description / Dimensions / Care / Shipping sections.
+ * Description starts expanded; others start collapsed. Supports both click
+ * and keyboard (Enter/Space) toggling for accessibility.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @returns {void}
+ */
 export function initProductInfoAccordion($w) {
   try {
     const sections = ['Description', 'Dimensions', 'Care', 'Shipping'];
@@ -79,8 +102,16 @@ export function initProductInfoAccordion($w) {
   } catch (e) {}
 }
 
-// ── Social Share ──────────────────────────────────────────────────────
+// --- Social Sharing ---
 
+/**
+ * Wire up Facebook, Pinterest, email, and copy-link share buttons.
+ * Each click fires engagement tracking before opening the share target.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {void}
+ */
 export function initSocialShare($w, state) {
   try {
     if (!state.product) return;
@@ -121,8 +152,16 @@ export function initSocialShare($w, state) {
   } catch (e) {}
 }
 
-// ── Delivery Estimate ─────────────────────────────────────────────────
+// --- Delivery Estimate ---
 
+/**
+ * Show a default 5-10 business day delivery estimate and wire up the
+ * zip-code input for zone-specific estimates (local WNC / Southeast / national).
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {void}
+ */
 export function initDeliveryEstimate($w, state) {
   try {
     const el = $w('#deliveryEstimate');
@@ -207,8 +246,16 @@ function updateEstimateForZip($w, state, rawZip) {
   } catch (e) {}
 }
 
-// ── SEO Schema Injection ──────────────────────────────────────────────
+// --- SEO Schema Injection ---
 
+/**
+ * Inject Product, FAQ, and OpenGraph structured data into hidden
+ * HtmlComponent elements so search engines can index rich snippets.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {Promise<void>}
+ */
 export async function injectProductSchema($w, state) {
   try {
     if (!state.product) return;
@@ -221,8 +268,17 @@ export async function injectProductSchema($w, state) {
   } catch (e) {}
 }
 
-// ── Swatch Request Form ───────────────────────────────────────────────
+// --- Swatch Request Form ---
 
+/**
+ * Show the "Request Free Swatches" button for products that have
+ * finish/fabric/color options. Opens a modal where users select swatches
+ * and submit their mailing address via the emailService backend.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {void}
+ */
 export function initSwatchRequest($w, state) {
   try {
     const btn = $w('#swatchRequestBtn');
@@ -296,10 +352,17 @@ async function handleSwatchSubmit($w, state) {
   }
 }
 
-// ── Prominent "Get Free Swatches" CTA ────────────────────────────────
-// Always-visible branded button that opens the swatch request modal.
-// Uses Coral (#E8845C) background per brand palette for high visibility.
+// --- Prominent "Get Free Swatches" CTA ---
 
+/**
+ * Always-visible branded button that opens the swatch request modal.
+ * Uses Coral (#E8845C) background per brand palette for high visibility.
+ * Adapts label text based on whether the product has fabric options.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {void}
+ */
 export function initSwatchCTA($w, state) {
   try {
     const btn = $w('#swatchCTABtn');

--- a/src/public/ProductGallery.js
+++ b/src/public/ProductGallery.js
@@ -1,4 +1,10 @@
-// ProductGallery.js - Image gallery, video, and badge overlay
+/**
+ * @module ProductGallery
+ * Product Page image gallery, video player, and badge overlay.
+ * Handles thumbnail navigation, mobile swipe, keyboard arrow-key
+ * navigation (WCAG 2.1.1), lightbox, zoom, placeholder fallbacks,
+ * and cleanup for SPA navigation.
+ */
 import { generateAltText } from 'backend/seoHelpers.web';
 import { getProductBadge, initImageLightbox, initImageZoom } from 'public/galleryHelpers.js';
 import { getProductFallbackImage, getPlaceholderProductImages } from 'public/placeholderImages.js';
@@ -6,6 +12,16 @@ import { enableSwipe } from 'public/touchHelpers';
 import { trackGalleryInteraction } from 'public/engagementTracker';
 import { announce } from 'public/a11yHelpers.js';
 
+/**
+ * Initialize the main product image gallery with thumbnail clicks, mobile
+ * swipe, keyboard arrow navigation, lightbox, and zoom. Falls back to
+ * category-specific placeholder images when the product has fewer than 3
+ * media items.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {{ destroy: Function }} Cleanup handle — call destroy() on SPA navigation to remove keydown listeners
+ */
 export function initImageGallery($w, state) {
   try {
     const product = state.product;
@@ -121,6 +137,14 @@ export function initImageGallery($w, state) {
   return { destroy() {} };
 }
 
+/**
+ * Show or hide the product badge overlay (e.g., "Sale", "New", "In-Store Only")
+ * based on the product's ribbon, discount, or creation date.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {void}
+ */
 export function initProductBadge($w, state) {
   try {
     const badge = getProductBadge(state.product);
@@ -131,6 +155,15 @@ export function initProductBadge($w, state) {
   } catch (e) {}
 }
 
+/**
+ * If the product has a video media item, expand the video section, load
+ * the player (muted for autoplay compliance), and wire up the "View All
+ * Videos" link. Collapses the section when no video exists.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {void}
+ */
 export function initProductVideo($w, state) {
   try {
     const section = $w('#productVideoSection');
@@ -157,5 +190,9 @@ export function initProductVideo($w, state) {
   }
 }
 
-// No-op stub: Wix gallery handles its own image loading
+/**
+ * No-op stub retained for backward compatibility — Wix gallery handles
+ * its own image loading natively.
+ * @returns {void}
+ */
 export function preloadGalleryThumbnails() {}

--- a/src/public/ProductOptions.js
+++ b/src/public/ProductOptions.js
@@ -1,12 +1,26 @@
-// ProductOptions.js - Variant selector, swatch grid, swatch gallery modal
+/**
+ * @module ProductOptions
+ * Product Page variant selection — size/finish dropdowns that update price,
+ * stock status, and gallery images; an inline swatch grid for fabric
+ * browsing; and a full-screen swatch gallery modal with search and detail view.
+ */
 import { getProductVariants } from 'public/cartService';
 import { getProductSwatches, getSwatchCount, getAllSwatchFamilies } from 'backend/swatchService.web';
 import { colors } from 'public/designTokens.js';
 import { formatCurrency } from 'public/productPageUtils.js';
 import { updateStickyPrice } from 'public/AddToCart.js';
 
-// ── Variant Selector ──────────────────────────────────────────────────
+// --- Variant Selector ---
 
+/**
+ * Attach onChange handlers to the size and finish dropdowns so variant
+ * changes cascade to price, stock badge, gallery, and sticky bar.
+ * Also listens to the product dataset for external updates.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object (mutated on dataset change)
+ * @returns {void}
+ */
 export function initVariantSelector($w, state) {
   try {
     const size = $w('#sizeDropdown');
@@ -22,6 +36,14 @@ export function initVariantSelector($w, state) {
   } catch (e) {}
 }
 
+/**
+ * Read current size/finish dropdown values, fetch matching variants from
+ * cartService, and update the display (price, stock, image, sticky bar).
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @returns {Promise<void>}
+ */
 export async function handleCustomVariantChange($w, state) {
   try {
     const size = $w('#sizeDropdown').value;
@@ -78,8 +100,18 @@ function updateVariantDisplay($w, state, selected) {
   } catch (e) {}
 }
 
-// ── Swatch Selector (Inline Grid) ────────────────────────────────────
+// --- Swatch Selector (Inline Grid) ---
 
+/**
+ * Fetch available fabric swatches for this product and render an inline
+ * swatch grid with color-family filtering. Provides a "View All" button
+ * that opens the full swatch gallery modal.
+ * @param {Function} $w - Wix Velo selector function for querying page elements
+ * @param {Object} state - Shared product page state
+ * @param {Object} state.product - Current Wix Stores product object
+ * @param {string} [state.selectedSwatchId] - ID of the currently selected swatch (mutated on selection)
+ * @returns {Promise<void>}
+ */
 export async function initSwatchSelector($w, state) {
   try {
     const section = $w('#swatchSection');

--- a/src/public/sharedTokens.js
+++ b/src/public/sharedTokens.js
@@ -1,94 +1,225 @@
-// Carolina Futons — Shared Design Tokens (Platform-Agnostic)
-// These tokens are the single source of truth for brand identity across web and mobile.
-// Web: imported by designTokens.js (adds web-specific config)
-// Mobile: consumed via design-tokens.json (generated from this file)
-//
-// Reference: Blue Ridge Mountain Illustrative aesthetic
+/**
+ * @module sharedTokens
+ * @description Platform-agnostic brand design tokens for Carolina Futons.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for brand identity across all platforms.
+ * Every color, spacing value, shadow, and business constant originates here.
+ *
+ * Consumers:
+ *  - Web: imported by `designTokens.js` which adds web-specific config (CSS strings, SEO, grid)
+ *  - Mobile: consumed via `design-tokens.json` (generated from this file by the build pipeline)
+ *
+ * Aesthetic reference: Blue Ridge Mountain Illustrative style — warm, rustic,
+ * hand-illustrated cabin feel. See `design.jpeg` for the visual north star.
+ *
+ * IMPORTANT: Never hardcode color hex values in consuming code. Always import
+ * from this module (or from designTokens.js for web) to keep the brand
+ * consistent and updatable from one place.
+ */
 
+/**
+ * Brand identity metadata used in structured data, emails, and app manifests.
+ * @type {{ name: string, shortName: string, foundedYear: number }}
+ */
 export const brand = {
   name: 'Carolina Futons',
+  /** Abbreviated name for mobile home screens and tight UI spaces */
   shortName: 'CF Futons',
+  /** Year the business was founded — used in "Since 1991" taglines */
   foundedYear: 1991,
 };
 
+/**
+ * Brand color palette derived from the Blue Ridge Mountain aesthetic.
+ *
+ * Organized into three groups:
+ *  - **Primary** — the core brand colors used for backgrounds, text, accents, and CTAs
+ *  - **Decorative** — gradient endpoints and overlays for mountain skyline illustrations
+ *  - **Semantic** — status feedback colors (success, error) and muted/disabled tones
+ *
+ * Each primary color has light/dark variants for hover states and contrast needs.
+ * CTA buttons MUST use `sunsetCoral` — never green or blue.
+ *
+ * @type {Object<string, string>}
+ */
 export const colors = {
-  // Primary palette
+  // ── Primary palette ────────────────────────────────────────────
+  /** Warm sand — primary background, evokes natural wood tones */
   sandBase: '#E8D5B7',
+  /** Lighter sand — secondary backgrounds, card fills, alternating rows */
   sandLight: '#F2E8D5',
+  /** Darker sand — hover state for sand backgrounds, subtle borders */
   sandDark: '#D4BC96',
+  /** Deep espresso brown — primary text color, headings, high-contrast elements */
   espresso: '#3A2518',
+  /** Lighter espresso — secondary text, placeholder text, subtle UI elements */
   espressoLight: '#5C4033',
+  /** Mountain blue — links, secondary buttons, informational accents */
   mountainBlue: '#5B8FA8',
+  /** Darker mountain blue — hover state for blue interactive elements */
   mountainBlueDark: '#3D6B80',
+  /** Light mountain blue — tinted backgrounds, tag fills, info banners */
   mountainBlueLight: '#A8CCD8',
+  /** Sunset coral — ALL call-to-action buttons and primary interactive elements */
   sunsetCoral: '#E8845C',
+  /** Darker coral — hover/active state for CTA buttons */
   sunsetCoralDark: '#C96B44',
+  /** Light coral — sale badges, subtle accent backgrounds */
   sunsetCoralLight: '#F2A882',
+  /** Off-white — page background, provides warmth vs pure white */
   offWhite: '#FAF7F2',
+  /** Pure white — card backgrounds, modal surfaces */
   white: '#FFFFFF',
 
-  // Decorative
+  // ── Decorative ─────────────────────────────────────────────────
+  /** Top of mountain skyline gradient — cool morning sky blue */
   skyGradientTop: '#B8D4E3',
+  /** Bottom of mountain skyline gradient — warm golden horizon */
   skyGradientBottom: '#F0C87A',
+  /** Semi-transparent espresso overlay for hero images and modals */
   overlay: 'rgba(58, 37, 24, 0.6)',
 
-  // Semantic / status
+  // ── Semantic / status ──────────────────────────────────────────
+  /** Success feedback — order confirmations, in-stock indicators */
   success: '#4A7C59',
+  /** Error feedback — validation errors, out-of-stock, destructive actions */
   error: '#C0392B',
+  /** Muted gray — disabled controls, secondary metadata (meets WCAG AA on white) */
   muted: '#767676',
+  /** Muted brown — blends better than gray on warm sand backgrounds */
   mutedBrown: '#816D51',
 };
 
+/**
+ * Font family stacks for the two-typeface system.
+ *
+ * Playfair Display (headings) provides the elegant, editorial character.
+ * Source Sans 3 (body) ensures readability at small sizes.
+ * Fallbacks are chosen to match x-height and weight of the primary fonts
+ * so layout shift is minimal while web fonts load.
+ *
+ * @type {{ heading: string, body: string }}
+ */
 export const fontFamilies = {
+  /** Playfair Display — serif display face for h1-h4, hero text, prices */
   heading: '"Playfair Display", Georgia, serif',
+  /** Source Sans 3 — clean sans-serif for body copy, nav, buttons, form labels */
   body: '"Source Sans 3", "Helvetica Neue", Arial, sans-serif',
 };
 
+/**
+ * Spacing scale based on a 4px base unit.
+ *
+ * All values are raw numbers (pixels) so they work on both web (append "px")
+ * and mobile (use as density-independent pixels). The web layer in
+ * designTokens.js converts these to CSS strings via `spacingPx()`.
+ *
+ * @type {{ xs: number, sm: number, md: number, lg: number, xl: number, xxl: number, xxxl: number }}
+ */
 export const spacing = {
-  xs: 4,
-  sm: 8,
-  md: 16,
-  lg: 24,
-  xl: 32,
-  xxl: 48,
-  xxxl: 64,
+  xs: 4,    // Tight gaps: icon-to-label, inline badge padding
+  sm: 8,    // Small gaps: form field spacing, list item padding
+  md: 16,   // Default gap: card padding, section element spacing
+  lg: 24,   // Comfortable gap: between card groups, form sections
+  xl: 32,   // Large gap: between major page sections
+  xxl: 48,  // Extra-large: hero content padding, major visual breaks
+  xxxl: 64, // Maximum: full section vertical padding on desktop
 };
 
+/**
+ * Border radius scale for rounded corners.
+ *
+ * Values are raw pixels. The `pill` value (9999px) creates fully rounded
+ * ends on any element regardless of height — used for tags, badges, and
+ * pill-shaped buttons.
+ *
+ * @type {{ sm: number, md: number, lg: number, xl: number, pill: number }}
+ */
 export const borderRadius = {
-  sm: 4,
-  md: 8,
-  lg: 12,
-  xl: 16,
-  pill: 9999,
+  sm: 4,     // Subtle rounding: input fields, small buttons
+  md: 8,     // Default: cards, dropdowns, tooltips
+  lg: 12,    // Prominent rounding: featured cards, image containers
+  xl: 16,    // Large rounding: modals, bottom sheets
+  pill: 9999, // Fully rounded ends: tags, badges, pill buttons
 };
 
+/**
+ * Box shadow definitions using warm espresso-tinted tones (NOT neutral gray).
+ *
+ * Shadows use the espresso base color (rgb 58,37,24) at varying opacities
+ * to stay consistent with the warm aesthetic. The `button` shadow uses the
+ * coral CTA color for a subtle glow effect on primary actions.
+ *
+ * Stored as structured objects so both web (via `shadowToCSS()`) and mobile
+ * can consume them in their native shadow formats.
+ *
+ * @type {Object<string, { x: number, y: number, blur: number, color: string }>}
+ */
 export const shadows = {
+  /** Default card resting state — subtle lift off the background */
   card: { x: 0, y: 2, blur: 12, color: 'rgba(58, 37, 24, 0.08)' },
+  /** Card hover/focus — elevated to signal interactivity */
   cardHover: { x: 0, y: 8, blur: 24, color: 'rgba(58, 37, 24, 0.12)' },
+  /** Navigation bar — minimal shadow to separate from page content */
   nav: { x: 0, y: 2, blur: 8, color: 'rgba(58, 37, 24, 0.06)' },
+  /** Modal/dialog overlay — strong depth to focus attention */
   modal: { x: 0, y: 16, blur: 48, color: 'rgba(58, 37, 24, 0.2)' },
+  /** CTA button — coral-tinted glow to draw the eye to primary actions */
   button: { x: 0, y: 2, blur: 8, color: 'rgba(232, 132, 92, 0.3)' },
 };
 
+/**
+ * Animation/transition durations in milliseconds.
+ *
+ * Three tiers cover all UI motion needs. The web layer appends "ms ease"
+ * to produce CSS transition values. Raw numbers here for cross-platform use.
+ *
+ * @type {{ fast: number, medium: number, slow: number }}
+ */
 export const transitions = {
+  /** Fast — micro-interactions: button hover, focus rings, tooltip show */
   fast: 150,
+  /** Medium — standard UI transitions: panel open, tab switch, fade in */
   medium: 250,
+  /** Slow — dramatic transitions: page hero reveal, modal entrance */
   slow: 400,
 };
 
+/**
+ * Responsive breakpoints in pixels (min-width convention).
+ *
+ * These define the viewport widths at which layout shifts occur.
+ * On web, Wix Studio handles most responsive behavior in the editor,
+ * but these are used by `mobileHelpers.js` for JS-driven responsive logic.
+ * On mobile, these inform adaptive layout decisions.
+ *
+ * @type {{ mobile: number, mobileLarge: number, tablet: number, desktop: number, wide: number, ultraWide: number }}
+ */
 export const breakpoints = {
-  mobile: 320,
-  mobileLarge: 480,
-  tablet: 768,
-  desktop: 1024,
-  wide: 1280,
-  ultraWide: 1440,
+  mobile: 320,       // Smallest supported viewport (1 column, 16px gap)
+  mobileLarge: 480,  // Larger phones in portrait (1 column)
+  tablet: 768,       // Tablets and small laptops (2 columns, 20px gap)
+  desktop: 1024,     // Standard desktop (3 columns, 24px gap)
+  wide: 1280,        // Wide desktop — max-width container kicks in
+  ultraWide: 1440,   // Ultra-wide — content centered, extra margin
 };
 
-// Business contact — single source of truth for all platforms
+/**
+ * Business contact and location info — single source of truth for all platforms.
+ *
+ * Used in structured data (JSON-LD), footer, contact page, emails, and the
+ * mobile app. Phone is stored in three formats to avoid runtime reformatting:
+ *  - `phone` — human-readable display format
+ *  - `phoneE164` — international standard for tel: links and APIs
+ *  - `phoneDigits` — digits only for click-to-call on mobile
+ *
+ * @type {Object}
+ */
 export const business = {
   phone: '(828) 252-9449',
+  /** E.164 format (international tel: link standard) */
   phoneE164: '+18282529449',
+  /** Digits only — used in mobile native dialer intents */
   phoneDigits: '8282529449',
   baseUrl: 'https://www.carolinafutons.com',
   address: {
@@ -97,25 +228,52 @@ export const business = {
     state: 'NC',
     zip: '28792',
   },
+  /** Display string for store hours — showroom is open 4 days/week */
   hours: 'Wed-Sat 10am-5pm',
+  /** JS Date day-of-week indices (0=Sun) used by deliveryScheduling.web.js */
   deliveryDays: [3, 4, 5, 6], // Wed=3, Thu=4, Fri=5, Sat=6
 };
 
-// Shipping configuration
+/**
+ * Domestic shipping rate configuration.
+ *
+ * Zones are determined by the first 3 digits of the destination ZIP code.
+ * "WNC" = Western North Carolina (local delivery area).
+ * White-glove service includes in-home delivery and assembly.
+ *
+ * All monetary values are in USD (whole dollars, no cents).
+ *
+ * @type {Object}
+ */
 export const shippingConfig = {
+  /** Orders at or above this amount (USD) qualify for free standard shipping */
   freeThreshold: 999,
   whiteGlove: {
+    /** Orders at or above this amount get free white-glove delivery */
     freeThreshold: 1999,
+    /** White-glove price for local zone (WNC — within ~50 miles) */
     localPrice: 149,
+    /** White-glove price for regional zone (Southeast — NC/SC/GA/TN/VA) */
     regionalPrice: 249,
   },
+  /** ZIP prefix ranges for shipping zone determination */
   zones: {
+    /** WNC = Western North Carolina — local delivery area */
     local: { prefixMin: 287, prefixMax: 289, name: 'WNC' },
+    /** Southeast region — broader delivery area with higher shipping cost */
     regional: { prefixMin: 270, prefixMax: 399, name: 'Southeast' },
   },
 };
 
-// Supported currencies for multi-currency display
+/**
+ * Supported currencies for multi-currency price display.
+ *
+ * Each entry provides the ISO 4217 currency code, display symbol, human name,
+ * and the BCP 47 locale used by `Intl.NumberFormat` for proper formatting
+ * (decimal separators, symbol placement, grouping).
+ *
+ * @type {Object<string, { code: string, symbol: string, name: string, locale: string }>}
+ */
 export const supportedCurrencies = {
   USD: { code: 'USD', symbol: '$', name: 'US Dollar', locale: 'en-US' },
   CAD: { code: 'CAD', symbol: 'CA$', name: 'Canadian Dollar', locale: 'en-CA' },
@@ -125,16 +283,29 @@ export const supportedCurrencies = {
   JPY: { code: 'JPY', symbol: '¥', name: 'Japanese Yen', locale: 'ja-JP' },
 };
 
+/** @type {string} ISO 4217 code — fallback currency when user preference is unknown */
 export const defaultCurrency = 'USD';
 
-// International shipping zones and rate multipliers
+/**
+ * International shipping zones, rates, and restrictions.
+ *
+ * Shipping cost = `baseRate` + (item weight in lbs * `perPoundRate`).
+ * Country codes are ISO 3166-1 alpha-2. The `other` zone is a catch-all
+ * for countries not in a named zone and not on the restricted list.
+ *
+ * @type {Object}
+ */
 export const internationalShippingConfig = {
   zones: {
     canada: {
+      /** ISO 3166-1 alpha-2 country codes in this zone */
       countries: ['CA'],
       name: 'Canada',
+      /** Flat base shipping fee in USD */
       baseRate: 79.99,
+      /** Additional cost per pound (lb) of product weight in USD */
       perPoundRate: 1.25,
+      /** Estimated transit time displayed to the customer */
       estimatedDays: '7-14',
     },
     europe: {
@@ -151,6 +322,7 @@ export const internationalShippingConfig = {
       perPoundRate: 3.25,
       estimatedDays: '14-28',
     },
+    /** Catch-all for countries not in a named zone (empty countries array = fallback) */
     other: {
       countries: [],
       name: 'International',
@@ -159,16 +331,30 @@ export const internationalShippingConfig = {
       estimatedDays: '21-35',
     },
   },
-  // Countries we ship to (ISO 3166 alpha-2)
+  /** ISO 3166-1 alpha-2 codes of embargoed/sanctioned countries — orders are blocked */
   restrictedCountries: ['CU', 'IR', 'KP', 'SY', 'SD'],
+  /** Orders at or above this USD amount qualify for free international shipping */
   freeInternationalThreshold: 2999,
 };
 
-// Customs / duties estimation config
+/**
+ * Customs and duties estimation configuration for international orders.
+ *
+ * HS = Harmonized System — international product classification standard.
+ * HS code 9403 covers "Other furniture and parts thereof."
+ * VAT = Value Added Tax. GST = Goods and Services Tax.
+ *
+ * Duty and VAT rates are approximate and used for estimation only — actual
+ * amounts are determined by the destination country's customs authority.
+ * De minimis thresholds define the order value (in approximate USD) below
+ * which no import duty is charged.
+ *
+ * @type {Object}
+ */
 export const customsConfig = {
-  // HS code for furniture (9403 = other furniture and parts)
+  /** HS (Harmonized System) code for furniture — 9403 = "other furniture and parts" */
   defaultHSCode: '9403',
-  // Typical duty rates by destination region (percentage of declared value)
+  /** Typical duty rates by country (decimal fraction of declared value) */
   dutyRates: {
     CA: { rate: 0, description: 'Duty-free under USMCA for qualifying goods' },
     MX: { rate: 0, description: 'Duty-free under USMCA for qualifying goods' },
@@ -181,7 +367,7 @@ export const customsConfig = {
     AU: { rate: 0.05, description: '~5% duty + 10% GST on furniture' },
     NZ: { rate: 0.05, description: '~5% duty + 15% GST on furniture' },
   },
-  // VAT/GST rates
+  /** VAT (Value Added Tax) / GST (Goods and Services Tax) rates by country (decimal fraction) */
   vatRates: {
     GB: 0.20, DE: 0.19, FR: 0.20, IT: 0.22, ES: 0.21,
     NL: 0.21, BE: 0.21, AT: 0.20, IE: 0.23, PT: 0.23,
@@ -189,18 +375,34 @@ export const customsConfig = {
     AU: 0.10, NZ: 0.15, JP: 0.10, KR: 0.10, SG: 0.09,
     CA: 0.05, HK: 0, TW: 0.05,
   },
-  // De minimis thresholds (value below which no duty is charged, in local currency equivalent USD)
+  /** De minimis thresholds in approximate USD — orders below this value are duty-free */
   deMinimisUSD: {
     CA: 150, GB: 135, DE: 150, FR: 150, AU: 1000, NZ: 1000, JP: 10000,
   },
 };
 
-// Helper: format shadow for CSS (web consumers)
+/**
+ * Converts a structured shadow object to a CSS `box-shadow` value string.
+ *
+ * Used by `designTokens.js` to transform platform-agnostic shadow definitions
+ * into ready-to-use CSS. Mobile consumers use the structured objects directly.
+ *
+ * @param {{ x: number, y: number, blur: number, color: string }} shadow - Shadow definition from the `shadows` constant
+ * @returns {string} CSS box-shadow value, e.g. "0px 2px 12px rgba(58, 37, 24, 0.08)"
+ */
 export function shadowToCSS(shadow) {
   return `${shadow.x}px ${shadow.y}px ${shadow.blur}px ${shadow.color}`;
 }
 
-// Helper: format spacing for CSS (web consumers)
+/**
+ * Converts a spacing token key to a CSS pixel string.
+ *
+ * Provides the bridge between raw numeric spacing values (used cross-platform)
+ * and CSS-ready strings (used on web). For example, `spacingPx('md')` returns `"16px"`.
+ *
+ * @param {'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl'} key - Spacing scale key from the `spacing` constant
+ * @returns {string} Pixel value string, e.g. "16px"
+ */
 export function spacingPx(key) {
   return `${spacing[key]}px`;
 }


### PR DESCRIPTION
## Summary

- Added module headers, `@param`/`@returns` JSDoc, and explanatory comments to the 13 files with weakest documentation coverage
- **Backend** (8 files): buyingGuides, categorySearch, fulfillment, inventoryAlerts, liveChat, mediaGallery, shipping-rates-plugin, ups-shipping
- **Public** (5 files): AddToCart, ProductDetails, ProductGallery, ProductOptions, sharedTokens

## Details

No logic changes — documentation only. Every exported function now has JSDoc with typed params and return values. Module headers describe purpose, dependencies, and architecture context.

## Test plan

- [x] `npx vitest run` — 9736 pass, 1 pre-existing failure (deliveryScheduling duplicate rejection, tracked as cf-v0t)
- [x] Verified failure exists on clean main (not introduced by this PR)
- [x] No code logic changes — safe to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)