### PR TITLE
fix(test): dynamic dates in duplicate scheduling test (cf-v0t)

### DIFF
--- a/tests/deliveryScheduling.test.js
+++ b/tests/deliveryScheduling.test.js
@@ -135,12 +135,16 @@ describe('scheduleDelivery', () => {
   });
 
   it('rejects duplicate scheduling for same order', async () => {
+    const nextWed = getNextDayOfWeek(3);
+    const dateStr = nextWed.toISOString().split('T')[0];
+    const nextThu = getNextDayOfWeek(4);
+    const dateStr2 = nextThu.toISOString().split('T')[0];
     __seed('DeliverySchedule', [
-      { _id: 'ds-1', orderId: 'order-123', date: '2026-03-04', timeWindow: 'morning', type: 'standard', status: 'scheduled' },
+      { _id: 'ds-1', orderId: 'order-123', date: dateStr, timeWindow: 'morning', type: 'standard', status: 'scheduled' },
     ]);
     const result = await scheduleDelivery({
       orderId: 'order-123',
-      date: '2026-03-05',
+      date: dateStr2,
       timeWindow: 'afternoon',
       type: 'standard',
     });


### PR DESCRIPTION
## Summary
- **Bead**: cf-v0t (P0 bug)
- Test `rejects duplicate scheduling for same order` used hardcoded dates (`2026-03-04`, `2026-03-05`) that became past dates, causing the future-date validation to reject before the duplicate check ran
- Replaced with `getNextDayOfWeek(3)` / `getNextDayOfWeek(4)` so the test uses dynamic future dates, consistent with all other tests in the file

## Test plan
- [x] `npx vitest run tests/deliveryScheduling.test.js` — 44/44 passing
- [x] Previously failing test now correctly hits the duplicate check path

🤖 Generated with [Claude Code](https://claude.com/claude-code)