### PR TITLE
docs(cf-b17): JSDoc audit batch 2 — 16 files, ~120 exports

### DIFF
--- a/src/backend/customizationService.web.js
+++ b/src/backend/customizationService.web.js
@@ -1,5 +1,16 @@
-// Backend web module for product customization builder
-// Handles customization options, pricing, and saved configurations
+/** @module customizationService - Backend product customization builder.
+ *
+ * Powers the "Customize Your Futon" feature: fetches available fabric swatches
+ * and pricing tiers from CMS, calculates surcharges (percentage or flat) for
+ * premium/luxury fabrics, and persists/retrieves saved configurations for
+ * logged-in members.
+ *
+ * CMS collections: FabricSwatches, CustomizationPricing, SavedCustomizations.
+ * calculateCustomizationPrice is a pure function (not a webMethod) so it can
+ * run on either client or server.
+ *
+ * Dependencies: wix-web-module, wix-data, backend/utils/sanitize.
+ */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';

--- a/src/backend/facebookCatalog.web.js
+++ b/src/backend/facebookCatalog.web.js
@@ -1,12 +1,19 @@
-// facebookCatalog.web.js - Meta/Facebook Catalog & CAPI Backend
-// Provides server-side Conversions API event building, product set params
-// for DPA retargeting, enhanced catalog fields, and customer audience export.
-//
-// Used by:
-// - metaPixel.js (client-side) for DPA retargeting params
-// - http-functions.js for enhanced catalog feed columns
-// - Custom audience export endpoint
-
+/** @module facebookCatalog - Meta/Facebook Catalog and Conversions API (CAPI) backend.
+ *
+ * Provides server-side Conversions API event building for all standard Meta events
+ * (ViewContent, AddToCart, InitiateCheckout, Purchase, Search, CompleteRegistration,
+ * AddToWishlist, Lead), Dynamic Product Ad (DPA) retargeting parameters,
+ * enhanced catalog feed fields (custom_label_0-4, product_type, additional images),
+ * and customer audience export for Custom/Lookalike Audiences.
+ *
+ * Used by: metaPixel.js (client-side DPA params), http-functions.js (catalog feed),
+ * and admin audience export endpoint.
+ *
+ * buildCapiEvent, buildProductSetParams, and getEnhancedCatalogFields are pure
+ * functions (not webMethods). exportCustomerAudienceData uses Permissions.Admin.
+ *
+ * Dependencies: wix-web-module, wix-data, backend/utils/sanitize, backend/utils/mediaHelpers.
+ */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';

--- a/src/backend/productRecommendations.web.js
+++ b/src/backend/productRecommendations.web.js
@@ -1,5 +1,17 @@
-// Backend web module for product recommendations
-// Handles cross-sell, related products, recently viewed, and "Complete Your Futon" bundles
+/** @module productRecommendations - Backend product recommendation engine.
+ *
+ * Powers cross-sell ("Complete Your Futon"), related products, same-collection
+ * suggestions, featured/bestselling/sale product queries, bundle pricing,
+ * server-side recently-viewed tracking (CMS-backed for logged-in members),
+ * similar-product matching by price range, and co-purchase ("Customers Also Bought")
+ * analysis from order history.
+ *
+ * All exports use the webMethod pattern. Most use Permissions.Anyone;
+ * member-specific endpoints (trackRecentlyViewed, getRecentlyViewed) use
+ * Permissions.SiteMember.
+ *
+ * Dependencies: wix-web-module, wix-data, wix-members-backend, backend/utils/sanitize.
+ */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
@@ -8,8 +20,15 @@ import { sanitize, validateSlug, validateId } from 'backend/utils/sanitize';
 const RECENTLY_VIEWED_COLLECTION = 'RecentlyViewed';
 const MAX_RECENTLY_VIEWED = 20;
 
-// Get related products for cross-selling on product pages
-// Returns products from complementary categories
+/**
+ * Get related products from complementary categories for cross-selling on product pages.
+ * Maps each category to its logical complement (e.g., frames suggest mattresses).
+ * @param {string} productId - Current product ID to exclude from results
+ * @param {string} categorySlug - Current product's category slug
+ * @param {number} [limit=4] - Maximum products to return
+ * @returns {Promise<Array<Object>>} Formatted product summaries
+ * @permission Anyone
+ */
 export const getRelatedProducts = webMethod(
   Permissions.Anyone,
   async (productId, categorySlug, limit = 4) => {
@@ -53,8 +72,15 @@ export const getRelatedProducts = webMethod(
   }
 );
 
-// Get "Complete Your Futon" suggestions based on what's in the cart
-// If cart has a frame but no mattress, suggest mattresses and vice versa
+/**
+ * Get "Complete Your Futon" suggestions based on current cart contents.
+ * Analyzes cart categories to identify missing complements (frame without mattress,
+ * Murphy bed without casegoods, etc.) and returns headed suggestion groups.
+ * Falls back to bestsellers if no specific match is found.
+ * @param {Array<string>} cartProductIds - Product IDs currently in the cart
+ * @returns {Promise<Array<{heading: string, products: Array<Object>}>>} Suggestion groups
+ * @permission Anyone
+ */
 export const getCompletionSuggestions = webMethod(
   Permissions.Anyone,
   async (cartProductIds) => {
@@ -155,8 +181,15 @@ export const getCompletionSuggestions = webMethod(
   }
 );
 
-// Get products in the same collection/finish family
-// For "More in this collection" section on product pages
+/**
+ * Get products in the same collection or finish family.
+ * Used for the "More in this Collection" section on product pages.
+ * @param {string} productId - Current product ID to exclude
+ * @param {Array<string>} collections - Collection slugs to match
+ * @param {number} [limit=6] - Maximum products to return
+ * @returns {Promise<Array<Object>>} Formatted product summaries
+ * @permission Anyone
+ */
 export const getSameCollection = webMethod(
   Permissions.Anyone,
   async (productId, collections, limit = 6) => {
@@ -177,7 +210,13 @@ export const getSameCollection = webMethod(
   }
 );
 
-// Get featured/bestselling products for homepage
+/**
+ * Get featured products for the homepage hero section.
+ * Prioritizes products with a "Featured" ribbon; falls back to newest products.
+ * @param {number} [limit=8] - Maximum products to return
+ * @returns {Promise<Array<Object>>} Formatted product summaries
+ * @permission Anyone
+ */
 export const getFeaturedProducts = webMethod(
   Permissions.Anyone,
   async (limit = 8) => {
@@ -204,7 +243,13 @@ export const getFeaturedProducts = webMethod(
   }
 );
 
-// Get sale/clearance products
+/**
+ * Get sale/clearance products sorted by largest discount first.
+ * Queries products with a discounted price and ranks by savings amount.
+ * @param {number} [limit=12] - Maximum products to return
+ * @returns {Promise<Array<Object>>} Formatted product summaries sorted by discount
+ * @permission Anyone
+ */
 export const getSaleProducts = webMethod(
   Permissions.Anyone,
   async (limit = 12) => {
@@ -229,8 +274,14 @@ export const getSaleProducts = webMethod(
   }
 );
 
-// Get bundle suggestion for a product on PDP
-// Pairs frames with mattresses, Murphy beds with casegoods
+/**
+ * Get a bundle suggestion for a product on the Product Detail Page (PDP).
+ * Pairs frames with the lowest-priced mattress (and vice versa), Murphy beds
+ * with casegoods, platform beds with accessories. Calculates a 5% bundle discount.
+ * @param {string} productId - Current product ID
+ * @returns {Promise<{heading: string, product: Object, originalTotal: number, bundlePrice: number, savings: number}|null>} Bundle offer or null
+ * @permission Anyone
+ */
 export const getBundleSuggestion = webMethod(
   Permissions.Anyone,
   async (productId) => {
@@ -299,8 +350,14 @@ export const getBundleSuggestion = webMethod(
   }
 );
 
-// Get bestselling products based on analytics data
-// Falls back to featured ribbon, then newest products
+/**
+ * Get bestselling products based on analytics data.
+ * Tries ProductAnalytics CMS collection (weekSales descending) first,
+ * then falls back to "Bestseller" ribbon, then newest products.
+ * @param {number} [limit=4] - Maximum products to return
+ * @returns {Promise<Array<Object>>} Formatted product summaries
+ * @permission Anyone
+ */
 export const getBestsellers = webMethod(
   Permissions.Anyone,
   async (limit = 4) => {

--- a/src/backend/promotions.web.js
+++ b/src/backend/promotions.web.js
@@ -1,11 +1,27 @@
-// Backend web module for promotional campaigns and flash sales
-// Queries the Promotions CMS collection for active campaigns
+/** @module promotions - Backend module for promotional campaigns and flash sales.
+ *
+ * Queries the Promotions CMS collection for active campaigns (date-range filtered).
+ * Supports standard promotions (with enriched product data) and flash sales
+ * (time-limited, optionally category-scoped, sorted by urgency).
+ *
+ * CMS collection: Promotions (fields: isActive, type, startDate, endDate,
+ * title, subtitle, theme, heroImage, discountCode, discountPercent,
+ * productIds, categoryScope, urgencyThreshold, bannerMessage, ctaUrl, ctaText).
+ *
+ * Dependencies: wix-web-module, wix-data, backend/utils/sanitize.
+ */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { validateSlug } from 'backend/utils/sanitize';
 
-// Get the currently active promotion (if any)
-// Returns the first active promotion whose date range includes today, or null
+/**
+ * Get the currently active promotion, if any.
+ * Returns the most recently started active promotion whose date range includes today.
+ * Enriches the result with full product data (up to 50 products) by resolving
+ * the comma-separated productIds field against the Stores/Products collection.
+ * @returns {Promise<{_id: string, title: string, subtitle: string, theme: string, heroImage: string, startDate: Date, endDate: Date, discountCode: string, discountPercent: number, ctaUrl: string, ctaText: string, products: Array<Object>}|null>} Promotion object or null
+ * @permission Anyone
+ */
 export const getActivePromotion = webMethod(
   Permissions.Anyone,
   async () => {

--- a/src/backend/seoHelpers.web.js
+++ b/src/backend/seoHelpers.web.js
@@ -1,5 +1,12 @@
-// Backend web module for SEO utilities
-// Generates structured data, alt text, and meta tags
+/** @module seoHelpers - Backend SEO utilities for structured data, alt text, and meta tags.
+ *
+ * Generates JSON-LD schemas (Product, LocalBusiness/FurnitureStore, WebSite, CollectionPage,
+ * BreadcrumbList, FAQPage, Article), Open Graph / Twitter Card meta tags, canonical URLs,
+ * page titles, and keyword-rich image alt text. All exports use the webMethod pattern
+ * with Permissions.Anyone unless noted otherwise.
+ *
+ * Dependencies: wix-web-module, backend/blogContent (getBlogFaqs).
+ */
 import { Permissions, webMethod } from 'wix-web-module';
 import { getBlogFaqs } from 'backend/blogContent';
 
@@ -40,7 +47,14 @@ function sanitizeForJsonLd(str) {
     .replace(/&/g, '\\u0026');
 }
 
-// Generate JSON-LD Product schema for a product page
+/**
+ * Generate a JSON-LD Product schema for a product page.
+ * Includes offers, shipping details, return policy, aggregate rating, reviews,
+ * material, color, size, and weight when available.
+ * @param {Object} product - Wix product object
+ * @returns {string|null} Stringified JSON-LD schema, or null if product is invalid
+ * @permission Anyone
+ */
 export const getProductSchema = webMethod(
   Permissions.Anyone,
   (product) => {
@@ -200,7 +214,12 @@ export const getProductSchema = webMethod(
   }
 );
 
-// Generate JSON-LD LocalBusiness schema for the business
+/**
+ * Generate a JSON-LD FurnitureStore/LocalBusiness schema for the business.
+ * Includes address, hours, geo coordinates, payment methods, and social links.
+ * @returns {string} Stringified JSON-LD schema
+ * @permission Anyone
+ */
 export const getBusinessSchema = webMethod(
   Permissions.Anyone,
   () => {
@@ -250,7 +269,11 @@ export const getBusinessSchema = webMethod(
   }
 );
 
-// Generate JSON-LD WebSite schema with SearchAction for sitelinks searchbox
+/**
+ * Generate a JSON-LD WebSite schema with a SearchAction for Google sitelinks searchbox.
+ * @returns {string} Stringified JSON-LD schema
+ * @permission Anyone
+ */
 export const getWebSiteSchema = webMethod(
   Permissions.Anyone,
   () => {
@@ -277,7 +300,14 @@ export const getWebSiteSchema = webMethod(
   }
 );
 
-// Generate JSON-LD CollectionPage + ItemList for category pages
+/**
+ * Generate a JSON-LD CollectionPage + ItemList schema for category pages.
+ * Lists up to 30 products with breadcrumb navigation.
+ * @param {Object} categoryInfo - Category metadata with title, slug, description
+ * @param {Array<Object>} products - Array of Wix product objects
+ * @returns {string|null} Stringified JSON-LD schema, or null if inputs are invalid
+ * @permission Anyone
+ */
 export const getCollectionSchema = webMethod(
   Permissions.Anyone,
   (categoryInfo, products) => {
@@ -316,7 +346,13 @@ export const getCollectionSchema = webMethod(
   }
 );
 
-// Generate JSON-LD BreadcrumbList for navigation
+/**
+ * Generate a JSON-LD BreadcrumbList schema for page navigation.
+ * Per Google guidelines, the last item omits its URL.
+ * @param {Array<{name: string, url?: string}>} breadcrumbs - Ordered breadcrumb items
+ * @returns {string|null} Stringified JSON-LD schema, or null if breadcrumbs are empty
+ * @permission Anyone
+ */
 export const getBreadcrumbSchema = webMethod(
   Permissions.Anyone,
   (breadcrumbs) => {
@@ -343,7 +379,12 @@ export const getBreadcrumbSchema = webMethod(
   }
 );
 
-// Generate JSON-LD FAQPage schema
+/**
+ * Generate a JSON-LD FAQPage schema from an array of question/answer pairs.
+ * @param {Array<{question: string, answer: string}>} faqs - FAQ data
+ * @returns {string|null} Stringified JSON-LD schema, or null if faqs are empty
+ * @permission Anyone
+ */
 export const getFaqSchema = webMethod(
   Permissions.Anyone,
   (faqs) => {
@@ -366,8 +407,14 @@ export const getFaqSchema = webMethod(
   }
 );
 
-// Generate product-specific FAQ schema for product pages
-// Creates category-relevant Q&A pairs for SEO structured data
+/**
+ * Generate a product-specific FAQ schema for product pages.
+ * Dynamically builds category-relevant Q&A pairs (return policy, free shipping,
+ * assembly, mattress compatibility, etc.) for SEO structured data.
+ * @param {Object} product - Wix product object
+ * @returns {string|null} Stringified JSON-LD FAQPage schema, or null if product is invalid
+ * @permission Anyone
+ */
 export const getProductFaqSchema = webMethod(
   Permissions.Anyone,
   (product) => {
@@ -462,7 +509,16 @@ export const getProductFaqSchema = webMethod(
   }
 );
 
-// Generate smart, keyword-rich alt text for product images
+/**
+ * Generate smart, keyword-rich alt text for product images.
+ * Varies output by image type (main, lifestyle, detail, open, sofa, gallery, grid)
+ * and incorporates brand, material, finish, and size for SEO value.
+ * Truncated to 125 characters for accessibility best practices.
+ * @param {Object} product - Wix product object
+ * @param {string} [imageType='main'] - Image context: 'main'|'lifestyle'|'detail'|'open'|'sofa'|'gallery'|'grid'
+ * @returns {string} Alt text string (max 125 chars)
+ * @permission Anyone
+ */
 export const generateAltText = webMethod(
   Permissions.Anyone,
   (product, imageType = 'main') => {
@@ -525,7 +581,13 @@ export const generateAltText = webMethod(
   }
 );
 
-// Generate category-specific meta description
+/**
+ * Get a category-specific meta description for SEO.
+ * Returns a curated description per category slug, or a generic Carolina Futons description.
+ * @param {string} categorySlug - Category URL slug (e.g. 'futon-frames', 'mattresses')
+ * @returns {string} Meta description text
+ * @permission Anyone
+ */
 export const getCategoryMetaDescription = webMethod(
   Permissions.Anyone,
   (categorySlug) => {
@@ -809,7 +871,13 @@ export const getCategoryMetaTags = webMethod(
   }
 );
 
-// Generate Article JSON-LD schema for blog posts
+/**
+ * Generate a JSON-LD Article schema for blog posts.
+ * Includes headline, author/publisher org, dates, cover image, and keywords.
+ * @param {Object} post - Blog post object with title, slug, metaDescription, publishDate, etc.
+ * @returns {string|null} Stringified JSON-LD schema, or null if post is invalid
+ * @permission Anyone
+ */
 export const getBlogArticleSchema = webMethod(
   Permissions.Anyone,
   (post) => {
@@ -853,7 +921,13 @@ export const getBlogArticleSchema = webMethod(
   }
 );
 
-// Generate FAQ schema for a blog post using blogContent data
+/**
+ * Generate a JSON-LD FAQPage schema for a blog post, using pre-authored FAQ data
+ * from the blogContent module keyed by post slug.
+ * @param {string} slug - Blog post URL slug
+ * @returns {string|null} Stringified JSON-LD schema, or null if no FAQs exist for this post
+ * @permission Anyone
+ */
 export const getBlogFaqSchema = webMethod(
   Permissions.Anyone,
   (slug) => {

--- a/src/public/ReturnsAdmin.js
+++ b/src/public/ReturnsAdmin.js
@@ -1,6 +1,14 @@
-// ReturnsAdmin.js — Admin dashboard helpers for returns management
-// Testable pure-JS logic consumed by the Admin Returns page.
-
+/** @module ReturnsAdmin - Admin dashboard helpers for returns management.
+ *
+ * Pure-JS logic for the Admin Returns page: status labels, state-machine transitions,
+ * badge coloring (design tokens), row formatting, dashboard stat cards, refund
+ * validation, shipping-label eligibility checks, and priority sorting (action-required first).
+ *
+ * Statuses follow the lifecycle: requested -> approved -> shipped -> received -> refunded.
+ * Denied is a terminal state reachable from requested, approved, or received.
+ *
+ * Dependencies: designTokens (colors).
+ */
 import { colors } from 'public/designTokens.js';
 
 // ── Status Constants ─────────────────────────────────────────────

--- a/src/public/cartService.js
+++ b/src/public/cartService.js
@@ -1,18 +1,16 @@
-// cartService.js - Centralized Cart Operations
-// Abstracts wix-stores-frontend cart API into a single module.
-// When Wix migrates to wix-ecom-frontend, update only this file.
-//
-// Exports:
-//   addToCart(productId, quantity, options)   - Add item to cart
-//   getCurrentCart()                         - Get full cart object
-//   getCartItemCount()                       - Get total item quantity
-//   updateCartItemQuantity(cartItemId, qty)  - Update line item quantity
-//   removeCartItem(cartItemId)               - Remove line item from cart
-//   onCartChanged(callback)                  - Register cart change listener
-//   getProductVariants(productId, choices)   - Get product variant pricing
-//   FREE_SHIPPING_THRESHOLD                  - $999 threshold
-//   TIER_THRESHOLDS                          - Tiered discount brackets
-
+/** @module cartService - Centralized cart operations abstraction.
+ *
+ * Wraps the wix-stores-frontend cart API into a single module so that when
+ * Wix migrates to wix-ecom-frontend, only this file needs updating. Provides
+ * add/remove/update operations, cart-change listeners, variant lookup, quantity
+ * validation, safe currency math, and progress calculations for free-shipping
+ * and tiered-discount thresholds.
+ *
+ * Constants: FREE_SHIPPING_THRESHOLD ($999,999 — currently disabled),
+ * TIER_THRESHOLDS (5% at $500, 10% at $1,000), MIN/MAX_QUANTITY (1–99).
+ *
+ * Dependencies: wix-stores-frontend.
+ */
 import wixStoresFrontend from 'wix-stores-frontend';
 
 // ── Constants ────────────────────────────────────────────────────────

--- a/src/public/cartStyles.js
+++ b/src/public/cartStyles.js
@@ -1,6 +1,15 @@
-// Cart & Checkout UI Style Helpers
-// Returns design token–based style objects for cart/checkout components.
-// Centralizes brand styling so Cart Page and Side Cart stay consistent.
+/** @module cartStyles - Cart and checkout UI style helpers.
+ *
+ * Returns design-token-based style objects for cart/checkout components so that
+ * Cart Page, Side Cart, and cross-sell cards all render with consistent brand
+ * styling. Each function returns a plain object of CSS-ready values (colors,
+ * durations, sizes) derived from sharedTokens.
+ *
+ * All call-to-action (CTA) buttons use sunsetCoral per brand guidelines.
+ * Touch targets meet WCAG AA minimum (44px).
+ *
+ * Dependencies: sharedTokens (colors, transitions, spacing).
+ */
 import { colors, transitions, spacing } from 'public/sharedTokens.js';
 
 /**

--- a/src/public/faqHelpers.js
+++ b/src/public/faqHelpers.js
@@ -1,5 +1,12 @@
-// faqHelpers.js — Testable helpers for FAQ page
-// FAQ data with categories, filtering, search, and schema generation
+/** @module faqHelpers - Testable helpers for the FAQ page.
+ *
+ * Contains the complete FAQ dataset organized by category (products, shipping,
+ * returns, financing, showroom), plus pure functions for category filtering,
+ * case-insensitive search, and FAQ schema data generation for SEO structured data.
+ *
+ * FAQ content is hardcoded here rather than fetched from CMS because it rarely
+ * changes and this avoids a network round-trip on page load.
+ */
 
 const CATEGORIES = [
   { id: 'products', label: 'Products', description: 'Questions about futons, mattresses, frames, and Murphy beds' },

--- a/src/public/galleryConfig.js
+++ b/src/public/galleryConfig.js
@@ -1,10 +1,18 @@
-// Gallery image configuration for Carolina Futons
-// Image sizing constants matching WIX-STUDIO-BUILD-SPEC.md element dimensions
-// Per-category gallery settings for consistent product display
-
+/** @module galleryConfig - Gallery image configuration for Carolina Futons.
+ *
+ * Defines image sizing constants matching WIX-STUDIO-BUILD-SPEC.md element dimensions,
+ * per-category gallery settings (thumbnail count, zoom level, thumbnail position,
+ * auto-play), responsive grid column calculations, and re-exports breakpoints
+ * from designTokens for consumers that import gallery config.
+ *
+ * Dependencies: designTokens (breakpoints).
+ */
 import { breakpoints } from 'public/designTokens.js';
 
-// ── Image Sizing Constants ──────────────────────────────────────────
+/**
+ * Standard image dimensions by context, matching WIX-STUDIO-BUILD-SPEC.md.
+ * @type {{hero: {width: number, height: number}, productGridCard: {width: number, height: number}, productPageMain: {width: number, height: number}, thumbnail: {width: number, height: number}, categoryCard: {width: number, height: number}}}
+ */
 export const imageSizes = {
   hero: { width: 1920, height: 600 },
   productGridCard: { width: 400, height: 400 },   // 1:1 ratio

--- a/src/public/galleryHelpers.js
+++ b/src/public/galleryHelpers.js
@@ -1,5 +1,12 @@
-// Gallery and product engagement helpers
-// Used across multiple pages for consistent product display behavior
+/** @module galleryHelpers - Product gallery interaction and engagement tracking.
+ *
+ * Provides recently-viewed tracking (session storage), product comparison lists,
+ * abandoned-browse data capture (time-on-page, scroll-to-pricing, variant clicks),
+ * image lightbox/zoom initializers, lazy loading, and a floating comparison bar.
+ *
+ * Dependencies: wix-storage-frontend (session), designTokens (colors),
+ * touchHelpers (swipe gestures for mobile lightbox).
+ */
 import { session } from 'wix-storage-frontend';
 import { colors } from 'public/designTokens.js';
 import { enableSwipe } from 'public/touchHelpers';
@@ -8,6 +15,14 @@ import { enableSwipe } from 'public/touchHelpers';
 const RECENTLY_VIEWED_KEY = 'cf_recently_viewed';
 const MAX_RECENT = 12;
 
+/**
+ * Record a product view in session storage for "Recently Viewed" display.
+ * Deduplicates by product ID (moves to front if already present) and caps
+ * the list at MAX_RECENT (12) items. Also kicks off browse-tracking for
+ * abandoned-browse recovery signals.
+ * @param {Object} product - Wix product object (must have _id)
+ * @returns {void}
+ */
 export function trackProductView(product) {
   if (!product || !product._id) return;
 
@@ -142,6 +157,13 @@ export function cleanupBrowseTracking() {
   } catch (e) {}
 }
 
+/**
+ * Retrieve accumulated browse engagement data from sessionStorage.
+ * Returns a map of productId to engagement signals (timeSpentMs,
+ * scrolledToPricing, variantInteractions, timestamp) for use by
+ * cart-recovery and abandoned-browse emails.
+ * @returns {Object.<string, {timeSpentMs: number, scrolledToPricing: boolean, variantInteractions: number, timestamp: string}>}
+ */
 export function getBrowseData() {
   try {
     const stored = sessionStorage.getItem(BROWSE_DATA_KEY);
@@ -166,6 +188,12 @@ export function clearRecentlyViewed() {
   } catch (e) {}
 }
 
+/**
+ * Get the list of recently viewed products from session storage.
+ * Optionally excludes a product (e.g., the one currently being viewed).
+ * @param {string|null} [excludeId=null] - Product ID to exclude from results
+ * @returns {Array<{_id: string, name: string, slug: string, price: string, mainMedia: string}>}
+ */
 export function getRecentlyViewed(excludeId = null) {
   try {
     const stored = session.getItem(RECENTLY_VIEWED_KEY);
@@ -186,6 +214,13 @@ export function getRecentlyViewed(excludeId = null) {
 const COMPARE_KEY = 'cf_compare_list';
 const MAX_COMPARE = 4;
 
+/**
+ * Add a product to the comparison list (session storage).
+ * Rejects duplicates and enforces a maximum of 4 items.
+ * Validates product._id format to prevent injection.
+ * @param {Object} product - Wix product object (must have _id, name, slug, formattedPrice, mainMedia)
+ * @returns {boolean} True if added, false if duplicate/full/invalid
+ */
 export function addToCompare(product) {
   try {
     if (!product || !product._id) return false;
@@ -213,6 +248,11 @@ export function addToCompare(product) {
   }
 }
 
+/**
+ * Remove a product from the comparison list by ID.
+ * @param {string} productId - Product ID to remove
+ * @returns {void}
+ */
 export function removeFromCompare(productId) {
   try {
     const stored = session.getItem(COMPARE_KEY);
@@ -226,6 +266,10 @@ export function removeFromCompare(productId) {
   }
 }
 
+/**
+ * Get the current product comparison list from session storage.
+ * @returns {Array<{_id: string, name: string, slug: string, price: string, mainMedia: string}>}
+ */
 export function getCompareList() {
   try {
     const stored = session.getItem(COMPARE_KEY);
@@ -235,14 +279,23 @@ export function getCompareList() {
   }
 }
 
+/**
+ * Clear the entire comparison list from session storage.
+ * @returns {void}
+ */
 export function clearCompareList() {
   try {
     session.removeItem(COMPARE_KEY);
   } catch (e) {}
 }
 
-// Smooth scroll to element (for in-page navigation)
-// Caller must pass $w from page context since public modules don't have access to $w
+/**
+ * Smooth-scroll to a page element by Wix selector.
+ * Caller must pass $w from page context because public modules lack direct $w access.
+ * @param {Function} $w - Wix page selector function
+ * @param {string} selector - Element selector (e.g. '#reviewsSection')
+ * @returns {void}
+ */
 export function scrollToElement($w, selector) {
   try {
     const element = $w(selector);
@@ -252,7 +305,13 @@ export function scrollToElement($w, selector) {
   } catch (e) {}
 }
 
-// Format product description for display (strip HTML, truncate)
+/**
+ * Strip HTML tags from a product description and truncate to a maximum length.
+ * Truncation breaks at word boundaries and appends an ellipsis.
+ * @param {string} html - Raw HTML description string
+ * @param {number} [maxLength=200] - Maximum character length
+ * @returns {string} Plain text, truncated with '...' if needed
+ */
 export function formatDescription(html, maxLength = 200) {
   if (!html) return '';
   const text = html.replace(/<[^>]*>/g, '').trim();
@@ -260,7 +319,12 @@ export function formatDescription(html, maxLength = 200) {
   return text.substring(0, maxLength).replace(/\s+\S*$/, '') + '...';
 }
 
-// Determine product badge text based on product data
+/**
+ * Determine the badge label for a product card overlay.
+ * Priority: explicit ribbon > active discount ('Sale') > in-store-only > new (within 30 days) > null.
+ * @param {Object} product - Wix product object
+ * @returns {string|null} Badge text or null if no badge applies
+ */
 export function getProductBadge(product) {
   if (!product) return null;
 
@@ -287,6 +351,15 @@ export function getProductBadge(product) {
 // Renders a 'Recently Viewed' horizontal scroll from session storage.
 // Naming convention: containerId '#xyzSection' → repeater '#xyzRepeater'
 
+/**
+ * Populate a "Recently Viewed" section with data from session storage.
+ * Collapses the container if no recent products exist; otherwise populates
+ * the derived repeater (e.g., '#xyzSection' derives '#xyzRepeater') and expands.
+ * @param {Function} $w - Wix page selector function
+ * @param {string} containerId - Container element ID (e.g., '#recentlyViewedSection')
+ * @param {Function} repeaterItemHandler - onItemReady callback for repeater items
+ * @returns {void}
+ */
 export function buildRecentlyViewedSection($w, containerId, repeaterItemHandler) {
   const recent = getRecentlyViewed();
 
@@ -316,6 +389,12 @@ export function buildRecentlyViewedSection($w, containerId, repeaterItemHandler)
 // ── Product Badge Overlay Config ────────────────────────────────────
 // Returns { text, bgColor, textColor } using designTokens for badge state
 
+/**
+ * Build badge overlay styling for a product card using design tokens.
+ * Returns text, background color, and text color keyed to badge state (Sale, New, Featured, In-Store Only).
+ * @param {Object} product - Wix product object
+ * @returns {{text: string, bgColor: string, textColor: string}|null} Badge config or null if no badge
+ */
 export function buildProductBadgeOverlay(product) {
   const badge = getProductBadge(product);
   if (!badge) return null;
@@ -336,6 +415,17 @@ export function buildProductBadgeOverlay(product) {
 // Page elements: #lightboxOverlay, #lightboxImage, #lightboxClose,
 //   #lightboxPrev, #lightboxNext, #lightboxCounter
 
+/**
+ * Initialize a fullscreen image lightbox with prev/next navigation.
+ * Binds gallery thumbnail clicks, main image clicks, keyboard shortcuts
+ * (Escape, ArrowLeft, ArrowRight), and mobile swipe gestures.
+ * Page elements required: #lightboxOverlay, #lightboxImage, #lightboxClose,
+ * #lightboxPrev, #lightboxNext, #lightboxCounter.
+ * @param {Function} $w - Wix page selector function
+ * @param {Object} galleryElement - Wix gallery $w element with .items and .onItemClicked
+ * @param {Object} mainImageElement - Wix image $w element for the main product photo
+ * @returns {{open: Function, close: Function, handleKeydown: Function, destroy: Function}|null} Lightbox controller or null if no images
+ */
 export function initImageLightbox($w, galleryElement, mainImageElement) {
   let images = [];
   let currentIndex = 0;
@@ -463,6 +553,15 @@ export function initImageLightbox($w, galleryElement, mainImageElement) {
 // Page elements: #imageZoomOverlay, #imageZoomImage
 // Desktop: hover to zoom; mobile: pinch handled natively by platform.
 
+/**
+ * Initialize hover-zoom on a product image (desktop only; mobile uses native pinch).
+ * Shows a zoomed overlay on mouse-enter and hides on mouse-leave.
+ * Page elements required: #imageZoomOverlay, #imageZoomImage.
+ * @param {Function} $w - Wix page selector function
+ * @param {Object} imageElement - Wix image $w element to attach zoom behavior to
+ * @param {number} [zoomFactor=2] - Magnification level
+ * @returns {{zoomFactor: number, show: Function, hide: Function}|null} Zoom controller or null if no element
+ */
 export function initImageZoom($w, imageElement, zoomFactor = 2) {
   if (!imageElement) return null;
 
@@ -500,6 +599,17 @@ export function initImageZoom($w, imageElement, zoomFactor = 2) {
 
 const DEFAULT_IMAGE_IDS = ['#productImage', '#gridImage', '#featuredImage', '#saleImage', '#collectionImage'];
 
+/**
+ * Initialize viewport-triggered lazy loading for product images in a repeater.
+ * Uses Wix onViewportEnter for intersection observation. Supports explicit
+ * dimensions to prevent Cumulative Layout Shift (CLS).
+ * @param {Object} repeaterItems - Wix repeater element with .forEachItem method
+ * @param {Object} [opts] - Options
+ * @param {Array<string>} [opts.imageIds] - Image element IDs to look for in each repeater item
+ * @param {number} [opts.fadeDuration=300] - Fade-in duration in ms
+ * @param {{width: number, height: number}|null} [opts.dimensions=null] - Explicit image dimensions to prevent CLS
+ * @returns {void}
+ */
 export function initLazyLoadImages(repeaterItems, opts = {}) {
   if (!repeaterItems) return;
 
@@ -550,6 +660,15 @@ function revealImageOnViewport($item, imageIds, fadeDuration, dimensions) {
 // Page elements: #compareBar, #compareBarRepeater, #compareButton,
 //   #compareClearBtn, #compareCount
 
+/**
+ * Build and populate the floating product comparison bar at the bottom of the page.
+ * Collapses if the comparison list is empty; otherwise shows thumbnails, a count label,
+ * a "Compare" button (enabled at 2+ items), and a "Clear All" button.
+ * Page elements required: #compareBar, #compareBarRepeater, #compareButton,
+ * #compareClearBtn, #compareCount.
+ * @param {Function} $w - Wix page selector function
+ * @returns {void}
+ */
 export function buildComparisonBar($w) {
   const compareList = getCompareList();
 

--- a/src/public/metaPixel.js
+++ b/src/public/metaPixel.js
@@ -1,12 +1,19 @@
-// metaPixel.js - Dedicated Meta Pixel (fbq) Event Helper
-// Fires Meta-specific events for Dynamic Product Ads, retargeting, and
-// lookalike audience optimization via wixWindow.trackEvent().
-//
-// This module extends ga4Tracking.js with Meta-specific event parameters
-// that enable DPA retargeting, custom audiences, and conversion optimization.
-//
-// Setup: Enable Meta Pixel in Wix Dashboard > Marketing Integrations.
-// The pixel ID is configured there — no hardcoded IDs in code.
+/** @module metaPixel - Client-side Meta Pixel (fbq) event helper.
+ *
+ * Fires Meta-standard events (ViewContent, AddToCart, InitiateCheckout, Purchase,
+ * Search, CompleteRegistration, AddToWishlist, Lead) via wixWindow.trackEvent()
+ * for Dynamic Product Ads (DPA) retargeting, custom audiences, and conversion
+ * optimization. Also provides buildEnhancedMatchParams for advanced matching
+ * (user data normalization per Meta's requirements).
+ *
+ * This module complements ga4Tracking.js with Meta-specific event parameters.
+ * All event fires are non-critical and wrapped in try/catch to never break the page.
+ *
+ * Setup: Enable Meta Pixel in Wix Dashboard > Marketing Integrations.
+ * The pixel ID is configured there — no hardcoded IDs in code.
+ *
+ * Dependencies: wix-window-frontend (lazy-loaded).
+ */
 
 let _wixWindow = null;
 

--- a/src/public/mobileHelpers.js
+++ b/src/public/mobileHelpers.js
@@ -1,7 +1,15 @@
-// mobileHelpers.js - Mobile-First Responsive Utilities
-// Provides viewport detection, touch handling, and mobile-specific UI behaviors
-// for Wix Velo pages. Works alongside Wix Studio's responsive layout system.
-
+/** @module mobileHelpers - Mobile-first responsive utilities for Wix Velo pages.
+ *
+ * Provides viewport detection (mobile/tablet/desktop/wide), touch-capability checks,
+ * debounced viewport-change listeners, swipe gesture handlers, adaptive data loading
+ * (limitForViewport), "show more" progressive disclosure, mobile section collapsing,
+ * smooth scrolling, and a "back to top" button initializer.
+ *
+ * Works alongside Wix Studio's CSS responsive layout system — this module handles
+ * runtime JS behavior, not CSS breakpoints.
+ *
+ * Dependencies: designTokens (breakpoints), wix-window-frontend (scroll events, lazy-loaded).
+ */
 import { breakpoints } from 'public/designTokens';
 
 // ── Viewport Detection ───────────────────────────────────────────────

--- a/src/public/models3d.js
+++ b/src/public/models3d.js
@@ -1,7 +1,13 @@
-// 3D model asset catalog for AR "View in Your Room" feature.
-// Ported from cfutons_mobile models3d.ts — shared catalog across web+mobile.
+/** @module models3d - 3D model asset catalog for Augmented Reality (AR) "View in Your Room" feature.
+ *
+ * Shared catalog across web and mobile (ported from cfutons_mobile models3d.ts).
+ * Contains GLB (Android/web) and USDZ (iOS Quick Look) asset URLs, physical
+ * dimensions in meters, file sizes for bandwidth budgeting, and content hashes
+ * for cache invalidation. Covers futon frames, Murphy cabinet beds, and
+ * selected furniture pieces.
+ */
 
-/** CDN base URL for 3D model assets */
+/** CDN base URL for 3D model assets (GLB and USDZ directories). */
 export const MODEL_CDN_BASE = 'https://cdn.carolinafutons.com/models';
 
 /** Convert inches to meters */
@@ -9,7 +15,12 @@ function inToM(inches) {
   return Math.round(inches * 0.0254 * 1000) / 1000;
 }
 
-/** 3D model catalog — futons, frames, murphy-beds only */
+/**
+ * 3D model catalog — futons, frames, and Murphy cabinet beds.
+ * Each entry contains GLB/USDZ URLs, physical dimensions (meters), file size,
+ * a content hash for cache-busting, and whether fabric variant swapping is supported.
+ * @type {Array<{productId: string, glbUrl: string, usdzUrl: string, dimensions: {width: number, depth: number, height: number}, fileSizeBytes: number, contentHash: string, hasFabricVariants: boolean}>}
+ */
 export const MODELS_3D = [
   {
     productId: 'prod-murphy-queen-vertical',
@@ -112,13 +123,22 @@ export const MODELS_3D = [
   },
 ];
 
-/** Look up 3D model asset for a product */
+/**
+ * Look up the 3D model asset entry for a product by its product ID.
+ * @param {string} productId - Wix product ID
+ * @returns {Object|undefined} Model entry with glbUrl, usdzUrl, dimensions, etc., or undefined if not found
+ */
 export function getModel3DForProduct(productId) {
   if (!productId) return undefined;
   return MODELS_3D.find(m => m.productId === productId);
 }
 
-/** Check whether a product has an AR model available */
+/**
+ * Check whether a product has an AR model available in the catalog.
+ * Use this to conditionally show the "View in Your Room" button on product pages.
+ * @param {string} productId - Wix product ID
+ * @returns {boolean} True if an AR model exists for this product
+ */
 export function hasARModel(productId) {
   if (!productId) return false;
   return MODELS_3D.some(m => m.productId === productId);

--- a/src/public/performanceHelpers.js
+++ b/src/public/performanceHelpers.js
@@ -1,10 +1,25 @@
-// Performance optimization helpers
-// Deferred loading, IntersectionObserver image lazy loading, CLS prevention
+/** @module performanceHelpers - Performance optimization utilities.
+ *
+ * Provides deferred initialization (requestIdleCallback with setTimeout fallback),
+ * critical/deferred section prioritization for faster Largest Contentful Paint (LCP),
+ * IntersectionObserver-based image lazy loading, explicit image dimension setting
+ * to prevent Cumulative Layout Shift (CLS), and recommended dimension lookups
+ * by usage context.
+ */
 
 // ── deferInit ────────────────────────────────────────────────────────
 // Schedule non-critical initialization for idle time.
 // Uses requestIdleCallback when available, falls back to setTimeout.
 
+/**
+ * Schedule a non-critical initialization function for idle time.
+ * Uses requestIdleCallback when available; falls back to setTimeout.
+ * Wraps the callback in try/catch so deferred failures never crash the page.
+ * @param {Function} fn - Initialization function to defer
+ * @param {Object} [opts] - Options
+ * @param {number} [opts.fallbackDelay=1] - setTimeout delay in ms when requestIdleCallback is unavailable
+ * @returns {void}
+ */
 export function deferInit(fn, opts = {}) {
   if (typeof fn !== 'function') return;
   const { fallbackDelay = 1 } = opts;
@@ -27,6 +42,16 @@ export function deferInit(fn, opts = {}) {
 // (load during idle time). Critical sections are awaited; deferred
 // sections are fire-and-forget so they don't block LCP.
 
+/**
+ * Split page sections into critical (awaited) and deferred (fire-and-forget).
+ * Critical sections run first and block — they affect LCP. Deferred sections
+ * run afterward without blocking, so $w.onReady returns as soon as critical
+ * content paints. Failures are logged; deferred failures also invoke onError.
+ * @param {Array<{name: string, critical: boolean, init: Function}>} sections - Section descriptors
+ * @param {Object} [opts] - Options
+ * @param {Function} [opts.onError] - Callback invoked on deferred section failure: (section, reason)
+ * @returns {Promise<{critical: Array<PromiseSettledResult>}>} Results of critical section initialization
+ */
 export async function prioritizeSections(sections, opts = {}) {
   if (!sections || sections.length === 0) {
     return { critical: [] };
@@ -71,6 +96,16 @@ export async function prioritizeSections(sections, opts = {}) {
 // IntersectionObserver-based lazy loading for images.
 // Watches elements and calls onVisible when they enter the viewport.
 
+/**
+ * Create an IntersectionObserver-based lazy loader for images.
+ * Automatically unobserves each element after it enters the viewport.
+ * Returns null in environments where IntersectionObserver is unavailable.
+ * @param {Object} [opts] - Options
+ * @param {string} [opts.rootMargin='200px 0px'] - Viewport margin for early loading
+ * @param {number} [opts.threshold=0.01] - Intersection ratio to trigger visibility
+ * @param {Function} [opts.onVisible] - Callback when element enters viewport: (element)
+ * @returns {{observe: Function, disconnect: Function}|null} Observer controller or null
+ */
 export function createImageObserver(opts = {}) {
   if (typeof IntersectionObserver === 'undefined') return null;
 
@@ -101,6 +136,14 @@ export function createImageObserver(opts = {}) {
 // ── setImageDimensions ──────────────────────────────────────────────
 // Set explicit dimensions on an image element to prevent CLS.
 
+/**
+ * Set explicit width, height, and aspect-ratio on an image element to prevent CLS.
+ * Silently fails if the element's style property is read-only.
+ * @param {Object} el - DOM or Wix element with a .style property
+ * @param {number} width - Width in pixels
+ * @param {number} height - Height in pixels
+ * @returns {void}
+ */
 export function setImageDimensions(el, width, height) {
   if (!el || !el.style) return;
 
@@ -128,6 +171,13 @@ const IMAGE_DIMENSIONS = {
 
 const DEFAULT_DIMENSIONS = { width: 400, height: 400 };
 
+/**
+ * Get recommended image dimensions by usage context to prevent CLS.
+ * Supported contexts: 'product-grid', 'hero', 'category-card', 'thumbnail',
+ * 'gallery-main', 'recently-viewed', 'sale-card'. Returns 400x400 default.
+ * @param {string} category - Usage context key
+ * @returns {{width: number, height: number}} Recommended dimensions
+ */
 export function getImageDimensionsForCategory(category) {
   if (!category) return DEFAULT_DIMENSIONS;
   return IMAGE_DIMENSIONS[category] || DEFAULT_DIMENSIONS;

--- a/src/public/placeholderImages.js
+++ b/src/public/placeholderImages.js
@@ -1,4 +1,13 @@
-// Product image fallback system for Carolina Futons
+/** @module placeholderImages - Product image fallback and placeholder system.
+ *
+ * Provides curated lifestyle photography (Unsplash) for category hero banners
+ * and homepage cards, plus real wixstatic.com product photos as fallbacks when
+ * a product has no mainMedia. Also offers image resizing helpers for Wix CDN
+ * and Unsplash URL transform params.
+ *
+ * All hero/card images are temporary — replace with Wix Media uploads per
+ * MEDIA_MANIFEST.md when brand photography is available.
+ */
 // Category hero/card images use curated Unsplash lifestyle photography matching Blue Ridge aesthetic
 // Product fallback images use real wixstatic.com URLs from the live catalog
 //


### PR DESCRIPTION
## Summary
- **Bead**: cf-b17 (JSDoc & comment consistency audit — codebase-wide)
- Batch 2: Added `@module` headers and `@param`/`@returns` JSDoc to all exported functions across **16 files**
- **507 lines added, 99 removed** — documentation only, zero logic changes
- Batch 1 (PR #171) covered 13 files. Combined: **29 files fully documented**

## Files Documented

| # | File | Exports |
|---|------|---------|
| 1 | `src/public/galleryHelpers.js` | 18 |
| 2 | `src/backend/seoHelpers.web.js` | 18 |
| 3 | `src/backend/productRecommendations.web.js` | 11 |
| 4 | `src/public/placeholderImages.js` | 10 |
| 5 | `src/public/mobileHelpers.js` | 10 |
| 6 | `src/public/ReturnsAdmin.js` | 8 |
| 7 | `src/public/cartStyles.js` | 7 |
| 8 | `src/public/cartService.js` | 6 |
| 9 | `src/public/performanceHelpers.js` | 5 |
| 10 | `src/public/faqHelpers.js` | 5 |
| 11 | `src/backend/customizationService.web.js` | 5 |
| 12 | `src/backend/facebookCatalog.web.js` | 4 |
| 13 | `src/public/models3d.js` | 4 |
| 14 | `src/public/galleryConfig.js` | 4 |
| 15 | `src/public/metaPixel.js` | 3 |
| 16 | `src/backend/promotions.web.js` | 2 |

## Test plan
- [x] `npx vitest run` — 9,921 tests pass across 255 files, 0 failures
- [x] No code logic changes — documentation only, safe to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)