### PR TITLE
feat(CF-b99): wire Figma-first mountain skyline into masterPage header

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -994,10 +994,10 @@ function dismissNewsletterModal() {
 
 function initMountainSkylineHeader() {
   try {
-    import('public/MountainSkyline.js').then(({ initMountainSkyline }) => {
-      initMountainSkyline($w, { variant: 'silhouette', containerId: '#headerSkyline' });
+    import('public/MountainSkylineFigma.js').then(({ initMountainSkylineFigma }) => {
+      initMountainSkylineFigma($w, { containerId: '#headerSkyline' });
     }).catch(() => {
-      // MountainSkyline module not yet available — silently skip
+      // MountainSkylineFigma module not yet available — silently skip
     });
   } catch (e) {
     // Non-critical decorative element

--- a/tests/headerSkylineFigma.test.js
+++ b/tests/headerSkylineFigma.test.js
@@ -1,0 +1,154 @@
+/**
+ * Tests for CF-b99: Header skyline Figma-first upgrade
+ *
+ * Verifies masterPage.js uses MountainSkylineFigma (static pipeline SVG)
+ * instead of the deprecated MountainSkyline.js (programmatic SVG).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getMountainSkylineSvg,
+  initMountainSkylineFigma,
+} from '../src/public/MountainSkylineFigma.js';
+import { colors } from '../src/public/sharedTokens.js';
+
+// ── $w Mock ─────────────────────────────────────────────────────────
+
+function create$w() {
+  const elements = new Map();
+  function mockEl(id) {
+    return {
+      _id: id,
+      html: '',
+      show: vi.fn(() => Promise.resolve()),
+      hide: vi.fn(() => Promise.resolve()),
+      style: {},
+    };
+  }
+  const $w = (sel) => {
+    if (!elements.has(sel)) elements.set(sel, mockEl(sel));
+    return elements.get(sel);
+  };
+  $w._elements = elements;
+  return $w;
+}
+
+let $w;
+beforeEach(() => { $w = create$w(); vi.clearAllMocks(); });
+
+// ── 1. masterPage imports MountainSkylineFigma, not MountainSkyline ──
+
+describe('masterPage header skyline — Figma-first upgrade', () => {
+  it('masterPage.js imports MountainSkylineFigma, not MountainSkyline', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync('src/pages/masterPage.js', 'utf8');
+
+    // Must import the Figma version
+    expect(src).toContain('MountainSkylineFigma');
+
+    // Must NOT import the deprecated programmatic version for header
+    // (other pages may still use it, but masterPage header should not)
+    const headerFn = src.match(/function\s+initMountainSkylineHeader[\s\S]*?^}/m);
+    expect(headerFn).not.toBeNull();
+    const fnBody = headerFn[0];
+    expect(fnBody).toContain('MountainSkylineFigma');
+    expect(fnBody).not.toContain("'public/MountainSkyline.js'");
+  });
+
+  it('initMountainSkylineHeader uses containerId #headerSkyline', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync('src/pages/masterPage.js', 'utf8');
+    const headerFn = src.match(/function\s+initMountainSkylineHeader[\s\S]*?^}/m);
+    expect(headerFn).not.toBeNull();
+    expect(headerFn[0]).toContain('#headerSkyline');
+  });
+});
+
+// ── 2. initMountainSkylineFigma renders into #headerSkyline ──────────
+
+describe('initMountainSkylineFigma — header context', () => {
+  it('sets html on #headerSkyline container', () => {
+    initMountainSkylineFigma($w, { containerId: '#headerSkyline' });
+    const el = $w('#headerSkyline');
+    expect(el.html).toContain('<svg');
+    expect(el.html).toContain('</svg>');
+  });
+
+  it('renders valid SVG with correct attributes', () => {
+    initMountainSkylineFigma($w, { containerId: '#headerSkyline' });
+    const html = $w('#headerSkyline').html;
+    expect(html).toContain('xmlns="http://www.w3.org/2000/svg"');
+    expect(html).toContain('viewBox="0 0 1440 200"');
+    expect(html).toContain('preserveAspectRatio="none"');
+    expect(html).toContain('width="100%"');
+  });
+
+  it('SVG has accessibility attributes (decorative)', () => {
+    initMountainSkylineFigma($w, { containerId: '#headerSkyline' });
+    const html = $w('#headerSkyline').html;
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain('role="presentation"');
+  });
+
+  it('defaults to #mountainSkyline if no containerId given', () => {
+    initMountainSkylineFigma($w);
+    const el = $w('#mountainSkyline');
+    expect(el.html).toContain('<svg');
+  });
+
+  it('does not throw when $w is null', () => {
+    expect(() => initMountainSkylineFigma(null)).not.toThrow();
+  });
+
+  it('does not throw when container element missing', () => {
+    const broken$w = () => { throw new Error('Element not found'); };
+    expect(() => initMountainSkylineFigma(broken$w, { containerId: '#missing' })).not.toThrow();
+  });
+});
+
+// ── 3. SVG content uses brand tokens (no hardcoded non-brand hex) ────
+
+describe('Header SVG brand token compliance', () => {
+  it('contains brand colors from sharedTokens', () => {
+    const svg = getMountainSkylineSvg();
+    // Must contain at least some brand colors
+    const brandHexes = [
+      colors.mountainBlue, colors.espresso, colors.skyGradientTop,
+      colors.skyGradientBottom, colors.espressoLight,
+    ];
+    const found = brandHexes.filter(hex => svg.includes(hex));
+    expect(found.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('has 7 ridge layers for Blue Ridge depth', () => {
+    const svg = getMountainSkylineSvg();
+    const ridges = svg.match(/class="ridge-\d+"/g) || [];
+    expect(ridges.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('has atmospheric haze filters', () => {
+    const svg = getMountainSkylineSvg();
+    expect(svg).toContain('feGaussianBlur');
+  });
+
+  it('has detail elements (birds, trees, wildflowers)', () => {
+    const svg = getMountainSkylineSvg();
+    expect(svg).toContain('class="birds"');
+    expect(svg).toContain('class="pine-trees"');
+    expect(svg).toContain('class="wildflowers"');
+  });
+
+  it('has sky gradient with 5+ stops', () => {
+    const svg = getMountainSkylineSvg();
+    const skyGrad = svg.match(/id="sky-grad"[\s\S]*?<\/linearGradient>/);
+    expect(skyGrad).not.toBeNull();
+    const stops = (skyGrad[0].match(/<stop /g) || []).length;
+    expect(stops).toBeGreaterThanOrEqual(5);
+  });
+
+  it('has no deprecated SVG filters (feTurbulence, feDisplacementMap)', () => {
+    const svg = getMountainSkylineSvg();
+    expect(svg).not.toContain('feTurbulence');
+    expect(svg).not.toContain('feDisplacementMap');
+    expect(svg).not.toContain('fractalNoise');
+  });
+});

--- a/tests/mountainSkylineIntegration.test.js
+++ b/tests/mountainSkylineIntegration.test.js
@@ -57,12 +57,20 @@ function $wFn(sel) {
   return getEl(sel);
 }
 
-// ── Mock initMountainSkyline ─────────────────────────────────────────
+// ── Mock initMountainSkyline (deprecated — used by Home, Category, Product pages) ──
 
 const mockInitMountainSkyline = vi.fn();
 
 vi.mock('public/MountainSkyline.js', () => ({
   initMountainSkyline: mockInitMountainSkyline,
+}));
+
+// ── Mock initMountainSkylineFigma (masterPage header uses Figma-first version) ──
+
+const mockInitMountainSkylineFigma = vi.fn();
+
+vi.mock('public/MountainSkylineFigma.js', () => ({
+  initMountainSkylineFigma: mockInitMountainSkylineFigma,
 }));
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -71,30 +79,29 @@ describe('Mountain Skyline Integration', () => {
   beforeEach(() => {
     elements.clear();
     mockInitMountainSkyline.mockReset();
+    mockInitMountainSkylineFigma.mockReset();
   });
 
-  describe('masterPage integration', () => {
-    it('should call initMountainSkyline with silhouette variant for global header', async () => {
-      // Simulate how masterPage calls the skyline init
-      const { initMountainSkyline } = await import('public/MountainSkyline.js');
-      initMountainSkyline($wFn, { variant: 'silhouette', containerId: '#headerSkyline' });
+  describe('masterPage integration (Figma-first)', () => {
+    it('should call initMountainSkylineFigma with #headerSkyline for global header', async () => {
+      const { initMountainSkylineFigma } = await import('public/MountainSkylineFigma.js');
+      initMountainSkylineFigma($wFn, { containerId: '#headerSkyline' });
 
-      expect(mockInitMountainSkyline).toHaveBeenCalledTimes(1);
-      expect(mockInitMountainSkyline).toHaveBeenCalledWith(
+      expect(mockInitMountainSkylineFigma).toHaveBeenCalledTimes(1);
+      expect(mockInitMountainSkylineFigma).toHaveBeenCalledWith(
         $wFn,
-        expect.objectContaining({ variant: 'silhouette', containerId: '#headerSkyline' })
+        expect.objectContaining({ containerId: '#headerSkyline' })
       );
     });
 
-    it('should not break if initMountainSkyline throws', async () => {
-      mockInitMountainSkyline.mockImplementation(() => {
+    it('should not break if initMountainSkylineFigma throws', async () => {
+      mockInitMountainSkylineFigma.mockImplementation(() => {
         throw new Error('SVG render failed');
       });
 
-      // Wrapped in try/catch as the integration code does
       expect(() => {
         try {
-          mockInitMountainSkyline($wFn, { variant: 'silhouette', containerId: '#headerSkyline' });
+          mockInitMountainSkylineFigma($wFn, { containerId: '#headerSkyline' });
         } catch (e) {
           // Should be caught silently
         }
@@ -232,10 +239,10 @@ describe('Mountain Skyline Integration', () => {
   });
 
   describe('variant selection per page', () => {
-    it('masterPage uses silhouette variant', () => {
-      mockInitMountainSkyline($wFn, { variant: 'silhouette', containerId: '#headerSkyline' });
-      const call = mockInitMountainSkyline.mock.calls[0];
-      expect(call[1].variant).toBe('silhouette');
+    it('masterPage uses Figma-first version (no variant needed)', () => {
+      mockInitMountainSkylineFigma($wFn, { containerId: '#headerSkyline' });
+      const call = mockInitMountainSkylineFigma.mock.calls[0];
+      expect(call[1].containerId).toBe('#headerSkyline');
     });
 
     it('Home uses gradient variant', () => {
@@ -258,18 +265,18 @@ describe('Mountain Skyline Integration', () => {
   });
 
   describe('multiple skylines on same page', () => {
-    it('masterPage silhouette should not conflict with page-level gradient', () => {
-      // masterPage init (runs on all pages)
-      mockInitMountainSkyline($wFn, { variant: 'silhouette', containerId: '#headerSkyline' });
-      // Home page init (runs additionally on home page)
+    it('masterPage Figma skyline should not conflict with page-level gradient', () => {
+      // masterPage init (runs on all pages) — uses Figma version
+      mockInitMountainSkylineFigma($wFn, { containerId: '#headerSkyline' });
+      // Home page init (runs additionally on home page) — still uses old version
       mockInitMountainSkyline($wFn, { variant: 'gradient', containerId: '#heroSkyline' });
 
-      expect(mockInitMountainSkyline).toHaveBeenCalledTimes(2);
+      expect(mockInitMountainSkylineFigma).toHaveBeenCalledTimes(1);
+      expect(mockInitMountainSkyline).toHaveBeenCalledTimes(1);
 
       // Verify different containers used
-      const calls = mockInitMountainSkyline.mock.calls;
-      expect(calls[0][1].containerId).toBe('#headerSkyline');
-      expect(calls[1][1].containerId).toBe('#heroSkyline');
+      expect(mockInitMountainSkylineFigma.mock.calls[0][1].containerId).toBe('#headerSkyline');
+      expect(mockInitMountainSkyline.mock.calls[0][1].containerId).toBe('#heroSkyline');
     });
   });
 });


### PR DESCRIPTION
## Summary
- **masterPage.js**: `initMountainSkylineHeader()` now imports `MountainSkylineFigma.js` instead of deprecated `MountainSkyline.js`
- Figma-first static SVG replaces programmatic SVG with feTurbulence/feDisplacementMap filters
- Every page now shows the pipeline-processed Blue Ridge skyline in the global header
- Error handling preserved (try/catch + .catch() for missing elements)

## Changes
- `src/pages/masterPage.js` — 1 function updated (6 line diff)
- `tests/headerSkylineFigma.test.js` — 14 new tests (source verification, SVG quality, brand tokens, a11y, error resilience)
- `tests/mountainSkylineIntegration.test.js` — Updated masterPage section to reflect Figma version

## Test plan
- [x] 14 new header skyline tests — all pass
- [x] 62 total skyline tests (header + integration + figma module) — all pass
- [x] Full suite: 9935/9935 pass, 256/256 files, 0 failures
- [x] No deprecated filters (feTurbulence, feDisplacementMap) in header SVG
- [x] Brand token compliance verified (sharedTokens colors)

Refs: `docs/guides/figma-draw-tool-reference.md`, `docs/guides/svg-export-pipeline.md`

Generated with [Claude Code](https://claude.com/claude-code)