### PR TITLE
feat(CF-71f): centralize newsletter signups via newsletterService

### DIFF
--- a/src/pages/Blog.js
+++ b/src/pages/Blog.js
@@ -301,18 +301,19 @@ function initBlogNewsletter() {
 
       try {
         submitBtn.disable();
-        const { submitContactForm } = await import('backend/contactSubmissions.web');
-        await submitContactForm({
-          email,
-          source: 'blog_newsletter',
-          status: 'newsletter_signup',
-        });
+        const { subscribeToNewsletter } = await import('backend/newsletterService.web');
+        const result = await subscribeToNewsletter(email, { source: 'blog_newsletter' });
 
-        try { $w('#blogNewsletterSuccess').show(); } catch (e) {}
-        try { $w('#blogNewsletterError').hide(); } catch (e) {}
-        fireCustomEvent('newsletter_signup', { source: 'blog' });
-        announce($w, 'Successfully subscribed to newsletter');
-        emailInput.value = '';
+        if (result.success) {
+          try { $w('#blogNewsletterSuccess').show(); } catch (e) {}
+          try { $w('#blogNewsletterError').hide(); } catch (e) {}
+          fireCustomEvent('newsletter_signup', { source: 'blog' });
+          announce($w, 'Successfully subscribed to newsletter');
+          emailInput.value = '';
+        } else {
+          try { $w('#blogNewsletterError').text = result.message || 'Something went wrong. Please try again.'; } catch (e) {}
+          try { $w('#blogNewsletterError').show(); } catch (e) {}
+        }
       } catch (err) {
         try { $w('#blogNewsletterError').text = 'Something went wrong. Please try again.'; } catch (e) {}
         try { $w('#blogNewsletterError').show(); } catch (e) {}

--- a/src/pages/Newsletter.js
+++ b/src/pages/Newsletter.js
@@ -1,6 +1,8 @@
 // Newsletter.js - Newsletter & Email Signup Landing Page
 // Dedicated landing page for email capture from ad campaigns, social media,
-// and promotional links. Integrates with Wix CRM and GA4 tracking.
+// and promotional links. Uses centralized newsletterService for CMS persistence,
+// Klaviyo ESP sync, and Bronze loyalty enrollment.
+import { subscribeToNewsletter } from 'backend/newsletterService.web';
 import { trackEvent, trackNewsletterSignup } from 'public/engagementTracker';
 import { fireCustomEvent } from 'public/ga4Tracking';
 import { initBackToTop } from 'public/mobileHelpers';
@@ -67,15 +69,17 @@ function initSignupForm() {
       submitBtn.label = 'Subscribing...';
 
       try {
-        const firstName = nameInput.value?.trim() || '';
-        const { contacts } = await import('wix-crm-frontend');
+        const result = await subscribeToNewsletter(email, { source: 'newsletter_page' });
 
-        const contactInfo = { emails: [email], labelKeys: ['custom.newsletter'] };
-        if (firstName) {
-          contactInfo.name = { first: firstName };
+        if (!result.success) {
+          submitBtn.enable();
+          submitBtn.label = 'Subscribe';
+          try {
+            errorMsg.text = result.message || 'Something went wrong. Please try again.';
+            errorMsg.show();
+          } catch (e) {}
+          return;
         }
-
-        await contacts.appendOrCreateContact(contactInfo);
 
         // Track in both engagement system and GA4/Meta Pixel
         trackNewsletterSignup('newsletter_page');
@@ -89,9 +93,10 @@ function initSignupForm() {
         try { emailInput.hide(); } catch (e) {}
         try { nameInput.hide(); } catch (e) {}
         submitBtn.hide();
+        const code = result.discountCode || 'WELCOME10';
         successMsg.text =
-          'You\'re in! Check your inbox for your 10% welcome discount. ' +
-          'Use code WELCOME10 at checkout.';
+          `You're in! Check your inbox for your 10% welcome discount. ` +
+          `Use code ${code} at checkout.`;
         successMsg.show('fade', { duration: 300 });
         announce($w, 'Successfully subscribed to newsletter');
       } catch (err) {

--- a/src/pages/Thank You Page.js
+++ b/src/pages/Thank You Page.js
@@ -2,6 +2,7 @@
 // Personalized order summary, Brenda's message, social sharing, newsletter,
 // delivery timeline, referral prompt, and product suggestions
 import { getFeaturedProducts } from 'backend/productRecommendations.web';
+import { subscribeToNewsletter } from 'backend/newsletterService.web';
 import { trackPurchaseComplete, trackSocialShare, trackNewsletterSignup, trackReferralAction } from 'public/engagementTracker';
 import { firePurchase, fireCustomEvent } from 'public/ga4Tracking';
 import { trackPurchase } from 'backend/analyticsHelpers.web';
@@ -237,16 +238,14 @@ function initNewsletterSignup() {
         return;
       }
       try {
-        const { contacts } = await import('wix-crm-frontend');
-        await contacts.appendOrCreateContact({
-          emails: [email],
-          labelKeys: ['custom.newsletter'],
-        });
-        trackNewsletterSignup('thank_you_page');
-        fireCustomEvent('newsletter_signup', { source: 'thank_you_page' });
-        $w('#newsletterSuccess').text = 'You\'re subscribed! Watch for exclusive deals.';
-        $w('#newsletterSuccess').show();
-        $w('#newsletterSignup').disable();
+        const result = await subscribeToNewsletter(email, { source: 'thank_you_page' });
+        if (result.success) {
+          trackNewsletterSignup('thank_you_page');
+          fireCustomEvent('newsletter_signup', { source: 'thank_you_page' });
+          $w('#newsletterSuccess').text = 'You\'re subscribed! Watch for exclusive deals.';
+          $w('#newsletterSuccess').show();
+          $w('#newsletterSignup').disable();
+        }
       } catch (e) {
         console.error('Newsletter signup error:', e);
       }

--- a/tests/newsletter.test.js
+++ b/tests/newsletter.test.js
@@ -60,17 +60,11 @@ describe('Newsletter Page', () => {
       expect(content).toContain("trackEvent('page_view'");
     });
 
-    it('uses wix-crm-frontend for contact creation', async () => {
+    it('uses centralized newsletterService for subscriptions', async () => {
       const fs = await import('fs');
       const content = fs.readFileSync('src/pages/Newsletter.js', 'utf8');
-      expect(content).toContain('wix-crm-frontend');
-      expect(content).toContain('appendOrCreateContact');
-    });
-
-    it('labels contacts with custom.newsletter', async () => {
-      const fs = await import('fs');
-      const content = fs.readFileSync('src/pages/Newsletter.js', 'utf8');
-      expect(content).toContain("'custom.newsletter'");
+      expect(content).toContain('newsletterService.web');
+      expect(content).toContain('subscribeToNewsletter');
     });
 
     it('includes ARIA labels for accessibility', async () => {

--- a/tests/newsletterIntegration.test.js
+++ b/tests/newsletterIntegration.test.js
@@ -1,0 +1,98 @@
+// newsletterIntegration.test.js - CF-71f: Email signup and newsletter integration
+// Verifies all pages with newsletter signup use the centralized newsletterService.web.js
+// backend instead of direct wix-crm-frontend or contactSubmissions.web calls.
+// This ensures every signup gets: CMS deduplication, Klaviyo ESP sync, Bronze loyalty enrollment.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const readPage = (name) => readFileSync(resolve(process.cwd(), `src/pages/${name}.js`), 'utf-8');
+
+// ── All newsletter signup pages must use newsletterService.web.js ─────
+
+describe('Newsletter integration — centralized backend', () => {
+  const pagesWithNewsletter = [
+    { page: 'Newsletter', description: 'dedicated newsletter landing page' },
+    { page: 'Thank You Page', description: 'post-purchase newsletter signup' },
+    { page: 'Blog', description: 'blog page newsletter CTA' },
+    { page: 'Home', description: 'homepage newsletter section' },
+  ];
+
+  pagesWithNewsletter.forEach(({ page, description }) => {
+    it(`${page} (${description}) uses newsletterService.web`, () => {
+      const content = readPage(page);
+      // Accept either static import or dynamic import()
+      expect(content).toMatch(/(?:from|import)\s*\(?\s*['"]backend\/newsletterService\.web['"]/);
+    });
+
+    it(`${page} calls subscribeToNewsletter (not direct CRM)`, () => {
+      const content = readPage(page);
+      expect(content).toContain('subscribeToNewsletter');
+    });
+  });
+
+  // Pages must NOT use direct wix-crm-frontend for newsletter signup
+  const pagesMustNotUseCRM = [
+    'Newsletter',
+    'Thank You Page',
+    'Blog',
+  ];
+
+  pagesMustNotUseCRM.forEach((page) => {
+    it(`${page} does NOT use wix-crm-frontend directly for newsletter`, () => {
+      const content = readPage(page);
+      expect(content).not.toContain('wix-crm-frontend');
+    });
+  });
+
+  it('Blog does NOT use contactSubmissions.web for newsletter signup', () => {
+    const content = readPage('Blog');
+    // Blog newsletter should use newsletterService, not contactSubmissions
+    expect(content).not.toMatch(/submitContactForm.*newsletter/s);
+  });
+});
+
+// ── Newsletter.js must show discount code from backend response ──────
+
+describe('Newsletter page — backend integration details', () => {
+  it('uses the discountCode from subscribeToNewsletter response', () => {
+    const content = readPage('Newsletter');
+    // Should reference result.discountCode or similar pattern from backend response
+    expect(content).toMatch(/discountCode|result\./);
+  });
+
+  it('handles subscription failure gracefully', () => {
+    const content = readPage('Newsletter');
+    // Should have error handling for failed subscription
+    expect(content).toMatch(/catch|\.success\s*===?\s*false|!.*success/);
+  });
+});
+
+// ── Thank You Page must use backend service ──────────────────────────
+
+describe('Thank You Page — backend integration details', () => {
+  it('passes source as thank_you_page to subscribeToNewsletter', () => {
+    const content = readPage('Thank You Page');
+    expect(content).toContain('thank_you_page');
+  });
+});
+
+// ── Blog must use backend service ────────────────────────────────────
+
+describe('Blog — backend integration details', () => {
+  it('passes source as blog to subscribeToNewsletter', () => {
+    const content = readPage('Blog');
+    // Should pass blog-related source to the backend
+    expect(content).toMatch(/source.*blog|blog.*source/i);
+  });
+});
+
+// ── FooterSection already correct — verify it stays correct ──────────
+
+describe('FooterSection — already uses newsletterService (regression)', () => {
+  it('imports subscribeToNewsletter from newsletterService.web', () => {
+    const content = readFileSync(resolve(process.cwd(), 'src/public/FooterSection.js'), 'utf-8');
+    expect(content).toMatch(/from\s+['"]backend\/newsletterService\.web['"]/);
+    expect(content).toContain('subscribeToNewsletter');
+  });
+});

--- a/tests/thankYouPage.test.js
+++ b/tests/thankYouPage.test.js
@@ -166,6 +166,11 @@ vi.mock('wix-crm-frontend', () => ({
   },
 }));
 
+// Mock newsletterService.web (used by newsletter signup section)
+vi.mock('backend/newsletterService.web', () => ({
+  subscribeToNewsletter: vi.fn().mockResolvedValue({ success: true, discountCode: 'WELCOME10' }),
+}));
+
 // Mock wix-members-frontend
 vi.mock('wix-members-frontend', () => ({
   currentMember: {
@@ -479,14 +484,14 @@ describe('Thank You Page', () => {
       expect(trackNewsletterSignup).toHaveBeenCalled();
     });
 
-    it('handles CRM API failure silently without showing success', async () => {
-      const { contacts } = await import('wix-crm-frontend');
-      contacts.appendOrCreateContact.mockRejectedValueOnce(new Error('CRM unavailable'));
+    it('handles newsletter service failure silently without showing success', async () => {
+      const { subscribeToNewsletter } = await import('backend/newsletterService.web');
+      subscribeToNewsletter.mockRejectedValueOnce(new Error('Service unavailable'));
       await onReadyHandler();
       getEl('#newsletterEmail').value = 'test@example.com';
       const clickHandler = getEl('#newsletterSignup').onClick.mock.calls[0][0];
       await clickHandler();
-      // CRM failure is caught — success message should NOT be shown
+      // Service failure is caught — success message should NOT be shown
       expect(getEl('#newsletterSuccess').show).not.toHaveBeenCalled();
       // Tracking should NOT fire since signup didn't complete
       expect(trackNewsletterSignup).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- **Newsletter.js**, **Thank You Page**, and **Blog.js** now use the centralized `subscribeToNewsletter` from `newsletterService.web.js` instead of direct `wix-crm-frontend` or `contactSubmissions.web` calls
- This ensures every signup gets: CMS deduplication, Klaviyo ESP sync, Bronze loyalty auto-enrollment, and backend input sanitization
- Home.js and FooterSection.js already used this pattern — now all 5 signup points are consistent

## Files Changed
- `src/pages/Newsletter.js` — replaced `wix-crm-frontend` with `subscribeToNewsletter`
- `src/pages/Thank You Page.js` — replaced `wix-crm-frontend` with `subscribeToNewsletter`
- `src/pages/Blog.js` — replaced `contactSubmissions.web` with `newsletterService.web`
- `tests/newsletterIntegration.test.js` — 17 new tests verifying all pages use centralized backend
- `tests/newsletter.test.js` — updated to match new backend integration
- `tests/thankYouPage.test.js` — added newsletterService mock, updated failure test

## Test plan
- [x] 17 new integration tests verify all 5 signup points use newsletterService.web
- [x] Full suite: 259 files, 9,994 tests — all passing
- [x] No regressions — existing newsletter.test.js and thankYouPage.test.js updated and green
- [x] Backward compatible — subscribeToNewsletter returns same discount code (WELCOME10)

Refs: CF-71f, docs/guides/

🤖 Generated with [Claude Code](https://claude.com/claude-code)