### PR TITLE
feat(CF-w5m): test coverage for 14 untested public helpers

### DIFF
--- a/tests/MemberPageHelpers.test.js
+++ b/tests/MemberPageHelpers.test.js
@@ -1,0 +1,396 @@
+/**
+ * Tests for MemberPageHelpers.js — Customer account dashboard logic
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  STATUS_COLORS,
+  getStatusColor,
+  formatOrderDate,
+  formatOrderTotal,
+  formatOrderNumber,
+  hasTrackingInfo,
+  isReturnEligible,
+  buildOrderGalleryItems,
+  sortWishlist,
+  WISHLIST_SORT_OPTIONS,
+  getWishlistStockStatus,
+  getWishlistSaleInfo,
+  buildWishlistShareUrl,
+  getWelcomeMessage,
+  formatLoyaltyDisplay,
+  DASHBOARD_QUICK_LINKS,
+  formatAddress,
+  normalizeAddresses,
+  COMM_PREF_TOGGLES,
+  DEFAULT_COMM_PREFS,
+  PAGE_SECTIONS,
+} from '../src/public/MemberPageHelpers.js';
+
+// ── getStatusColor ────────────────────────────────────────────────────
+
+describe('getStatusColor', () => {
+  it('returns color for known statuses', () => {
+    expect(getStatusColor('Processing')).toBeTruthy();
+    expect(getStatusColor('Shipped')).toBeTruthy();
+    expect(getStatusColor('Delivered')).toBeTruthy();
+    expect(getStatusColor('Cancelled')).toBeTruthy();
+  });
+
+  it('returns default color for unknown status', () => {
+    expect(getStatusColor('UnknownStatus')).toBeTruthy();
+  });
+});
+
+// ── formatOrderDate ───────────────────────────────────────────────────
+
+describe('formatOrderDate', () => {
+  it('formats Date object', () => {
+    const result = formatOrderDate(new Date('2026-02-20T12:00:00'));
+    expect(result).toContain('2026');
+  });
+
+  it('formats date string', () => {
+    const result = formatOrderDate('2026-02-20');
+    expect(result).toBeTruthy();
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(formatOrderDate(null)).toBe('');
+    expect(formatOrderDate(undefined)).toBe('');
+  });
+
+  it('returns empty string for invalid date', () => {
+    expect(formatOrderDate('not-a-date')).toBe('');
+  });
+});
+
+// ── formatOrderTotal ──────────────────────────────────────────────────
+
+describe('formatOrderTotal', () => {
+  it('formats total from totals object', () => {
+    expect(formatOrderTotal({ total: 150 })).toBe('$150.00');
+  });
+
+  it('returns $0.00 for null', () => {
+    expect(formatOrderTotal(null)).toBe('$0.00');
+  });
+
+  it('returns $0.00 for missing total', () => {
+    expect(formatOrderTotal({})).toBe('$0.00');
+  });
+
+  it('returns $0.00 for negative total', () => {
+    expect(formatOrderTotal({ total: -50 })).toBe('$0.00');
+  });
+
+  it('returns $0.00 for NaN total', () => {
+    expect(formatOrderTotal({ total: 'abc' })).toBe('$0.00');
+  });
+});
+
+// ── formatOrderNumber ─────────────────────────────────────────────────
+
+describe('formatOrderNumber', () => {
+  it('formats order number', () => {
+    expect(formatOrderNumber(12345)).toBe('Order #12345');
+    expect(formatOrderNumber('CF-001')).toBe('Order #CF-001');
+  });
+
+  it('returns placeholder for null/undefined/empty', () => {
+    expect(formatOrderNumber(null)).toContain('#');
+    expect(formatOrderNumber(undefined)).toContain('#');
+    expect(formatOrderNumber('')).toContain('#');
+  });
+});
+
+// ── hasTrackingInfo ───────────────────────────────────────────────────
+
+describe('hasTrackingInfo', () => {
+  it('returns true when tracking number exists', () => {
+    expect(hasTrackingInfo({ shippingInfo: { trackingNumber: '1Z999' } })).toBe(true);
+  });
+
+  it('returns false when no tracking number', () => {
+    expect(hasTrackingInfo({ shippingInfo: {} })).toBe(false);
+    expect(hasTrackingInfo({})).toBe(false);
+  });
+
+  it('returns false for null/undefined order', () => {
+    expect(hasTrackingInfo(null)).toBe(false);
+    expect(hasTrackingInfo(undefined)).toBe(false);
+  });
+});
+
+// ── isReturnEligible ──────────────────────────────────────────────────
+
+describe('isReturnEligible', () => {
+  it('returns false for Cancelled', () => {
+    expect(isReturnEligible('Cancelled')).toBe(false);
+  });
+
+  it('returns true for Processing, Shipped, Delivered', () => {
+    expect(isReturnEligible('Processing')).toBe(true);
+    expect(isReturnEligible('Shipped')).toBe(true);
+    expect(isReturnEligible('Delivered')).toBe(true);
+  });
+});
+
+// ── buildOrderGalleryItems ────────────────────────────────────────────
+
+describe('buildOrderGalleryItems', () => {
+  it('builds gallery items from line items', () => {
+    const lineItems = [
+      { name: 'Futon Frame', mediaItem: { src: 'img.jpg' } },
+      { name: 'Mattress', mediaItem: { src: 'img2.jpg' } },
+    ];
+    const items = buildOrderGalleryItems(lineItems);
+    expect(items).toHaveLength(2);
+    expect(items[0].src).toBe('img.jpg');
+    expect(items[0].alt).toContain('Futon Frame');
+  });
+
+  it('filters out items without media', () => {
+    const lineItems = [
+      { name: 'A', mediaItem: { src: 'a.jpg' } },
+      { name: 'B' },
+      { name: 'C', mediaItem: {} },
+    ];
+    expect(buildOrderGalleryItems(lineItems)).toHaveLength(1);
+  });
+
+  it('returns empty for non-array', () => {
+    expect(buildOrderGalleryItems(null)).toEqual([]);
+    expect(buildOrderGalleryItems('string')).toEqual([]);
+  });
+
+  it('provides default alt text when name missing', () => {
+    const items = buildOrderGalleryItems([{ mediaItem: { src: 'x.jpg' } }]);
+    expect(items[0].alt).toBe('Ordered item');
+  });
+});
+
+// ── sortWishlist ──────────────────────────────────────────────────────
+
+describe('sortWishlist', () => {
+  const items = [
+    { name: 'Beta', price: 200, _createdDate: '2026-02-01' },
+    { name: 'Alpha', price: 100, _createdDate: '2026-03-01' },
+    { name: 'Charlie', price: 300, _createdDate: '2026-01-01' },
+  ];
+
+  it('sorts by date descending (newest first)', () => {
+    const sorted = sortWishlist(items, 'date-desc');
+    expect(sorted[0].name).toBe('Alpha');
+  });
+
+  it('sorts by date ascending (oldest first)', () => {
+    const sorted = sortWishlist(items, 'date-asc');
+    expect(sorted[0].name).toBe('Charlie');
+  });
+
+  it('sorts by price ascending', () => {
+    const sorted = sortWishlist(items, 'price-asc');
+    expect(sorted[0].price).toBe(100);
+  });
+
+  it('sorts by price descending', () => {
+    const sorted = sortWishlist(items, 'price-desc');
+    expect(sorted[0].price).toBe(300);
+  });
+
+  it('sorts by name ascending', () => {
+    const sorted = sortWishlist(items, 'name-asc');
+    expect(sorted[0].name).toBe('Alpha');
+  });
+
+  it('returns copy for unknown sort order', () => {
+    const sorted = sortWishlist(items, 'unknown');
+    expect(sorted).toHaveLength(3);
+    expect(sorted).not.toBe(items);
+  });
+
+  it('returns empty for non-array', () => {
+    expect(sortWishlist(null, 'date-desc')).toEqual([]);
+  });
+
+  it('handles items with missing price', () => {
+    const withMissing = [{ name: 'A', price: null }, { name: 'B', price: 50 }];
+    const sorted = sortWishlist(withMissing, 'price-asc');
+    expect(sorted[0].price).toBe(0 || null); // null coerced to 0
+  });
+});
+
+// ── getWishlistStockStatus ────────────────────────────────────────────
+
+describe('getWishlistStockStatus', () => {
+  it('returns In Stock for in-stock item', () => {
+    const result = getWishlistStockStatus({ inStock: true });
+    expect(result.text).toBe('In Stock');
+  });
+
+  it('returns Special Order for out-of-stock', () => {
+    const result = getWishlistStockStatus({ inStock: false });
+    expect(result.text).toBe('Special Order');
+  });
+
+  it('returns Special Order for null item', () => {
+    expect(getWishlistStockStatus(null).text).toBe('Special Order');
+  });
+});
+
+// ── getWishlistSaleInfo ───────────────────────────────────────────────
+
+describe('getWishlistSaleInfo', () => {
+  it('detects sale when comparePrice > price', () => {
+    const result = getWishlistSaleInfo({ price: 100, comparePrice: 150 });
+    expect(result.onSale).toBe(true);
+    expect(result.salePriceText).toContain('150');
+  });
+
+  it('returns not on sale when no compare price', () => {
+    expect(getWishlistSaleInfo({ price: 100 }).onSale).toBe(false);
+  });
+
+  it('returns not on sale when compare <= price', () => {
+    expect(getWishlistSaleInfo({ price: 100, comparePrice: 100 }).onSale).toBe(false);
+  });
+
+  it('handles null item', () => {
+    expect(getWishlistSaleInfo(null).onSale).toBe(false);
+  });
+});
+
+// ── buildWishlistShareUrl ─────────────────────────────────────────────
+
+describe('buildWishlistShareUrl', () => {
+  it('builds share URL with member ID', () => {
+    const url = buildWishlistShareUrl('https://carolinafutons.com', 'member123');
+    expect(url).toBe('https://carolinafutons.com/wishlist?member=member123');
+  });
+
+  it('handles empty baseUrl', () => {
+    const url = buildWishlistShareUrl('', 'member123');
+    expect(url).toBe('/wishlist?member=member123');
+  });
+
+  it('handles null values', () => {
+    const url = buildWishlistShareUrl(null, null);
+    expect(url).toContain('/wishlist?member=');
+  });
+});
+
+// ── getWelcomeMessage ─────────────────────────────────────────────────
+
+describe('getWelcomeMessage', () => {
+  it('uses first name', () => {
+    const member = { contactDetails: { firstName: 'Jane' } };
+    expect(getWelcomeMessage(member)).toBe('Welcome back, Jane!');
+  });
+
+  it('falls back to "Member" for null', () => {
+    expect(getWelcomeMessage(null)).toBe('Welcome back, Member!');
+  });
+
+  it('falls back when no firstName', () => {
+    expect(getWelcomeMessage({ contactDetails: {} })).toBe('Welcome back, Member!');
+  });
+});
+
+// ── formatLoyaltyDisplay ──────────────────────────────────────────────
+
+describe('formatLoyaltyDisplay', () => {
+  it('formats points and tier', () => {
+    const result = formatLoyaltyDisplay({ points: 1500, tier: 'Gold' });
+    expect(result.pointsText).toBe('1,500 pts');
+    expect(result.tierText).toBe('Gold');
+  });
+
+  it('returns join message for null account', () => {
+    expect(formatLoyaltyDisplay(null).pointsText).toBe('Join Rewards');
+  });
+
+  it('returns join message when points missing', () => {
+    expect(formatLoyaltyDisplay({}).pointsText).toBe('Join Rewards');
+  });
+
+  it('handles zero points', () => {
+    const result = formatLoyaltyDisplay({ points: 0 });
+    expect(result.pointsText).toBe('0 pts');
+  });
+});
+
+// ── formatAddress ─────────────────────────────────────────────────────
+
+describe('formatAddress', () => {
+  it('formats full address', () => {
+    const addr = { street: '123 Main St', city: 'Hendersonville', state: 'NC', zip: '28792' };
+    const result = formatAddress(addr);
+    expect(result).toContain('123 Main St');
+    expect(result).toContain('Hendersonville, NC 28792');
+  });
+
+  it('returns fallback for null', () => {
+    expect(formatAddress(null)).toBe('No address saved');
+  });
+
+  it('handles missing fields', () => {
+    expect(formatAddress({})).toBe('No address saved');
+  });
+});
+
+// ── normalizeAddresses ────────────────────────────────────────────────
+
+describe('normalizeAddresses', () => {
+  it('adds _id if missing', () => {
+    const addresses = [{ street: 'A' }, { street: 'B' }];
+    const result = normalizeAddresses(addresses);
+    expect(result[0]._id).toBe('0');
+    expect(result[1]._id).toBe('1');
+  });
+
+  it('preserves existing _id', () => {
+    const result = normalizeAddresses([{ _id: 'custom', street: 'A' }]);
+    expect(result[0]._id).toBe('custom');
+  });
+
+  it('returns empty for non-array', () => {
+    expect(normalizeAddresses(null)).toEqual([]);
+  });
+});
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('WISHLIST_SORT_OPTIONS has entries with label and value', () => {
+    expect(WISHLIST_SORT_OPTIONS.length).toBeGreaterThan(0);
+    WISHLIST_SORT_OPTIONS.forEach(o => {
+      expect(o).toHaveProperty('label');
+      expect(o).toHaveProperty('value');
+    });
+  });
+
+  it('DASHBOARD_QUICK_LINKS has entries', () => {
+    expect(DASHBOARD_QUICK_LINKS.length).toBeGreaterThan(0);
+  });
+
+  it('COMM_PREF_TOGGLES has entries', () => {
+    expect(COMM_PREF_TOGGLES.length).toBeGreaterThan(0);
+  });
+
+  it('DEFAULT_COMM_PREFS has expected keys', () => {
+    expect(DEFAULT_COMM_PREFS).toHaveProperty('newsletter');
+    expect(DEFAULT_COMM_PREFS).toHaveProperty('saleAlerts');
+    expect(DEFAULT_COMM_PREFS).toHaveProperty('backInStock');
+  });
+
+  it('PAGE_SECTIONS is non-empty array', () => {
+    expect(PAGE_SECTIONS.length).toBeGreaterThan(0);
+  });
+
+  it('STATUS_COLORS has expected statuses', () => {
+    expect(STATUS_COLORS).toHaveProperty('Processing');
+    expect(STATUS_COLORS).toHaveProperty('Shipped');
+    expect(STATUS_COLORS).toHaveProperty('Delivered');
+    expect(STATUS_COLORS).toHaveProperty('Cancelled');
+  });
+});

--- a/tests/assemblyGuideHelpers.test.js
+++ b/tests/assemblyGuideHelpers.test.js
@@ -1,0 +1,281 @@
+/**
+ * Tests for assemblyGuideHelpers.js — Assembly guide page utility functions
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getGuideCategories,
+  getCategoryLabel,
+  getCategoryIcon,
+  groupGuidesByCategory,
+  filterGuides,
+  buildVideoEmbedUrl,
+  formatEstimatedTime,
+  buildHowToSchema,
+} from '../src/public/assemblyGuideHelpers.js';
+
+// ── getGuideCategories ────────────────────────────────────────────────
+
+describe('getGuideCategories', () => {
+  it('returns array of categories', () => {
+    const cats = getGuideCategories();
+    expect(Array.isArray(cats)).toBe(true);
+    expect(cats.length).toBeGreaterThan(0);
+  });
+
+  it('each category has id, label, description, icon', () => {
+    getGuideCategories().forEach(c => {
+      expect(c).toHaveProperty('id');
+      expect(c).toHaveProperty('label');
+      expect(c).toHaveProperty('description');
+      expect(c).toHaveProperty('icon');
+    });
+  });
+
+  it('returns a defensive copy', () => {
+    const cats1 = getGuideCategories();
+    const cats2 = getGuideCategories();
+    expect(cats1).not.toBe(cats2);
+  });
+});
+
+// ── getCategoryLabel ──────────────────────────────────────────────────
+
+describe('getCategoryLabel', () => {
+  it('returns known category label', () => {
+    expect(getCategoryLabel('futon-frames')).toBe('Futon Frames');
+    expect(getCategoryLabel('mattresses')).toBe('Mattresses');
+  });
+
+  it('returns title-cased fallback for unknown category', () => {
+    expect(getCategoryLabel('some-new-type')).toBe('Some New Type');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(getCategoryLabel(null)).toBe('');
+    expect(getCategoryLabel(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(getCategoryLabel('')).toBe('');
+  });
+});
+
+// ── getCategoryIcon ───────────────────────────────────────────────────
+
+describe('getCategoryIcon', () => {
+  it('returns icon for known category', () => {
+    const icon = getCategoryIcon('futon-frames');
+    expect(typeof icon).toBe('string');
+    expect(icon.length).toBeGreaterThan(0);
+  });
+
+  it('returns default icon for unknown category', () => {
+    const icon = getCategoryIcon('unknown');
+    expect(typeof icon).toBe('string');
+    expect(icon.length).toBeGreaterThan(0);
+  });
+
+  it('returns default icon for null', () => {
+    expect(typeof getCategoryIcon(null)).toBe('string');
+  });
+});
+
+// ── groupGuidesByCategory ─────────────────────────────────────────────
+
+describe('groupGuidesByCategory', () => {
+  it('groups guides by category field', () => {
+    const guides = [
+      { title: 'A', category: 'frames' },
+      { title: 'B', category: 'mattresses' },
+      { title: 'C', category: 'frames' },
+    ];
+    const grouped = groupGuidesByCategory(guides);
+    expect(grouped.frames).toHaveLength(2);
+    expect(grouped.mattresses).toHaveLength(1);
+  });
+
+  it('puts guides without category into "uncategorized"', () => {
+    const guides = [{ title: 'No Cat' }];
+    const grouped = groupGuidesByCategory(guides);
+    expect(grouped.uncategorized).toHaveLength(1);
+  });
+
+  it('returns empty object for null/undefined', () => {
+    expect(groupGuidesByCategory(null)).toEqual({});
+    expect(groupGuidesByCategory(undefined)).toEqual({});
+  });
+
+  it('returns empty object for non-array', () => {
+    expect(groupGuidesByCategory('not-array')).toEqual({});
+  });
+});
+
+// ── filterGuides ──────────────────────────────────────────────────────
+
+describe('filterGuides', () => {
+  const guides = [
+    { title: 'Frame Assembly', sku: 'FR-001', category: 'frames' },
+    { title: 'Mattress Setup', sku: 'MT-001', category: 'mattresses' },
+    { title: 'Murphy Install', sku: 'MB-001', category: 'murphy' },
+  ];
+
+  it('filters by category', () => {
+    const result = filterGuides(guides, 'frames', '');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Frame Assembly');
+  });
+
+  it('filters by search query (title)', () => {
+    const result = filterGuides(guides, null, 'murphy');
+    expect(result).toHaveLength(1);
+  });
+
+  it('filters by search query (sku)', () => {
+    const result = filterGuides(guides, null, 'MT-001');
+    expect(result).toHaveLength(1);
+  });
+
+  it('combines category and query filters', () => {
+    const result = filterGuides(guides, 'frames', 'assembly');
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns all when no filters applied', () => {
+    expect(filterGuides(guides, null, '')).toHaveLength(3);
+  });
+
+  it('returns empty array for null guides', () => {
+    expect(filterGuides(null, null, '')).toEqual([]);
+  });
+
+  it('search is case-insensitive', () => {
+    expect(filterGuides(guides, null, 'FRAME')).toHaveLength(1);
+  });
+
+  it('trims query whitespace', () => {
+    expect(filterGuides(guides, null, '  murphy  ')).toHaveLength(1);
+  });
+
+  it('returns empty when query matches nothing', () => {
+    expect(filterGuides(guides, null, 'nonexistent')).toEqual([]);
+  });
+});
+
+// ── buildVideoEmbedUrl ────────────────────────────────────────────────
+
+describe('buildVideoEmbedUrl', () => {
+  it('converts youtube.com/watch URL to embed', () => {
+    const result = buildVideoEmbedUrl('https://www.youtube.com/watch?v=abc123');
+    expect(result).toBe('https://www.youtube.com/embed/abc123');
+  });
+
+  it('converts youtu.be short URL to embed', () => {
+    const result = buildVideoEmbedUrl('https://youtu.be/abc123');
+    expect(result).toBe('https://www.youtube.com/embed/abc123');
+  });
+
+  it('handles youtube.com without www', () => {
+    const result = buildVideoEmbedUrl('https://youtube.com/watch?v=xyz789');
+    expect(result).toBe('https://www.youtube.com/embed/xyz789');
+  });
+
+  it('strips extra query params from watch URL', () => {
+    const result = buildVideoEmbedUrl('https://www.youtube.com/watch?v=abc123&t=30');
+    expect(result).toBe('https://www.youtube.com/embed/abc123');
+  });
+
+  it('returns non-YouTube URLs as-is', () => {
+    const url = 'https://vimeo.com/12345';
+    expect(buildVideoEmbedUrl(url)).toBe(url);
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(buildVideoEmbedUrl(null)).toBeNull();
+    expect(buildVideoEmbedUrl(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(buildVideoEmbedUrl('')).toBeNull();
+  });
+});
+
+// ── formatEstimatedTime ───────────────────────────────────────────────
+
+describe('formatEstimatedTime', () => {
+  it('trims and returns time string', () => {
+    expect(formatEstimatedTime('  30 minutes  ')).toBe('30 minutes');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(formatEstimatedTime(null)).toBe('');
+    expect(formatEstimatedTime(undefined)).toBe('');
+  });
+});
+
+// ── buildHowToSchema ──────────────────────────────────────────────────
+
+describe('buildHowToSchema', () => {
+  it('returns null for null guide', () => {
+    expect(buildHowToSchema(null)).toBeNull();
+  });
+
+  it('builds valid HowTo schema', () => {
+    const guide = {
+      title: 'Assemble Frame',
+      estimatedTime: '30 minutes',
+      steps: '<ol><li>Unpack parts</li><li>Attach legs</li></ol>',
+    };
+    const schema = buildHowToSchema(guide);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('HowTo');
+    expect(schema.name).toBe('Assemble Frame');
+    expect(schema.totalTime).toBe('PT30M');
+    expect(schema.step).toHaveLength(2);
+    expect(schema.step[0].text).toBe('Unpack parts');
+    expect(schema.step[0].position).toBe(1);
+  });
+
+  it('includes video when videoUrl is present', () => {
+    const guide = {
+      title: 'Frame Guide',
+      steps: '<ol><li>Step 1</li></ol>',
+      videoUrl: 'https://youtube.com/watch?v=abc',
+    };
+    const schema = buildHowToSchema(guide);
+    expect(schema.video['@type']).toBe('VideoObject');
+    expect(schema.video.contentUrl).toBe(guide.videoUrl);
+  });
+
+  it('omits video when no videoUrl', () => {
+    const guide = { title: 'Basic', steps: '' };
+    const schema = buildHowToSchema(guide);
+    expect(schema.video).toBeUndefined();
+  });
+
+  it('handles empty steps HTML', () => {
+    const guide = { title: 'Test', steps: '' };
+    const schema = buildHowToSchema(guide);
+    expect(schema.step).toEqual([]);
+  });
+
+  it('handles null steps', () => {
+    const guide = { title: 'Test', steps: null };
+    const schema = buildHowToSchema(guide);
+    expect(schema.step).toEqual([]);
+  });
+
+  it('strips HTML from step text', () => {
+    const guide = {
+      title: 'Test',
+      steps: '<ol><li><strong>Bold step</strong> text</li></ol>',
+    };
+    const schema = buildHowToSchema(guide);
+    expect(schema.step[0].text).toBe('Bold step text');
+  });
+
+  it('handles missing estimatedTime', () => {
+    const guide = { title: 'Test', steps: '' };
+    const schema = buildHowToSchema(guide);
+    expect(schema.totalTime).toBeUndefined();
+  });
+});

--- a/tests/blogHelpers.test.js
+++ b/tests/blogHelpers.test.js
@@ -1,0 +1,242 @@
+/**
+ * Tests for blogHelpers.js — Blog listing and post page utilities
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  estimateReadingTime,
+  getCategories,
+  filterPostsByCategory,
+  getFeaturedPost,
+  getRelatedPosts,
+  formatPublishDate,
+  buildAuthorBio,
+  buildShareUrls,
+} from '../src/public/blogHelpers.js';
+
+// ── estimateReadingTime ───────────────────────────────────────────────
+
+describe('estimateReadingTime', () => {
+  it('returns 1 for short text', () => {
+    expect(estimateReadingTime('Hello world')).toBe(1);
+  });
+
+  it('returns correct minutes for longer text', () => {
+    const words = new Array(400).fill('word').join(' ');
+    expect(estimateReadingTime(words)).toBe(2);
+  });
+
+  it('rounds up to nearest minute', () => {
+    const words = new Array(201).fill('word').join(' ');
+    expect(estimateReadingTime(words)).toBe(2);
+  });
+
+  it('returns minimum 1 for empty string', () => {
+    expect(estimateReadingTime('')).toBe(1);
+    expect(estimateReadingTime('   ')).toBe(1);
+  });
+
+  it('returns 1 for null/undefined', () => {
+    expect(estimateReadingTime(null)).toBe(1);
+    expect(estimateReadingTime(undefined)).toBe(1);
+  });
+
+  it('returns 1 for non-string input', () => {
+    expect(estimateReadingTime(123)).toBe(1);
+    expect(estimateReadingTime({})).toBe(1);
+  });
+});
+
+// ── getCategories ─────────────────────────────────────────────────────
+
+describe('getCategories', () => {
+  it('extracts unique sorted categories from posts', () => {
+    const posts = [
+      { category: 'Design' },
+      { category: 'Tips' },
+      { category: 'Design' },
+      { category: 'News' },
+    ];
+    expect(getCategories(posts)).toEqual(['Design', 'News', 'Tips']);
+  });
+
+  it('returns empty array for null/undefined', () => {
+    expect(getCategories(null)).toEqual([]);
+    expect(getCategories(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for non-array', () => {
+    expect(getCategories('not-array')).toEqual([]);
+  });
+
+  it('skips posts without category', () => {
+    const posts = [{ category: 'A' }, {}, { category: null }, { category: 'B' }];
+    expect(getCategories(posts)).toEqual(['A', 'B']);
+  });
+
+  it('skips null entries in array', () => {
+    expect(getCategories([null, { category: 'X' }])).toEqual(['X']);
+  });
+});
+
+// ── filterPostsByCategory ─────────────────────────────────────────────
+
+describe('filterPostsByCategory', () => {
+  const posts = [
+    { title: 'A', category: 'Design' },
+    { title: 'B', category: 'Tips' },
+    { title: 'C', category: 'Design' },
+  ];
+
+  it('filters by category', () => {
+    const result = filterPostsByCategory(posts, 'Design');
+    expect(result).toHaveLength(2);
+    expect(result.every(p => p.category === 'Design')).toBe(true);
+  });
+
+  it('returns all posts when category is null', () => {
+    expect(filterPostsByCategory(posts, null)).toHaveLength(3);
+  });
+
+  it('returns all posts when category is empty string', () => {
+    expect(filterPostsByCategory(posts, '')).toHaveLength(3);
+  });
+
+  it('returns empty array for null posts', () => {
+    expect(filterPostsByCategory(null, 'Design')).toEqual([]);
+  });
+
+  it('returns empty for no matches', () => {
+    expect(filterPostsByCategory(posts, 'Nonexistent')).toEqual([]);
+  });
+});
+
+// ── getFeaturedPost ───────────────────────────────────────────────────
+
+describe('getFeaturedPost', () => {
+  it('returns the most recently published post', () => {
+    const posts = [
+      { title: 'Old', publishDate: '2025-01-01' },
+      { title: 'Newest', publishDate: '2026-03-01' },
+      { title: 'Middle', publishDate: '2025-06-15' },
+    ];
+    expect(getFeaturedPost(posts).title).toBe('Newest');
+  });
+
+  it('returns null for empty array', () => {
+    expect(getFeaturedPost([])).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(getFeaturedPost(null)).toBeNull();
+    expect(getFeaturedPost(undefined)).toBeNull();
+  });
+
+  it('handles posts with missing publishDate', () => {
+    const posts = [{ title: 'A' }, { title: 'B', publishDate: '2026-01-01' }];
+    const featured = getFeaturedPost(posts);
+    expect(featured.title).toBe('B');
+  });
+});
+
+// ── getRelatedPosts ───────────────────────────────────────────────────
+
+describe('getRelatedPosts', () => {
+  const allPosts = [
+    { slug: 'current', category: 'Design', tags: ['furniture', 'style'] },
+    { slug: 'same-cat', category: 'Design', tags: ['tips'] },
+    { slug: 'same-tag', category: 'Tips', tags: ['furniture'] },
+    { slug: 'no-match', category: 'News', tags: ['other'] },
+    { slug: 'both', category: 'Design', tags: ['furniture', 'style'] },
+  ];
+
+  it('excludes the current post', () => {
+    const related = getRelatedPosts(allPosts[0], allPosts);
+    expect(related.find(p => p.slug === 'current')).toBeUndefined();
+  });
+
+  it('prioritizes same category posts', () => {
+    const related = getRelatedPosts(allPosts[0], allPosts);
+    expect(related[0].slug).toBe('both'); // same category + same tags
+  });
+
+  it('returns at most 3 posts', () => {
+    const related = getRelatedPosts(allPosts[0], allPosts);
+    expect(related.length).toBeLessThanOrEqual(3);
+  });
+
+  it('returns empty for null inputs', () => {
+    expect(getRelatedPosts(null, allPosts)).toEqual([]);
+    expect(getRelatedPosts(allPosts[0], null)).toEqual([]);
+  });
+
+  it('returns empty when only current post exists', () => {
+    expect(getRelatedPosts(allPosts[0], [allPosts[0]])).toEqual([]);
+  });
+});
+
+// ── formatPublishDate ─────────────────────────────────────────────────
+
+describe('formatPublishDate', () => {
+  it('formats YYYY-MM-DD to readable format', () => {
+    const result = formatPublishDate('2026-02-20');
+    expect(result).toContain('February');
+    expect(result).toContain('20');
+    expect(result).toContain('2026');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(formatPublishDate(null)).toBe('');
+    expect(formatPublishDate(undefined)).toBe('');
+  });
+
+  it('returns empty string for non-string', () => {
+    expect(formatPublishDate(123)).toBe('');
+  });
+
+  it('returns empty string for invalid date format', () => {
+    expect(formatPublishDate('not-a-date')).toBe('');
+    expect(formatPublishDate('2026/02/20')).toBe('');
+  });
+
+  it('returns empty string for invalid date values', () => {
+    expect(formatPublishDate('2026-13-01')).toBe('');
+  });
+});
+
+// ── buildAuthorBio ────────────────────────────────────────────────────
+
+describe('buildAuthorBio', () => {
+  it('returns Carolina Futons brand info', () => {
+    const bio = buildAuthorBio();
+    expect(bio.name).toBe('Carolina Futons');
+    expect(bio.location).toBe('Hendersonville, NC');
+    expect(bio.established).toBe('1991');
+    expect(bio.description).toBeTruthy();
+  });
+});
+
+// ── buildShareUrls ────────────────────────────────────────────────────
+
+describe('buildShareUrls', () => {
+  it('returns all share platform URLs', () => {
+    const urls = buildShareUrls('https://example.com/post', 'My Post');
+    expect(urls.facebook).toContain('facebook.com/sharer');
+    expect(urls.pinterest).toContain('pinterest.com/pin');
+    expect(urls.twitter).toContain('twitter.com/intent');
+    expect(urls.email).toContain('mailto:');
+  });
+
+  it('encodes URL and title', () => {
+    const urls = buildShareUrls('https://example.com/post?a=1', 'Post & Title');
+    expect(urls.facebook).toContain(encodeURIComponent('https://example.com/post?a=1'));
+    expect(urls.twitter).toContain(encodeURIComponent('Post & Title'));
+  });
+
+  it('returns empty object when url is null', () => {
+    expect(buildShareUrls(null, 'Title')).toEqual({});
+  });
+
+  it('returns empty object when title is null', () => {
+    expect(buildShareUrls('https://example.com', null)).toEqual({});
+  });
+});

--- a/tests/cartStyles.test.js
+++ b/tests/cartStyles.test.js
@@ -1,0 +1,150 @@
+/**
+ * Tests for cartStyles.js — Cart/checkout UI style token helpers
+ */
+import { describe, it, expect } from 'vitest';
+import { colors, transitions, spacing } from '../src/public/sharedTokens.js';
+import {
+  getCartItemStyles,
+  getProgressBarStyles,
+  getEmptyCartStyles,
+  getSideCartPanelStyles,
+  getCheckoutButtonStyles,
+  getQuantitySpinnerStyles,
+  getCrossSellCardStyles,
+} from '../src/public/cartStyles.js';
+
+// ── getCartItemStyles ─────────────────────────────────────────────────
+
+describe('getCartItemStyles', () => {
+  it('returns all required style properties', () => {
+    const styles = getCartItemStyles();
+    expect(styles).toHaveProperty('nameColor');
+    expect(styles).toHaveProperty('variantColor');
+    expect(styles).toHaveProperty('priceColor');
+    expect(styles).toHaveProperty('rowBackground');
+    expect(styles).toHaveProperty('borderColor');
+    expect(styles).toHaveProperty('removeColor');
+  });
+
+  it('uses brand tokens, not hardcoded values', () => {
+    const styles = getCartItemStyles();
+    expect(styles.nameColor).toBe(colors.espresso);
+    expect(styles.removeColor).toBe(colors.sunsetCoral);
+    expect(styles.rowBackground).toBe(colors.sandLight);
+  });
+});
+
+// ── getProgressBarStyles ──────────────────────────────────────────────
+
+describe('getProgressBarStyles', () => {
+  it('uses sunsetCoral fill when not qualified', () => {
+    const styles = getProgressBarStyles('shipping', false);
+    expect(styles.fillColor).toBe(colors.sunsetCoral);
+  });
+
+  it('uses success fill when qualified', () => {
+    const styles = getProgressBarStyles('shipping', true);
+    expect(styles.fillColor).toBe(colors.success);
+  });
+
+  it('uses espresso text color', () => {
+    const styles = getProgressBarStyles('tier');
+    expect(styles.textColor).toBe(colors.espresso);
+  });
+
+  it('defaults qualifies to false', () => {
+    const styles = getProgressBarStyles('shipping');
+    expect(styles.fillColor).toBe(colors.sunsetCoral);
+  });
+});
+
+// ── getEmptyCartStyles ────────────────────────────────────────────────
+
+describe('getEmptyCartStyles', () => {
+  it('uses sunsetCoral for CTA background', () => {
+    const styles = getEmptyCartStyles();
+    expect(styles.ctaBackground).toBe(colors.sunsetCoral);
+  });
+
+  it('uses white for CTA text', () => {
+    const styles = getEmptyCartStyles();
+    expect(styles.ctaTextColor).toBe(colors.white);
+  });
+
+  it('uses offWhite for page background', () => {
+    const styles = getEmptyCartStyles();
+    expect(styles.pageBackground).toBe(colors.offWhite);
+  });
+});
+
+// ── getSideCartPanelStyles ────────────────────────────────────────────
+
+describe('getSideCartPanelStyles', () => {
+  it('uses sunsetCoral for checkout button', () => {
+    const styles = getSideCartPanelStyles();
+    expect(styles.checkoutBtnBackground).toBe(colors.sunsetCoral);
+  });
+
+  it('uses mountainBlue for view cart link', () => {
+    const styles = getSideCartPanelStyles();
+    expect(styles.viewCartLinkColor).toBe(colors.mountainBlue);
+  });
+
+  it('includes slide duration from transitions', () => {
+    const styles = getSideCartPanelStyles();
+    expect(styles.slideDuration).toBe(transitions.medium);
+    expect(typeof styles.slideDuration).toBe('number');
+  });
+});
+
+// ── getCheckoutButtonStyles ───────────────────────────────────────────
+
+describe('getCheckoutButtonStyles', () => {
+  it('uses sunsetCoral as primary CTA background', () => {
+    const styles = getCheckoutButtonStyles();
+    expect(styles.background).toBe(colors.sunsetCoral);
+  });
+
+  it('meets WCAG AA touch target minimum (44px)', () => {
+    const styles = getCheckoutButtonStyles();
+    expect(styles.minHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  it('uses white text on CTA', () => {
+    const styles = getCheckoutButtonStyles();
+    expect(styles.textColor).toBe(colors.white);
+  });
+});
+
+// ── getQuantitySpinnerStyles ──────────────────────────────────────────
+
+describe('getQuantitySpinnerStyles', () => {
+  it('meets WCAG AA touch target minimum (44px)', () => {
+    const styles = getQuantitySpinnerStyles();
+    expect(styles.buttonMinSize).toBeGreaterThanOrEqual(44);
+  });
+
+  it('uses mountainBlue for buttons', () => {
+    const styles = getQuantitySpinnerStyles();
+    expect(styles.buttonColor).toBe(colors.mountainBlue);
+  });
+});
+
+// ── getCrossSellCardStyles ────────────────────────────────────────────
+
+describe('getCrossSellCardStyles', () => {
+  it('uses sunsetCoral for add button', () => {
+    const styles = getCrossSellCardStyles();
+    expect(styles.addBtnBackground).toBe(colors.sunsetCoral);
+  });
+
+  it('uses success color for added state', () => {
+    const styles = getCrossSellCardStyles();
+    expect(styles.addedColor).toBe(colors.success);
+  });
+
+  it('uses mountainBlue for price', () => {
+    const styles = getCrossSellCardStyles();
+    expect(styles.priceColor).toBe(colors.mountainBlue);
+  });
+});

--- a/tests/checkoutProgress.test.js
+++ b/tests/checkoutProgress.test.js
@@ -1,0 +1,125 @@
+/**
+ * Tests for checkoutProgress.js — Checkout step progress indicator logic
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getCheckoutSteps,
+  getActiveStepIndex,
+  getStepAriaAttributes,
+} from '../src/public/checkoutProgress.js';
+
+// ── getCheckoutSteps ──────────────────────────────────────────────────
+
+describe('getCheckoutSteps', () => {
+  it('returns 4 checkout steps', () => {
+    const steps = getCheckoutSteps();
+    expect(steps).toHaveLength(4);
+  });
+
+  it('returns steps in correct order', () => {
+    const steps = getCheckoutSteps();
+    expect(steps.map(s => s.id)).toEqual(['information', 'shipping', 'payment', 'review']);
+  });
+
+  it('each step has id, label, and number', () => {
+    const steps = getCheckoutSteps();
+    steps.forEach(step => {
+      expect(step).toHaveProperty('id');
+      expect(step).toHaveProperty('label');
+      expect(step).toHaveProperty('number');
+      expect(typeof step.id).toBe('string');
+      expect(typeof step.label).toBe('string');
+      expect(typeof step.number).toBe('number');
+    });
+  });
+
+  it('returns a defensive copy (not a reference)', () => {
+    const steps1 = getCheckoutSteps();
+    const steps2 = getCheckoutSteps();
+    expect(steps1).not.toBe(steps2);
+    steps1[0].label = 'Modified';
+    expect(getCheckoutSteps()[0].label).toBe('Information');
+  });
+});
+
+// ── getActiveStepIndex ────────────────────────────────────────────────
+
+describe('getActiveStepIndex', () => {
+  it('returns correct index for each step ID', () => {
+    expect(getActiveStepIndex('information')).toBe(0);
+    expect(getActiveStepIndex('shipping')).toBe(1);
+    expect(getActiveStepIndex('payment')).toBe(2);
+    expect(getActiveStepIndex('review')).toBe(3);
+  });
+
+  it('returns 0 for unknown step ID', () => {
+    expect(getActiveStepIndex('unknown')).toBe(0);
+    expect(getActiveStepIndex('confirmation')).toBe(0);
+  });
+
+  it('returns 0 for null/undefined', () => {
+    expect(getActiveStepIndex(null)).toBe(0);
+    expect(getActiveStepIndex(undefined)).toBe(0);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(getActiveStepIndex('')).toBe(0);
+  });
+
+  it('returns 0 for non-string types', () => {
+    expect(getActiveStepIndex(123)).toBe(0);
+    expect(getActiveStepIndex({})).toBe(0);
+  });
+});
+
+// ── getStepAriaAttributes ─────────────────────────────────────────────
+
+describe('getStepAriaAttributes', () => {
+  it('returns completed state for steps before active', () => {
+    const attrs = getStepAriaAttributes(0, 2, 'Information');
+    expect(attrs.state).toBe('completed');
+    expect(attrs.ariaLabel).toContain('completed');
+    expect(attrs.ariaLabel).toContain('Information');
+    expect(attrs).not.toHaveProperty('ariaCurrent');
+  });
+
+  it('returns active state for current step', () => {
+    const attrs = getStepAriaAttributes(1, 1, 'Shipping');
+    expect(attrs.state).toBe('active');
+    expect(attrs.ariaCurrent).toBe('step');
+    expect(attrs.ariaLabel).toContain('current');
+    expect(attrs.ariaLabel).toContain('Shipping');
+  });
+
+  it('returns pending state for steps after active', () => {
+    const attrs = getStepAriaAttributes(3, 1, 'Review');
+    expect(attrs.state).toBe('pending');
+    expect(attrs.ariaLabel).toContain('Review');
+    expect(attrs.ariaLabel).not.toContain('completed');
+    expect(attrs.ariaLabel).not.toContain('current');
+    expect(attrs).not.toHaveProperty('ariaCurrent');
+  });
+
+  it('includes step number in aria-label', () => {
+    const attrs = getStepAriaAttributes(2, 2, 'Payment');
+    expect(attrs.ariaLabel).toContain('Step 3');
+  });
+
+  it('uses default label when none provided', () => {
+    const attrs = getStepAriaAttributes(0, 0);
+    expect(attrs.ariaLabel).toContain('Step 1');
+  });
+
+  it('handles first step as active', () => {
+    const attrs = getStepAriaAttributes(0, 0, 'Information');
+    expect(attrs.state).toBe('active');
+    expect(attrs.ariaCurrent).toBe('step');
+  });
+
+  it('handles last step as active with all preceding completed', () => {
+    expect(getStepAriaAttributes(0, 3).state).toBe('completed');
+    expect(getStepAriaAttributes(1, 3).state).toBe('completed');
+    expect(getStepAriaAttributes(2, 3).state).toBe('completed');
+    expect(getStepAriaAttributes(3, 3).state).toBe('active');
+  });
+});

--- a/tests/financingPageHelpers.test.js
+++ b/tests/financingPageHelpers.test.js
@@ -1,0 +1,257 @@
+/**
+ * Tests for financingPageHelpers.js — Financing calculator page utilities
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  QUICK_PRICES,
+  validatePriceInput,
+  formatCurrency,
+  formatMonthlyPayment,
+  buildComparisonRows,
+  getProviderInfo,
+  getPriceRangeLabel,
+  getFinancingFaqs,
+  filterFaqsByTopic,
+} from '../src/public/financingPageHelpers.js';
+
+// ── QUICK_PRICES ──────────────────────────────────────────────────────
+
+describe('QUICK_PRICES', () => {
+  it('contains preset price options', () => {
+    expect(Array.isArray(QUICK_PRICES)).toBe(true);
+    expect(QUICK_PRICES.length).toBeGreaterThan(0);
+  });
+
+  it('each entry has price and label', () => {
+    QUICK_PRICES.forEach(p => {
+      expect(typeof p.price).toBe('number');
+      expect(typeof p.label).toBe('string');
+    });
+  });
+});
+
+// ── validatePriceInput ────────────────────────────────────────────────
+
+describe('validatePriceInput', () => {
+  it('accepts valid numeric price', () => {
+    const result = validatePriceInput(500);
+    expect(result.valid).toBe(true);
+    expect(result.price).toBe(500);
+    expect(result.error).toBeNull();
+  });
+
+  it('accepts string price with $ and commas', () => {
+    const result = validatePriceInput('$1,500');
+    expect(result.valid).toBe(true);
+    expect(result.price).toBe(1500);
+  });
+
+  it('accepts string price with leading spaces', () => {
+    const result = validatePriceInput('  999  ');
+    expect(result.valid).toBe(true);
+    expect(result.price).toBe(999);
+  });
+
+  it('rejects null/undefined/empty', () => {
+    expect(validatePriceInput(null).valid).toBe(false);
+    expect(validatePriceInput(undefined).valid).toBe(false);
+    expect(validatePriceInput('').valid).toBe(false);
+  });
+
+  it('provides error message for empty input', () => {
+    expect(validatePriceInput('').error).toContain('enter a price');
+  });
+
+  it('rejects non-numeric strings', () => {
+    const result = validatePriceInput('abc');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('valid number');
+  });
+
+  it('rejects zero and negative values', () => {
+    expect(validatePriceInput(0).valid).toBe(false);
+    expect(validatePriceInput(-100).valid).toBe(false);
+    expect(validatePriceInput(0).error).toContain('greater than $0');
+  });
+
+  it('rejects values above $25,000', () => {
+    const result = validatePriceInput(30000);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('25,000');
+  });
+
+  it('accepts boundary value $25,000', () => {
+    expect(validatePriceInput(25000).valid).toBe(true);
+  });
+
+  it('accepts boundary value just above $0', () => {
+    expect(validatePriceInput(0.01).valid).toBe(true);
+  });
+
+  it('rejects NaN/Infinity', () => {
+    expect(validatePriceInput(NaN).valid).toBe(false);
+    expect(validatePriceInput(Infinity).valid).toBe(false);
+  });
+});
+
+// ── formatCurrency ────────────────────────────────────────────────────
+
+describe('formatCurrency', () => {
+  it('formats whole dollar amount', () => {
+    expect(formatCurrency(1500)).toBe('$1,500.00');
+  });
+
+  it('formats cents', () => {
+    expect(formatCurrency(42.5)).toBe('$42.50');
+  });
+
+  it('formats zero', () => {
+    expect(formatCurrency(0)).toBe('$0.00');
+  });
+
+  it('adds comma separators for thousands', () => {
+    expect(formatCurrency(1000000)).toBe('$1,000,000.00');
+  });
+
+  it('rounds to 2 decimal places', () => {
+    expect(formatCurrency(10.999)).toBe('$11.00');
+  });
+});
+
+// ── formatMonthlyPayment ──────────────────────────────────────────────
+
+describe('formatMonthlyPayment', () => {
+  it('appends /mo suffix', () => {
+    expect(formatMonthlyPayment(42.5)).toBe('$42.50/mo');
+  });
+
+  it('formats with commas', () => {
+    expect(formatMonthlyPayment(1500)).toBe('$1,500.00/mo');
+  });
+});
+
+// ── buildComparisonRows ───────────────────────────────────────────────
+
+describe('buildComparisonRows', () => {
+  it('includes afterpay row when eligible', () => {
+    const afterpay = { eligible: true, installmentAmount: 125, total: 500 };
+    const rows = buildComparisonRows([], afterpay);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('afterpay');
+    expect(rows[0].isZeroInterest).toBe(true);
+  });
+
+  it('excludes afterpay when not eligible', () => {
+    const afterpay = { eligible: false };
+    const rows = buildComparisonRows([], afterpay);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('includes term rows', () => {
+    const terms = [
+      { label: '6 months', monthly: 83.33, total: 500, interest: 0, apr: 0, isZeroInterest: true, months: 6 },
+      { label: '12 months', monthly: 45, total: 540, interest: 40, apr: 8.99, isZeroInterest: false, months: 12 },
+    ];
+    const rows = buildComparisonRows(terms, null);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].type).toBe('term');
+    expect(rows[0].isZeroInterest).toBe(true);
+    expect(rows[1].interestText).toContain('8.99%');
+  });
+
+  it('puts afterpay first, then terms', () => {
+    const afterpay = { eligible: true, installmentAmount: 125, total: 500 };
+    const terms = [{ label: '6 months', monthly: 83, total: 500, interest: 0, apr: 0, isZeroInterest: true, months: 6 }];
+    const rows = buildComparisonRows(terms, afterpay);
+    expect(rows[0].type).toBe('afterpay');
+    expect(rows[1].type).toBe('term');
+  });
+});
+
+// ── getProviderInfo ───────────────────────────────────────────────────
+
+describe('getProviderInfo', () => {
+  it('returns provider information', () => {
+    const providers = getProviderInfo();
+    expect(providers.length).toBeGreaterThan(0);
+    providers.forEach(p => {
+      expect(p).toHaveProperty('name');
+      expect(p).toHaveProperty('description');
+      expect(p).toHaveProperty('range');
+    });
+  });
+
+  it('includes Afterpay and Affirm', () => {
+    const names = getProviderInfo().map(p => p.name);
+    expect(names).toContain('Afterpay');
+    expect(names).toContain('Affirm');
+  });
+});
+
+// ── getPriceRangeLabel ────────────────────────────────────────────────
+
+describe('getPriceRangeLabel', () => {
+  it('returns afterpay-only message for low prices', () => {
+    expect(getPriceRangeLabel(100)).toContain('Afterpay');
+  });
+
+  it('returns 6-month message for $200-499', () => {
+    expect(getPriceRangeLabel(300)).toContain('6-month');
+  });
+
+  it('returns multiple plans for $500-749', () => {
+    expect(getPriceRangeLabel(600)).toContain('6 and 12');
+  });
+
+  it('returns multiple + afterpay for $750-1000', () => {
+    expect(getPriceRangeLabel(900)).toContain('Afterpay');
+  });
+
+  it('returns full range for $1000+', () => {
+    expect(getPriceRangeLabel(2000)).toContain('Full range');
+  });
+});
+
+// ── getFinancingFaqs ──────────────────────────────────────────────────
+
+describe('getFinancingFaqs', () => {
+  it('returns FAQ array with question, answer, topic', () => {
+    const faqs = getFinancingFaqs();
+    expect(faqs.length).toBeGreaterThan(0);
+    faqs.forEach(faq => {
+      expect(faq).toHaveProperty('question');
+      expect(faq).toHaveProperty('answer');
+      expect(faq).toHaveProperty('topic');
+    });
+  });
+});
+
+// ── filterFaqsByTopic ─────────────────────────────────────────────────
+
+describe('filterFaqsByTopic', () => {
+  const faqs = [
+    { question: 'About Affirm?', answer: 'Affirm lets you split...', topic: 'affirm' },
+    { question: 'Credit check?', answer: 'Soft credit check...', topic: 'credit' },
+    { question: 'Minimum purchase?', answer: 'From $35...', topic: 'eligibility' },
+  ];
+
+  it('filters by topic keyword in question/answer', () => {
+    const result = filterFaqsByTopic(faqs, 'affirm');
+    expect(result).toHaveLength(1);
+  });
+
+  it('is case-insensitive', () => {
+    expect(filterFaqsByTopic(faqs, 'AFFIRM')).toHaveLength(1);
+  });
+
+  it('returns all when topic is null/empty', () => {
+    expect(filterFaqsByTopic(faqs, null)).toHaveLength(3);
+    expect(filterFaqsByTopic(faqs, '')).toHaveLength(3);
+    expect(filterFaqsByTopic(faqs, '   ')).toHaveLength(3);
+  });
+
+  it('searches across question and answer text', () => {
+    const result = filterFaqsByTopic(faqs, 'credit');
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/navigationHelpers.test.js
+++ b/tests/navigationHelpers.test.js
@@ -1,0 +1,353 @@
+/**
+ * Tests for navigationHelpers.js — Navigation, layout & footer helpers
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies
+vi.mock('public/designTokens.js', () => ({
+  colors: {
+    espresso: '#3A2518',
+    mountainBlue: '#5B8FA8',
+    sunsetCoral: '#E8845C',
+    sandLight: '#F2E8D5',
+    offWhite: '#FAF7F2',
+  },
+  spacing: { md: 16 },
+  shadows: { nav: '0 2px 4px rgba(0,0,0,0.1)' },
+}));
+
+vi.mock('public/sharedTokens', () => ({
+  transitions: { fast: 150, medium: 250, slow: 400 },
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+  makeClickable: vi.fn((el, handler, opts) => {
+    if (el && el.onClick) el.onClick(handler);
+  }),
+  createFocusTrap: vi.fn(() => ({ release: vi.fn() })),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  isMobile: vi.fn(() => false),
+  getViewport: vi.fn(() => ({ width: 1024 })),
+}));
+
+import {
+  NAV_LINKS,
+  MEGA_MENU_CATEGORIES,
+  getActiveNavId,
+  applyActiveNavState,
+  initMegaMenu,
+  initMobileDrawer,
+  initMobileAccordions,
+  buildBreadcrumbs,
+  breadcrumbsFromPath,
+  initAnnouncementBar,
+} from '../src/public/navigationHelpers.js';
+
+// ── Helper: mock $w ───────────────────────────────────────────────────
+
+function createMock$w(elements = {}) {
+  return (id) => {
+    if (elements[id]) return elements[id];
+    return {
+      style: {},
+      accessibility: {},
+      text: '',
+      show: vi.fn(() => Promise.resolve()),
+      hide: vi.fn(() => Promise.resolve()),
+      onClick: vi.fn(),
+      onMouseIn: vi.fn(),
+      onMouseOut: vi.fn(),
+      onKeyPress: vi.fn(),
+      focus: vi.fn(),
+      collapse: vi.fn(),
+      expand: vi.fn(),
+      postMessage: vi.fn(),
+    };
+  };
+}
+
+// ── NAV_LINKS ─────────────────────────────────────────────────────────
+
+describe('NAV_LINKS', () => {
+  it('contains home link', () => {
+    expect(NAV_LINKS['#navHome']).toBeDefined();
+    expect(NAV_LINKS['#navHome'].path).toBe('/');
+  });
+
+  it('all entries have path and label', () => {
+    Object.values(NAV_LINKS).forEach(link => {
+      expect(link).toHaveProperty('path');
+      expect(link).toHaveProperty('label');
+    });
+  });
+});
+
+// ── MEGA_MENU_CATEGORIES ──────────────────────────────────────────────
+
+describe('MEGA_MENU_CATEGORIES', () => {
+  it('has category groups', () => {
+    expect(MEGA_MENU_CATEGORIES.length).toBeGreaterThan(0);
+  });
+
+  it('each group has title and items', () => {
+    MEGA_MENU_CATEGORIES.forEach(group => {
+      expect(group).toHaveProperty('title');
+      expect(group).toHaveProperty('items');
+      expect(group.items.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ── getActiveNavId ────────────────────────────────────────────────────
+
+describe('getActiveNavId', () => {
+  it('returns #navHome for /', () => {
+    expect(getActiveNavId('/')).toBe('#navHome');
+  });
+
+  it('returns matching nav for exact path', () => {
+    expect(getActiveNavId('/futon-frames')).toBe('#navFutonFrames');
+    expect(getActiveNavId('/mattresses')).toBe('#navMattresses');
+    expect(getActiveNavId('/faq')).toBe('#navFAQ');
+  });
+
+  it('matches child paths', () => {
+    expect(getActiveNavId('/futon-frames/some-product')).toBe('#navFutonFrames');
+  });
+
+  it('returns null for unknown paths', () => {
+    expect(getActiveNavId('/nonexistent-page')).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(getActiveNavId(null)).toBeNull();
+    expect(getActiveNavId(undefined)).toBeNull();
+  });
+
+  it('strips trailing slash', () => {
+    expect(getActiveNavId('/futon-frames/')).toBe('#navFutonFrames');
+  });
+});
+
+// ── applyActiveNavState ───────────────────────────────────────────────
+
+describe('applyActiveNavState', () => {
+  it('sets bold and mountainBlue on active link', () => {
+    const activeEl = { style: {}, accessibility: {} };
+    const otherEl = { style: {}, accessibility: {} };
+    const $w = (id) => {
+      if (id === '#navHome') return activeEl;
+      return otherEl;
+    };
+    applyActiveNavState($w, '/');
+    expect(activeEl.style.fontWeight).toBe('700');
+    expect(activeEl.style.color).toBe('#5B8FA8');
+  });
+
+  it('does nothing when no path matches', () => {
+    const $w = vi.fn(() => ({ style: {}, accessibility: {} }));
+    applyActiveNavState($w, '/nonexistent');
+    // No errors thrown
+  });
+});
+
+// ── initMegaMenu ──────────────────────────────────────────────────────
+
+describe('initMegaMenu', () => {
+  it('returns open and close functions', () => {
+    const $w = createMock$w();
+    const menu = initMegaMenu($w);
+    expect(typeof menu.open).toBe('function');
+    expect(typeof menu.close).toBe('function');
+  });
+
+  it('open and close do not throw', () => {
+    const $w = createMock$w();
+    const menu = initMegaMenu($w);
+    expect(() => menu.open()).not.toThrow();
+    expect(() => menu.close()).not.toThrow();
+  });
+});
+
+// ── initMobileDrawer ──────────────────────────────────────────────────
+
+describe('initMobileDrawer', () => {
+  it('returns open and close functions', () => {
+    const $w = createMock$w();
+    const drawer = initMobileDrawer($w, '/');
+    expect(typeof drawer.open).toBe('function');
+    expect(typeof drawer.close).toBe('function');
+  });
+
+  it('open and close do not throw', () => {
+    const $w = createMock$w();
+    const drawer = initMobileDrawer($w, '/');
+    expect(() => drawer.open()).not.toThrow();
+    expect(() => drawer.close()).not.toThrow();
+  });
+});
+
+// ── initMobileAccordions ──────────────────────────────────────────────
+
+describe('initMobileAccordions', () => {
+  it('does not throw with empty sections', () => {
+    const $w = createMock$w();
+    expect(() => initMobileAccordions($w, [])).not.toThrow();
+    expect(() => initMobileAccordions($w, null)).not.toThrow();
+  });
+
+  it('initializes accordion sections', () => {
+    const header = {
+      accessibility: {},
+      onClick: vi.fn(),
+    };
+    const panel = {
+      collapse: vi.fn(),
+      expand: vi.fn(),
+    };
+    const $w = (id) => {
+      if (id === '#header1') return header;
+      if (id === '#panel1') return panel;
+      return null;
+    };
+    initMobileAccordions($w, [{ headerId: '#header1', panelId: '#panel1', label: 'Test' }]);
+    expect(panel.collapse).toHaveBeenCalled();
+  });
+});
+
+// ── buildBreadcrumbs ──────────────────────────────────────────────────
+
+describe('buildBreadcrumbs', () => {
+  it('returns items and schema', () => {
+    const result = buildBreadcrumbs([
+      { label: 'Home', path: '/' },
+      { label: 'Futon Frames', path: '/futon-frames' },
+    ]);
+    expect(result.items).toHaveLength(2);
+    expect(result.schema['@type']).toBe('BreadcrumbList');
+  });
+
+  it('marks last item as isLast', () => {
+    const result = buildBreadcrumbs([
+      { label: 'Home', path: '/' },
+      { label: 'Product', path: '/product' },
+    ]);
+    expect(result.items[0].isLast).toBe(false);
+    expect(result.items[1].isLast).toBe(true);
+  });
+
+  it('defaults to Home when empty', () => {
+    const result = buildBreadcrumbs([]);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].label).toBe('Home');
+  });
+
+  it('defaults to Home when null', () => {
+    const result = buildBreadcrumbs(null);
+    expect(result.items[0].label).toBe('Home');
+  });
+
+  it('schema omits item URL for last breadcrumb', () => {
+    const result = buildBreadcrumbs([
+      { label: 'Home', path: '/' },
+      { label: 'Current', path: '/current' },
+    ]);
+    const lastSchema = result.schema.itemListElement[1];
+    expect(lastSchema.item).toBeUndefined();
+  });
+
+  it('schema includes URL for non-last breadcrumbs', () => {
+    const result = buildBreadcrumbs([
+      { label: 'Home', path: '/' },
+      { label: 'Current', path: '/current' },
+    ]);
+    const firstSchema = result.schema.itemListElement[0];
+    expect(firstSchema.item).toContain('carolinafutons.com');
+  });
+});
+
+// ── breadcrumbsFromPath ───────────────────────────────────────────────
+
+describe('breadcrumbsFromPath', () => {
+  it('returns just Home for root path', () => {
+    const crumbs = breadcrumbsFromPath('/');
+    expect(crumbs).toHaveLength(1);
+    expect(crumbs[0].label).toBe('Home');
+  });
+
+  it('adds matched nav link as second crumb', () => {
+    const crumbs = breadcrumbsFromPath('/futon-frames');
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[1].label).toBe('Futon Frames');
+  });
+
+  it('adds product-level crumb for deep paths', () => {
+    const crumbs = breadcrumbsFromPath('/futon-frames/autumn-rosewood');
+    expect(crumbs.length).toBeGreaterThanOrEqual(2);
+    const last = crumbs[crumbs.length - 1];
+    expect(last.label).toContain('Autumn');
+  });
+
+  it('title-cases segment names', () => {
+    const crumbs = breadcrumbsFromPath('/futon-frames/my-product');
+    const last = crumbs[crumbs.length - 1];
+    expect(last.label).toBe('My Product');
+  });
+
+  it('returns just Home for null path', () => {
+    expect(breadcrumbsFromPath(null)).toHaveLength(1);
+  });
+});
+
+// ── initAnnouncementBar ───────────────────────────────────────────────
+
+describe('initAnnouncementBar', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns dismiss, pause, resume functions', () => {
+    const $w = createMock$w();
+    const bar = initAnnouncementBar($w, ['Free shipping on orders over $999!']);
+    expect(typeof bar.dismiss).toBe('function');
+    expect(typeof bar.pause).toBe('function');
+    expect(typeof bar.resume).toBe('function');
+  });
+
+  it('sets initial message text', () => {
+    const textEl = { text: '', accessibility: {} };
+    const $w = (id) => {
+      if (id === '#announcementText') return textEl;
+      return {
+        style: {},
+        accessibility: {},
+        show: vi.fn(),
+        hide: vi.fn(() => Promise.resolve()),
+        onClick: vi.fn(),
+      };
+    };
+    initAnnouncementBar($w, ['Hello World']);
+    expect(textEl.text).toBe('Hello World');
+  });
+
+  it('dismiss sets session storage flag', () => {
+    const $w = createMock$w();
+    const bar = initAnnouncementBar($w, ['Message']);
+    bar.dismiss();
+    expect(sessionStorage.getItem('cf_announcement_dismissed')).toBe('1');
+  });
+
+  it('returns early if already dismissed this session', () => {
+    sessionStorage.setItem('cf_announcement_dismissed', '1');
+    const hideSpy = vi.fn();
+    const $w = (id) => {
+      if (id === '#announcementBar') return { hide: hideSpy, show: vi.fn(), style: {}, accessibility: {} };
+      return { text: '', accessibility: {}, show: vi.fn(), hide: vi.fn(), onClick: vi.fn(), style: {} };
+    };
+    initAnnouncementBar($w, ['Message']);
+    expect(hideSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/product360Data.test.js
+++ b/tests/product360Data.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for product360Data.js — 360-degree image spin set data module
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get360Images, has360View, register360SpinSet } from '../src/public/product360Data.js';
+
+describe('get360Images', () => {
+  it('returns empty array for unknown slug', () => {
+    expect(get360Images('nonexistent-product')).toEqual([]);
+  });
+
+  it('returns empty array for null/undefined input', () => {
+    expect(get360Images(null)).toEqual([]);
+    expect(get360Images(undefined)).toEqual([]);
+    expect(get360Images('')).toEqual([]);
+  });
+
+  it('returns empty array for non-string input', () => {
+    expect(get360Images(123)).toEqual([]);
+    expect(get360Images({})).toEqual([]);
+  });
+
+  it('returns registered spin set after registration', () => {
+    const images = [
+      { src: 'img1.jpg', alt: 'View 1' },
+      { src: 'img2.jpg', alt: 'View 2' },
+    ];
+    register360SpinSet('test-product-360', images);
+    expect(get360Images('test-product-360')).toEqual(images);
+  });
+});
+
+describe('has360View', () => {
+  it('returns false for null product', () => {
+    expect(has360View(null)).toBe(false);
+    expect(has360View(undefined)).toBe(false);
+  });
+
+  it('returns false for product without spin set', () => {
+    expect(has360View({ slug: 'no-spin-set', _id: 'abc' })).toBe(false);
+  });
+
+  it('returns true for product with registered spin set (by slug)', () => {
+    register360SpinSet('has-spin', [{ src: 'a.jpg', alt: 'A' }]);
+    expect(has360View({ slug: 'has-spin' })).toBe(true);
+  });
+
+  it('returns true for product with registered spin set (by _id)', () => {
+    register360SpinSet('id-spin', [{ src: 'b.jpg', alt: 'B' }]);
+    expect(has360View({ _id: 'id-spin' })).toBe(true);
+  });
+
+  it('prefers slug over _id', () => {
+    register360SpinSet('slug-pref', [{ src: 'c.jpg', alt: 'C' }]);
+    expect(has360View({ slug: 'slug-pref', _id: 'unknown' })).toBe(true);
+  });
+});
+
+describe('register360SpinSet', () => {
+  it('ignores null/empty slug', () => {
+    register360SpinSet(null, [{ src: 'x.jpg', alt: 'X' }]);
+    register360SpinSet('', [{ src: 'x.jpg', alt: 'X' }]);
+    // No error thrown
+  });
+
+  it('ignores non-array images', () => {
+    register360SpinSet('bad-images', 'not-array');
+    expect(get360Images('bad-images')).toEqual([]);
+  });
+
+  it('overwrites existing spin set', () => {
+    register360SpinSet('overwrite-test', [{ src: 'old.jpg', alt: 'Old' }]);
+    register360SpinSet('overwrite-test', [{ src: 'new.jpg', alt: 'New' }]);
+    expect(get360Images('overwrite-test')).toEqual([{ src: 'new.jpg', alt: 'New' }]);
+  });
+});

--- a/tests/pwaHelpers.test.js
+++ b/tests/pwaHelpers.test.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for pwaHelpers.js — PWA service worker and install prompt utilities
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  registerServiceWorker,
+  captureInstallPrompt,
+  canShowInstallPrompt,
+  showInstallPrompt,
+  isInstalledPWA,
+  __resetPrompt,
+} from '../src/public/pwaHelpers.js';
+
+describe('registerServiceWorker', () => {
+  it('returns null when navigator is undefined', async () => {
+    const origNav = globalThis.navigator;
+    delete globalThis.navigator;
+    const result = await registerServiceWorker();
+    expect(result).toBeNull();
+    globalThis.navigator = origNav;
+  });
+
+  it('returns null when serviceWorker not in navigator', async () => {
+    const origSW = globalThis.navigator?.serviceWorker;
+    if (globalThis.navigator) {
+      delete globalThis.navigator.serviceWorker;
+    }
+    const result = await registerServiceWorker();
+    expect(result).toBeNull();
+    if (globalThis.navigator && origSW) {
+      globalThis.navigator.serviceWorker = origSW;
+    }
+  });
+
+  it('registers service worker and returns registration', async () => {
+    const mockReg = { scope: '/' };
+    const origNav = globalThis.navigator;
+    globalThis.navigator = {
+      ...origNav,
+      serviceWorker: {
+        register: vi.fn().mockResolvedValue(mockReg),
+      },
+    };
+    const result = await registerServiceWorker();
+    expect(result).toBe(mockReg);
+    expect(globalThis.navigator.serviceWorker.register).toHaveBeenCalledWith(
+      '/_functions/serviceWorker',
+      { scope: '/' }
+    );
+    globalThis.navigator = origNav;
+  });
+
+  it('returns null on registration error', async () => {
+    const origNav = globalThis.navigator;
+    globalThis.navigator = {
+      ...origNav,
+      serviceWorker: {
+        register: vi.fn().mockRejectedValue(new Error('fail')),
+      },
+    };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await registerServiceWorker();
+    expect(result).toBeNull();
+    consoleSpy.mockRestore();
+    globalThis.navigator = origNav;
+  });
+});
+
+describe('captureInstallPrompt', () => {
+  beforeEach(() => {
+    __resetPrompt();
+  });
+
+  it('does not throw when window is undefined', () => {
+    const origWindow = globalThis.window;
+    delete globalThis.window;
+    expect(() => captureInstallPrompt()).not.toThrow();
+    globalThis.window = origWindow;
+  });
+
+  it('adds beforeinstallprompt event listener', () => {
+    globalThis.window = globalThis.window || {};
+    globalThis.window.addEventListener = vi.fn();
+    captureInstallPrompt();
+    expect(globalThis.window.addEventListener).toHaveBeenCalledWith('beforeinstallprompt', expect.any(Function));
+  });
+});
+
+describe('canShowInstallPrompt', () => {
+  beforeEach(() => {
+    __resetPrompt();
+  });
+
+  it('returns false when no prompt captured', () => {
+    expect(canShowInstallPrompt()).toBe(false);
+  });
+});
+
+describe('showInstallPrompt', () => {
+  beforeEach(() => {
+    __resetPrompt();
+  });
+
+  it('returns "dismissed" when no prompt available', async () => {
+    const result = await showInstallPrompt();
+    expect(result).toBe('dismissed');
+  });
+});
+
+describe('isInstalledPWA', () => {
+  it('returns false when window is undefined', () => {
+    const origWindow = globalThis.window;
+    delete globalThis.window;
+    expect(isInstalledPWA()).toBe(false);
+    globalThis.window = origWindow;
+  });
+
+  it('returns false when not in standalone mode', () => {
+    globalThis.window = globalThis.window || {};
+    globalThis.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+    globalThis.window.navigator = { standalone: false };
+    expect(isInstalledPWA()).toBe(false);
+  });
+
+  it('returns true when in standalone mode', () => {
+    globalThis.window = globalThis.window || {};
+    globalThis.window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    expect(isInstalledPWA()).toBe(true);
+  });
+});
+
+describe('__resetPrompt', () => {
+  it('clears the deferred prompt', () => {
+    __resetPrompt();
+    expect(canShowInstallPrompt()).toBe(false);
+  });
+});

--- a/tests/referralPageHelpers.test.js
+++ b/tests/referralPageHelpers.test.js
@@ -1,0 +1,220 @@
+/**
+ * Tests for referralPageHelpers.js — Referral page utility functions
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatReferralLink,
+  formatCreditAmount,
+  getReferralStatusLabel,
+  getReferralStatusColor,
+  getHowItWorksSteps,
+  getSocialShareLinks,
+  calculateReferralProgress,
+  formatExpiryDate,
+  buildReferralHistoryItems,
+} from '../src/public/referralPageHelpers.js';
+
+// ── formatReferralLink ────────────────────────────────────────────────
+
+describe('formatReferralLink', () => {
+  it('builds referral URL from code', () => {
+    const url = formatReferralLink('ABC123');
+    expect(url).toBe('https://www.carolinafutons.com?ref=ABC123');
+  });
+
+  it('uppercases and strips non-alphanumeric chars', () => {
+    const url = formatReferralLink('abc-123!@#');
+    expect(url).toBe('https://www.carolinafutons.com?ref=ABC123');
+  });
+
+  it('returns base URL for null/empty code', () => {
+    expect(formatReferralLink(null)).toBe('https://www.carolinafutons.com');
+    expect(formatReferralLink('')).toBe('https://www.carolinafutons.com');
+  });
+
+  it('returns base URL when code is only special chars', () => {
+    expect(formatReferralLink('!@#$%')).toBe('https://www.carolinafutons.com');
+  });
+});
+
+// ── formatCreditAmount ────────────────────────────────────────────────
+
+describe('formatCreditAmount', () => {
+  it('formats whole dollar amount', () => {
+    expect(formatCreditAmount(50)).toBe('$50');
+  });
+
+  it('formats fractional amount', () => {
+    expect(formatCreditAmount(25.5)).toBe('$25.50');
+  });
+
+  it('returns $0 for NaN/non-number', () => {
+    expect(formatCreditAmount(NaN)).toBe('$0');
+    expect(formatCreditAmount('abc')).toBe('$0');
+    expect(formatCreditAmount(null)).toBe('$0');
+  });
+
+  it('clamps negative to zero', () => {
+    expect(formatCreditAmount(-10)).toBe('$0');
+  });
+});
+
+// ── getReferralStatusLabel ────────────────────────────────────────────
+
+describe('getReferralStatusLabel', () => {
+  it('maps known statuses to labels', () => {
+    expect(getReferralStatusLabel('pending')).toBe('Invite Sent');
+    expect(getReferralStatusLabel('credited')).toBe('Credit Earned');
+    expect(getReferralStatusLabel('expired')).toBe('Expired');
+  });
+
+  it('returns Unknown for unrecognized status', () => {
+    expect(getReferralStatusLabel('bogus')).toBe('Unknown');
+  });
+});
+
+// ── getReferralStatusColor ────────────────────────────────────────────
+
+describe('getReferralStatusColor', () => {
+  it('returns color for known statuses', () => {
+    expect(getReferralStatusColor('pending')).toBeTruthy();
+    expect(getReferralStatusColor('credited')).toBeTruthy();
+  });
+
+  it('returns muted fallback for unknown status', () => {
+    expect(getReferralStatusColor('bogus')).toBeTruthy();
+  });
+});
+
+// ── getHowItWorksSteps ────────────────────────────────────────────────
+
+describe('getHowItWorksSteps', () => {
+  it('returns 3 steps', () => {
+    const steps = getHowItWorksSteps();
+    expect(steps).toHaveLength(3);
+  });
+
+  it('each step has _id, title, description, icon', () => {
+    getHowItWorksSteps().forEach(s => {
+      expect(s).toHaveProperty('_id');
+      expect(s).toHaveProperty('title');
+      expect(s).toHaveProperty('description');
+      expect(s).toHaveProperty('icon');
+    });
+  });
+
+  it('mentions credit amounts in descriptions', () => {
+    const steps = getHowItWorksSteps();
+    const allText = steps.map(s => s.description).join(' ');
+    expect(allText).toContain('$25');
+    expect(allText).toContain('$50');
+  });
+});
+
+// ── getSocialShareLinks ───────────────────────────────────────────────
+
+describe('getSocialShareLinks', () => {
+  it('returns email, sms, facebook links', () => {
+    const links = getSocialShareLinks('ABC123');
+    expect(links.email).toContain('mailto:');
+    expect(links.sms).toContain('sms:');
+    expect(links.facebook).toContain('facebook.com');
+  });
+
+  it('includes referral URL in link bodies', () => {
+    const links = getSocialShareLinks('XYZ');
+    expect(links.email).toContain('ref%3DXYZ');
+  });
+
+  it('returns empty object for null/empty code', () => {
+    expect(getSocialShareLinks(null)).toEqual({});
+    expect(getSocialShareLinks('')).toEqual({});
+  });
+
+  it('returns empty for code that is only special chars', () => {
+    expect(getSocialShareLinks('!@#')).toEqual({});
+  });
+});
+
+// ── calculateReferralProgress ─────────────────────────────────────────
+
+describe('calculateReferralProgress', () => {
+  it('calculates progress from stats', () => {
+    const stats = { totalReferrals: 10, completedReferrals: 3, totalEarned: 150, totalAvailable: 50 };
+    const result = calculateReferralProgress(stats);
+    expect(result.totalFriends).toBe(10);
+    expect(result.successRate).toBe(30);
+    expect(result.totalEarned).toBe(150);
+    expect(result.availableCredit).toBe(50);
+  });
+
+  it('returns zeros for null stats', () => {
+    const result = calculateReferralProgress(null);
+    expect(result.totalFriends).toBe(0);
+    expect(result.successRate).toBe(0);
+  });
+
+  it('handles zero referrals without division error', () => {
+    const result = calculateReferralProgress({ totalReferrals: 0, completedReferrals: 0 });
+    expect(result.successRate).toBe(0);
+  });
+
+  it('floors success rate percentage', () => {
+    const stats = { totalReferrals: 3, completedReferrals: 1 };
+    expect(calculateReferralProgress(stats).successRate).toBe(33);
+  });
+});
+
+// ── formatExpiryDate ──────────────────────────────────────────────────
+
+describe('formatExpiryDate', () => {
+  it('formats date string', () => {
+    const result = formatExpiryDate('2026-12-25T12:00:00');
+    expect(result).toContain('Dec');
+    expect(result).toContain('25');
+    expect(result).toContain('2026');
+  });
+
+  it('formats Date object', () => {
+    const result = formatExpiryDate(new Date('2026-06-15'));
+    expect(result).toContain('Jun');
+  });
+
+  it('returns "No expiry" for null', () => {
+    expect(formatExpiryDate(null)).toBe('No expiry');
+  });
+
+  it('returns "No expiry" for invalid date', () => {
+    expect(formatExpiryDate('invalid')).toBe('No expiry');
+  });
+});
+
+// ── buildReferralHistoryItems ─────────────────────────────────────────
+
+describe('buildReferralHistoryItems', () => {
+  it('transforms referrals to repeater items', () => {
+    const referrals = [
+      { code: 'ABC', refereeName: 'Jane', status: 'credited', credit: 50, createdDate: '2026-01-15' },
+      { code: 'DEF', refereeName: null, status: 'pending', credit: 0, createdDate: null },
+    ];
+    const items = buildReferralHistoryItems(referrals);
+    expect(items).toHaveLength(2);
+    expect(items[0].friendName).toBe('Jane');
+    expect(items[0].statusLabel).toBe('Credit Earned');
+    expect(items[0].creditText).toBe('$50');
+    expect(items[1].friendName).toBe('Awaiting friend');
+  });
+
+  it('returns empty for null/non-array', () => {
+    expect(buildReferralHistoryItems(null)).toEqual([]);
+    expect(buildReferralHistoryItems(undefined)).toEqual([]);
+  });
+
+  it('generates unique _id for each item', () => {
+    const items = buildReferralHistoryItems([
+      { status: 'pending', credit: 0 },
+      { status: 'pending', credit: 0 },
+    ]);
+    expect(items[0]._id).not.toBe(items[1]._id);
+  });
+});

--- a/tests/socialProofToast.test.js
+++ b/tests/socialProofToast.test.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for socialProofToast.js — Social proof toast notification system
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanupToast } from '../src/public/socialProofToast.js';
+
+// Mock the backend imports
+vi.mock('backend/socialProof.web', () => ({
+  getProductSocialProof: vi.fn(),
+  getCategorySocialProof: vi.fn(),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  isMobile: vi.fn(() => false),
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+}));
+
+describe('cleanupToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not throw when called with no active timer', () => {
+    expect(() => cleanupToast()).not.toThrow();
+  });
+
+  it('can be called multiple times safely', () => {
+    cleanupToast();
+    cleanupToast();
+    cleanupToast();
+  });
+});
+
+// Test initProductSocialProof via dynamic import to get fresh module state
+describe('initProductSocialProof', () => {
+  let initProductSocialProof;
+  let getProductSocialProof;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    const mod = await import('../src/public/socialProofToast.js');
+    initProductSocialProof = mod.initProductSocialProof;
+    const backend = await import('backend/socialProof.web');
+    getProductSocialProof = backend.getProductSocialProof;
+    getProductSocialProof.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanupToast();
+  });
+
+  it('does nothing when productId is null/empty', async () => {
+    await initProductSocialProof(() => null, null);
+    await initProductSocialProof(() => null, '');
+    expect(getProductSocialProof).not.toHaveBeenCalled();
+  });
+
+  it('calls backend with productId', async () => {
+    getProductSocialProof.mockResolvedValue({
+      notifications: [],
+      config: { maxPerSession: 3, minIntervalMs: 5000, autoDismissMs: 8000 },
+    });
+    await initProductSocialProof(() => null, 'prod-123', 'Test Product');
+    expect(getProductSocialProof).toHaveBeenCalledWith('prod-123', 'Test Product');
+  });
+
+  it('does nothing when no notifications returned', async () => {
+    getProductSocialProof.mockResolvedValue({
+      notifications: [],
+      config: { maxPerSession: 3, minIntervalMs: 5000, autoDismissMs: 8000 },
+    });
+    const $w = vi.fn(() => null);
+    await initProductSocialProof($w, 'prod-123');
+    vi.advanceTimersByTime(10000);
+    // No toast shown — $w not called for toast elements
+  });
+
+  it('does not throw when backend errors', async () => {
+    getProductSocialProof.mockRejectedValue(new Error('network'));
+    await expect(initProductSocialProof(() => null, 'prod-123')).resolves.not.toThrow();
+  });
+});
+
+describe('initCategorySocialProof', () => {
+  let initCategorySocialProof;
+  let getCategorySocialProof;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    const mod = await import('../src/public/socialProofToast.js');
+    initCategorySocialProof = mod.initCategorySocialProof;
+    const backend = await import('backend/socialProof.web');
+    getCategorySocialProof = backend.getCategorySocialProof;
+    getCategorySocialProof.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanupToast();
+  });
+
+  it('does nothing when categorySlug is null/empty', async () => {
+    await initCategorySocialProof(() => null, null);
+    await initCategorySocialProof(() => null, '');
+    expect(getCategorySocialProof).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on backend error', async () => {
+    getCategorySocialProof.mockRejectedValue(new Error('fail'));
+    await expect(initCategorySocialProof(() => null, 'futon-frames')).resolves.not.toThrow();
+  });
+});

--- a/tests/testProducts.test.js
+++ b/tests/testProducts.test.js
@@ -1,0 +1,119 @@
+/**
+ * Tests for testProducts.js — Mock product data for development/preview
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  testProductsByCategory,
+  getTestProducts,
+  getAllTestProducts,
+  getFeaturedTestProducts,
+  getSaleTestProducts,
+} from '../src/public/testProducts.js';
+
+// ── testProductsByCategory ────────────────────────────────────────────
+
+describe('testProductsByCategory', () => {
+  it('has products for expected categories', () => {
+    expect(testProductsByCategory).toHaveProperty('futon-frames');
+    expect(testProductsByCategory).toHaveProperty('mattresses');
+    expect(testProductsByCategory).toHaveProperty('murphy-cabinet-beds');
+    expect(testProductsByCategory).toHaveProperty('platform-beds');
+  });
+
+  it('each category has multiple products', () => {
+    Object.values(testProductsByCategory).forEach(products => {
+      expect(products.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('products have required fields', () => {
+    const allProducts = Object.values(testProductsByCategory).flat();
+    allProducts.forEach(p => {
+      expect(p).toHaveProperty('_id');
+      expect(p).toHaveProperty('name');
+      expect(p).toHaveProperty('slug');
+      expect(p).toHaveProperty('price');
+      expect(p).toHaveProperty('formattedPrice');
+      expect(p).toHaveProperty('mainMedia');
+      expect(p).toHaveProperty('mediaItems');
+      expect(typeof p.price).toBe('number');
+    });
+  });
+});
+
+// ── getTestProducts ───────────────────────────────────────────────────
+
+describe('getTestProducts', () => {
+  it('returns products for known category', () => {
+    const products = getTestProducts('futon-frames');
+    expect(products.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array for unknown category', () => {
+    expect(getTestProducts('nonexistent')).toEqual([]);
+  });
+
+  it('returns empty array for null', () => {
+    expect(getTestProducts(null)).toEqual([]);
+  });
+});
+
+// ── getAllTestProducts ─────────────────────────────────────────────────
+
+describe('getAllTestProducts', () => {
+  it('returns flat array of all products', () => {
+    const all = getAllTestProducts();
+    expect(all.length).toBeGreaterThan(10);
+  });
+
+  it('includes products from multiple categories', () => {
+    const all = getAllTestProducts();
+    const categories = new Set(all.flatMap(p => p.collections));
+    expect(categories.size).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ── getFeaturedTestProducts ───────────────────────────────────────────
+
+describe('getFeaturedTestProducts', () => {
+  it('returns requested count', () => {
+    const featured = getFeaturedTestProducts(3);
+    expect(featured).toHaveLength(3);
+  });
+
+  it('prioritizes Best Seller and New ribbons', () => {
+    const featured = getFeaturedTestProducts(4);
+    const ribbons = featured.map(p => p.ribbon).filter(Boolean);
+    expect(ribbons.some(r => r === 'Best Seller' || r === 'New')).toBe(true);
+  });
+
+  it('does not exceed total available products', () => {
+    const all = getAllTestProducts();
+    const featured = getFeaturedTestProducts(999);
+    expect(featured.length).toBeLessThanOrEqual(all.length);
+  });
+
+  it('returns empty for count 0', () => {
+    expect(getFeaturedTestProducts(0)).toHaveLength(0);
+  });
+});
+
+// ── getSaleTestProducts ───────────────────────────────────────────────
+
+describe('getSaleTestProducts', () => {
+  it('returns only products with discounted price', () => {
+    const sale = getSaleTestProducts(10);
+    sale.forEach(p => {
+      expect(p.formattedDiscountedPrice).toBeTruthy();
+    });
+  });
+
+  it('respects count limit', () => {
+    const sale = getSaleTestProducts(1);
+    expect(sale).toHaveLength(1);
+  });
+
+  it('returns empty if no sale products match count', () => {
+    expect(getSaleTestProducts(0)).toHaveLength(0);
+  });
+});

--- a/tests/tikTokPixel.test.js
+++ b/tests/tikTokPixel.test.js
@@ -1,0 +1,61 @@
+/**
+ * Tests for tikTokPixel.js — TikTok Pixel tracking initialization
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initTikTokPixel, fireTikTokEvent } from '../src/public/tikTokPixel.js';
+
+describe('initTikTokPixel', () => {
+  beforeEach(() => {
+    // Ensure clean window state
+    delete globalThis.window?.ttq;
+  });
+
+  it('does not throw when window is undefined', () => {
+    const origWindow = globalThis.window;
+    delete globalThis.window;
+    expect(() => initTikTokPixel()).not.toThrow();
+    globalThis.window = origWindow;
+  });
+
+  it('does not throw when called normally (PIXEL_ID is empty)', () => {
+    // PIXEL_ID is '' by default, so init should return early
+    expect(() => initTikTokPixel()).not.toThrow();
+  });
+
+  it('does not initialize when PIXEL_ID is empty', () => {
+    initTikTokPixel();
+    // ttq should NOT be set because PIXEL_ID is empty
+    expect(globalThis.window?.ttq).toBeUndefined();
+  });
+});
+
+describe('fireTikTokEvent', () => {
+  beforeEach(() => {
+    if (typeof globalThis.window === 'undefined') {
+      globalThis.window = {};
+    }
+  });
+
+  it('does not throw when ttq is not initialized', () => {
+    delete globalThis.window.ttq;
+    expect(() => fireTikTokEvent('ViewContent', {})).not.toThrow();
+  });
+
+  it('calls ttq.track when ttq is available', () => {
+    const mockTrack = vi.fn();
+    globalThis.window.ttq = { track: mockTrack };
+    fireTikTokEvent('AddToCart', { value: 100, currency: 'USD' });
+    expect(mockTrack).toHaveBeenCalledWith('AddToCart', { value: 100, currency: 'USD' });
+  });
+
+  it('does not throw when ttq.track throws', () => {
+    globalThis.window.ttq = {
+      track: () => { throw new Error('network error'); },
+    };
+    expect(() => fireTikTokEvent('Purchase', {})).not.toThrow();
+  });
+
+  afterEach(() => {
+    delete globalThis.window?.ttq;
+  });
+});

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,0 +1,155 @@
+/**
+ * Tests for validators.js — Frontend input validation utilities
+ */
+import { describe, it, expect } from 'vitest';
+import { validateEmail, validateDimension, sanitizeText } from '../src/public/validators.js';
+
+// ── validateEmail ─────────────────────────────────────────────────────
+
+describe('validateEmail', () => {
+  it('accepts valid email addresses', () => {
+    expect(validateEmail('user@example.com')).toBe(true);
+    expect(validateEmail('first.last@domain.co')).toBe(true);
+    expect(validateEmail('user+tag@example.org')).toBe(true);
+  });
+
+  it('accepts email with leading/trailing whitespace (trimmed)', () => {
+    expect(validateEmail('  user@example.com  ')).toBe(true);
+  });
+
+  it('rejects missing @ symbol', () => {
+    expect(validateEmail('userexample.com')).toBe(false);
+  });
+
+  it('rejects missing domain', () => {
+    expect(validateEmail('user@')).toBe(false);
+  });
+
+  it('rejects missing local part', () => {
+    expect(validateEmail('@example.com')).toBe(false);
+  });
+
+  it('rejects missing TLD', () => {
+    expect(validateEmail('user@example')).toBe(false);
+  });
+
+  it('rejects email with spaces in body', () => {
+    expect(validateEmail('user name@example.com')).toBe(false);
+  });
+
+  it('rejects angle brackets (XSS vector)', () => {
+    expect(validateEmail('<script>@example.com')).toBe(false);
+    expect(validateEmail('user@<script>.com')).toBe(false);
+  });
+
+  it('rejects domain starting with dot', () => {
+    expect(validateEmail('user@.example.com')).toBe(false);
+  });
+
+  it('returns false for non-string input', () => {
+    expect(validateEmail(null)).toBe(false);
+    expect(validateEmail(undefined)).toBe(false);
+    expect(validateEmail(123)).toBe(false);
+    expect(validateEmail({})).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(validateEmail('')).toBe(false);
+  });
+});
+
+// ── validateDimension ─────────────────────────────────────────────────
+
+describe('validateDimension', () => {
+  it('accepts values within default range (1-600)', () => {
+    expect(validateDimension(1)).toBe(true);
+    expect(validateDimension(300)).toBe(true);
+    expect(validateDimension(600)).toBe(true);
+  });
+
+  it('rejects values below minimum', () => {
+    expect(validateDimension(0)).toBe(false);
+    expect(validateDimension(-5)).toBe(false);
+  });
+
+  it('rejects values above maximum', () => {
+    expect(validateDimension(601)).toBe(false);
+    expect(validateDimension(9999)).toBe(false);
+  });
+
+  it('accepts custom min/max range', () => {
+    expect(validateDimension(50, 10, 100)).toBe(true);
+    expect(validateDimension(5, 10, 100)).toBe(false);
+    expect(validateDimension(150, 10, 100)).toBe(false);
+  });
+
+  it('accepts boundary values with custom range', () => {
+    expect(validateDimension(10, 10, 100)).toBe(true);
+    expect(validateDimension(100, 10, 100)).toBe(true);
+  });
+
+  it('rejects NaN', () => {
+    expect(validateDimension(NaN)).toBe(false);
+  });
+
+  it('rejects non-number types', () => {
+    expect(validateDimension('50')).toBe(false);
+    expect(validateDimension(null)).toBe(false);
+    expect(validateDimension(undefined)).toBe(false);
+  });
+
+  it('rejects Infinity', () => {
+    expect(validateDimension(Infinity)).toBe(false);
+    expect(validateDimension(-Infinity)).toBe(false);
+  });
+});
+
+// ── sanitizeText ──────────────────────────────────────────────────────
+
+describe('sanitizeText', () => {
+  it('passes through plain text unchanged', () => {
+    expect(sanitizeText('Hello World')).toBe('Hello World');
+  });
+
+  it('strips complete HTML tags', () => {
+    expect(sanitizeText('<b>bold</b>')).toBe('bold');
+    expect(sanitizeText('<script>alert("xss")</script>')).toBe('alert("xss")');
+  });
+
+  it('strips unclosed/malformed tags', () => {
+    expect(sanitizeText('<img src=x onerror=alert(1)')).toBe('');
+  });
+
+  it('strips nested HTML', () => {
+    expect(sanitizeText('<div><p>text</p></div>')).toBe('text');
+  });
+
+  it('enforces default max length of 1000', () => {
+    const long = 'a'.repeat(1500);
+    expect(sanitizeText(long).length).toBe(1000);
+  });
+
+  it('enforces custom max length', () => {
+    expect(sanitizeText('abcdefghij', 5)).toBe('abcde');
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizeText('  hello  ')).toBe('hello');
+  });
+
+  it('returns empty string for non-string input', () => {
+    expect(sanitizeText(null)).toBe('');
+    expect(sanitizeText(undefined)).toBe('');
+    expect(sanitizeText(123)).toBe('');
+    expect(sanitizeText({})).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(sanitizeText('')).toBe('');
+  });
+
+  it('handles XSS vectors', () => {
+    expect(sanitizeText('<img src=x onerror=alert(1)>')).toBe('');
+    expect(sanitizeText('"><script>alert(1)</script>')).toBe('">alert(1)');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds test files for all 14 untested public helper modules identified by rennala's CI audit (CF-bqz)
- **351 new tests** across 14 new test files
- Total suite: 10,448 tests / 272 files (was 10,097 / 258)

## Modules Covered
assemblyGuideHelpers, blogHelpers, cartStyles, checkoutProgress, financingPageHelpers, MemberPageHelpers, navigationHelpers, product360Data, pwaHelpers, referralPageHelpers, socialProofToast, testProducts, tikTokPixel, validators

## Test Coverage Includes
- Happy path for all exported functions and constants
- Null/undefined/empty input handling
- Boundary conditions (max price, min dimensions, edge dates)
- XSS/injection vectors (sanitizeText, validateEmail)
- WCAG compliance (touch targets >= 44px, ARIA attributes)
- Design token verification (brand colors, not hardcoded)
- Schema generation (HowTo JSON-LD, BreadcrumbList)
- Browser API mocking (serviceWorker, matchMedia, sessionStorage)

## Test plan
- [x] All 351 new tests pass
- [x] Full suite (10,448 tests) passes with no regressions
- [x] No new dependencies added

Ref: docs/reports/2026-03-07-testing-ci-audit.md (Section 5: Coverage Gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)