### PR TITLE
feat(cf-n1c): Category Page keyboard navigation (A11y)

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -144,12 +144,12 @@ function initCategoryHero(currentPath) {
     $w('#categoryHeroSubtitle').text = content.subtitle;
   } catch (e) {}
 
-  // Visible breadcrumb row: Home > Category
+  // Visible breadcrumb row: Home > Category (keyboard-accessible)
   try {
     $w('#breadcrumbHome').text = 'Home';
-    $w('#breadcrumbHome').onClick(() => {
+    makeClickable($w('#breadcrumbHome'), () => {
       import('wix-location-frontend').then(({ to }) => to('/'));
-    });
+    }, { ariaLabel: 'Navigate to home page', role: 'link' });
     $w('#breadcrumbCurrent').text = content.title;
   } catch (e) {}
 
@@ -296,8 +296,6 @@ function initFilterControls() {
   try { $w('#filterBrand').accessibility.ariaLabel = 'Filter by brand'; } catch (e) {}
   try { $w('#filterPrice').accessibility.ariaLabel = 'Filter by price range'; } catch (e) {}
   try { $w('#filterSize').accessibility.ariaLabel = 'Filter by size'; } catch (e) {}
-  try { $w('#clearFilters').accessibility.ariaLabel = 'Clear all filters'; } catch (e) {}
-
   // Brand filter — includes Wall Hugger and Unfinished Wood brands
   try {
     const brandFilter = $w('#filterBrand');
@@ -357,14 +355,17 @@ function initFilterControls() {
     }
   } catch (e) {}
 
-  // Clear all filters button
+  // Clear all filters button (keyboard-accessible)
   try {
-    $w('#clearFilters').onClick(() => {
+    const clearHandler = () => {
       currentFilters = {};
       try { $w('#filterBrand').value = ''; } catch (e) {}
       try { $w('#filterPrice').value = ''; } catch (e) {}
       try { $w('#filterSize').value = ''; } catch (e) {}
       applyFilters();
+    };
+    makeClickable($w('#clearFilters'), clearHandler, {
+      ariaLabel: 'Clear all filters',
     });
   } catch (e) {}
 }
@@ -508,10 +509,11 @@ function initProductGrid() {
         renderCardStarRating($item, itemData._id, ratingsMap);
       }).catch(() => {});
 
-      // Quick view button
+      // Quick view button (keyboard-accessible)
       try {
-        $item('#quickViewBtn').onClick(() => {
-          openQuickView(itemData);
+        const qvHandler = () => { openQuickView(itemData); };
+        makeClickable($item('#quickViewBtn'), qvHandler, {
+          ariaLabel: `Quick view ${itemData.name}`,
         });
       } catch (e) {}
 
@@ -529,7 +531,7 @@ function initProductGrid() {
         }
       } catch (e) {}
 
-      // Compare button
+      // Compare button (keyboard-accessible)
       try {
         const compareBtn = $item('#gridCompareBtn');
         if (compareBtn) {
@@ -538,13 +540,14 @@ function initProductGrid() {
           const isInList = currentList.some(p => p._id === itemData._id);
           compareBtn.label = isInList ? 'Remove from Compare' : 'Compare';
 
-          compareBtn.onClick(() => {
+          const compareHandler = () => {
             const list = getCompareList();
             const alreadyComparing = list.some(p => p._id === itemData._id);
 
             if (alreadyComparing) {
               removeFromCompare(itemData._id);
               compareBtn.label = 'Compare';
+              announce($w, `${itemData.name} removed from compare`);
             } else {
               const added = addToCompare({
                 _id: itemData._id,
@@ -555,11 +558,16 @@ function initProductGrid() {
               });
               if (added) {
                 compareBtn.label = 'Remove from Compare';
+                announce($w, `${itemData.name} added to compare`);
               }
             }
 
             // Refresh the global compare bar on masterPage
             refreshCompareBarUI();
+          };
+
+          makeClickable(compareBtn, compareHandler, {
+            ariaLabel: isInList ? `Remove ${itemData.name} from compare` : `Compare ${itemData.name}`,
           });
         }
       } catch (e) {}
@@ -997,12 +1005,18 @@ async function initAdvancedFilters(currentPath) {
       $w('#filterResultCount').text = `${facets.totalProducts} products`;
     } catch (e) {}
 
-    // Clear All button (enhanced)
+    // Clear All button (keyboard-accessible)
     try {
-      $w('#clearAllFilters').onClick(() => {
+      makeClickable($w('#clearAllFilters'), () => {
         clearAllAdvancedFilters(currentPath);
-      });
-      try { $w('#clearAllFilters').accessibility.ariaLabel = 'Clear all filters'; } catch (e) {}
+      }, { ariaLabel: 'Clear all filters' });
+    } catch (e) {}
+
+    // Clear All chip button (keyboard-accessible)
+    try {
+      makeClickable($w('#clearAllFiltersChip'), () => {
+        clearAllAdvancedFilters(currentPath);
+      }, { ariaLabel: 'Clear all active filters' });
     } catch (e) {}
 
     // Mobile: filter drawer toggle
@@ -1172,8 +1186,14 @@ function renderFilterChips() {
       $w('#filterChipsText').text = chips.map(c => c.label).join(' · ');
     } catch (e) {}
 
-    // Show Clear All chip button
-    try { $w('#clearAllFiltersChip').show(); } catch (e) {}
+    // Show Clear All chip button (keyboard-accessible)
+    try {
+      const currentPath = wixLocationFrontend.path?.[0] || '';
+      makeClickable($w('#clearAllFiltersChip'), () => {
+        clearAllAdvancedFilters(currentPath);
+      }, { ariaLabel: 'Clear all active filters' });
+      $w('#clearAllFiltersChip').show();
+    } catch (e) {}
 
     container.show();
     announce($w, `${chips.length} filter${chips.length !== 1 ? 's' : ''} active`);
@@ -1460,12 +1480,14 @@ function refreshCompareBarUI() {
       });
     }
 
-    // Compare view button
+    // Compare view button (keyboard-accessible)
     try {
       const compareViewBtn = $w('#compareViewBtn');
       if (compareViewBtn) {
         compareViewBtn.label = `Compare ${items.length} Items`;
-        compareViewBtn.onClick(() => openCompareView());
+        makeClickable(compareViewBtn, () => openCompareView(), {
+          ariaLabel: `Compare ${items.length} items side by side`,
+        });
         if (items.length >= 2) {
           compareViewBtn.enable();
         } else {

--- a/tests/categoryPageKeyboard.test.js
+++ b/tests/categoryPageKeyboard.test.js
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { futonFrame, wallHuggerFrame } from './fixtures/products.js';
+import { __setPath } from './__mocks__/wix-location-frontend.js';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '',
+    src: '',
+    alt: '',
+    value: '',
+    label: '',
+    hidden: true,
+    options: [],
+    data: [],
+    style: { color: '' },
+    accessibility: {},
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(),
+    expand: vi.fn(),
+    enable: vi.fn(),
+    disable: vi.fn(),
+    focus: vi.fn(),
+    scrollTo: vi.fn(),
+    postMessage: vi.fn(),
+    onClick: vi.fn(),
+    onChange: vi.fn(),
+    onKeyPress: vi.fn(),
+    onFocus: vi.fn(),
+    onItemReady: vi.fn(),
+    onItemClicked: vi.fn(),
+    onReady: vi.fn((cb) => { if (cb) cb(); return Promise.resolve(); }),
+    onCurrentIndexChanged: vi.fn(),
+    getCurrentItem: vi.fn(() => futonFrame),
+    getTotalCount: vi.fn(() => 5),
+    getItems: vi.fn(() => ({
+      items: [{ slug: 'eureka', name: 'Eureka', mainMedia: 'img.jpg' }],
+    })),
+    setSort: vi.fn(),
+    setFilter: vi.fn(),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Mock Backend Modules ────────────────────────────────────────────
+
+vi.mock('backend/seoHelpers.web', () => ({
+  getCollectionSchema: vi.fn().mockResolvedValue('{"@type":"ItemList"}'),
+  getBreadcrumbSchema: vi.fn().mockResolvedValue('{"@type":"BreadcrumbList"}'),
+  getCategoryMetaDescription: vi.fn().mockResolvedValue('desc'),
+  getCategoryOgTags: vi.fn().mockResolvedValue(null),
+  getCanonicalUrl: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('backend/searchService.web', () => ({
+  getFilterValues: vi.fn().mockResolvedValue({
+    materials: [],
+    colors: [],
+    features: [],
+    dimensions: { width: { min: 0, max: 0 }, depth: { min: 0, max: 0 } },
+    totalProducts: 5,
+  }),
+}));
+
+vi.mock('backend/categorySearch.web', () => ({
+  searchProducts: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+  suggestFilterRelaxation: vi.fn().mockResolvedValue({ suggestions: [] }),
+  getFacetMetadata: vi.fn().mockResolvedValue(null),
+}));
+
+// Helper: create a mock $item function for repeater items
+function createItemScope() {
+  const itemElements = {};
+  const $item = (sel) => {
+    if (!itemElements[sel]) {
+      itemElements[sel] = {
+        text: '', src: '', alt: '', label: '', value: '', options: [],
+        style: { color: '', backgroundColor: '' },
+        accessibility: {},
+        show: vi.fn(), hide: vi.fn(), collapse: vi.fn(), expand: vi.fn(),
+        enable: vi.fn(), disable: vi.fn(), focus: vi.fn(),
+        onClick: vi.fn(), onKeyPress: vi.fn(), onFocus: vi.fn(),
+      };
+    }
+    return itemElements[sel];
+  };
+  return { $item, itemElements };
+}
+
+// ── Import Page ─────────────────────────────────────────────────────
+
+describe('Category Page — Keyboard Navigation (CF-n1c)', () => {
+  beforeAll(async () => {
+    await import('../src/pages/Category Page.js');
+  });
+
+  beforeEach(() => {
+    elements.clear();
+  });
+
+  // ── Product Grid Card Keyboard Access ─────────────────────────────
+
+  describe('product grid card keyboard access', () => {
+    it('compare button is keyboard-accessible (onKeyPress for Enter/Space)', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      expect(compareBtn.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('compare button responds to Enter key', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      const keyHandler = compareBtn.onKeyPress.mock.calls[0][0];
+
+      // Simulate Enter key — should toggle compare without error
+      expect(() => keyHandler({ key: 'Enter', preventDefault: vi.fn() })).not.toThrow();
+    });
+
+    it('compare button responds to Space key', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      const keyHandler = compareBtn.onKeyPress.mock.calls[0][0];
+
+      expect(() => keyHandler({ key: ' ', preventDefault: vi.fn() })).not.toThrow();
+    });
+
+    it('compare button has aria-label', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      expect(compareBtn.accessibility.ariaLabel).toBeTruthy();
+    });
+
+    it('compare button has tabIndex 0', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      expect(compareBtn.accessibility.tabIndex).toBe(0);
+    });
+
+    it('quick view button is keyboard-accessible (onKeyPress)', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const qvBtn = itemElements['#quickViewBtn'];
+      expect(qvBtn.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('quick view button has aria-label', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const qvBtn = itemElements['#quickViewBtn'];
+      expect(qvBtn.accessibility.ariaLabel).toBeTruthy();
+      expect(qvBtn.accessibility.ariaLabel).toContain(futonFrame.name);
+    });
+
+    it('quick view button has tabIndex 0', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const qvBtn = itemElements['#quickViewBtn'];
+      expect(qvBtn.accessibility.tabIndex).toBe(0);
+    });
+  });
+
+  // ── Compare Bar Keyboard Access ──────────────────────────────────
+
+  describe('compare bar keyboard access', () => {
+    it('compare view button gets keyboard handler when compare bar refreshes', async () => {
+      await onReadyHandler();
+
+      // Trigger compare flow: add a product via compare button click
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      const clickHandler = compareBtn.onClick.mock.calls[0][0];
+      clickHandler(); // triggers refreshCompareBarUI
+
+      const compareViewBtn = getEl('#compareViewBtn');
+      expect(compareViewBtn.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('compare view button has tabIndex 0 after compare bar refresh', async () => {
+      await onReadyHandler();
+
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const clickHandler = itemElements['#gridCompareBtn'].onClick.mock.calls[0][0];
+      clickHandler();
+
+      const compareViewBtn = getEl('#compareViewBtn');
+      expect(compareViewBtn.accessibility.tabIndex).toBe(0);
+    });
+  });
+
+  // ── Filter Controls Keyboard Access ──────────────────────────────
+
+  describe('filter controls keyboard access', () => {
+    it('clear filters button is keyboard-accessible (onKeyPress)', async () => {
+      await onReadyHandler();
+      const clearBtn = getEl('#clearFilters');
+      expect(clearBtn.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('clear filters responds to Enter key', async () => {
+      await onReadyHandler();
+      const clearBtn = getEl('#clearFilters');
+      const keyHandler = clearBtn.onKeyPress.mock.calls[0][0];
+
+      // Should reset filters without error
+      expect(() => keyHandler({ key: 'Enter', preventDefault: vi.fn() })).not.toThrow();
+    });
+
+    it('clear all advanced filters button is keyboard-accessible', async () => {
+      await onReadyHandler();
+      const clearAllBtn = getEl('#clearAllFilters');
+      expect(clearAllBtn.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('clear filters button has tabIndex 0', async () => {
+      await onReadyHandler();
+      const clearBtn = getEl('#clearFilters');
+      expect(clearBtn.accessibility.tabIndex).toBe(0);
+    });
+
+    it('filter panel section has role="search" or aria-label', async () => {
+      await onReadyHandler();
+      const filterBrand = getEl('#filterBrand');
+      expect(filterBrand.accessibility.ariaLabel).toBeTruthy();
+    });
+  });
+
+  // ── Filter Chip Keyboard Access ──────────────────────────────────
+
+  describe('filter chip keyboard access', () => {
+    it('clear all chips button is keyboard-accessible', async () => {
+      await onReadyHandler();
+      const clearAllChip = getEl('#clearAllFiltersChip');
+      expect(clearAllChip.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('clear all chips button has tabIndex 0', async () => {
+      await onReadyHandler();
+      const clearAllChip = getEl('#clearAllFiltersChip');
+      expect(clearAllChip.accessibility.tabIndex).toBe(0);
+    });
+  });
+
+  // ── Breadcrumb Keyboard Access ──────────────────────────────────
+
+  describe('breadcrumb keyboard access', () => {
+    it('breadcrumb home link is keyboard-accessible', async () => {
+      __setPath(['futon-frames']);
+      elements.clear();
+      await onReadyHandler();
+      const breadcrumbHome = getEl('#breadcrumbHome');
+      expect(breadcrumbHome.onKeyPress).toHaveBeenCalled();
+    });
+
+    it('breadcrumb home link has tabIndex 0', async () => {
+      __setPath(['futon-frames']);
+      elements.clear();
+      await onReadyHandler();
+      const breadcrumbHome = getEl('#breadcrumbHome');
+      expect(breadcrumbHome.accessibility.tabIndex).toBe(0);
+    });
+  });
+
+  // ── Screen Reader Announcements ──────────────────────────────────
+
+  describe('keyboard action screen reader announcements', () => {
+    it('compare toggle announces state change', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      const clickHandler = compareBtn.onClick.mock.calls[0][0];
+
+      // Trigger compare toggle
+      clickHandler();
+
+      // After toggling compare, an announcement should have been made
+      const liveRegion = getEl('#a11yLiveRegion');
+      // The announce function sets text on the live region
+      expect(liveRegion.text !== undefined).toBe(true);
+    });
+  });
+
+  // ── Non-keyboard keys are ignored ────────────────────────────────
+
+  describe('non-activation keys are ignored', () => {
+    it('compare button ignores Tab key press', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const compareBtn = itemElements['#gridCompareBtn'];
+      const keyHandler = compareBtn.onKeyPress.mock.calls[0][0];
+      const preventDefault = vi.fn();
+
+      // Tab should not trigger action
+      keyHandler({ key: 'Tab', preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('quick view button ignores non-activation keys', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#productGridRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const { $item, itemElements } = createItemScope();
+      itemReadyCb($item, futonFrame);
+
+      const qvBtn = itemElements['#quickViewBtn'];
+      const keyHandler = qvBtn.onKeyPress.mock.calls[0][0];
+      const preventDefault = vi.fn();
+
+      keyHandler({ key: 'Shift', preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `onClick`-only handlers with `makeClickable()` across 7 Category Page interactive elements for full keyboard accessibility (Enter/Space activation, `tabIndex: 0`, ARIA labels)
- Adds screen reader announcements (`announce()`) for compare toggle actions
- Elements fixed: compare button, quick view button, clear filters, clear all filters, clear all chips, compare view button, breadcrumb home link

## Bead
CF-n1c — A11y: Category Page keyboard navigation

## Test plan
- [x] 22 new TDD tests in `tests/categoryPageKeyboard.test.js`
- [x] Full suite green: 10,316 tests passing (266 files)
- [ ] Manual keyboard-only navigation through filter panel, product grid, compare bar
- [ ] Screen reader testing (VoiceOver) for compare toggle announcements

## Docs referenced
- `docs/guides/` — Figma-first workflow (no illustration changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)