### PR TITLE
ci(CF-glw): add job timeouts to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [18, 20]
@@ -35,6 +36,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -58,6 +60,7 @@ jobs:
   nightly-integration:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 10` to all 3 CI jobs (test, lint, nightly-integration)
- Prevents runaway builds from consuming the 6hr GitHub Actions default timeout

## Bead
CF-glw

## Test plan
- [x] All 10,706 tests pass locally
- [ ] Verify CI jobs respect the 10-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)