### PR TITLE
feat(CF-e6f): SSR breadcrumb + collection structured data for Category Page

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -222,6 +222,40 @@ async function injectCategoryMeta(currentPath) {
     if (canonical) {
       head.setLinks([{ rel: 'canonical', href: canonical }]);
     }
+
+    // Inject structured data via SSR for crawler indexability
+    const schemas = [];
+    try {
+      // Fetch products from dataset for SSR CollectionPage schema
+      const dataset = $w('#categoryDataset');
+      if (dataset) {
+        await dataset.onReady();
+        const total = Math.min(dataset.getTotalCount(), 30);
+        const result = await dataset.getItems(0, total);
+        const products = (result?.items || []).map(item => ({
+          slug: item.slug, name: item.name, mainMedia: item.mainMedia,
+        }));
+        if (products.length > 0) {
+          const collectionJson = await getCollectionSchema(
+            { slug: currentPath, title: content?.title || currentPath },
+            products
+          );
+          if (collectionJson) schemas.push(JSON.parse(collectionJson));
+        }
+      }
+    } catch (e) { /* collection schema failed */ }
+
+    try {
+      const breadcrumbJson = await getBreadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: content?.title || currentPath, url: null },
+      ]);
+      if (breadcrumbJson) schemas.push(JSON.parse(breadcrumbJson));
+    } catch (e) { /* breadcrumb schema failed */ }
+
+    if (schemas.length > 0) {
+      head.setStructuredData(schemas);
+    }
   } catch (e) {}
 }
 

--- a/tests/categoryPage.test.js
+++ b/tests/categoryPage.test.js
@@ -53,11 +53,27 @@ globalThis.$w = Object.assign(
   { onReady: (fn) => { onReadyHandler = fn; } }
 );
 
+// ── Mock wix-seo-frontend ─────────────────────────────────────────
+
+const mockHead = {
+  setTitle: vi.fn(),
+  setMetaTag: vi.fn(),
+  setLinks: vi.fn(),
+  setStructuredData: vi.fn(),
+};
+
+vi.mock('wix-seo-frontend', () => ({
+  head: mockHead,
+}));
+
 // ── Mock Backend Modules ────────────────────────────────────────────
 
 vi.mock('backend/seoHelpers.web', () => ({
   getCollectionSchema: vi.fn().mockResolvedValue('{"@type":"ItemList"}'),
-  getBreadcrumbSchema: vi.fn().mockResolvedValue('{"@type":"BreadcrumbList"}'),
+  getBreadcrumbSchema: vi.fn().mockResolvedValue('{"@type":"BreadcrumbList","itemListElement":[]}'),
+  getCategoryMetaDescription: vi.fn().mockResolvedValue('Test category description'),
+  getCategoryOgTags: vi.fn().mockResolvedValue('{"og:type":"website"}'),
+  getCanonicalUrl: vi.fn().mockResolvedValue('https://www.carolinafutons.com/futon-frames'),
 }));
 
 // ── Import Page ─────────────────────────────────────────────────────
@@ -69,6 +85,10 @@ describe('Category Page', () => {
 
   beforeEach(() => {
     elements.clear();
+    mockHead.setTitle.mockClear();
+    mockHead.setMetaTag.mockClear();
+    mockHead.setLinks.mockClear();
+    mockHead.setStructuredData.mockClear();
   });
 
   // ── Sort Controls ─────────────────────────────────────────────────
@@ -752,6 +772,56 @@ describe('Category Page', () => {
       await onReadyHandler();
       await new Promise(r => setTimeout(r, 50));
       expect(getEl('#categoryBreadcrumbSchemaHtml').postMessage).toHaveBeenCalled();
+    });
+  });
+
+  // ── SSR SEO Meta (wix-seo-frontend) ──────────────────────────────
+
+  describe('SSR SEO meta injection via wix-seo-frontend', () => {
+    it('sets page title via head.setTitle', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setTitle).toHaveBeenCalled();
+      const title = mockHead.setTitle.mock.calls[0][0];
+      expect(title).toContain('Futon Frames');
+      expect(title).toContain('Carolina Futons');
+    });
+
+    it('sets meta description via head.setMetaTag', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('description', 'Test category description');
+    });
+
+    it('sets canonical URL via head.setLinks', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setLinks).toHaveBeenCalledWith([
+        { rel: 'canonical', href: 'https://www.carolinafutons.com/futon-frames' },
+      ]);
+    });
+
+    it('injects BreadcrumbList structured data via head.setStructuredData for SSR', async () => {
+      __setPath(['mattresses']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setStructuredData).toHaveBeenCalled();
+      const schemas = mockHead.setStructuredData.mock.calls[0][0];
+      const breadcrumb = schemas.find(s => s['@type'] === 'BreadcrumbList');
+      expect(breadcrumb).toBeDefined();
+    });
+
+    it('injects CollectionPage structured data via head.setStructuredData for SSR', async () => {
+      __setPath(['platform-beds']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setStructuredData).toHaveBeenCalled();
+      const schemas = mockHead.setStructuredData.mock.calls[0][0];
+      const collection = schemas.find(s => s['@type'] === 'ItemList');
+      expect(collection).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- **SSR structured data**: Category Page now injects BreadcrumbList and CollectionPage JSON-LD via `wix-seo-frontend` `head.setStructuredData` — enables Google rich snippet indexing
- Previously only used HtmlComponent postMessage (client-side, invisible to crawlers)
- Brings Category Page to parity with Product Page SSR injection

## Test plan
- [x] 5 new tests for SSR meta injection: title, description, canonical, BreadcrumbList schema, CollectionPage schema
- [x] Existing 56 category page tests still pass
- [x] Full suite: 10,733 tests passing, 0 regressions

Closes CF-e6f

🤖 Generated with [Claude Code](https://claude.com/claude-code)