### PR TITLE
feat(CF-duvk): Category Page SSR Open Graph + Twitter Card meta tags

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -223,6 +223,19 @@ async function injectCategoryMeta(currentPath) {
       head.setLinks([{ rel: 'canonical', href: canonical }]);
     }
 
+    // Set OG + Twitter Card meta tags via SSR for social sharing
+    try {
+      const ogJson = await getCategoryOgTags(currentPath);
+      if (ogJson) {
+        const tags = JSON.parse(ogJson);
+        for (const [key, value] of Object.entries(tags)) {
+          if (key.startsWith('og:') || key.startsWith('twitter:')) {
+            head.setMetaTag(key, value);
+          }
+        }
+      }
+    } catch (e) { /* OG tag injection failed */ }
+
     // Inject structured data via SSR for crawler indexability
     const schemas = [];
     try {

--- a/tests/categoryPage.test.js
+++ b/tests/categoryPage.test.js
@@ -72,7 +72,17 @@ vi.mock('backend/seoHelpers.web', () => ({
   getCollectionSchema: vi.fn().mockResolvedValue('{"@type":"ItemList"}'),
   getBreadcrumbSchema: vi.fn().mockResolvedValue('{"@type":"BreadcrumbList","itemListElement":[]}'),
   getCategoryMetaDescription: vi.fn().mockResolvedValue('Test category description'),
-  getCategoryOgTags: vi.fn().mockResolvedValue('{"og:type":"website"}'),
+  getCategoryOgTags: vi.fn().mockResolvedValue(JSON.stringify({
+    'og:type': 'website',
+    'og:title': 'Futon Frames | Carolina Futons',
+    'og:description': 'Shop quality futon frames',
+    'og:url': 'https://www.carolinafutons.com/futon-frames',
+    'og:site_name': 'Carolina Futons',
+    'og:locale': 'en_US',
+    'twitter:card': 'summary',
+    'twitter:title': 'Futon Frames | Carolina Futons',
+    'twitter:description': 'Shop quality futon frames',
+  })),
   getCanonicalUrl: vi.fn().mockResolvedValue('https://www.carolinafutons.com/futon-frames'),
 }));
 
@@ -822,6 +832,48 @@ describe('Category Page', () => {
       const schemas = mockHead.setStructuredData.mock.calls[0][0];
       const collection = schemas.find(s => s['@type'] === 'ItemList');
       expect(collection).toBeDefined();
+    });
+
+    it('sets og:type via head.setMetaTag for SSR', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('og:type', 'website');
+    });
+
+    it('sets og:url via head.setMetaTag for SSR', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('og:url', 'https://www.carolinafutons.com/futon-frames');
+    });
+
+    it('sets og:site_name via head.setMetaTag for SSR', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('og:site_name', 'Carolina Futons');
+    });
+
+    it('sets twitter:card via head.setMetaTag for SSR', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('twitter:card', 'summary');
+    });
+
+    it('sets twitter:title via head.setMetaTag for SSR', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('twitter:title', 'Futon Frames | Carolina Futons');
+    });
+
+    it('sets twitter:description via head.setMetaTag for SSR', async () => {
+      __setPath(['futon-frames']);
+      await onReadyHandler();
+      await new Promise(r => setTimeout(r, 50));
+      expect(mockHead.setMetaTag).toHaveBeenCalledWith('twitter:description', 'Shop quality futon frames');
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Full OG tag SSR injection**: Category Page now sets `og:type`, `og:url`, `og:site_name`, `og:locale` via `wix-seo-frontend` `head.setMetaTag` — previously only `og:title` and `og:description` were SSR-injected
- **Twitter Card SSR injection**: `twitter:card`, `twitter:title`, `twitter:description` now set via SSR for social sharing crawlers
- Parses `getCategoryOgTags` JSON and iterates all `og:*`/`twitter:*` keys into individual `head.setMetaTag` calls

## Test plan
- [x] 6 new tests for SSR OG/Twitter injection (og:type, og:url, og:site_name, twitter:card, twitter:title, twitter:description)
- [x] All 67 category page tests pass
- [x] Full suite: 10,776 tests passing, 0 regressions

Closes CF-duvk

🤖 Generated with [Claude Code](https://claude.com/claude-code)