### PR TITLE
feat(CF-92w): SSR LocalBusiness structured data for Contact + Store Locator

### DIFF
--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -23,6 +23,7 @@ import {
   initContactHeroSkyline,
   initContactShowroomScene,
 } from 'public/contactIllustrations.js';
+import { injectContactSeoSsr } from 'public/localBusinessSeo.js';
 
 $w.onReady(async function () {
   initBackToTop($w);
@@ -37,6 +38,7 @@ $w.onReady(async function () {
   await Promise.allSettled([
     injectContactSchema(),
     injectContactMeta(),
+    injectContactSeoSsr(),
   ]);
   trackEvent('page_view', { page: 'contact' });
 });

--- a/src/pages/Store Locator.js
+++ b/src/pages/Store Locator.js
@@ -20,6 +20,7 @@ import {
   getMapConfig,
   getShowroomContactInfo,
 } from 'public/storeLocatorHelpers.js';
+import { injectStoreLocatorSeoSsr } from 'public/localBusinessSeo.js';
 
 $w.onReady(async function () {
   initBackToTop($w);
@@ -34,6 +35,7 @@ $w.onReady(async function () {
     initOpenStatus(),
     initDirectionsCities(),
     injectStoreSchema(),
+    injectStoreLocatorSeoSsr(),
   ]);
   trackEvent('page_view', { page: 'store-locator' });
 });

--- a/src/public/localBusinessSeo.js
+++ b/src/public/localBusinessSeo.js
@@ -1,0 +1,76 @@
+/**
+ * @module localBusinessSeo
+ * SSR injection of LocalBusiness/FurnitureStore structured data, meta tags,
+ * and canonical URLs for Contact and Store Locator pages via wix-seo-frontend.
+ *
+ * These functions complement the existing HtmlComponent-based schema injection
+ * by adding SSR-level head tags that crawlers can index without JavaScript.
+ */
+import { getBusinessSchema, getPageTitle, getPageMetaDescription, getCanonicalUrl } from 'backend/seoHelpers.web';
+import { getStoreLocatorSchema } from 'backend/storeLocatorService.web';
+
+/**
+ * Inject SSR meta tags and FurnitureStore structured data for the Contact page.
+ * Sets title, description, canonical, and JSON-LD via wix-seo-frontend head.
+ * @returns {Promise<void>}
+ */
+export async function injectContactSeoSsr() {
+  try {
+    const { head } = await import('wix-seo-frontend');
+
+    const [title, description, canonical] = await Promise.all([
+      getPageTitle('contact'),
+      getPageMetaDescription('contact'),
+      getCanonicalUrl('contact'),
+    ]);
+
+    if (title) head.setTitle(title);
+    if (description) head.setMetaTag('description', description);
+    if (canonical) head.setLinks([{ rel: 'canonical', href: canonical }]);
+
+    const schemas = [];
+    try {
+      const businessJson = await getBusinessSchema();
+      if (businessJson) schemas.push(JSON.parse(businessJson));
+    } catch (e) { /* schema failed */ }
+
+    if (schemas.length > 0) {
+      head.setStructuredData(schemas);
+    }
+  } catch (e) {
+    // SSR injection is non-critical
+  }
+}
+
+/**
+ * Inject SSR meta tags and FurnitureStore structured data for the Store Locator page.
+ * Uses the store-locator-specific schema which includes showroom-specific details.
+ * @returns {Promise<void>}
+ */
+export async function injectStoreLocatorSeoSsr() {
+  try {
+    const { head } = await import('wix-seo-frontend');
+
+    const [title, description, canonical] = await Promise.all([
+      getPageTitle('contact', { variant: 'store-locator' }),
+      getPageMetaDescription('contact'),
+      getCanonicalUrl('contact', 'store-locator'),
+    ]);
+
+    if (title) head.setTitle(title);
+    if (description) head.setMetaTag('description', description);
+    if (canonical) head.setLinks([{ rel: 'canonical', href: canonical }]);
+
+    const schemas = [];
+    try {
+      const storeJson = await getStoreLocatorSchema();
+      if (storeJson) schemas.push(JSON.parse(storeJson));
+    } catch (e) { /* schema failed */ }
+
+    if (schemas.length > 0) {
+      head.setStructuredData(schemas);
+    }
+  } catch (e) {
+    // SSR injection is non-critical
+  }
+}

--- a/tests/localBusinessSsr.test.js
+++ b/tests/localBusinessSsr.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Tests for SSR LocalBusiness structured data injection on Contact and Store Locator pages.
+// Validates that JSON-LD FurnitureStore schema is injected via wix-seo-frontend
+// head.setStructuredData for crawler indexability (not just client-side HtmlComponent).
+
+// ── Mock wix-seo-frontend ─────────────────────────────────────────
+
+const mockHead = {
+  setTitle: vi.fn(),
+  setMetaTag: vi.fn(),
+  setLinks: vi.fn(),
+  setStructuredData: vi.fn(),
+};
+
+vi.mock('wix-seo-frontend', () => ({
+  head: mockHead,
+}));
+
+// ── Mock backend modules ──────────────────────────────────────────
+
+const mockBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FurnitureStore',
+  name: 'Carolina Futons',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: '824 Locust St, Ste 200',
+    addressLocality: 'Hendersonville',
+    addressRegion: 'NC',
+    postalCode: '28792',
+  },
+  telephone: '+18282529449',
+};
+
+const mockStoreSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FurnitureStore',
+  name: 'Carolina Futons Showroom',
+  address: { '@type': 'PostalAddress', addressLocality: 'Hendersonville' },
+};
+
+vi.mock('backend/seoHelpers.web', () => ({
+  getBusinessSchema: vi.fn(() => JSON.stringify(mockBusinessSchema)),
+  getPageTitle: vi.fn((type) => `${type} | Carolina Futons`),
+  getPageMetaDescription: vi.fn(() => 'Test meta description'),
+  getCanonicalUrl: vi.fn((type) => `https://www.carolinafutons.com/${type}`),
+}));
+
+vi.mock('backend/storeLocatorService.web', () => ({
+  getStoreLocatorSchema: vi.fn(() => JSON.stringify(mockStoreSchema)),
+  isShowroomOpen: vi.fn(() => ({ open: true, message: 'Open now' })),
+  getNearbyCities: vi.fn(() => []),
+  getDirectionsUrl: vi.fn(() => 'https://maps.google.com'),
+}));
+
+// ── Import the SSR injection functions ────────────────────────────
+
+import {
+  injectContactSeoSsr,
+  injectStoreLocatorSeoSsr,
+} from '../src/public/localBusinessSeo.js';
+
+// ── Contact Page SSR Tests ────────────────────────────────────────
+
+describe('injectContactSeoSsr — Contact page SSR meta + structured data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets page title via head.setTitle', async () => {
+    await injectContactSeoSsr();
+    expect(mockHead.setTitle).toHaveBeenCalledWith('contact | Carolina Futons');
+  });
+
+  it('sets meta description via head.setMetaTag', async () => {
+    await injectContactSeoSsr();
+    expect(mockHead.setMetaTag).toHaveBeenCalledWith('description', 'Test meta description');
+  });
+
+  it('sets canonical URL via head.setLinks', async () => {
+    await injectContactSeoSsr();
+    expect(mockHead.setLinks).toHaveBeenCalledWith([
+      { rel: 'canonical', href: 'https://www.carolinafutons.com/contact' },
+    ]);
+  });
+
+  it('injects FurnitureStore structured data via head.setStructuredData', async () => {
+    await injectContactSeoSsr();
+    expect(mockHead.setStructuredData).toHaveBeenCalled();
+    const schemas = mockHead.setStructuredData.mock.calls[0][0];
+    const business = schemas.find(s => s['@type'] === 'FurnitureStore');
+    expect(business).toBeDefined();
+    expect(business.name).toBe('Carolina Futons');
+    expect(business.address.addressLocality).toBe('Hendersonville');
+  });
+
+  it('includes telephone in structured data', async () => {
+    await injectContactSeoSsr();
+    const schemas = mockHead.setStructuredData.mock.calls[0][0];
+    const business = schemas.find(s => s['@type'] === 'FurnitureStore');
+    expect(business.telephone).toBe('+18282529449');
+  });
+
+  it('handles backend failure gracefully', async () => {
+    const { getBusinessSchema } = await import('backend/seoHelpers.web');
+    getBusinessSchema.mockReturnValueOnce(null);
+    await expect(injectContactSeoSsr()).resolves.not.toThrow();
+  });
+});
+
+// ── Store Locator Page SSR Tests ──────────────────────────────────
+
+describe('injectStoreLocatorSeoSsr — Store Locator page SSR structured data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets page title via head.setTitle', async () => {
+    await injectStoreLocatorSeoSsr();
+    expect(mockHead.setTitle).toHaveBeenCalled();
+  });
+
+  it('sets canonical URL via head.setLinks', async () => {
+    await injectStoreLocatorSeoSsr();
+    expect(mockHead.setLinks).toHaveBeenCalled();
+  });
+
+  it('injects FurnitureStore structured data via head.setStructuredData', async () => {
+    await injectStoreLocatorSeoSsr();
+    expect(mockHead.setStructuredData).toHaveBeenCalled();
+    const schemas = mockHead.setStructuredData.mock.calls[0][0];
+    const store = schemas.find(s => s['@type'] === 'FurnitureStore');
+    expect(store).toBeDefined();
+    expect(store.name).toBe('Carolina Futons Showroom');
+  });
+
+  it('handles backend failure gracefully', async () => {
+    const { getStoreLocatorSchema } = await import('backend/storeLocatorService.web');
+    getStoreLocatorSchema.mockReturnValueOnce(null);
+    await expect(injectStoreLocatorSeoSsr()).resolves.not.toThrow();
+    // Should still set title even if schema fails
+    expect(mockHead.setTitle).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **New module `localBusinessSeo.js`**: Shared SSR injection functions for Contact and Store Locator pages
- **Contact page**: `injectContactSeoSsr()` injects FurnitureStore JSON-LD + title/description/canonical via `wix-seo-frontend` SSR
- **Store Locator page**: `injectStoreLocatorSeoSsr()` injects store-specific FurnitureStore schema via SSR
- Previously both pages only injected schemas via client-side HtmlComponent postMessage (invisible to crawlers)

## Test plan
- [x] 10 new tests in `localBusinessSsr.test.js`:
  - Contact: title, description, canonical, FurnitureStore schema, telephone, error handling
  - Store Locator: title, canonical, FurnitureStore schema, error handling
- [x] Full suite: 10,857 tests passing, 0 regressions

Closes CF-92w

🤖 Generated with [Claude Code](https://claude.com/claude-code)