### PR TITLE
feat(CF-lb1a): Buying Guides hub — category filtering + reading time

### DIFF
--- a/src/backend/buyingGuides.web.js
+++ b/src/backend/buyingGuides.web.js
@@ -692,13 +692,23 @@ export const getAllBuyingGuides = webMethod(
         success: true,
         guides: GUIDE_SLUGS.map(slug => {
           const g = GUIDES[slug];
+          let wordCount = 0;
+          if (g.sections) {
+            for (const s of g.sections) {
+              if (s.body) wordCount += s.body.split(/\s+/).filter(Boolean).length;
+              if (s.heading) wordCount += s.heading.split(/\s+/).filter(Boolean).length;
+            }
+          }
+          const readingTime = wordCount > 0 ? Math.max(1, Math.round(wordCount / 200)) : 0;
           return {
             slug: g.slug,
             title: g.title,
             metaDescription: g.metaDescription,
+            category: g.category,
             categoryLabel: g.categoryLabel,
             heroImage: g.heroImage,
             publishDate: g.publishDate,
+            readingTime,
           };
         }),
       };

--- a/src/pages/Buying Guides.js
+++ b/src/pages/Buying Guides.js
@@ -12,6 +12,8 @@ import {
   buildHubCardData,
   formatGuideDate,
   getCategoryIcon,
+  getGuideCategories,
+  filterGuidesByCategory,
 } from 'public/buyingGuidesHelpers';
 
 $w.onReady(async function () {
@@ -32,6 +34,7 @@ $w.onReady(async function () {
       : null;
 
     initBreadcrumbs();
+    initCategoryFilters(guides);
     initGuideGrid(guides);
     initHubSeo(hub);
     initHubMeta();
@@ -64,6 +67,41 @@ function initBreadcrumbs() {
   } catch (e) {}
 }
 
+// ── Category Filters ─────────────────────────────────────────────────
+
+let allGuides = [];
+let activeCategory = 'all';
+
+function initCategoryFilters(guides) {
+  allGuides = guides;
+
+  try {
+    const filterRepeater = $w('#categoryFilterRepeater');
+    if (!filterRepeater) return;
+
+    const categories = getGuideCategories();
+    const filterItems = [
+      { _id: 'filter-all', slug: 'all', label: 'All Guides' },
+      ...categories.map(c => ({ _id: `filter-${c.slug}`, slug: c.slug, label: c.label })),
+    ];
+
+    filterRepeater.data = filterItems;
+    filterRepeater.onItemReady(($item, itemData) => {
+      try { $item('#filterLabel').text = itemData.label; } catch (e) {}
+      try {
+        $item('#filterButton').label = itemData.label;
+        $item('#filterButton').onClick(() => {
+          activeCategory = itemData.slug;
+          const filtered = filterGuidesByCategory(allGuides, activeCategory);
+          initGuideGrid(filtered);
+          trackEvent('guide_category_filter', { category: itemData.slug });
+          announce($w, `Showing ${filtered.length} guides for ${itemData.label}`);
+        });
+      } catch (e) {}
+    });
+  } catch (e) {}
+}
+
 // ── Guide Grid ────────────────────────────────────────────────────────
 
 function initGuideGrid(guides) {
@@ -79,6 +117,7 @@ function initGuideGrid(guides) {
     }
 
     try { $w('#emptyStateBox').hide(); } catch (e) {}
+    try { gridRepeater.show(); } catch (e) {}
     gridRepeater.data = cards;
 
     gridRepeater.onItemReady(($item, itemData) => {
@@ -86,6 +125,11 @@ function initGuideGrid(guides) {
       try { $item('#guideDescription').text = itemData.description; } catch (e) {}
       try { $item('#guideCategoryLabel').text = itemData.categoryLabel; } catch (e) {}
       try { $item('#guideDate').text = formatGuideDate(itemData.publishDate); } catch (e) {}
+      try {
+        if (itemData.readingTime) {
+          $item('#guideReadTime').text = `${itemData.readingTime} min read`;
+        }
+      } catch (e) {}
       try { $item('#guideHeroImage').src = itemData.heroImage; } catch (e) {}
       try { $item('#guideHeroImage').alt = `${itemData.title} hero image`; } catch (e) {}
 

--- a/src/public/buyingGuidesHelpers.js
+++ b/src/public/buyingGuidesHelpers.js
@@ -226,6 +226,20 @@ export function buildFaqAccordionData(faqs) {
   }));
 }
 
+// ── Filter By Category ───────────────────────────────────────────────
+
+/**
+ * Filters guide summaries by category slug.
+ * @param {Array} guides - Guide summaries with category field.
+ * @param {string} [category] - Category slug to filter by, or null/'all' for all.
+ * @returns {Array}
+ */
+export function filterGuidesByCategory(guides, category) {
+  if (!guides || !guides.length) return [];
+  if (!category || category === 'all') return guides;
+  return guides.filter(g => g.category === category);
+}
+
 // ── Hub Card Data ─────────────────────────────────────────────────────
 
 /**
@@ -240,9 +254,11 @@ export function buildHubCardData(guides) {
     slug: g.slug,
     title: g.title,
     description: truncateDescription(g.metaDescription, 160),
+    category: g.category,
     categoryLabel: g.categoryLabel,
     heroImage: g.heroImage,
     url: `/buying-guides/${g.slug}`,
     publishDate: g.publishDate,
+    readingTime: g.readingTime || 0,
   }));
 }

--- a/tests/buyingGuides.test.js
+++ b/tests/buyingGuides.test.js
@@ -65,6 +65,22 @@ describe('getAllBuyingGuides', () => {
       expect(guide.metaDescription.length).toBeLessThanOrEqual(160);
     }
   });
+
+  it('each summary includes category slug', async () => {
+    const result = await getAllBuyingGuides();
+    for (const guide of result.guides) {
+      expect(typeof guide.category).toBe('string');
+      expect(guide.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('each summary includes readingTime as positive number', async () => {
+    const result = await getAllBuyingGuides();
+    for (const guide of result.guides) {
+      expect(typeof guide.readingTime).toBe('number');
+      expect(guide.readingTime).toBeGreaterThanOrEqual(1);
+    }
+  });
 });
 
 // ── getBuyingGuide ──────────────────────────────────────────────────

--- a/tests/buyingGuidesHelpers.test.js
+++ b/tests/buyingGuidesHelpers.test.js
@@ -12,6 +12,7 @@ import {
   getCategoryIcon,
   buildFaqAccordionData,
   buildHubCardData,
+  filterGuidesByCategory,
 } from '../src/public/buyingGuidesHelpers.js';
 
 // ── Guide Categories ──────────────────────────────────────────────────
@@ -311,6 +312,42 @@ describe('buildFaqAccordionData', () => {
   });
 });
 
+// ── Filter Guides By Category ─────────────────────────────────────────
+
+describe('filterGuidesByCategory', () => {
+  const guides = [
+    { slug: 'futon-frames', title: 'Frames', category: 'futon-frames', categoryLabel: 'Futon Frames' },
+    { slug: 'mattresses', title: 'Mattresses', category: 'mattresses', categoryLabel: 'Mattresses' },
+    { slug: 'covers', title: 'Covers', category: 'covers', categoryLabel: 'Covers' },
+    { slug: 'pillows', title: 'Pillows', category: 'pillows', categoryLabel: 'Pillows' },
+  ];
+
+  it('returns all guides when category is null/undefined/empty', () => {
+    expect(filterGuidesByCategory(guides, null)).toEqual(guides);
+    expect(filterGuidesByCategory(guides, undefined)).toEqual(guides);
+    expect(filterGuidesByCategory(guides, '')).toEqual(guides);
+  });
+
+  it('returns all guides when category is "all"', () => {
+    expect(filterGuidesByCategory(guides, 'all')).toEqual(guides);
+  });
+
+  it('filters guides by category slug', () => {
+    const result = filterGuidesByCategory(guides, 'futon-frames');
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe('futon-frames');
+  });
+
+  it('returns empty array when no guides match', () => {
+    expect(filterGuidesByCategory(guides, 'nonexistent')).toEqual([]);
+  });
+
+  it('returns empty array for null/empty guides input', () => {
+    expect(filterGuidesByCategory(null, 'futon-frames')).toEqual([]);
+    expect(filterGuidesByCategory([], 'futon-frames')).toEqual([]);
+  });
+});
+
 // ── Hub Card Data ─────────────────────────────────────────────────────
 
 describe('buildHubCardData', () => {
@@ -319,9 +356,11 @@ describe('buildHubCardData', () => {
       slug: 'futon-frames',
       title: 'Complete Frame Guide',
       metaDescription: 'Everything about frames',
+      category: 'futon-frames',
       categoryLabel: 'Futon Frames',
       heroImage: '/hero.jpg',
       publishDate: '2026-02-20',
+      readingTime: 5,
     },
   ];
 
@@ -334,6 +373,8 @@ describe('buildHubCardData', () => {
     expect(cards[0].url).toBe('/buying-guides/futon-frames');
     expect(cards[0].description).toBe('Everything about frames');
     expect(cards[0].heroImage).toBe('/hero.jpg');
+    expect(cards[0].category).toBe('futon-frames');
+    expect(cards[0].readingTime).toBe(5);
   });
 
   it('returns empty array for null/empty', () => {


### PR DESCRIPTION
## Summary
- **Category filtering**: Added `filterGuidesByCategory` helper + `#categoryFilterRepeater` UI with "All Guides" + 8 category chips. Filter click re-renders grid, tracks analytics, announces count via ARIA live region.
- **Reading time**: Backend `getAllBuyingGuides` now computes `readingTime` from section word counts. Displayed as `X min read` on each guide card.
- **Backend**: Added `category` (slug) and `readingTime` fields to guide summary response.

## Test plan
- [x] 7 new tests: `filterGuidesByCategory` (5 cases) + backend summary fields (2 cases)
- [x] Updated `buildHubCardData` test for new `category`/`readingTime` fields
- [x] Full suite: 10,854 tests passing across 284 files

Bead: CF-lb1a

🤖 Generated with [Claude Code](https://claude.com/claude-code)