### PR TITLE
refactor(CF-jlwa): consolidate brand detection into single function

### DIFF
--- a/src/backend/seoHelpers.web.js
+++ b/src/backend/seoHelpers.web.js
@@ -9,6 +9,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { getBlogFaqs } from 'backend/blogContent';
+import { detectProductBrand } from 'public/productPageUtils.js';
 
 const BUSINESS_INFO = {
   name: 'Carolina Futons',
@@ -62,7 +63,7 @@ export const getProductSchema = webMethod(
 
     const slug = typeof product.slug === 'string' ? product.slug : '';
     const productUrl = `${BUSINESS_INFO.url}/product-page/${slug}`;
-    const brand = getBrandName(product);
+    const brand = detectProductBrand(product);
     const category = getCategoryLabel(product);
 
     const schema = {
@@ -421,7 +422,7 @@ export const getProductFaqSchema = webMethod(
     if (!product) return null;
 
     const category = getCategoryLabel(product);
-    const brand = getBrandName(product);
+    const brand = detectProductBrand(product);
     const faqs = [];
 
     // Return policy — universal
@@ -524,7 +525,7 @@ export const generateAltText = webMethod(
   (product, imageType = 'main') => {
     if (!product) return '';
 
-    const brand = getBrandName(product);
+    const brand = detectProductBrand(product);
     const category = getCategoryLabel(product);
     const material = detectMaterial(product);
     const finish = product.options?.finish || product.options?.color || '';
@@ -604,21 +605,6 @@ export const getCategoryMetaDescription = webMethod(
     return descriptions[categorySlug] || 'The largest selection of quality futon furniture in the Carolinas. Futon frames, mattresses, Murphy cabinet beds, and platform beds. Family-owned in Hendersonville, NC since 1991.';
   }
 );
-
-// Helper: determine brand from product data
-function getBrandName(product) {
-  if (!product || !product.collections) return '';
-
-  const collections = Array.isArray(product.collections)
-    ? product.collections
-    : [product.collections];
-
-  if (collections.some(c => c.includes('wall-hugger'))) return 'Strata Furniture';
-  if (collections.some(c => c.includes('unfinished'))) return 'KD Frames';
-  if (collections.some(c => c.includes('otis') || c.includes('mattress'))) return 'Otis Bed';
-  if (collections.some(c => c.includes('arizona'))) return 'Arizona';
-  return 'Night & Day Furniture';
-}
 
 // Helper: get human-readable category label
 function getCategoryLabel(product) {
@@ -712,7 +698,7 @@ export const getProductOgTags = webMethod(
     const image = product.mainMedia || '';
     const url = `https://www.carolinafutons.com/product-page/${product.slug || ''}`;
     const price = product.price || 0;
-    const brand = getBrandName(product);
+    const brand = detectProductBrand(product);
 
     return JSON.stringify({
       'og:type': 'product',

--- a/src/public/product/productSchema.js
+++ b/src/public/product/productSchema.js
@@ -4,6 +4,7 @@
 
 import { getProductSchema, getBreadcrumbSchema, getProductOgTags, getProductFaqSchema, getPageTitle, getPageMetaDescription, getCanonicalUrl } from 'backend/seoHelpers.web';
 import { getProductPinData } from 'backend/pinterestRichPins.web';
+import { detectProductBrand } from 'public/productPageUtils.js';
 
 /**
  * Initialize breadcrumb navigation and inject breadcrumb schema.
@@ -179,19 +180,6 @@ export function buildGridAlt(product) {
   return alt.length > 125 ? alt.substring(0, 122) + '...' : alt;
 }
 
-/**
- * Detect brand name from product collections.
- * @param {Object|null} product - Wix product object
- * @returns {string} Brand name, or empty string if undetectable
- */
-export function detectProductBrand(product) {
-  if (!product || !product.collections) return '';
-  const colls = Array.isArray(product.collections) ? product.collections : [product.collections];
-  if (colls.some(c => c.includes('wall-hugger'))) return 'Strata Furniture';
-  if (colls.some(c => c.includes('unfinished'))) return 'KD Frames';
-  if (colls.some(c => c.includes('mattress'))) return 'Otis Bed';
-  return 'Night & Day Furniture';
-}
 
 /**
  * Detect product category label from collections.

--- a/src/public/productPageUtils.js
+++ b/src/public/productPageUtils.js
@@ -40,12 +40,19 @@ export function buildGridAlt(product) {
   return alt.length > 125 ? alt.substring(0, 122) + '...' : alt;
 }
 
+/**
+ * Detect product brand from collections. Canonical brand detection — all other
+ * copies (productSchema, seoHelpers) should import this function.
+ * @param {Object|null|undefined} product - Wix product object
+ * @returns {string} Brand name, or empty string if undetectable
+ */
 export function detectProductBrand(product) {
-  if (!product.collections) return '';
+  if (!product || !product.collections) return '';
   const colls = Array.isArray(product.collections) ? product.collections : [product.collections];
   if (colls.some(c => c.includes('wall-hugger'))) return 'Strata Furniture';
   if (colls.some(c => c.includes('unfinished'))) return 'KD Frames';
-  if (colls.some(c => c.includes('mattress'))) return 'Otis Bed';
+  if (colls.some(c => c.includes('otis') || c.includes('mattress'))) return 'Otis Bed';
+  if (colls.some(c => c.includes('arizona'))) return 'Arizona';
   return 'Night & Day Furniture';
 }
 

--- a/tests/categorySearch.test.js
+++ b/tests/categorySearch.test.js
@@ -92,7 +92,7 @@ describe('searchProducts', () => {
 
   it('filters by multiple materials', async () => {
     const result = await searchProducts({ materials: ['metal', 'fabric'] });
-    expect(result.items).toHaveLength(2);
+    expect(result.items).toHaveLength(3);
     const ids = result.items.map(i => i._id);
     expect(ids).toContain(metalFrame._id);
     expect(ids).toContain(futonMattress._id);
@@ -141,7 +141,7 @@ describe('searchProducts', () => {
 
   it('filters by multiple brands', async () => {
     const result = await searchProducts({ brands: ['Strata', 'KD Frames'] });
-    expect(result.items).toHaveLength(2);
+    expect(result.items).toHaveLength(3);
   });
 
   it('filters by width range', async () => {
@@ -422,8 +422,8 @@ describe('getFacetMetadata', () => {
 
   it('returns correct price range for category', async () => {
     const facets = await getFacetMetadata('futon-frames');
-    // futon-frames: 499, 699, 499, 299, 849
-    expect(facets.priceRange.min).toBe(299);
+    // futon-frames: 499, 699, 499, 299, 849, 249
+    expect(facets.priceRange.min).toBe(249);
     expect(facets.priceRange.max).toBe(849);
   });
 

--- a/tests/fixtures/products.js
+++ b/tests/fixtures/products.js
@@ -219,6 +219,75 @@ export const outdoorFrame = {
   numericRating: 4.8,
 };
 
+export const unfinishedFrame = {
+  _id: 'prod-frame-005',
+  name: 'Nomad Unfinished Futon Frame',
+  slug: 'nomad-unfinished-futon-frame',
+  price: 249,
+  formattedPrice: '$249.00',
+  discountedPrice: null,
+  formattedDiscountedPrice: null,
+  mainMedia: 'https://example.com/nomad.jpg',
+  sku: 'NMD-UNF-001',
+  ribbon: '',
+  collections: ['futon-frames', 'unfinished-frames'],
+  description: 'Raw unfinished hardwood futon frame — sand and stain yourself.',
+  inStock: true,
+  _createdDate: new Date('2025-09-01'),
+  discount: 0,
+  dimensions: { width: 54, depth: 38, height: 33 },
+  material: 'hardwood',
+  color: 'unfinished',
+  featureTags: ['sleeper'],
+  brand: 'KD Frames',
+};
+
+export const otisMattress = {
+  _id: 'prod-matt-002',
+  name: 'Otis Haley 110 Futon Mattress',
+  slug: 'otis-haley-110-futon-mattress',
+  price: 449,
+  formattedPrice: '$449.00',
+  discountedPrice: null,
+  formattedDiscountedPrice: null,
+  mainMedia: 'https://example.com/otis-haley.jpg',
+  sku: 'OTS-HAL-001',
+  ribbon: '',
+  collections: ['otis-mattresses'],
+  description: 'Premium Otis innerspring futon mattress.',
+  inStock: true,
+  _createdDate: new Date('2025-10-01'),
+  discount: 0,
+  dimensions: { width: 54, depth: 75, height: 8 },
+  material: 'fabric',
+  color: 'white',
+  featureTags: [],
+  brand: 'Otis',
+};
+
+export const arizonaFrame = {
+  _id: 'prod-frame-006',
+  name: 'Arizona Rustic Futon Frame',
+  slug: 'arizona-rustic-futon-frame',
+  price: 599,
+  formattedPrice: '$599.00',
+  discountedPrice: null,
+  formattedDiscountedPrice: null,
+  mainMedia: 'https://example.com/arizona-rustic.jpg',
+  sku: 'AZ-RST-001',
+  ribbon: '',
+  collections: ['arizona-collection'],
+  description: 'Southwestern-style futon frame from the Arizona line.',
+  inStock: true,
+  _createdDate: new Date('2025-11-01'),
+  discount: 0,
+  dimensions: { width: 56, depth: 40, height: 34 },
+  material: 'hardwood',
+  color: 'honey',
+  featureTags: ['sleeper'],
+  brand: 'Arizona',
+};
+
 // All products for seeding collections
 export const allProducts = [
   futonFrame,
@@ -230,6 +299,9 @@ export const allProducts = [
   saleProduct,
   metalFrame,
   outdoorFrame,
+  unfinishedFrame,
+  otisMattress,
+  arizonaFrame,
 ];
 
 // Sample analytics records

--- a/tests/productPageJsonLd.test.js
+++ b/tests/productPageJsonLd.test.js
@@ -89,10 +89,11 @@ const {
   injectProductMeta,
   injectPinterestMeta,
   buildGridAlt,
-  detectProductBrand,
   detectProductCategory,
   getCategoryFromCollections,
 } = await import('../src/public/product/productSchema.js');
+
+const { detectProductBrand } = await import('../src/public/productPageUtils.js');
 
 const {
   getProductSchema,

--- a/tests/productPageUtils.test.js
+++ b/tests/productPageUtils.test.js
@@ -9,7 +9,7 @@ import {
   HEART_FILLED_SVG,
   HEART_OUTLINE_SVG,
 } from '../src/public/productPageUtils.js';
-import { futonFrame, wallHuggerFrame, futonMattress, murphyBed, casegoodsItem } from './fixtures/products.js';
+import { futonFrame, wallHuggerFrame, futonMattress, murphyBed, casegoodsItem, unfinishedFrame, otisMattress, arizonaFrame } from './fixtures/products.js';
 
 describe('productPageUtils', () => {
   describe('formatCurrency', () => {
@@ -31,8 +31,20 @@ describe('productPageUtils', () => {
       expect(detectProductBrand(wallHuggerFrame)).toBe('Strata Furniture');
     });
 
-    it('detects Otis Bed for mattress', () => {
+    it('detects KD Frames for unfinished collection', () => {
+      expect(detectProductBrand(unfinishedFrame)).toBe('KD Frames');
+    });
+
+    it('detects Otis Bed for mattress collection', () => {
       expect(detectProductBrand(futonMattress)).toBe('Otis Bed');
+    });
+
+    it('detects Otis Bed for otis collection', () => {
+      expect(detectProductBrand(otisMattress)).toBe('Otis Bed');
+    });
+
+    it('detects Arizona brand', () => {
+      expect(detectProductBrand(arizonaFrame)).toBe('Arizona');
     });
 
     it('defaults to Night & Day Furniture', () => {
@@ -41,6 +53,18 @@ describe('productPageUtils', () => {
 
     it('returns empty string when no collections', () => {
       expect(detectProductBrand({})).toBe('');
+    });
+
+    it('returns empty string for null product', () => {
+      expect(detectProductBrand(null)).toBe('');
+    });
+
+    it('returns empty string for undefined product', () => {
+      expect(detectProductBrand(undefined)).toBe('');
+    });
+
+    it('handles single string collection (non-array)', () => {
+      expect(detectProductBrand({ collections: 'wall-hugger-frames' })).toBe('Strata Furniture');
     });
   });
 

--- a/tests/productSeoInjection.test.js
+++ b/tests/productSeoInjection.test.js
@@ -40,10 +40,11 @@ const {
   injectProductMeta,
   injectPinterestMeta,
   buildGridAlt,
-  detectProductBrand,
   detectProductCategory,
   getCategoryFromCollections,
 } = await import('../src/public/product/productSchema.js');
+
+const { detectProductBrand } = await import('../src/public/productPageUtils.js');
 
 // ── Tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Consolidated 3 duplicate brand detection functions (`detectProductBrand` in productPageUtils + productSchema, `getBrandName` in seoHelpers.web) into a single canonical function in `productPageUtils.js`
- Added missing brands from backend: `otis` collection detection and `Arizona` brand (previously only in seoHelpers)
- Added null/undefined product guard (was missing in productPageUtils)
- `productSchema.js` and `seoHelpers.web.js` now import from the canonical source

## Changes

| File | Change |
|------|--------|
| `src/public/productPageUtils.js` | Canonical `detectProductBrand` — added null guard, otis collection, Arizona brand |
| `src/public/product/productSchema.js` | Removed local copy, imports from productPageUtils |
| `src/backend/seoHelpers.web.js` | Removed local `getBrandName`, imports `detectProductBrand` from productPageUtils |
| `tests/fixtures/products.js` | Added `unfinishedFrame`, `otisMattress`, `arizonaFrame` fixtures |
| `tests/productPageUtils.test.js` | Added tests: otis collection, arizona brand, null/undefined product, string collection |
| `tests/productPageJsonLd.test.js` | Updated import source |
| `tests/productSeoInjection.test.js` | Updated import source |
| `tests/categorySearch.test.js` | Updated counts for new fixtures |

## Test plan

- [x] All 10,853 tests pass (284 files)
- [x] New tests cover: otis collection, arizona brand, null product, undefined product, string collection
- [x] Existing brand detection tests still pass with canonical import
- [ ] Verify SEO schema output includes otis/arizona brands in JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)