### PR TITLE
feat(CF-a756): Pinterest Rich Pins availability fix

### DIFF
--- a/src/public/product/productSchema.js
+++ b/src/public/product/productSchema.js
@@ -148,6 +148,7 @@ export async function injectPinterestMeta(product) {
     const pinterestTags = [
       'pinterest:description',
       'pinterest-rich-pin',
+      'product:availability',
       'product:retailer_item_id',
       'product:category',
       'product:sale_price:amount',

--- a/tests/productSeoInjection.test.js
+++ b/tests/productSeoInjection.test.js
@@ -171,6 +171,56 @@ describe('injectPinterestMeta — Pinterest Rich Pin injection', () => {
     expect(mockHead.setMetaTag).toHaveBeenCalledWith('product:retailer_item_id', 'EUR-FRM-001');
   });
 
+  it('overrides product:availability with Pinterest format (instock/oos)', async () => {
+    const { getProductPinData } = await import('backend/pinterestRichPins.web');
+    getProductPinData.mockReturnValueOnce({
+      success: true,
+      meta: {
+        'pinterest:description': 'Test',
+        'pinterest-rich-pin': 'true',
+        'product:availability': 'instock',
+      },
+    });
+
+    await injectPinterestMeta(futonFrame);
+
+    expect(mockHead.setMetaTag).toHaveBeenCalledWith('product:availability', 'instock');
+  });
+
+  it('sets oos availability for out-of-stock products', async () => {
+    const { getProductPinData } = await import('backend/pinterestRichPins.web');
+    getProductPinData.mockReturnValueOnce({
+      success: true,
+      meta: {
+        'pinterest:description': 'Test',
+        'pinterest-rich-pin': 'true',
+        'product:availability': 'oos',
+      },
+    });
+
+    await injectPinterestMeta({ ...futonFrame, inStock: false });
+
+    expect(mockHead.setMetaTag).toHaveBeenCalledWith('product:availability', 'oos');
+  });
+
+  it('sets sale price tags when present', async () => {
+    const { getProductPinData } = await import('backend/pinterestRichPins.web');
+    getProductPinData.mockReturnValueOnce({
+      success: true,
+      meta: {
+        'pinterest:description': 'Test',
+        'pinterest-rich-pin': 'true',
+        'product:sale_price:amount': '449.99',
+        'product:sale_price:currency': 'USD',
+      },
+    });
+
+    await injectPinterestMeta(futonFrame);
+
+    expect(mockHead.setMetaTag).toHaveBeenCalledWith('product:sale_price:amount', '449.99');
+    expect(mockHead.setMetaTag).toHaveBeenCalledWith('product:sale_price:currency', 'USD');
+  });
+
   it('does nothing when pin data returns failure', async () => {
     const { getProductPinData } = await import('backend/pinterestRichPins.web');
     getProductPinData.mockReturnValueOnce({ success: false, meta: null });


### PR DESCRIPTION
## Summary
- Fixed `product:availability` format mismatch: OG path set `"in stock"`/`"out of stock"` but Pinterest requires `"instock"`/`"oos"`
- Added `product:availability` to the `pinterestTags` override list in `injectPinterestMeta()` so the Pinterest-correct value overwrites the OG path value
- Added 3 tests: instock override, oos for out-of-stock, sale price injection

## Context
The Pinterest Rich Pins feature was already fully implemented (backend, frontend orchestration, catalog feed, tests). The only bug was that `injectPinterestMeta` did not override `product:availability` — leaving the OG-format value which Pinterest's validator rejects.

## Test plan
- [x] 3 new tests for availability override and sale price
- [x] All 10,951 tests pass (289 test files)

Generated with Claude Code