### PR TITLE
feat(CF-vnk2): Social proof toasts — review count notification

### DIFF
--- a/src/backend/socialProof.web.js
+++ b/src/backend/socialProof.web.js
@@ -27,7 +27,10 @@ const NOTIFICATION_TYPES = {
   recent_purchase: 'recent_purchase',
   low_stock: 'low_stock',
   popularity: 'popularity',
+  review_count: 'review_count',
 };
+
+const MIN_REVIEW_COUNT = 5;
 
 /**
  * Get social proof notifications for a product.
@@ -48,10 +51,11 @@ export const getProductSocialProof = webMethod(
       const id = sanitize(productId, 50);
       const name = sanitize(productName || '', 200);
 
-      const [recentPurchases, stockLevel, viewCount] = await Promise.all([
+      const [recentPurchases, stockLevel, viewCount, reviewData] = await Promise.all([
         getRecentPurchases(id),
         getStockLevel(id),
         getApproxViewCount(id),
+        getReviewCount(id),
       ]);
 
       const notifications = [];
@@ -83,6 +87,15 @@ export const getProductSocialProof = webMethod(
           type: NOTIFICATION_TYPES.popularity,
           message: `${viewCount} people viewed this recently`,
           priority: 3,
+        });
+      }
+
+      // Priority 4: Review count
+      if (reviewData.count >= MIN_REVIEW_COUNT) {
+        notifications.push({
+          type: NOTIFICATION_TYPES.review_count,
+          message: `${reviewData.count} reviews — rated ${reviewData.averageRating}/5 stars`,
+          priority: 4,
         });
       }
 
@@ -241,6 +254,25 @@ function anonymizeName(firstName) {
   // Return first name only, capitalized
   const name = firstName.trim();
   return name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
+}
+
+async function getReviewCount(productId) {
+  try {
+    const result = await wixData.query('Reviews')
+      .eq('productId', productId)
+      .eq('status', 'approved')
+      .find();
+
+    const items = result.items || [];
+    if (items.length === 0) return { count: 0, averageRating: 0 };
+
+    const sum = items.reduce((acc, r) => acc + (r.rating || 0), 0);
+    const avg = Math.round((sum / items.length) * 10) / 10;
+
+    return { count: items.length, averageRating: avg };
+  } catch (err) {
+    return { count: 0, averageRating: 0 };
+  }
 }
 
 function anonymizeCity(city) {

--- a/src/public/socialProofToast.js
+++ b/src/public/socialProofToast.js
@@ -124,6 +124,8 @@ function showToast($w, notification, config) {
         toastIcon.text = '\u26A0'; // Warning
       } else if (notification.type === 'recent_purchase') {
         toastIcon.text = '\u2705'; // Checkmark
+      } else if (notification.type === 'review_count') {
+        toastIcon.text = '\u2B50'; // Star
       } else {
         toastIcon.text = '\uD83D\uDC41'; // Eye
       }

--- a/tests/socialProof.test.js
+++ b/tests/socialProof.test.js
@@ -244,6 +244,86 @@ describe('getCategorySocialProof', () => {
   });
 });
 
+// ── getProductSocialProof — review count ─────────────────────────────
+
+describe('getProductSocialProof — review count', () => {
+  it('returns review_count notification when product has 5+ reviews', async () => {
+    const reviews = [];
+    for (let i = 0; i < 8; i++) {
+      reviews.push({
+        _id: `rev-${i}`,
+        productId: 'prod-reviewed',
+        status: 'approved',
+        rating: 4 + (i % 2),
+      });
+    }
+    __seed('Reviews', reviews);
+    const result = await getProductSocialProof('prod-reviewed', 'Comfy Futon');
+    const reviewNotif = result.notifications.find(n => n.type === 'review_count');
+    expect(reviewNotif).toBeDefined();
+    expect(reviewNotif.message).toContain('8');
+    expect(reviewNotif.message).toMatch(/review/i);
+    expect(reviewNotif.priority).toBe(4);
+  });
+
+  it('includes average rating in review_count message', async () => {
+    const reviews = [];
+    for (let i = 0; i < 6; i++) {
+      reviews.push({
+        _id: `rev-${i}`,
+        productId: 'prod-rated',
+        status: 'approved',
+        rating: 5,
+      });
+    }
+    __seed('Reviews', reviews);
+    const result = await getProductSocialProof('prod-rated');
+    const reviewNotif = result.notifications.find(n => n.type === 'review_count');
+    expect(reviewNotif).toBeDefined();
+    expect(reviewNotif.message).toContain('5');
+  });
+
+  it('does not show review_count when fewer than 5 reviews', async () => {
+    __seed('Reviews', [
+      { _id: 'rev-1', productId: 'prod-few-rev', status: 'approved', rating: 5 },
+      { _id: 'rev-2', productId: 'prod-few-rev', status: 'approved', rating: 4 },
+    ]);
+    const result = await getProductSocialProof('prod-few-rev');
+    const reviewNotif = result.notifications.find(n => n.type === 'review_count');
+    expect(reviewNotif).toBeUndefined();
+  });
+
+  it('only counts approved reviews', async () => {
+    const reviews = [
+      { _id: 'rev-1', productId: 'prod-mix', status: 'approved', rating: 5 },
+      { _id: 'rev-2', productId: 'prod-mix', status: 'approved', rating: 4 },
+      { _id: 'rev-3', productId: 'prod-mix', status: 'pending', rating: 5 },
+      { _id: 'rev-4', productId: 'prod-mix', status: 'rejected', rating: 1 },
+    ];
+    __seed('Reviews', reviews);
+    const result = await getProductSocialProof('prod-mix');
+    const reviewNotif = result.notifications.find(n => n.type === 'review_count');
+    // Only 2 approved reviews, below threshold of 5
+    expect(reviewNotif).toBeUndefined();
+  });
+
+  it('does not count reviews for other products', async () => {
+    const reviews = [];
+    for (let i = 0; i < 10; i++) {
+      reviews.push({
+        _id: `rev-${i}`,
+        productId: 'prod-other',
+        status: 'approved',
+        rating: 5,
+      });
+    }
+    __seed('Reviews', reviews);
+    const result = await getProductSocialProof('prod-target');
+    const reviewNotif = result.notifications.find(n => n.type === 'review_count');
+    expect(reviewNotif).toBeUndefined();
+  });
+});
+
 // ── getSocialProofConfig ─────────────────────────────────────────────
 
 describe('getSocialProofConfig', () => {

--- a/tests/socialProofToast.test.js
+++ b/tests/socialProofToast.test.js
@@ -119,4 +119,224 @@ describe('initCategorySocialProof', () => {
     getCategorySocialProof.mockRejectedValue(new Error('fail'));
     await expect(initCategorySocialProof(() => null, 'futon-frames')).resolves.not.toThrow();
   });
+
+  it('builds low_stock notification from lowStockProducts', async () => {
+    getCategorySocialProof.mockResolvedValue({
+      recentSalesCount: 0,
+      lowStockProducts: [{ productName: 'Kodiak Frame', quantity: 2 }],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 5000 },
+    });
+
+    const elements = {};
+    const $w = (sel) => {
+      if (!elements[sel]) {
+        elements[sel] = {
+          text: '',
+          show: vi.fn(),
+          hide: vi.fn(),
+          onClick: vi.fn(),
+          style: {},
+          accessibility: {},
+        };
+      }
+      return elements[sel];
+    };
+
+    await initCategorySocialProof($w, 'futon-frames');
+    vi.advanceTimersByTime(6000);
+
+    expect(elements['#socialProofMessage'].text).toContain('Kodiak Frame');
+    expect(elements['#socialProofMessage'].text).toContain('2');
+    expect(elements['#socialProofToast'].show).toHaveBeenCalled();
+  });
+
+  it('builds recent_purchase notification when salesCount >= 3 and no low stock', async () => {
+    getCategorySocialProof.mockResolvedValue({
+      recentSalesCount: 7,
+      lowStockProducts: [],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 5000 },
+    });
+
+    const elements = {};
+    const $w = (sel) => {
+      if (!elements[sel]) {
+        elements[sel] = {
+          text: '',
+          show: vi.fn(),
+          hide: vi.fn(),
+          onClick: vi.fn(),
+          style: {},
+          accessibility: {},
+        };
+      }
+      return elements[sel];
+    };
+
+    await initCategorySocialProof($w, 'mattresses');
+    vi.advanceTimersByTime(6000);
+
+    expect(elements['#socialProofMessage'].text).toContain('7');
+    expect(elements['#socialProofMessage'].text).toContain('orders');
+  });
+
+  it('returns null notification when no signals', async () => {
+    getCategorySocialProof.mockResolvedValue({
+      recentSalesCount: 1,
+      lowStockProducts: [],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 5000 },
+    });
+
+    const showFn = vi.fn();
+    const $w = () => ({ text: '', show: showFn, hide: vi.fn(), onClick: vi.fn(), style: {}, accessibility: {} });
+
+    await initCategorySocialProof($w, 'covers');
+    vi.advanceTimersByTime(6000);
+
+    // Toast should NOT show — no notification built
+    expect(showFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('showToast — session frequency capping', () => {
+  let initProductSocialProof;
+  let getProductSocialProof;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    const mod = await import('../src/public/socialProofToast.js');
+    initProductSocialProof = mod.initProductSocialProof;
+    const backend = await import('backend/socialProof.web');
+    getProductSocialProof = backend.getProductSocialProof;
+    getProductSocialProof.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanupToast();
+  });
+
+  it('respects maxPerSession cap', async () => {
+    // Set session state to already at max
+    sessionStorage.setItem('cf_social_proof', JSON.stringify({ count: 5, lastShown: 0 }));
+
+    getProductSocialProof.mockResolvedValue({
+      notifications: [{ type: 'recent_purchase', message: 'Someone bought', priority: 1 }],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 5000 },
+    });
+
+    const showFn = vi.fn();
+    const $w = () => ({ text: '', show: showFn, hide: vi.fn(), onClick: vi.fn(), style: {}, accessibility: {} });
+
+    await initProductSocialProof($w, 'prod-1');
+    vi.advanceTimersByTime(10000);
+
+    // Should NOT show — session cap reached
+    expect(showFn).not.toHaveBeenCalled();
+  });
+
+  it('increments session count after showing toast', async () => {
+    getProductSocialProof.mockResolvedValue({
+      notifications: [{ type: 'recent_purchase', message: 'Someone bought', priority: 1 }],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 5000 },
+    });
+
+    const elements = {};
+    const $w = (sel) => {
+      if (!elements[sel]) {
+        elements[sel] = {
+          text: '',
+          show: vi.fn(),
+          hide: vi.fn(),
+          onClick: vi.fn(),
+          style: {},
+          accessibility: {},
+        };
+      }
+      return elements[sel];
+    };
+
+    await initProductSocialProof($w, 'prod-2', 'Test Product');
+    vi.advanceTimersByTime(5000);
+
+    const state = JSON.parse(sessionStorage.getItem('cf_social_proof'));
+    expect(state.count).toBe(1);
+    expect(state.lastShown).toBeGreaterThan(0);
+  });
+});
+
+describe('showToast — icon types', () => {
+  let initProductSocialProof;
+  let getProductSocialProof;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    const mod = await import('../src/public/socialProofToast.js');
+    initProductSocialProof = mod.initProductSocialProof;
+    const backend = await import('backend/socialProof.web');
+    getProductSocialProof = backend.getProductSocialProof;
+    getProductSocialProof.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanupToast();
+  });
+
+  it('sets star icon for review_count type', async () => {
+    getProductSocialProof.mockResolvedValue({
+      notifications: [{ type: 'review_count', message: '12 reviews', priority: 4 }],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 5000 },
+    });
+
+    const elements = {};
+    const $w = (sel) => {
+      if (!elements[sel]) {
+        elements[sel] = {
+          text: '',
+          show: vi.fn(),
+          hide: vi.fn(),
+          onClick: vi.fn(),
+          style: {},
+          accessibility: {},
+        };
+      }
+      return elements[sel];
+    };
+
+    await initProductSocialProof($w, 'prod-star');
+    vi.advanceTimersByTime(5000);
+
+    // Star icon for review_count
+    expect(elements['#socialProofIcon'].text).toBe('\u2B50');
+  });
+
+  it('auto-dismisses toast after configured time', async () => {
+    getProductSocialProof.mockResolvedValue({
+      notifications: [{ type: 'recent_purchase', message: 'Someone bought', priority: 1 }],
+      config: { maxPerSession: 5, minIntervalMs: 1000, autoDismissMs: 3000 },
+    });
+
+    const elements = {};
+    const $w = (sel) => {
+      if (!elements[sel]) {
+        elements[sel] = {
+          text: '',
+          show: vi.fn(),
+          hide: vi.fn(() => Promise.resolve()),
+          onClick: vi.fn(),
+          style: {},
+          accessibility: {},
+        };
+      }
+      return elements[sel];
+    };
+
+    await initProductSocialProof($w, 'prod-dismiss');
+    vi.advanceTimersByTime(4000); // past initial delay
+    vi.advanceTimersByTime(4000); // past auto-dismiss
+
+    expect(elements['#socialProofToast'].hide).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Add review_count notification type to social proof backend — queries Reviews collection for approved reviews, shows rating when product has 5+ reviews (Priority 4)
- Add star icon handling for review_count type in frontend toast
- Expand test coverage: session frequency capping, category notification building, auto-dismiss, icons, review count edge cases

## Test plan
- [x] 5 new backend tests for review_count notification
- [x] 7 new frontend tests
- [x] Full suite: 290 files, 11079 tests, all passing

## Bead
CF-vnk2: Engagement: social proof toasts

Generated with [Claude Code](https://claude.com/claude-code)