### PR TITLE
perf(CF-7zl): Defer non-critical tracking JS on Product Page

### DIFF
--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -5,8 +5,8 @@
 import { getRelatedProducts, getSameCollection, getCustomersAlsoBought } from 'backend/productRecommendations.web';
 import { trackProductView, getRecentlyViewed } from 'public/galleryHelpers.js';
 import { cacheProduct } from 'public/productCache';
-import { trackProductPageView } from 'public/engagementTracker';
-import { fireViewContent } from 'public/ga4Tracking';
+// engagementTracker and ga4Tracking are dynamically imported in deferred sections
+// to avoid blocking LCP (CF-7zl)
 import { collapseOnMobile, initBackToTop, isMobile } from 'public/mobileHelpers';
 import { buildGridAlt } from 'public/productPageUtils.js';
 import { getCachedProduct } from 'public/productCache';
@@ -69,8 +69,6 @@ async function initProductPage() {
 
     trackProductView(state.product);
     cacheProduct(state.product);
-    trackProductPageView(state.product);
-    fireViewContent(state.product);
 
     // Mountain skyline SVG border — gradient variant for product hero
     try {
@@ -113,6 +111,8 @@ async function initProductPage() {
       { name: 'collapseOnMobile', init: () => collapseOnMobile($w, ['#recentlyViewedSection', '#relatedSection', '#alsoBoughtSection']), critical: false },
       { name: 'backToTop', init: () => initBackToTop($w), critical: false },
       { name: 'browseTracking', init: () => initBrowseTrackingModule($w, state, _browseState), critical: false },
+      { name: 'engagementTracking', init: async () => { const m = await import('public/engagementTracker'); m.trackProductPageView(state.product); }, critical: false },
+      { name: 'ga4Tracking', init: async () => { const m = await import('public/ga4Tracking'); m.fireViewContent(state.product); }, critical: false },
       // Cross-sell sections (below fold, backend calls)
       { name: 'relatedProducts', init: loadRelatedProducts, critical: false },
       { name: 'collectionProducts', init: loadCollectionProducts, critical: false },

--- a/tests/productPageDeferral.test.js
+++ b/tests/productPageDeferral.test.js
@@ -1,0 +1,67 @@
+/**
+ * @file productPageDeferral.test.js
+ * @description Tests that non-critical tracking JS on the Product Page
+ * is deferred until after LCP (not statically imported or called in init path).
+ *
+ * CF-7zl: engagementTracker and ga4Tracking should be dynamically imported
+ * in deferred sections, not statically imported at module top level.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+const productPageContent = readFileSync('src/pages/Product Page.js', 'utf-8');
+
+describe('Product Page JS deferral — CF-7zl', () => {
+  describe('Static imports removed for tracking modules', () => {
+    it('does not statically import trackProductPageView from engagementTracker', () => {
+      // Static imports happen before any code runs — blocks LCP
+      const staticImportPattern = /^import\s+\{[^}]*trackProductPageView[^}]*\}\s+from\s+['"]public\/engagementTracker['"]/m;
+      expect(productPageContent).not.toMatch(staticImportPattern);
+    });
+
+    it('does not statically import fireViewContent from ga4Tracking', () => {
+      const staticImportPattern = /^import\s+\{[^}]*fireViewContent[^}]*\}\s+from\s+['"]public\/ga4Tracking['"]/m;
+      expect(productPageContent).not.toMatch(staticImportPattern);
+    });
+  });
+
+  describe('Tracking calls are deferred (not in init path)', () => {
+    it('trackProductPageView is called inside a deferred section or dynamic import', () => {
+      // Should appear after an `await import(` or inside a section init function
+      const hasDeferred = productPageContent.includes("import('public/engagementTracker')");
+      expect(hasDeferred).toBe(true);
+    });
+
+    it('fireViewContent is called inside a deferred section or dynamic import', () => {
+      const hasDeferred = productPageContent.includes("import('public/ga4Tracking')");
+      expect(hasDeferred).toBe(true);
+    });
+  });
+
+  describe('Tracking is still registered as a section', () => {
+    it('has a deferred section for engagement tracking', () => {
+      // Should be in the sections array with critical: false
+      expect(productPageContent).toMatch(/name:\s*['"]engagementTracking['"]/);
+      expect(productPageContent).toMatch(/engagementTracking['"],\s*init:.*critical:\s*false/s);
+    });
+
+    it('has a deferred section for GA4 tracking', () => {
+      expect(productPageContent).toMatch(/name:\s*['"]ga4Tracking['"]/);
+      expect(productPageContent).toMatch(/ga4Tracking['"],\s*init:.*critical:\s*false/s);
+    });
+  });
+
+  describe('Critical product operations remain in init path', () => {
+    it('trackProductView (gallery recently-viewed) stays in init path', () => {
+      // trackProductView is from galleryHelpers and populates recently viewed —
+      // it's lightweight and needed for cross-sell sections below
+      expect(productPageContent).toMatch(/trackProductView\(state\.product\)/);
+    });
+
+    it('cacheProduct stays in init path', () => {
+      // Caching is instant (localStorage write) and helps subsequent page loads
+      expect(productPageContent).toMatch(/cacheProduct\(state\.product\)/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Removed static imports** of `engagementTracker` and `ga4Tracking` from Product Page top-level
- **Moved tracking calls** (`trackProductPageView`, `fireViewContent`) to deferred sections with `dynamic import()` — loads after all critical above-fold content renders
- **Kept in init path**: `trackProductView` (populates recently-viewed for cross-sell) and `cacheProduct` (instant localStorage write)

## Before/After

| Module | Before | After |
|--------|--------|-------|
| engagementTracker | Static import, called before LCP | Dynamic import in deferred section |
| ga4Tracking | Static import, called before LCP | Dynamic import in deferred section |
| galleryHelpers (trackProductView) | Init path | Init path (no change — lightweight) |
| productCache | Init path | Init path (no change — localStorage) |

## Test plan

- [x] 8 new tests verifying static imports removed, dynamic imports present, sections registered as deferred
- [x] Full suite: 11,265 tests passing across 296 files
- [ ] Lighthouse: verify LCP improvement on Product Page

Bead: CF-7zl

🤖 Generated with [Claude Code](https://claude.com/claude-code)