### PR TITLE
ci(CF-2f4): configure vitest coverage thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ jsconfig.json
 *.secret
 credentials*
 package-lock.json
+coverage/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.18",
     "@wix/cli": "^1.0.0",
     "@wix/eslint-plugin-cli": "^1.0.0",
     "eslint": "^8.25.0",
@@ -12,6 +13,7 @@
     "dev": "wix dev",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   }
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,6 +7,17 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.js'],
     setupFiles: ['tests/setup.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.js'],
+      exclude: ['src/**/__mocks__/**'],
+      thresholds: {
+        lines: 70,
+        branches: 60,
+        functions: 70,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Install `@vitest/coverage-v8` and configure coverage thresholds in `vitest.config.js`
- Thresholds: lines 70%, branches 60%, functions 70%
- Reporters: text, json, html (html output in `coverage/`, gitignored)
- Add `npm run test:coverage` script

## Bead
CF-2f4

## Test plan
- [x] `npm test` — all 295 test files (11,257 tests) pass
- [x] `npm run test:coverage` — runs coverage and enforces thresholds
- [x] Threshold enforcement verified (functions at 69.63% correctly fails against 70% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)