### PR TITLE
fix(ci): add permissions for PR coverage comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,15 @@ on:
   schedule:
     - cron: '0 6 * * *'  # Nightly at 6am UTC
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 10
     strategy:
       matrix:
@@ -128,6 +134,9 @@ jobs:
   nightly-integration:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `pull-requests: write` permission to the `test` job so the coverage comment step can post/update PR comments via `github.rest.issues.createComment`
- Adds `issues: write` permission to the `nightly-integration` job so it can create GitHub issues on test failure
- Sets restrictive top-level `permissions: contents: read` default per GitHub security best practices

## Root Cause
The default `GITHUB_TOKEN` in GitHub Actions has restricted permissions. The coverage PR comment step (Node 20 matrix entry) called `github.rest.issues.createComment` which requires explicit `pull-requests: write` — resulting in a 403 "Resource not accessible by integration" error.

## Closes
CF-k04l

## Test plan
- [ ] Open a PR and verify the coverage comment posts successfully
- [ ] Verify lint and test jobs still pass (no permission regressions)
- [ ] Nightly job should still be able to create issues on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)