### PR TITLE
fix: add missing category folders to mediaGallery + VALID_CATEGORIES

### DIFF
--- a/src/backend/catalogContent.web.js
+++ b/src/backend/catalogContent.web.js
@@ -52,7 +52,7 @@ import { sanitize } from 'backend/utils/sanitize';
 
 const VALID_CATEGORIES = [
   'futon-frames', 'mattresses', 'murphy-cabinet-beds', 'platform-beds',
-  'casegoods-accessories', 'front-loading-nesting', 'wall-huggers',
+  'casegoods-accessories', 'front-loading-nesting', 'wall-huggers', 'wall-hugger-frames',
   'unfinished-wood', 'covers', 'outdoor-furniture', 'log-frames', 'pillows',
 ];
 

--- a/src/backend/mediaGallery.web.js
+++ b/src/backend/mediaGallery.web.js
@@ -53,6 +53,10 @@ const CATEGORY_FOLDERS = {
   'casegoods-accessories': '/products/casegoods-accessories',
   'covers': '/products/covers',
   'pillows-702': '/products/pillows',
+  'wall-hugger-frames': '/products/wall-hugger-frames',
+  'front-loading-nesting': '/products/front-loading-nesting',
+  'log-frames': '/products/log-frames',
+  'unfinished-wood': '/products/unfinished-wood',
 };
 
 // ── Admin check ─────────────────────────────────────────────────────

--- a/src/backend/productVideos.web.js
+++ b/src/backend/productVideos.web.js
@@ -34,7 +34,7 @@ const VALID_VIDEO_TYPES = ['assembly', 'demo', 'overview', 'animation', 'review'
 
 const VALID_CATEGORIES = [
   'futon-frames', 'mattresses', 'murphy-cabinet-beds', 'platform-beds',
-  'casegoods-accessories', 'front-loading-nesting', 'wall-huggers',
+  'casegoods-accessories', 'front-loading-nesting', 'wall-huggers', 'wall-hugger-frames',
   'unfinished-wood', 'covers', 'outdoor-furniture', 'log-frames', 'pillows',
 ];
 


### PR DESCRIPTION
## Summary
- Adds 4 missing entries to `CATEGORY_FOLDERS` in `mediaGallery.web.js`: `wall-hugger-frames`, `front-loading-nesting`, `log-frames`, `unfinished-wood`
- Adds `wall-hugger-frames` to `VALID_CATEGORIES` in `catalogContent.web.js` and `productVideos.web.js`
- Fixes gap where 12 products (10 wall-hugger-frames + 2 front-loading-nesting) couldn't resolve media folder paths

## Context
Found during product image audit (see `docs/PRODUCT-IMAGE-AUDIT.md`). The catalog has 88 products across 7 active categories, but `mediaGallery.web.js` only mapped 8 folders, missing 2 categories with actual products.

## Test plan
- [ ] 11,835 tests pass (verified locally)
- [ ] `getProductMedia()` resolves for wall-hugger-frames products
- [ ] `getCategoryThumbnails()` includes wall-hugger-frames and front-loading-nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)