### PR TITLE
feat(CF-kx0b): Bulk import 313 product photos to Wix Media Manager

### DIFF
--- a/scripts/importProductPhotos.js
+++ b/scripts/importProductPhotos.js
@@ -60,16 +60,25 @@ export function extractUniqueFolders(manifest) {
 
 /**
  * Infer MIME type from a wixstatic URL.
+ * Handles two URL formats:
+ *   - /media/hash_id.ext/v1/fit/... (current manifest format)
+ *   - /media/hash~mv2.ext/v1/fit/... (legacy Wix format)
+ * Falls back to image/jpeg if extension cannot be determined.
  * @param {string} url
  * @returns {string} MIME type string.
  */
 export function inferMimeType(url) {
-  // wixstatic URLs: .../media/hash~mv2.ext/v1/fit/.../file.ext
-  const match = url.match(/~mv2\.(\w+)/);
-  if (match) {
-    return MIME_MAP[match[1].toLowerCase()] || 'image/jpeg';
+  // Primary: match /media/hash.ext/ pattern (e.g., e04e89_cf15.jpg/v1/...)
+  const mediaMatch = url.match(/\/media\/[^/]+\.(\w+)\//);
+  if (mediaMatch) {
+    return MIME_MAP[mediaMatch[1].toLowerCase()] || 'image/jpeg';
   }
-  // Fallback: check file extension at end
+  // Legacy: match ~mv2.ext pattern
+  const mv2Match = url.match(/~mv2\.(\w+)/);
+  if (mv2Match) {
+    return MIME_MAP[mv2Match[1].toLowerCase()] || 'image/jpeg';
+  }
+  // Last resort: file extension at end of URL
   const extMatch = url.match(/\.(\w+)(?:\?|$)/);
   if (extMatch) {
     return MIME_MAP[extMatch[1].toLowerCase()] || 'image/jpeg';
@@ -88,15 +97,19 @@ export function buildImportRequests(manifest, folderIds) {
   for (const product of manifest) {
     if (!product.images || !product.images.length) continue;
     const parentFolderId = folderIds[product.folder] || 'media-root';
-    product.images.forEach((url, idx) => {
+    if (!folderIds[product.folder] && product.folder) {
+      console.warn(`Warning: No folder ID for "${product.folder}" — images will go to media-root`);
+    }
+    const slug = product.slug || String(product.name || 'product').toLowerCase().replace(/\s+/g, '-');
+    for (let idx = 0; idx < product.images.length; idx++) {
       requests.push({
-        url,
-        displayName: `${product.slug}-${idx + 1}`,
-        mimeType: inferMimeType(url),
+        url: product.images[idx],
+        displayName: `${slug}-${idx + 1}`,
+        mimeType: inferMimeType(product.images[idx]),
         mediaType: 'IMAGE',
         parentFolderId,
       });
-    });
+    }
   }
   return requests;
 }
@@ -197,12 +210,22 @@ export async function ensureFolderStructure(folderPaths, config) {
   const rootFolder = await createFolder('products', 'media-root', config);
   const rootId = rootFolder.id;
 
-  // Create each category sub-folder
+  // Create each category sub-folder (continue on individual failures)
   const folderIds = {};
+  const folderErrors = [];
   for (const path of folderPaths) {
     const categoryName = path.split('/').pop();
-    const folder = await createFolder(categoryName, rootId, config);
-    folderIds[path] = folder.id;
+    try {
+      const folder = await createFolder(categoryName, rootId, config);
+      folderIds[path] = folder.id;
+    } catch (err) {
+      console.error(`Failed to create folder "${categoryName}": ${err.message}`);
+      folderErrors.push({ path, error: err.message });
+    }
+  }
+
+  if (folderErrors.length) {
+    console.warn(`${folderErrors.length} folder(s) failed — their images will go to media-root`);
   }
 
   return folderIds;
@@ -244,19 +267,27 @@ export async function runImport(manifest, config, options = {}) {
     const batch = batches[i];
     console.log(`Importing batch ${i + 1}/${batches.length} (${batch.length} images)...`);
 
-    const result = await bulkImportFiles(batch, config);
+    try {
+      const result = await bulkImportFiles(batch, config);
 
-    totalSuccess += result.bulkActionMetadata?.totalSuccesses || 0;
-    totalFailed += result.bulkActionMetadata?.totalFailures || 0;
+      totalSuccess += result.bulkActionMetadata?.totalSuccesses || 0;
+      totalFailed += result.bulkActionMetadata?.totalFailures || 0;
 
-    // Track individual failures
-    for (const r of result.results || []) {
-      if (!r.itemMetadata?.success) {
-        failures.push({
-          index: r.itemMetadata?.originalIndex,
-          error: r.itemMetadata?.error,
-          url: batch[r.itemMetadata?.originalIndex]?.url,
-        });
+      // Track individual failures
+      for (const r of result.results || []) {
+        if (!r.itemMetadata?.success) {
+          failures.push({
+            index: r.itemMetadata?.originalIndex,
+            error: r.itemMetadata?.error,
+            url: batch[r.itemMetadata?.originalIndex]?.url,
+          });
+        }
+      }
+    } catch (err) {
+      console.error(`Batch ${i + 1} failed: ${err.message}`);
+      totalFailed += batch.length;
+      for (const item of batch) {
+        failures.push({ url: item.url, error: { description: err.message } });
       }
     }
   }

--- a/tests/importProductPhotos.test.js
+++ b/tests/importProductPhotos.test.js
@@ -1,6 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // We'll import the module functions after mocking
 let importProductPhotos;
@@ -170,12 +168,31 @@ describe('importProductPhotos', () => {
       expect(requests[2].mimeType).toBe('image/webp');
     });
 
-    it('falls back to media-root if folder ID not found', () => {
+    it('falls back to media-root if folder ID not found and warns', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const manifest = [
         { slug: 'test', folder: '/unknown', images: ['https://example.com/img.jpg'] },
       ];
       const requests = importProductPhotos.buildImportRequests(manifest, {});
       expect(requests[0].parentFolderId).toBe('media-root');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('/unknown'));
+      warnSpy.mockRestore();
+    });
+
+    it('falls back to name-based slug when slug field is missing', () => {
+      const manifest = [
+        { name: 'My Cool Product', folder: '/products/foo', images: ['https://example.com/1.jpg'] },
+      ];
+      const requests = importProductPhotos.buildImportRequests(manifest, { '/products/foo': 'f1' });
+      expect(requests[0].displayName).toBe('my-cool-product-1');
+    });
+
+    it('uses "product" fallback when both slug and name are missing', () => {
+      const manifest = [
+        { folder: '/products/foo', images: ['https://example.com/1.jpg'] },
+      ];
+      const requests = importProductPhotos.buildImportRequests(manifest, { '/products/foo': 'f1' });
+      expect(requests[0].displayName).toBe('product-1');
     });
 
     it('returns empty array for empty manifest', () => {
@@ -332,6 +349,32 @@ describe('importProductPhotos', () => {
       expect(result).toEqual({});
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    it('continues when a sub-folder creation fails', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Root folder succeeds
+      mockFetch.mockResolvedValueOnce(folderResponse('rootId', 'products'));
+      // First sub-folder fails
+      mockFetch.mockResolvedValueOnce(errorResponse(500, 'Server Error'));
+      // Second sub-folder succeeds
+      mockFetch.mockResolvedValueOnce(folderResponse('ff2', 'mattresses', 'rootId'));
+
+      const result = await importProductPhotos.ensureFolderStructure(
+        ['/products/futon-frames', '/products/mattresses'],
+        { apiKey: 'IST.test', siteId: 'site123' }
+      );
+
+      // Only the successful folder should be in the map
+      expect(result).toEqual({ '/products/mattresses': 'ff2' });
+      expect(result['/products/futon-frames']).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('futon-frames'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('1 folder(s) failed'));
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
   });
 
   describe('inferMimeType', () => {
@@ -344,44 +387,45 @@ describe('importProductPhotos', () => {
       )).toBe('image/png');
     });
 
+    it('handles legacy ~mv2 URL format', () => {
+      expect(importProductPhotos.inferMimeType(
+        'https://static.wixstatic.com/media/ed8a72_abc123~mv2.png'
+      )).toBe('image/png');
+    });
+
     it('defaults to image/jpeg for unknown extensions', () => {
       expect(importProductPhotos.inferMimeType('https://example.com/file')).toBe('image/jpeg');
     });
   });
 
   describe('getConfig', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
     it('reads config from environment variables', () => {
-      const original = { ...process.env };
-      process.env.WIX_BACKEND_KEY = 'IST.testkey';
-      process.env.WIX_SITE_ID = 'test-site-id';
+      vi.stubEnv('WIX_BACKEND_KEY', 'IST.testkey');
+      vi.stubEnv('WIX_SITE_ID', 'test-site-id');
 
       const config = importProductPhotos.getConfig();
       expect(config).toEqual({
         apiKey: 'IST.testkey',
         siteId: 'test-site-id',
       });
-
-      process.env = original;
     });
 
     it('throws if WIX_BACKEND_KEY is missing', () => {
-      const original = { ...process.env };
-      delete process.env.WIX_BACKEND_KEY;
-      process.env.WIX_SITE_ID = 'test';
+      vi.stubEnv('WIX_BACKEND_KEY', '');
+      vi.stubEnv('WIX_SITE_ID', 'test');
 
       expect(() => importProductPhotos.getConfig()).toThrow(/WIX_BACKEND_KEY/);
-
-      process.env = original;
     });
 
     it('throws if WIX_SITE_ID is missing', () => {
-      const original = { ...process.env };
-      process.env.WIX_BACKEND_KEY = 'IST.test';
-      delete process.env.WIX_SITE_ID;
+      vi.stubEnv('WIX_BACKEND_KEY', 'IST.test');
+      vi.stubEnv('WIX_SITE_ID', '');
 
       expect(() => importProductPhotos.getConfig()).toThrow(/WIX_SITE_ID/);
-
-      process.env = original;
     });
   });
 
@@ -487,6 +531,38 @@ describe('importProductPhotos', () => {
       expect(mockFetch).toHaveBeenCalledTimes(4);
     });
   });
+
+    it('continues remaining batches when one batch API call fails', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const images = Array.from({ length: 150 }, (_, i) =>
+        `https://static.wixstatic.com/media/e04e89_${i}.jpg/v1/fit/w_2000,h_2000,q_90/file.jpg`
+      );
+      const manifest = [{ slug: 'prod', folder: '/products/cat', images }];
+
+      // Folders
+      mockFetch.mockResolvedValueOnce(folderResponse('rootId', 'products'));
+      mockFetch.mockResolvedValueOnce(folderResponse('catId', 'cat', 'rootId'));
+      // Batch 1 fails with API error
+      mockFetch.mockResolvedValueOnce(errorResponse(500, 'Internal Server Error'));
+      // Batch 2 succeeds
+      mockFetch.mockResolvedValueOnce(bulkImportResponse(
+        Array.from({ length: 50 }, (_, i) => ({ url: `u${i}`, displayName: `prod-${i + 101}` }))
+      ));
+
+      const result = await importProductPhotos.runImport(
+        manifest,
+        { apiKey: 'IST.test', siteId: 'site123' }
+      );
+
+      expect(result.totalSuccess).toBe(50);
+      expect(result.totalFailed).toBe(100); // Entire batch 1 counted as failed
+      expect(result.failures).toHaveLength(100);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Batch 1 failed'));
+
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
+    });
 
   describe('dry run mode', () => {
     it('does not call API in dry run mode', async () => {


### PR DESCRIPTION
## Summary
- TDD script (`scripts/importProductPhotos.js`) that bulk imports product photos to Wix Media Manager via REST API
- Creates 7 product category folders (`futon-frames`, `wall-hugger-frames`, `platform-beds`, `mattresses`, `murphy-cabinet-beds`, `front-loading-nesting`, `casegoods-accessories`) under `/products` root
- Imports all 313 images from `docs/product-image-manifest.json` in batches of 100 (Wix API limit)
- Supports `--dry-run` mode for safe previewing
- 29 tests covering: manifest loading, folder extraction, MIME inference, batch chunking, API calls, dry-run mode, partial failure handling, config validation

## Import Results
- **313/313 images imported successfully** (0 failures)
- 4 batches processed, 7 folders created
- All images now on account `ed8a72` (our account) instead of `e04e89`

## Test plan
- [x] 29 new tests pass (TDD — tests written before implementation)
- [x] Full suite: 11,864 tests pass (306 files)
- [x] Dry run verified correct manifest parsing (88 products, 313 images, 7 folders)
- [x] Live run completed: 313/313 succeeded, 0 failed
- [ ] Verify images visible in Wix Studio Media Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)