### PR TITLE
feat(CF-d6ro): Element ID remapping utility

### DIFF
--- a/scripts/remap-element-ids.js
+++ b/scripts/remap-element-ids.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Element ID Remapping Utility (CF-d6ro)
+ *
+ * Bulk-renames $w('#elementId') references across src/ and tests/.
+ * Takes a JSON mapping file { "oldId": "newId", ... }.
+ * Dry-run by default; pass --apply to write changes.
+ *
+ * Usage:
+ *   node scripts/remap-element-ids.js mapping.json [--apply]
+ *
+ * @module remap-element-ids
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join, extname } from 'path';
+
+/**
+ * Parse and validate a JSON mapping file.
+ * @param {string} filePath - Path to JSON mapping file
+ * @returns {Record<string, string>} oldId → newId mapping
+ * @throws {Error} On invalid file, JSON, or mapping structure
+ */
+export function parseMapping(filePath) {
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new Error(`Cannot read mapping file: ${filePath}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid JSON in mapping file: ${err.message}`);
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Mapping must be a JSON object { "oldId": "newId", ... }');
+  }
+
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) {
+    throw new Error('Mapping is empty — nothing to remap');
+  }
+
+  for (const [key, value] of entries) {
+    if (!key) {
+      throw new Error('Mapping keys must be non-empty strings');
+    }
+    if (typeof value !== 'string' || !value) {
+      throw new Error(`Mapping value for "${key}" must be a non-empty string, got: ${typeof value}`);
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Replace element IDs in source text according to a mapping.
+ * Handles: $w('#id'), $w("#id"), $w(`#id`), '#id' / "#id" in selector arrays.
+ * Does NOT replace bare prose references without # prefix.
+ * Avoids double-replacement by replacing all keys simultaneously.
+ *
+ * @param {string} source - Source file content
+ * @param {Record<string, string>} mapping - oldId → newId mapping
+ * @param {{ countMode?: boolean }} [options] - If countMode, return { text, count }
+ * @returns {string | { text: string, count: number }}
+ */
+export function replaceIds(source, mapping, options = {}) {
+  const keys = Object.keys(mapping);
+  if (keys.length === 0) return options.countMode ? { text: source, count: 0 } : source;
+
+  // Build a single regex that matches #oldId inside quotes/backticks
+  // Captures: (quote char)(#)(oldId)(quote char)
+  // We match: ['"`]#oldId['"`] but only within $w() or string contexts
+  // Strategy: match #oldId bounded by quote+word-boundary to avoid partial matches
+  const escapedKeys = keys.map(k => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const idAlternation = escapedKeys.join('|');
+
+  // Match: (single/double/backtick quote) # (one of our IDs) (same or any closing context)
+  // We need to ensure we don't match partial IDs, so we use word boundary after ID
+  const pattern = new RegExp(
+    `(['"\`])#(${idAlternation})\\b(?=\\1|[^a-zA-Z0-9_])`,
+    'g'
+  );
+
+  let count = 0;
+  const result = source.replace(pattern, (match, quote, oldId) => {
+    count++;
+    return `${quote}#${mapping[oldId]}`;
+  });
+
+  if (options.countMode) {
+    return { text: result, count };
+  }
+  return result;
+}
+
+/**
+ * Recursively collect all .js files in a directory.
+ * @param {string} dir - Directory to scan
+ * @returns {string[]} Array of absolute file paths
+ */
+function collectJsFiles(dir) {
+  const results = [];
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      results.push(...collectJsFiles(fullPath));
+    } else if (extname(entry) === '.js') {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Run element ID remapping across directories.
+ * @param {{ mappingPath: string, scanDirs: string[], apply?: boolean }} opts
+ * @returns {{ filesScanned: number, filesChanged: number, totalReplacements: number, fileDetails: Array<{ file: string, replacements: number }> }}
+ */
+export function remapElementIds({ mappingPath, scanDirs, apply = false }) {
+  const mapping = parseMapping(mappingPath);
+
+  // Validate scan directories exist
+  for (const dir of scanDirs) {
+    if (!existsSync(dir)) {
+      throw new Error(`Scan directory does not exist: ${dir}`);
+    }
+  }
+
+  // Collect all .js files
+  const allFiles = [];
+  for (const dir of scanDirs) {
+    allFiles.push(...collectJsFiles(dir));
+  }
+
+  let filesChanged = 0;
+  let totalReplacements = 0;
+  const fileDetails = [];
+
+  for (const filePath of allFiles) {
+    const content = readFileSync(filePath, 'utf8');
+    const { text, count } = replaceIds(content, mapping, { countMode: true });
+
+    if (count > 0) {
+      fileDetails.push({ file: filePath, replacements: count });
+      totalReplacements += count;
+      if (apply) {
+        writeFileSync(filePath, text, 'utf8');
+        filesChanged++;
+      }
+    }
+  }
+
+  return {
+    filesScanned: allFiles.length,
+    filesChanged: apply ? filesChanged : 0,
+    totalReplacements,
+    fileDetails,
+  };
+}
+
+// ── CLI entrypoint ───────────────────────────────────────────────────
+
+const isDirectRun = process.argv[1] && process.argv[1].endsWith('remap-element-ids.js');
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const applyFlag = args.includes('--apply');
+  const mappingPath = args.find(a => !a.startsWith('--'));
+
+  if (!mappingPath) {
+    console.error('Usage: node scripts/remap-element-ids.js <mapping.json> [--apply]');
+    process.exit(1);
+  }
+
+  const scanDirs = [join(process.cwd(), 'src'), join(process.cwd(), 'tests')];
+  const result = remapElementIds({ mappingPath, scanDirs, apply: applyFlag });
+
+  console.log(`\nElement ID Remapping ${applyFlag ? '(APPLIED)' : '(DRY RUN)'}`);
+  console.log('─'.repeat(50));
+  console.log(`Files scanned:  ${result.filesScanned}`);
+  console.log(`Files changed:  ${result.filesChanged}`);
+  console.log(`Replacements:   ${result.totalReplacements}`);
+
+  if (result.fileDetails.length > 0) {
+    console.log('\nPer-file details:');
+    for (const detail of result.fileDetails) {
+      console.log(`  ${detail.file}: ${detail.replacements} replacement(s)`);
+    }
+  }
+
+  if (!applyFlag && result.totalReplacements > 0) {
+    console.log('\nRun with --apply to write changes.');
+  }
+}

--- a/tests/scripts/remap-element-ids.test.js
+++ b/tests/scripts/remap-element-ids.test.js
@@ -1,0 +1,370 @@
+/**
+ * Element ID Remapping Utility Tests (CF-d6ro)
+ *
+ * TDD: Tests written FIRST. Script does not exist yet.
+ * Covers: mapping parsing, $w selector replacement, selector array replacement,
+ * dry-run vs apply mode, summary output, error handling, edge cases.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { remapElementIds, parseMapping, replaceIds } from '../../scripts/remap-element-ids.js';
+
+const TMP_DIR = join(process.cwd(), 'tests', 'scripts', '.tmp-remap');
+
+function setupTmpDir(files = {}) {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = join(TMP_DIR, relPath);
+    const dir = fullPath.substring(0, fullPath.lastIndexOf('/'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(fullPath, content, 'utf8');
+  }
+}
+
+function readTmpFile(relPath) {
+  return readFileSync(join(TMP_DIR, relPath), 'utf8');
+}
+
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+// ── parseMapping ─────────────────────────────────────────────────────
+
+describe('parseMapping', () => {
+  it('parses valid JSON mapping file', () => {
+    setupTmpDir({ 'mapping.json': JSON.stringify({ oldBtn: 'newBtn', oldInput: 'newInput' }) });
+    const mapping = parseMapping(join(TMP_DIR, 'mapping.json'));
+    expect(mapping).toEqual({ oldBtn: 'newBtn', oldInput: 'newInput' });
+  });
+
+  it('throws on non-existent mapping file', () => {
+    expect(() => parseMapping('/nonexistent/mapping.json')).toThrow();
+  });
+
+  it('throws on invalid JSON', () => {
+    setupTmpDir({ 'bad.json': '{ not valid json' });
+    expect(() => parseMapping(join(TMP_DIR, 'bad.json'))).toThrow(/invalid/i);
+  });
+
+  it('throws on non-object mapping (array)', () => {
+    setupTmpDir({ 'arr.json': '["a", "b"]' });
+    expect(() => parseMapping(join(TMP_DIR, 'arr.json'))).toThrow();
+  });
+
+  it('throws on empty mapping', () => {
+    setupTmpDir({ 'empty.json': '{}' });
+    expect(() => parseMapping(join(TMP_DIR, 'empty.json'))).toThrow(/empty/i);
+  });
+
+  it('throws when mapping values are not strings', () => {
+    setupTmpDir({ 'bad-val.json': JSON.stringify({ oldId: 123 }) });
+    expect(() => parseMapping(join(TMP_DIR, 'bad-val.json'))).toThrow();
+  });
+
+  it('throws when mapping keys are empty strings', () => {
+    setupTmpDir({ 'empty-key.json': JSON.stringify({ '': 'newId' }) });
+    expect(() => parseMapping(join(TMP_DIR, 'empty-key.json'))).toThrow();
+  });
+});
+
+// ── replaceIds (pure string transform) ───────────────────────────────
+
+describe('replaceIds', () => {
+  const mapping = { oldButton: 'newButton', oldInput: 'newInput' };
+
+  it('replaces $w single-quoted selectors', () => {
+    const input = `$w('#oldButton').onClick(() => {});`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(`$w('#newButton').onClick(() => {});`);
+  });
+
+  it('replaces $w double-quoted selectors', () => {
+    const input = `$w("#oldButton").show();`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(`$w("#newButton").show();`);
+  });
+
+  it('replaces multiple occurrences in same line', () => {
+    const input = `$w('#oldButton').hide(); $w('#oldInput').value = '';`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(`$w('#newButton').hide(); $w('#newInput').value = '';`);
+  });
+
+  it('replaces IDs across multiple lines', () => {
+    const input = [
+      `const btn = $w('#oldButton');`,
+      `const inp = $w('#oldInput');`,
+    ].join('\n');
+    const result = replaceIds(input, mapping);
+    expect(result).toContain(`$w('#newButton')`);
+    expect(result).toContain(`$w('#newInput')`);
+  });
+
+  it('replaces IDs in selector arrays (single-quoted)', () => {
+    const input = `collapseOnMobile($w, ['#oldButton', '#oldInput']);`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(`collapseOnMobile($w, ['#newButton', '#newInput']);`);
+  });
+
+  it('replaces IDs in selector arrays (double-quoted)', () => {
+    const input = `const ids = ["#oldButton", "#oldInput"];`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(`const ids = ["#newButton", "#newInput"];`);
+  });
+
+  it('does not replace IDs that are not in the mapping', () => {
+    const input = `$w('#keepMe').show();`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(input);
+  });
+
+  it('does not replace partial ID matches', () => {
+    const input = `$w('#oldButtonExtra').show();`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(input);
+  });
+
+  it('does not replace IDs in comments', () => {
+    // Note: basic implementation may still replace in comments.
+    // This tests that plain text "oldButton" without $w/#  is NOT replaced.
+    const input = `// reference to oldButton in prose`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(input);
+  });
+
+  it('handles backtick template literals with $w', () => {
+    const input = "const el = $w(`#oldButton`);";
+    const result = replaceIds(input, mapping);
+    expect(result).toBe("const el = $w(`#newButton`);");
+  });
+
+  it('returns original string when no replacements needed', () => {
+    const input = `$w('#unrelated').show();`;
+    const result = replaceIds(input, mapping);
+    expect(result).toBe(input);
+  });
+
+  it('returns replacement count', () => {
+    const input = `$w('#oldButton').hide(); $w('#oldButton').show(); $w('#oldInput').value;`;
+    const { text, count } = replaceIds(input, mapping, { countMode: true });
+    expect(text).toContain('#newButton');
+    expect(text).toContain('#newInput');
+    expect(count).toBe(3);
+  });
+});
+
+// ── remapElementIds (full pipeline) ──────────────────────────────────
+
+describe('remapElementIds', () => {
+  const mappingContent = JSON.stringify({
+    oldHeader: 'newHeader',
+    oldFooter: 'newFooter',
+  });
+
+  it('dry-run does not modify files', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/pages/Test.js': `$w('#oldHeader').show();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: false,
+    });
+    expect(result.filesChanged).toBe(0);
+    expect(result.totalReplacements).toBeGreaterThan(0);
+    expect(readTmpFile('src/pages/Test.js')).toBe(`$w('#oldHeader').show();`);
+  });
+
+  it('dry-run reports would-be changes accurately', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/pages/A.js': `$w('#oldHeader').show();\n$w('#oldFooter').hide();`,
+      'src/pages/B.js': `$w('#oldHeader').onClick(() => {});`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: false,
+    });
+    expect(result.totalReplacements).toBe(3);
+    expect(result.fileDetails).toHaveLength(2);
+  });
+
+  it('--apply writes modified files', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/pages/Test.js': `$w('#oldHeader').show();\n$w('#oldFooter').hide();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    expect(result.filesChanged).toBe(1);
+    const content = readTmpFile('src/pages/Test.js');
+    expect(content).toContain(`$w('#newHeader')`);
+    expect(content).toContain(`$w('#newFooter')`);
+    expect(content).not.toContain('#oldHeader');
+    expect(content).not.toContain('#oldFooter');
+  });
+
+  it('skips files with no matching IDs', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/pages/NoMatch.js': `$w('#unrelated').show();`,
+      'src/pages/Match.js': `$w('#oldHeader').show();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    expect(result.filesChanged).toBe(1);
+    expect(result.filesScanned).toBe(2);
+  });
+
+  it('scans multiple directories', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/pages/Page.js': `$w('#oldHeader').show();`,
+      'tests/page.test.js': `$w('#oldHeader').show();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src'), join(TMP_DIR, 'tests')],
+      apply: true,
+    });
+    expect(result.filesChanged).toBe(2);
+    expect(readTmpFile('src/pages/Page.js')).toContain('#newHeader');
+    expect(readTmpFile('tests/page.test.js')).toContain('#newHeader');
+  });
+
+  it('only scans .js files', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/data.json': `{ "id": "#oldHeader" }`,
+      'src/page.js': `$w('#oldHeader').show();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    expect(result.filesChanged).toBe(1);
+    // JSON file should be untouched
+    expect(readTmpFile('src/data.json')).toContain('#oldHeader');
+  });
+
+  it('handles deeply nested directory structures', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/public/helpers/deep/helper.js': `$w('#oldFooter').collapse();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    expect(result.filesChanged).toBe(1);
+    expect(readTmpFile('src/public/helpers/deep/helper.js')).toContain('#newFooter');
+  });
+
+  it('provides per-file detail in summary', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/a.js': `$w('#oldHeader').show(); $w('#oldFooter').hide();`,
+      'src/b.js': `$w('#oldHeader').click();`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: false,
+    });
+    expect(result.fileDetails).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ replacements: 2 }),
+        expect.objectContaining({ replacements: 1 }),
+      ])
+    );
+  });
+
+  it('handles selector arrays in apply mode', () => {
+    setupTmpDir({
+      'mapping.json': mappingContent,
+      'src/page.js': `collapseOnMobile($w, ['#oldHeader', '#oldFooter']);`,
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    expect(result.totalReplacements).toBe(2);
+    const content = readTmpFile('src/page.js');
+    expect(content).toBe(`collapseOnMobile($w, ['#newHeader', '#newFooter']);`);
+  });
+});
+
+// ── Edge cases & error handling ──────────────────────────────────────
+
+describe('edge cases', () => {
+  it('handles empty source files gracefully', () => {
+    setupTmpDir({
+      'mapping.json': JSON.stringify({ oldId: 'newId' }),
+      'src/empty.js': '',
+    });
+    const result = remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: false,
+    });
+    expect(result.filesScanned).toBe(1);
+    expect(result.filesChanged).toBe(0);
+  });
+
+  it('handles scan directory that does not exist', () => {
+    setupTmpDir({
+      'mapping.json': JSON.stringify({ oldId: 'newId' }),
+    });
+    expect(() =>
+      remapElementIds({
+        mappingPath: join(TMP_DIR, 'mapping.json'),
+        scanDirs: [join(TMP_DIR, 'nonexistent')],
+        apply: false,
+      })
+    ).toThrow();
+  });
+
+  it('preserves file encoding and line endings', () => {
+    const content = `$w('#oldId').show();\r\n$w('#oldId').hide();\r\n`;
+    setupTmpDir({
+      'mapping.json': JSON.stringify({ oldId: 'newId' }),
+      'src/crlf.js': content,
+    });
+    remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    const result = readTmpFile('src/crlf.js');
+    expect(result).toContain('\r\n');
+    expect(result).toContain('#newId');
+  });
+
+  it('does not double-replace when new ID matches another mapping key', () => {
+    // mapping: a→b, b→c should NOT result in a→c
+    setupTmpDir({
+      'mapping.json': JSON.stringify({ alpha: 'beta', beta: 'gamma' }),
+      'src/chain.js': `$w('#alpha').show(); $w('#beta').hide();`,
+    });
+    remapElementIds({
+      mappingPath: join(TMP_DIR, 'mapping.json'),
+      scanDirs: [join(TMP_DIR, 'src')],
+      apply: true,
+    });
+    const content = readTmpFile('src/chain.js');
+    expect(content).toBe(`$w('#beta').show(); $w('#gamma').hide();`);
+  });
+});


### PR DESCRIPTION
## Summary
- New Node.js script `scripts/remap-element-ids.js` for bulk-renaming `$w('#elementId')` references across the codebase
- Takes a JSON mapping file `{ "oldId": "newId" }`, scans `src/` and `tests/` directories
- Dry-run by default (reports changes without writing), `--apply` flag to write
- Handles: single/double/backtick-quoted selectors, selector arrays (`['#id1', '#id2']`), nested dirs
- Chain-safe: avoids double-replacement when new IDs match other mapping keys

## Test plan
- [x] 32 TDD tests in `tests/scripts/remap-element-ids.test.js`
- [x] Mapping parsing: valid JSON, invalid JSON, empty, non-object, bad values, empty keys
- [x] ID replacement: $w selectors (all quote types), selector arrays, partial match rejection, no-match passthrough
- [x] Pipeline: dry-run vs apply, multi-dir scan, .js-only filter, nested dirs, per-file summary
- [x] Edge cases: empty files, CRLF preservation, chain replacement (a→b, b→c no double-replace)
- [x] Full suite: 308 files, 12,050 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)