### PR TITLE
Category Page element mapping for template migration

### DIFF
--- a/scripts/category-page-mapping.json
+++ b/scripts/category-page-mapping.json
@@ -34,7 +34,7 @@
     "_comment": "BUILD-SPEC elements NOT in template — need manual editor placement",
 
     "heroSection": {
-      "id": "categoryHeroSection",
+      "ids": ["categoryHeroSection"],
       "type": "Section",
       "notes": "Dynamic bg per category. Template has static breadcrumb area — need styled hero section."
     },
@@ -106,7 +106,7 @@
     },
 
     "categorySidebar": {
-      "id": "browseBySidebar",
+      "ids": ["browseBySidebar"],
       "type": "Nav list",
       "notes": "Template HAS a 'Browse by' sidebar (All Products, Sofas, Lounge Chairs, Tables, Chairs). Not in our BUILD-SPEC as a named element — consider adopting or repurposing."
     }
@@ -116,6 +116,7 @@
     "matchedElements": 17,
     "gapElements": 56,
     "templateExtras": ["Browse by sidebar nav (not in BUILD-SPEC — repurpose or adopt)"],
-    "coverage": "~23% element coverage, but template covers core commerce grid (breadcrumbs, filters, sort, product cards with badges/swatches/sale pricing). Major gaps are advanced filters, mobile drawer, quick view, empty/no-match states, comparison bar, recently viewed, filter chips, and SEO schema."
+    "coveragePercent": 23,
+    "coverageNotes": "Template covers core commerce grid (breadcrumbs, filters, sort, product cards with badges/swatches/sale pricing). Major gaps are advanced filters, mobile drawer, quick view, empty/no-match states, comparison bar, recently viewed, filter chips, and SEO schema."
   }
 }


### PR DESCRIPTION
## Summary
- Maps 17 BUILD-SPEC Category Page elements to Furniture Store template (#3563) counterparts
- Documents 56 gap elements requiring manual editor placement
- Prep work for Category Page hookup (test-zou blocked bead)

## Mapping Coverage
| Category | Matched | Gaps |
|----------|---------|------|
| Breadcrumbs | 2 | 0 |
| Hero | 2 (partial) | 1 section container |
| Basic Filters | 3 (price, color, sort) | 3 (brand, size, clear) |
| Advanced Filters | 0 | 11 |
| Mobile Filter Drawer | 0 | 5 |
| Product Grid | 8 | 9 (extras: ribbon, reviews, compare, swatch dots) |
| Quick View Modal | 0 | 8 |
| Empty/No-Match States | 0 | 8 |
| Recently Viewed | 0 | 6 |
| Filter Chips | 0 | 6 |
| Comparison Bar | 0 | 7 |
| Schema/SEO | 0 | 3 |

**Template extra:** Browse-by sidebar nav exists in template but not in BUILD-SPEC — recommend adopting.

## Test plan
- [ ] JSON is valid and parseable by remap-element-ids.js
- [ ] All BUILD-SPEC Category Page element IDs (lines 634-785) accounted for
- [ ] Gap descriptions sufficient for manual editor placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)