### PR TITLE
chore: gitignore audit artifacts and local ops docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,12 @@ coverage/
 # Gas Town (added by gt)
 .claude/
 __pycache__/
+
+# Audit/research artifacts — not for repo
+.playwright-mcp/
+PHOTO-GALLERY-AUDIT.json
+live-site-images.json
+
+# Local strategy docs
+docs/EMAIL-ALIAS-STRATEGY.md
+PRODUCT-PAGE-BUILD-SPEC.md


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/`, `PHOTO-GALLERY-AUDIT.json`, `live-site-images.json` to `.gitignore` (audit/research tooling artifacts)
- Add `docs/EMAIL-ALIAS-STRATEGY.md` to `.gitignore` (internal ops doc with account info — not for public repo)
- Add `PRODUCT-PAGE-BUILD-SPEC.md` to `.gitignore` (local spec draft)

Per overseer directive 2026-03-12: "Do not store these files on repo."

## Test plan
- [ ] Verify `git status` shows no untracked files for the listed paths
- [ ] Confirm `.gitignore` patterns are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)