### PR TITLE
fix(specs): FAQ build order + Contact hardcoded colors (#276, #277)

### DIFF
--- a/CONTACT-PAGE-BUILD-SPEC.md
+++ b/CONTACT-PAGE-BUILD-SPEC.md
@@ -171,11 +171,11 @@ Full showroom appointment booking form with date/time slot selection.
 | Background | `#FAF7F2` (Off White) | Page background |
 | Card background | `#FFFFFF` | Form containers, testimonial cards, hours card |
 | Text color | `#3A2518` (Espresso) | All text |
-| Error color | `#D32F2F` | Validation error text |
-| Success color | `#388E3C` | Success confirmation text |
+| Error color | `colors.error` (`#C0392B`) | Validation error text |
+| Success color | `colors.success` (`#4A7C59`) | Success confirmation text |
 | Border radius | 8px | Cards, buttons, inputs |
 | Input border | `#E8D5B7` (Sand) | Form input borders |
 | Shadows | `rgba(58,37,24,0.08)` | Cards, form containers |
 | Star color | `#E8845C` (Coral) | Testimonial star ratings |
-| Open status | `#388E3C` (Green) | "Open Now" badge |
-| Closed status | `#D32F2F` (Red) | "Closed" badge |
+| Open status | `colors.success` (`#4A7C59`) | "Open Now" badge |
+| Closed status | `colors.error` (`#C0392B`) | "Closed" badge |

--- a/FAQ-PAGE-BUILD-SPEC.md
+++ b/FAQ-PAGE-BUILD-SPEC.md
@@ -69,7 +69,7 @@ Repeater of collapsible question/answer pairs.
 2. **Search Input** — Section 2 (above-fold)
 3. **FAQ Accordion** — Section 3 (main content)
 4. **No Results** — Section 4 (conditional empty state)
-5. **Live Region** — Section 5 (if not on masterPage)
+5. ~~Live Region~~ — **SKIP: lives on masterPage** (see Section 5)
 
 ---
 


### PR DESCRIPTION
## Summary
- **FAQ spec (#276):** Build Order step 5 contradicted Section 5 about the live region. Step 5 said "if not on masterPage" but Section 5 explicitly says "DO NOT ADD — lives on masterPage." Changed step 5 to SKIP.
- **Contact spec (#277):** Replaced 4 hardcoded hex colors (`#D32F2F`, `#388E3C`) with `sharedTokens.js` references (`colors.error` `#C0392B`, `colors.success` `#4A7C59`). Per CLAUDE.md: "Never hardcode colors."

Closes #276, closes #277

## Test plan
- [x] `npx vitest run` — 12,084 tests pass (no code changes, spec docs only)
- [ ] Verify FAQ Build Order step 5 reads as SKIP
- [ ] Verify Contact spec Design Tokens table references `colors.error` and `colors.success`

🤖 Generated with [Claude Code](https://claude.ai/code)