### PR TITLE
ci: add workflow_dispatch to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 6 * * *'  # Nightly at 6am UTC
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to CI workflow for manual runs from Actions tab

## Test plan
- [ ] Manually trigger CI from Actions tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)