### PR TITLE
fix(product-page): catch sync TypeError in prioritizeSections

### DIFF
--- a/src/public/performanceHelpers.js
+++ b/src/public/performanceHelpers.js
@@ -61,9 +61,16 @@ export async function prioritizeSections(sections, opts = {}) {
   const critical = sections.filter(s => s.critical);
   const deferred = sections.filter(s => !s.critical);
 
+  // Wrap init calls to catch synchronous throws — $w() calls on missing
+  // template elements throw TypeError synchronously, which would escape
+  // Promise.allSettled if not converted to rejected promises first.
+  const safeInit = (s) => {
+    try { return Promise.resolve(s.init()); } catch (e) { return Promise.reject(e); }
+  };
+
   // Run critical sections first — these affect LCP
   const criticalResults = await Promise.allSettled(
-    critical.map(s => s.init())
+    critical.map(safeInit)
   );
 
   // Log critical failures
@@ -76,7 +83,7 @@ export async function prioritizeSections(sections, opts = {}) {
   // Fire-and-forget deferred sections — do NOT await.
   // This lets onReady return after critical content paints.
   if (deferred.length > 0) {
-    Promise.allSettled(deferred.map(s => s.init()))
+    Promise.allSettled(deferred.map(safeInit))
       .then(results => {
         results.forEach((result, i) => {
           if (result.status === 'rejected') {

--- a/tests/performanceHelpers.test.js
+++ b/tests/performanceHelpers.test.js
@@ -178,6 +178,42 @@ describe('prioritizeSections', () => {
     expect(deferredFn).toHaveBeenCalledOnce();
   });
 
+  it('handles critical section that throws synchronously', async () => {
+    const syncThrow = vi.fn(() => { throw new TypeError('Cannot read properties of undefined'); });
+    const okFn = vi.fn().mockResolvedValue('ok');
+
+    const sections = [
+      { name: 'hero', init: okFn, critical: true },
+      { name: 'syncBoom', init: syncThrow, critical: true },
+    ];
+
+    const result = await prioritizeSections(sections);
+    // Both sections should have results — sync throw should be caught as rejected
+    expect(result.critical).toHaveLength(2);
+    expect(result.critical[0].status).toBe('fulfilled');
+    expect(result.critical[1].status).toBe('rejected');
+    expect(result.critical[1].reason).toBeInstanceOf(TypeError);
+  });
+
+  it('handles deferred section that throws synchronously', async () => {
+    const criticalFn = vi.fn().mockResolvedValue('ok');
+    const syncThrow = vi.fn(() => { throw new TypeError('element not found'); });
+    const onError = vi.fn();
+
+    const sections = [
+      { name: 'hero', init: criticalFn, critical: true },
+      { name: 'syncBoom', init: syncThrow, critical: false },
+    ];
+
+    const result = await prioritizeSections(sections, { onError });
+    expect(result.critical).toHaveLength(1);
+    expect(result.critical[0].status).toBe('fulfilled');
+
+    // Let fire-and-forget settle
+    await new Promise(r => setTimeout(r, 50));
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
   it('returns empty arrays for empty input', async () => {
     const result = await prioritizeSections([]);
     expect(result.critical).toHaveLength(0);


### PR DESCRIPTION
## Summary
- Fixes "Error initializing product page: TypeError" console errors
- Root cause: `$w()` calls on missing template elements throw TypeError **synchronously**, escaping `Promise.allSettled` before it can catch them
- Fix: wrap each section `init()` call in try/catch, converting sync throws to rejected promises that `allSettled` handles gracefully
- Affects both critical and deferred sections in `prioritizeSections()`

## Root Cause Analysis
Product Page references ~119 element IDs across component modules, but the template only has ~10 connected. When a critical section init function calls `$w('#missingElement').someProperty`, the TypeError propagates through `.map()` before `Promise.allSettled` is reached, crashing the entire page init.

## What Changed
- `src/public/performanceHelpers.js`: Added `safeInit()` wrapper that converts sync throws to rejected promises
- `tests/performanceHelpers.test.js`: 2 new tests for sync throw handling (critical + deferred)

## Test plan
- [x] `npx vitest run` — 12,086 tests pass (309 files, +2 new tests)
- [x] New test: critical section sync throw → caught as rejected, doesn't break other sections
- [x] New test: deferred section sync throw → caught, onError callback invoked
- [ ] Manual: verify Product Page loads without TypeError in Wix Studio preview

🤖 Generated with [Claude Code](https://claude.ai/code)