### PR TITLE
feat(product-page): wire assembly guide links to Product Page

### DIFF
--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -133,6 +133,11 @@ async function initProductPage() {
       { name: 'lifestyleGallery', init: async () => { const m = await import('public/LifestyleGallery.js'); m.initLifestyleGallery($w, state); }, critical: false },
       { name: 'videoSection', init: async () => { const m = await import('public/ProductVideoSection.js'); m.initProductVideoSection($w, state); }, critical: false },
       { name: 'viewer360', init: async () => { const m = await import('public/Product360Viewer.js'); m.initProduct360Viewer($w, state); }, critical: false },
+      // Assembly guide link (fetches by SKU, shows PDF/video)
+      { name: 'assemblyGuide', init: async () => {
+        const m = await import('public/ProductAssemblyGuide.js');
+        await m.initProductAssemblyGuide($w, state);
+      }, critical: false },
       // Size guide modal (lazy-loads ProductSizeGuide components on open)
       { name: 'sizeGuide', init: async () => {
         const m = await import('public/SizeGuideModal.js');

--- a/src/public/ProductAssemblyGuide.js
+++ b/src/public/ProductAssemblyGuide.js
@@ -1,0 +1,76 @@
+// ProductAssemblyGuide.js - Assembly guide link section for Product Page
+// Fetches assembly guide by SKU and wires download/video buttons.
+
+/**
+ * Initialize the assembly guide section on a product page.
+ * Fetches guide by product SKU, shows PDF and video links if available.
+ *
+ * @param {Function} $w - Wix selector function
+ * @param {Object} state - Product page state with state.product
+ */
+export async function initProductAssemblyGuide($w, state) {
+  try {
+    if (!state?.product) return;
+
+    const sku = state.product.sku;
+    if (!sku) {
+      try { $w('#assemblyGuideSection').collapse(); } catch (e) {}
+      return;
+    }
+
+    const { getAssemblyGuide } = await import('backend/assemblyGuides.web');
+    const guide = await getAssemblyGuide(sku);
+
+    if (!guide) {
+      try { $w('#assemblyGuideSection').collapse(); } catch (e) {}
+      return;
+    }
+
+    // Section title
+    try { $w('#assemblyGuideTitle').text = 'Assembly & Care Guide'; } catch (e) {}
+
+    // Estimated time
+    if (guide.estimatedTime) {
+      try { $w('#assemblyGuideTime').text = `Estimated time: ${guide.estimatedTime}`; } catch (e) {}
+    }
+
+    // PDF download link
+    if (guide.pdfUrl) {
+      try {
+        $w('#assemblyGuideLink').link = guide.pdfUrl;
+        $w('#assemblyGuideLink').target = '_blank';
+        try { $w('#assemblyGuideLink').accessibility.ariaLabel = `Download ${guide.title} PDF`; } catch (e) {}
+      } catch (e) {}
+    } else {
+      try { $w('#assemblyGuideLink').hide(); } catch (e) {}
+    }
+
+    // Video link
+    if (guide.videoUrl) {
+      try {
+        $w('#assemblyGuideVideoLink').link = guide.videoUrl;
+        $w('#assemblyGuideVideoLink').target = '_blank';
+        try { $w('#assemblyGuideVideoLink').accessibility.ariaLabel = `Watch ${guide.title} video`; } catch (e) {}
+      } catch (e) {}
+    } else {
+      try { $w('#assemblyGuideVideoLink').hide(); } catch (e) {}
+    }
+
+    // Button opens PDF or navigates to guide page
+    try {
+      try { $w('#assemblyGuideBtn').accessibility.ariaLabel = 'View assembly guide'; } catch (e) {}
+      $w('#assemblyGuideBtn').onClick(() => {
+        if (guide.pdfUrl) {
+          import('wix-window-frontend').then(({ openUrl }) => {
+            openUrl(guide.pdfUrl);
+          });
+        }
+      });
+    } catch (e) {}
+
+    try { $w('#assemblyGuideSection').expand(); } catch (e) {}
+  } catch (e) {
+    // Assembly guide is non-critical — collapse section on error
+    try { $w('#assemblyGuideSection').collapse(); } catch (e2) {}
+  }
+}

--- a/tests/productAssemblyGuide.test.js
+++ b/tests/productAssemblyGuide.test.js
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __seed } from './__mocks__/wix-data.js';
+
+// Mock the backend module
+vi.mock('backend/assemblyGuides.web', () => ({
+  getAssemblyGuide: vi.fn(),
+}));
+
+// Mock wix-window-frontend
+vi.mock('wix-window-frontend', () => ({
+  default: { openUrl: vi.fn() },
+  openUrl: vi.fn(),
+}));
+
+import { initProductAssemblyGuide } from '../src/public/ProductAssemblyGuide.js';
+import { getAssemblyGuide } from 'backend/assemblyGuides.web';
+
+// ── Test helpers ──────────────────────────────────────────────────
+
+function make$w() {
+  const elements = {};
+  const $w = (id) => {
+    if (!elements[id]) {
+      elements[id] = {
+        text: '',
+        label: '',
+        src: '',
+        link: '',
+        target: '_blank',
+        hidden: false,
+        collapsed: true,
+        disabled: false,
+        accessibility: {},
+        onClick: vi.fn(),
+        show: vi.fn(function () { this.hidden = false; }),
+        hide: vi.fn(function () { this.hidden = true; }),
+        expand: vi.fn(function () { this.collapsed = false; }),
+        collapse: vi.fn(function () { this.collapsed = true; }),
+        enable: vi.fn(function () { this.disabled = false; }),
+        disable: vi.fn(function () { this.disabled = true; }),
+        style: {},
+      };
+    }
+    return elements[id];
+  };
+  $w._elements = elements;
+  return $w;
+}
+
+function makeState(overrides = {}) {
+  return {
+    product: {
+      _id: 'prod-1',
+      sku: 'NDF-SEATTLE',
+      name: 'Seattle Futon Frame',
+      ...overrides,
+    },
+  };
+}
+
+const MOCK_GUIDE = {
+  _id: 'ag-1',
+  sku: 'NDF-SEATTLE',
+  title: 'Seattle Futon Frame Assembly',
+  pdfUrl: 'https://cdn.example.com/seattle-assembly.pdf',
+  videoUrl: 'https://youtube.com/watch?v=abc123',
+  estimatedTime: '30 minutes',
+  steps: '<ol><li>Unbox</li></ol>',
+  tips: 'Use a Phillips screwdriver',
+  category: 'futon-frames',
+};
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('initProductAssemblyGuide', () => {
+  let $w;
+
+  beforeEach(() => {
+    $w = make$w();
+    vi.clearAllMocks();
+  });
+
+  it('fetches guide by product SKU and sets button text', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect(getAssemblyGuide).toHaveBeenCalledWith('NDF-SEATTLE');
+    expect($w('#assemblyGuideBtn').onClick).toHaveBeenCalled();
+  });
+
+  it('expands section when guide is found', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideSection').expand).toHaveBeenCalled();
+  });
+
+  it('shows estimated time when available', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideTime').text).toContain('30 minutes');
+  });
+
+  it('hides section when no guide exists', async () => {
+    getAssemblyGuide.mockResolvedValue(null);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideSection').collapse).toHaveBeenCalled();
+  });
+
+  it('hides section when product has no SKU', async () => {
+    getAssemblyGuide.mockResolvedValue(null);
+    await initProductAssemblyGuide($w, makeState({ sku: '' }));
+
+    expect($w('#assemblyGuideSection').collapse).toHaveBeenCalled();
+  });
+
+  it('returns early when no product in state', async () => {
+    await initProductAssemblyGuide($w, { product: null });
+
+    expect(getAssemblyGuide).not.toHaveBeenCalled();
+  });
+
+  it('sets ARIA label on guide button', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideBtn').accessibility.ariaLabel).toContain('assembly');
+  });
+
+  it('sets PDF link when pdfUrl is available', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideLink').link).toBe(MOCK_GUIDE.pdfUrl);
+    expect($w('#assemblyGuideLink').target).toBe('_blank');
+  });
+
+  it('hides PDF link when no pdfUrl', async () => {
+    getAssemblyGuide.mockResolvedValue({ ...MOCK_GUIDE, pdfUrl: null });
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideLink').hide).toHaveBeenCalled();
+  });
+
+  it('shows video link when videoUrl is available', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideVideoLink').link).toBe(MOCK_GUIDE.videoUrl);
+  });
+
+  it('hides video link when no videoUrl', async () => {
+    getAssemblyGuide.mockResolvedValue({ ...MOCK_GUIDE, videoUrl: null });
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideVideoLink').hide).toHaveBeenCalled();
+  });
+
+  it('sets guide title text', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    await initProductAssemblyGuide($w, makeState());
+
+    expect($w('#assemblyGuideTitle').text).toContain('Assembly');
+  });
+
+  it('handles backend error gracefully', async () => {
+    getAssemblyGuide.mockRejectedValue(new Error('Network error'));
+    await initProductAssemblyGuide($w, makeState());
+
+    // Should not throw — section collapses
+    expect($w('#assemblyGuideSection').collapse).toHaveBeenCalled();
+  });
+
+  it('does not crash when element IDs are missing', async () => {
+    getAssemblyGuide.mockResolvedValue(MOCK_GUIDE);
+    // Use a $w that throws on unknown elements
+    const throwing$w = (id) => {
+      if (id === '#assemblyGuideVideoLink') throw new TypeError('Element not found');
+      return $w(id);
+    };
+    // Should not throw
+    await initProductAssemblyGuide(throwing$w, makeState());
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -84,6 +84,7 @@ export default defineConfig({
       'backend/utils/mediaHelpers': path.resolve(__dirname, 'src/backend/utils/mediaHelpers.js'),
       'backend/utils/errorHandler': path.resolve(__dirname, 'src/backend/utils/errorHandler.js'),
       'backend/utils/safeParse': path.resolve(__dirname, 'src/backend/utils/safeParse.js'),
+      'backend/assemblyGuides.web': path.resolve(__dirname, 'src/backend/assemblyGuides.web.js'),
       'backend/errorMonitoring.web': path.resolve(__dirname, 'src/backend/errorMonitoring.web.js'),
       'backend/liveChat.web': path.resolve(__dirname, 'src/backend/liveChat.web.js'),
       // Public modules


### PR DESCRIPTION
## Summary
- **Part 1 — Assembly Guide Links**: New `ProductAssemblyGuide.js` helper wires `#assemblyGuideBtn`, `#assemblyGuideLink`, `#assemblyGuideVideoLink` to the existing `assemblyGuides.web.js` backend
- **Part 2 — Size Guide Modal**: Already wired via `SizeGuideModal.js` (PR #88) — verified, no changes needed

## Files Changed
| File | Change |
|------|--------|
| `src/public/ProductAssemblyGuide.js` | **NEW** — Fetches guide by SKU, wires PDF/video links |
| `tests/productAssemblyGuide.test.js` | **NEW** — 14 tests covering happy path, missing SKU, null product, error handling |
| `src/pages/Product Page.js` | Added `assemblyGuide` section to deferred sections array |
| `vitest.config.js` | Added `backend/assemblyGuides.web` alias |

## Pattern
- `initProductAssemblyGuide($w, state)` — follows same pattern as `SizeGuideModal.js`
- Dynamic import of backend module (lazy-loaded, deferred section)
- All `$w()` calls wrapped in try/catch per codebase convention
- Section collapses gracefully on error or missing data

## Test plan
- [x] `npx vitest run` — 12,098 tests pass (310 files), 14 new
- [x] Assembly guide tests cover: valid SKU, null SKU, no product, missing PDF, missing video, backend error, missing elements
- [ ] Manual verification in Wix Studio preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)