### PR TITLE
feat(cf-k67): replace tera logo with Carolina Futons brand logo

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -14,6 +14,7 @@ import { colors, typography, spacing } from 'public/designTokens.js';
 import { captureInstallPrompt, canShowInstallPrompt, showInstallPrompt, isInstalledPWA } from 'public/pwaHelpers';
 import { reportMetrics } from 'backend/coreWebVitals.web';
 import { initFooter } from 'public/FooterSection';
+import { getLogoDataUri } from 'public/carolinaFutonsLogo';
 import { initSkipNav, setupAccessibleDialog, announce, makeClickable } from 'public/a11yHelpers';
 import {
   applyActiveNavState,
@@ -358,6 +359,11 @@ function initSiteLogo() {
   try {
     const logo = $w('#siteLogo');
     if (!logo) return;
+
+    // Replace template logo with Carolina Futons brand logo
+    try { logo.src = getLogoDataUri(); } catch (e) {}
+    try { logo.alt = 'Carolina Futons'; } catch (e) {}
+    try { logo.accessibility.ariaLabel = 'Carolina Futons - Go to homepage'; } catch (e) {}
 
     makeClickable(logo, () => {
       wixLocationFrontend.to('/');

--- a/src/public/FooterSection.js
+++ b/src/public/FooterSection.js
@@ -22,6 +22,7 @@ import {
 import { trackEvent } from 'public/engagementTracker';
 import { fireCustomEvent } from 'public/ga4Tracking';
 import { colors, transitions, spacing } from 'public/designTokens.js';
+import { getFooterLogoDataUri } from 'public/carolinaFutonsLogo';
 
 // Static SVG inner content from pipeline output (footer-mountain-divider.optimized.svg).
 // This is a literal string — no template interpolation, no programmatic generation.
@@ -357,6 +358,8 @@ export function initFooterLogo($w) {
     const logo = $w('#footerLogo');
     if (!logo) return;
 
+    // Replace template logo with Carolina Futons brand logo
+    try { logo.src = getFooterLogoDataUri(); } catch (e) {}
     try { logo.alt = 'Carolina Futons'; } catch (e) {}
     try { logo.accessibility.ariaLabel = 'Carolina Futons - Go to homepage'; } catch (e) {}
 

--- a/src/public/carolinaFutonsLogo.js
+++ b/src/public/carolinaFutonsLogo.js
@@ -1,0 +1,78 @@
+/**
+ * carolinaFutonsLogo.js — Carolina Futons brand logo as inline SVG.
+ *
+ * Provides the text-based logo matching the hand-lettered style from design.jpeg.
+ * Uses Playfair Display (brand heading font) with espresso color from sharedTokens.
+ *
+ * Usage: Import and inject into an HtmlComponent for SVG rendering, or use
+ * getLogoDataUri() as an image src for Wix Image elements.
+ *
+ * @module carolinaFutonsLogo
+ */
+import { colors } from 'public/sharedTokens.js';
+
+/**
+ * Generate the Carolina Futons logo SVG string.
+ * Stacked layout: "Carolina" over "Futons" in Playfair Display.
+ * @param {Object} [options]
+ * @param {string} [options.color] - Text fill color (default: espresso from tokens)
+ * @param {number} [options.width] - SVG width in px (default: 180)
+ * @param {number} [options.height] - SVG height in px (default: 60)
+ * @returns {string} SVG markup string
+ */
+export function getLogoSvg({ color, width, height } = {}) {
+  const fill = color || colors.espresso;
+  const w = width || 180;
+  const h = height || 60;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 60" width="${w}" height="${h}" role="img" aria-label="Carolina Futons">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&amp;display=swap');
+    .cf-logo { font-family: 'Playfair Display', Georgia, serif; fill: ${fill}; }
+  </style>
+  <text class="cf-logo" x="90" y="26" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2">Carolina</text>
+  <text class="cf-logo" x="90" y="52" text-anchor="middle" font-size="24" font-weight="700" letter-spacing="4">Futons</text>
+</svg>`;
+}
+
+/**
+ * Get the logo as a data URI suitable for Wix Image element src.
+ * @param {Object} [options] - Same options as getLogoSvg
+ * @returns {string} data:image/svg+xml URI
+ */
+export function getLogoDataUri(options) {
+  const svg = getLogoSvg(options);
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Footer logo variant — smaller, single-line "Carolina Futons".
+ * @param {Object} [options]
+ * @param {string} [options.color] - Text fill color (default: espresso)
+ * @param {number} [options.width] - SVG width (default: 160)
+ * @param {number} [options.height] - SVG height (default: 30)
+ * @returns {string} SVG markup string
+ */
+export function getFooterLogoSvg({ color, width, height } = {}) {
+  const fill = color || colors.espresso;
+  const w = width || 160;
+  const h = height || 30;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 30" width="${w}" height="${h}" role="img" aria-label="Carolina Futons">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&amp;display=swap');
+    .cf-logo-sm { font-family: 'Playfair Display', Georgia, serif; fill: ${fill}; }
+  </style>
+  <text class="cf-logo-sm" x="80" y="22" text-anchor="middle" font-size="18" font-weight="700" letter-spacing="1.5">Carolina Futons</text>
+</svg>`;
+}
+
+/**
+ * Footer logo as data URI.
+ * @param {Object} [options] - Same options as getFooterLogoSvg
+ * @returns {string} data:image/svg+xml URI
+ */
+export function getFooterLogoDataUri(options) {
+  const svg = getFooterLogoSvg(options);
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/tests/carolinaFutonsLogo.test.js
+++ b/tests/carolinaFutonsLogo.test.js
@@ -1,0 +1,183 @@
+/**
+ * Tests for carolinaFutonsLogo.js — brand logo SVG generation.
+ * Covers header logo, footer logo, data URI encoding, and customization options.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getLogoSvg,
+  getLogoDataUri,
+  getFooterLogoSvg,
+  getFooterLogoDataUri,
+} from '../src/public/carolinaFutonsLogo';
+
+// ── getLogoSvg ──────────────────────────────────────────────────────
+
+describe('getLogoSvg', () => {
+  it('returns valid SVG string', () => {
+    const svg = getLogoSvg();
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('</svg>');
+    expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+  });
+
+  it('contains "Carolina" and "Futons" text', () => {
+    const svg = getLogoSvg();
+    expect(svg).toContain('Carolina');
+    expect(svg).toContain('Futons');
+  });
+
+  it('uses espresso color by default', () => {
+    const svg = getLogoSvg();
+    expect(svg).toContain('#3A2518');
+  });
+
+  it('includes Playfair Display font', () => {
+    const svg = getLogoSvg();
+    expect(svg).toContain('Playfair Display');
+  });
+
+  it('has accessible aria-label', () => {
+    const svg = getLogoSvg();
+    expect(svg).toContain('aria-label="Carolina Futons"');
+  });
+
+  it('uses default dimensions 180x60', () => {
+    const svg = getLogoSvg();
+    expect(svg).toContain('width="180"');
+    expect(svg).toContain('height="60"');
+  });
+
+  it('accepts custom color', () => {
+    const svg = getLogoSvg({ color: '#FF0000' });
+    expect(svg).toContain('#FF0000');
+    expect(svg).not.toContain('#3A2518');
+  });
+
+  it('accepts custom dimensions', () => {
+    const svg = getLogoSvg({ width: 240, height: 80 });
+    expect(svg).toContain('width="240"');
+    expect(svg).toContain('height="80"');
+  });
+
+  it('handles empty options object', () => {
+    const svg = getLogoSvg({});
+    expect(svg).toContain('Carolina');
+    expect(svg).toContain('#3A2518');
+  });
+
+  it('handles undefined options', () => {
+    const svg = getLogoSvg(undefined);
+    expect(svg).toContain('Carolina');
+  });
+});
+
+// ── getLogoDataUri ──────────────────────────────────────────────────
+
+describe('getLogoDataUri', () => {
+  it('returns data URI with SVG MIME type', () => {
+    const uri = getLogoDataUri();
+    expect(uri).toMatch(/^data:image\/svg\+xml,/);
+  });
+
+  it('contains encoded SVG content', () => {
+    const uri = getLogoDataUri();
+    expect(uri).toContain(encodeURIComponent('Carolina'));
+    expect(uri).toContain(encodeURIComponent('Futons'));
+  });
+
+  it('passes options through to getLogoSvg', () => {
+    const uri = getLogoDataUri({ color: '#FFFFFF' });
+    expect(uri).toContain(encodeURIComponent('#FFFFFF'));
+  });
+
+  it('handles no arguments', () => {
+    const uri = getLogoDataUri();
+    expect(typeof uri).toBe('string');
+    expect(uri.length).toBeGreaterThan(50);
+  });
+});
+
+// ── getFooterLogoSvg ────────────────────────────────────────────────
+
+describe('getFooterLogoSvg', () => {
+  it('returns valid SVG string', () => {
+    const svg = getFooterLogoSvg();
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('</svg>');
+  });
+
+  it('contains "Carolina Futons" on single line', () => {
+    const svg = getFooterLogoSvg();
+    expect(svg).toContain('Carolina Futons');
+  });
+
+  it('uses espresso color by default', () => {
+    const svg = getFooterLogoSvg();
+    expect(svg).toContain('#3A2518');
+  });
+
+  it('uses smaller default dimensions (160x30)', () => {
+    const svg = getFooterLogoSvg();
+    expect(svg).toContain('width="160"');
+    expect(svg).toContain('height="30"');
+  });
+
+  it('has accessible aria-label', () => {
+    const svg = getFooterLogoSvg();
+    expect(svg).toContain('aria-label="Carolina Futons"');
+  });
+
+  it('accepts custom color', () => {
+    const svg = getFooterLogoSvg({ color: '#FFFFFF' });
+    expect(svg).toContain('#FFFFFF');
+  });
+
+  it('accepts custom dimensions', () => {
+    const svg = getFooterLogoSvg({ width: 200, height: 40 });
+    expect(svg).toContain('width="200"');
+    expect(svg).toContain('height="40"');
+  });
+});
+
+// ── getFooterLogoDataUri ────────────────────────────────────────────
+
+describe('getFooterLogoDataUri', () => {
+  it('returns data URI with SVG MIME type', () => {
+    const uri = getFooterLogoDataUri();
+    expect(uri).toMatch(/^data:image\/svg\+xml,/);
+  });
+
+  it('contains encoded footer logo content', () => {
+    const uri = getFooterLogoDataUri();
+    expect(uri).toContain(encodeURIComponent('Carolina Futons'));
+  });
+
+  it('passes options through', () => {
+    const uri = getFooterLogoDataUri({ color: '#000000' });
+    expect(uri).toContain(encodeURIComponent('#000000'));
+  });
+});
+
+// ── Cross-cutting ───────────────────────────────────────────────────
+
+describe('logo consistency', () => {
+  it('header and footer logos use same espresso default', () => {
+    const header = getLogoSvg();
+    const footer = getFooterLogoSvg();
+    expect(header).toContain('#3A2518');
+    expect(footer).toContain('#3A2518');
+  });
+
+  it('header logo is larger than footer logo', () => {
+    const header = getLogoSvg();
+    const footer = getFooterLogoSvg();
+    const headerWidth = parseInt(header.match(/width="(\d+)"/)[1]);
+    const footerWidth = parseInt(footer.match(/width="(\d+)"/)[1]);
+    expect(headerWidth).toBeGreaterThan(footerWidth);
+  });
+
+  it('both logos have role="img" for accessibility', () => {
+    expect(getLogoSvg()).toContain('role="img"');
+    expect(getFooterLogoSvg()).toContain('role="img"');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -88,6 +88,8 @@ export default defineConfig({
       'backend/errorMonitoring.web': path.resolve(__dirname, 'src/backend/errorMonitoring.web.js'),
       'backend/liveChat.web': path.resolve(__dirname, 'src/backend/liveChat.web.js'),
       // Public modules
+      'public/carolinaFutonsLogo.js': path.resolve(__dirname, 'src/public/carolinaFutonsLogo.js'),
+      'public/carolinaFutonsLogo': path.resolve(__dirname, 'src/public/carolinaFutonsLogo.js'),
       'public/galleryHelpers.js': path.resolve(__dirname, 'src/public/galleryHelpers.js'),
       'public/galleryHelpers': path.resolve(__dirname, 'src/public/galleryHelpers.js'),
       'public/designTokens.js': path.resolve(__dirname, 'src/public/designTokens.js'),


### PR DESCRIPTION
## Summary
- Create `carolinaFutonsLogo.js` with SVG text logos matching design.jpeg hand-lettered style
- Header logo: stacked "Carolina" / "Futons" (180x60), footer: single-line (160x30)
- Uses Playfair Display font + espresso `#3A2518` from sharedTokens (zero hardcoded hex)
- `masterPage.js` and `FooterSection.js` now set `logo.src` via data URI on init
- Both logos include `role="img"` + `aria-label` for WCAG AA compliance
- 27 new tests, all 12,272 tests pass

## Editor action needed
Template SVG element `comp-kbgakxea_r_comp-liu7a4zw` (tera wordmark) should be replaced with a Wix Image element using ID `#siteLogo`. The code will set the image source automatically.

## Test plan
- [x] 27 unit tests for logo SVG generation, data URI, customization, accessibility
- [x] Full suite passes (315 files, 12,272 tests)
- [ ] Verify logo renders in Wix preview after editor element swap
- [ ] Verify footer logo matches header brand

🤖 Generated with [Claude Code](https://claude.com/claude-code)