### PR TITLE
feat(cf-xc7t): hide template press logos section on homepage

### DIFF
--- a/scripts/home-page-mapping.json
+++ b/scripts/home-page-mapping.json
@@ -119,6 +119,7 @@
 
   "home_press": {
     "_comment": "Press / As Seen In — section4",
+    "section4": { "templateNickname": "section4", "templateType": "Section", "confidence": "HIGH", "note": "Press / As Seen In section — collapsed to hide Tera template logos (CF-xc7t)" },
     "testimonialRepeater": { "templateNickname": "repeater1", "templateType": "Repeater", "confidence": "MISMATCH", "note": "Template's repeater1 is for PRESS LOGOS (As Seen In), but our code uses testimonialRepeater for customer testimonials. Content-type mismatch — press logos vs reviews. Need separate repeater for testimonials." },
     "testimonialSection": { "templateNickname": null, "confidence": "MISSING", "note": "Testimonial section — template has Press/As Seen In section instead. Need to add testimonial section or repurpose" },
     "testimonialSlideshow": { "templateNickname": null, "confidence": "MISSING", "note": "Testimonial slideshow — must be added" },
@@ -194,13 +195,13 @@
   },
 
   "_summary": {
-    "totalCodeElements": 97,
-    "highConfidence": 12,
+    "totalCodeElements": 98,
+    "highConfidence": 13,
     "mediumConfidence": 7,
     "mismatch": 6,
     "missing": 72,
     "notReferenced_templateOnly": 18,
-    "_countNote": "12 HIGH + 7 MEDIUM + 6 MISMATCH + 72 MISSING = 97 total. notReferenced_templateOnly counts template elements with no code counterpart (separate from code element mapping).",
+    "_countNote": "13 HIGH + 7 MEDIUM + 6 MISMATCH + 72 MISSING = 98 total. notReferenced_templateOnly counts template elements with no code counterpart (separate from code element mapping).",
     "criticalMismatches": [
       "featuredRepeater → gridGallery1: Pro Gallery, not Repeater. Code uses .onItemReady() which only works on Repeaters.",
       "saleRepeater → gridGallery2: Same Pro Gallery vs Repeater mismatch.",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -50,6 +50,10 @@ const CATEGORIES = [
 $w.onReady(async function () {
   resetRatingsCache();
 
+  // Hide template press logos section ("As Seen In" — section4/repeater1)
+  // These are Tera template logos, not Carolina Futons branding (CF-xc7t)
+  try { $w('#section4').collapse(); } catch (e) {}
+
   // Critical sections: above-fold content that affects LCP
   // Deferred sections: below-fold content loaded during idle time
   const sections = [

--- a/tests/homePage.test.js
+++ b/tests/homePage.test.js
@@ -359,6 +359,15 @@ describe('Home Page', () => {
     });
   });
 
+  // ── Press Logos (As Seen In) ────────────────────────────────────────
+
+  describe('press logos section', () => {
+    it('collapses template press logos section (CF-xc7t)', async () => {
+      await onReadyHandler();
+      expect(getEl('#section4').collapse).toHaveBeenCalled();
+    });
+  });
+
   // ── Swatch Promo Section ──────────────────────────────────────────
 
   describe('swatch promo section', () => {


### PR DESCRIPTION
## Summary
- Collapse template "As Seen In" / press logos section on homepage via Velo `$w` collapse
- Removes last visual debranding item from staging site

## Test plan
- [x] 12,414 tests pass
- [ ] Verify press logos no longer visible on live staging site

🤖 Generated with [Claude Code](https://claude.com/claude-code)