### PR TITLE
fix: correct phone number in footerContent.js

### DIFF
--- a/src/public/footerContent.js
+++ b/src/public/footerContent.js
@@ -62,7 +62,7 @@ export function getStoreInfo() {
   return {
     name: 'Carolina Futons',
     address: '824 Locust St, Hendersonville, NC 28792',
-    phone: '(828) 692-8550',
+    phone: '(828) 252-9449',
     hours: [
       { days: 'Wednesday – Friday', time: '10:00 AM – 5:00 PM' },
       { days: 'Saturday', time: '10:00 AM – 4:00 PM' },


### PR DESCRIPTION
## Summary
- Fix wrong phone `(828) 692-8550` → `(828) 252-9449` in `getStoreInfo()` (footerContent.js)
- Ground truth from `memory.md`: Owner Brenda Deal, (828) 252-9449

## Test plan
- [x] All 12,248 tests pass
- [x] Phone number grep confirms no remaining instances of old number

CF-loq6

🤖 Generated with [Claude Code](https://claude.com/claude-code)