### PR TITLE
fix(cf-j3uy): replace SVG text logo with real CF_SQUARE-blue.jpg

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -14,7 +14,7 @@ import { colors, typography, spacing } from 'public/designTokens.js';
 import { captureInstallPrompt, canShowInstallPrompt, showInstallPrompt, isInstalledPWA } from 'public/pwaHelpers';
 import { reportMetrics } from 'backend/coreWebVitals.web';
 import { initFooter } from 'public/FooterSection';
-import { getLogoDataUri } from 'public/carolinaFutonsLogo';
+import { getLogoImageUrl } from 'public/carolinaFutonsLogo';
 import { initSkipNav, setupAccessibleDialog, announce, makeClickable } from 'public/a11yHelpers';
 import {
   applyActiveNavState,
@@ -360,8 +360,8 @@ function initSiteLogo() {
     const logo = $w('#siteLogo');
     if (!logo) return;
 
-    // Replace template logo with Carolina Futons brand logo
-    try { logo.src = getLogoDataUri(); } catch (e) {}
+    // Replace template logo with real CF_SQUARE-blue.jpg from production
+    try { logo.src = getLogoImageUrl(); } catch (e) {}
     try { logo.alt = 'Carolina Futons'; } catch (e) {}
     try { logo.accessibility.ariaLabel = 'Carolina Futons - Go to homepage'; } catch (e) {}
 

--- a/src/public/FooterSection.js
+++ b/src/public/FooterSection.js
@@ -22,7 +22,7 @@ import {
 import { trackEvent } from 'public/engagementTracker';
 import { fireCustomEvent } from 'public/ga4Tracking';
 import { colors, transitions, spacing } from 'public/designTokens.js';
-import { getFooterLogoDataUri } from 'public/carolinaFutonsLogo';
+import { getFooterLogoImageUrl } from 'public/carolinaFutonsLogo';
 
 // Static SVG inner content from pipeline output (footer-mountain-divider.optimized.svg).
 // This is a literal string — no template interpolation, no programmatic generation.
@@ -358,8 +358,8 @@ export function initFooterLogo($w) {
     const logo = $w('#footerLogo');
     if (!logo) return;
 
-    // Replace template logo with Carolina Futons brand logo
-    try { logo.src = getFooterLogoDataUri(); } catch (e) {}
+    // Replace template logo with real CF_SQUARE-blue.jpg from production
+    try { logo.src = getFooterLogoImageUrl(); } catch (e) {}
     try { logo.alt = 'Carolina Futons'; } catch (e) {}
     try { logo.accessibility.ariaLabel = 'Carolina Futons - Go to homepage'; } catch (e) {}
 

--- a/src/public/carolinaFutonsLogo.js
+++ b/src/public/carolinaFutonsLogo.js
@@ -1,15 +1,37 @@
 /**
- * carolinaFutonsLogo.js — Carolina Futons brand logo as inline SVG.
+ * carolinaFutonsLogo.js — Carolina Futons brand logo.
  *
- * Provides the text-based logo matching the hand-lettered style from design.jpeg.
- * Uses Playfair Display (brand heading font) with espresso color from sharedTokens.
- *
- * Usage: Import and inject into an HtmlComponent for SVG rendering, or use
- * getLogoDataUri() as an image src for Wix Image elements.
+ * Primary: Real CF_SQUARE-blue.jpg logo from Wix Media (production asset).
+ * Fallback: SVG text logo using Playfair Display font.
  *
  * @module carolinaFutonsLogo
  */
 import { colors } from 'public/sharedTokens.js';
+
+// Real CF logo from Wix Media Manager (production site header/footer)
+const CF_LOGO_MEDIA_ID = 'e04e89_cab07c9f067748338ea32234e56dddf9~mv2.jpg';
+const CF_LOGO_BASE = `https://static.wixstatic.com/media/${CF_LOGO_MEDIA_ID}`;
+
+/**
+ * Get the real CF logo image URL from Wix CDN.
+ * @param {Object} [options]
+ * @param {number} [options.width] - Target width (default: 291, matches prod)
+ * @param {number} [options.height] - Target height (default: 140, matches prod)
+ * @returns {string} Wix CDN image URL
+ */
+export function getLogoImageUrl({ width, height } = {}) {
+  const w = width || 291;
+  const h = height || 140;
+  return `${CF_LOGO_BASE}/v1/fill/w_${w},h_${h},al_c,q_80/CF_SQUARE-blue.jpg`;
+}
+
+/**
+ * Get a smaller logo for footer use.
+ * @returns {string} Wix CDN image URL sized for footer
+ */
+export function getFooterLogoImageUrl() {
+  return getLogoImageUrl({ width: 160, height: 77 });
+}
 
 /**
  * Generate the Carolina Futons logo SVG string.

--- a/tests/carolinaFutonsLogo.test.js
+++ b/tests/carolinaFutonsLogo.test.js
@@ -8,6 +8,8 @@ import {
   getLogoDataUri,
   getFooterLogoSvg,
   getFooterLogoDataUri,
+  getLogoImageUrl,
+  getFooterLogoImageUrl,
 } from '../src/public/carolinaFutonsLogo';
 
 // ── getLogoSvg ──────────────────────────────────────────────────────
@@ -155,6 +157,55 @@ describe('getFooterLogoDataUri', () => {
   it('passes options through', () => {
     const uri = getFooterLogoDataUri({ color: '#000000' });
     expect(uri).toContain(encodeURIComponent('#000000'));
+  });
+});
+
+// ── getLogoImageUrl (real CF logo from Wix CDN) ─────────────────────
+
+describe('getLogoImageUrl', () => {
+  it('returns a wixstatic.com URL', () => {
+    const url = getLogoImageUrl();
+    expect(url).toContain('static.wixstatic.com');
+  });
+
+  it('contains CF_SQUARE-blue.jpg filename', () => {
+    const url = getLogoImageUrl();
+    expect(url).toContain('CF_SQUARE-blue.jpg');
+  });
+
+  it('uses default dimensions matching production (291x140)', () => {
+    const url = getLogoImageUrl();
+    expect(url).toContain('w_291');
+    expect(url).toContain('h_140');
+  });
+
+  it('accepts custom dimensions', () => {
+    const url = getLogoImageUrl({ width: 400, height: 200 });
+    expect(url).toContain('w_400');
+    expect(url).toContain('h_200');
+  });
+
+  it('contains the correct media ID', () => {
+    const url = getLogoImageUrl();
+    expect(url).toContain('e04e89_cab07c9f067748338ea32234e56dddf9');
+  });
+});
+
+describe('getFooterLogoImageUrl', () => {
+  it('returns a wixstatic.com URL', () => {
+    const url = getFooterLogoImageUrl();
+    expect(url).toContain('static.wixstatic.com');
+  });
+
+  it('uses smaller dimensions than header logo', () => {
+    const url = getFooterLogoImageUrl();
+    expect(url).toContain('w_160');
+    expect(url).toContain('h_77');
+  });
+
+  it('contains CF_SQUARE-blue.jpg filename', () => {
+    const url = getFooterLogoImageUrl();
+    expect(url).toContain('CF_SQUARE-blue.jpg');
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace the SVG text-based logo with the real CF_SQUARE-blue.jpg from the production Wix Media Manager
- Header logo: `getLogoImageUrl()` returns 291x140 Wix CDN URL (matches production)
- Footer logo: `getFooterLogoImageUrl()` returns 160x77 Wix CDN URL
- SVG fallback functions retained for backward compatibility

## How the URL was found
Used Playwright to inspect the production site (carolinafutons.com) header and footer. The logo `img` element has alt text "CF_SQUARE-blue.jpg" and loads from Wix CDN media ID `e04e89_cab07c9f067748338ea32234e56dddf9~mv2.jpg`.

## Test plan
- [x] 8 new tests for `getLogoImageUrl()` and `getFooterLogoImageUrl()`
- [x] All 27 existing SVG logo tests still pass (functions retained)
- [x] Full suite: 12,445 tests pass
- [ ] Visual verification on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)