### PR TITLE
feat(cf-05zf): add Getting It Home page — delivery & assembly info

### DIFF
--- a/src/pages/Getting It Home.js
+++ b/src/pages/Getting It Home.js
@@ -1,0 +1,75 @@
+// Getting It Home.js - Assembly & Delivery Information
+// Service tiers, delivery rates, and assembly options
+import { initPageSeo } from 'public/pageSeo.js';
+import { trackEvent } from 'public/engagementTracker';
+import { initBackToTop } from 'public/mobileHelpers';
+import { makeClickable } from 'public/a11yHelpers.js';
+import { getIntroText, getServiceTiers, getDeliveryRates } from 'public/deliveryHelpers.js';
+
+$w.onReady(async function () {
+  initBackToTop($w);
+  initIntro();
+  initServiceTiers();
+  initDeliveryRates();
+  initNavLinks();
+  initPageSeo('getting-it-home');
+  trackEvent('page_view', { page: 'getting-it-home' });
+});
+
+// ── Intro Section ───────────────────────────────────────────────────
+
+function initIntro() {
+  try {
+    const intro = $w('#deliveryIntro');
+    if (intro) intro.text = getIntroText();
+  } catch (e) { /* Element may not exist in template */ }
+}
+
+// ── Service Tiers ───────────────────────────────────────────────────
+
+function initServiceTiers() {
+  try {
+    const repeater = $w('#serviceTierRepeater');
+    if (!repeater) return;
+
+    try { repeater.accessibility.ariaLabel = 'Delivery and assembly service options'; } catch (e) {}
+    repeater.onItemReady(($item, itemData) => {
+      try { $item('#tierTitle').text = itemData.title; } catch (e) {}
+      try { $item('#tierPrice').text = itemData.price; } catch (e) {}
+      try { $item('#tierDescription').text = itemData.description; } catch (e) {}
+    });
+    repeater.data = getServiceTiers();
+  } catch (e) { /* Repeater may not exist in template */ }
+}
+
+// ── Delivery Rates ──────────────────────────────────────────────────
+
+function initDeliveryRates() {
+  try {
+    const rates = getDeliveryRates();
+    try {
+      const chargeEl = $w('#deliveryMinCharge');
+      if (chargeEl) chargeEl.text = `Minimum local charge (up to approx. ${rates.minimumRadius} radius from our store) ${rates.minimumCharge}`;
+    } catch (e) {}
+    try {
+      const noteEl = $w('#deliveryRateNote');
+      if (noteEl) noteEl.text = rates.note;
+    } catch (e) {}
+  } catch (e) { /* Rate elements may not exist */ }
+}
+
+// ── Navigation Links ────────────────────────────────────────────────
+
+function initNavLinks() {
+  try {
+    makeClickable($w('#deliveryFaqLink'), () => {
+      import('wix-location-frontend').then(({ to }) => to('/faq'));
+    }, { ariaLabel: 'View assembly videos and FAQs' });
+  } catch (e) {}
+
+  try {
+    makeClickable($w('#deliveryContactLink'), () => {
+      import('wix-location-frontend').then(({ to }) => to('/contact'));
+    }, { ariaLabel: 'Contact us about delivery rates' });
+  } catch (e) {}
+}

--- a/src/public/deliveryHelpers.js
+++ b/src/public/deliveryHelpers.js
@@ -1,0 +1,67 @@
+/**
+ * deliveryHelpers.js — Content data for the Getting It Home page.
+ * Service tiers, delivery rates, and assembly info for Carolina Futons.
+ */
+
+const SERVICE_TIERS = [
+  {
+    _id: 'diy',
+    title: 'Do It Yourself',
+    price: 'Free',
+    description: 'Are you an "I can do it myself" kind of person? Then you\'ll save the most by taking your purchase home and assembling it yourself with included box instructions or viewing the instructional videos online, available on our FAQ page. Most futon frames are simple to build and will fit in a small SUV or truck. You can also pick up your mattress in its original box or we can unbox for you to carry out (tied up vertically and wrapped in plastic). We will help you carry out and load your purchases into your vehicle.',
+    icon: 'wrench',
+  },
+  {
+    _id: 'dropoff',
+    title: 'Home Drop Off',
+    price: 'Delivery rate',
+    description: 'If you want to assemble your purchase yourself but don\'t have a suitable vehicle for transporting, we can deliver your items to your home. We can also deliver your mattress and take away your old mattress for a $10 landfill fee. Delivery rates are based on mileage from our store.',
+    icon: 'truck',
+  },
+  {
+    _id: 'instore',
+    title: 'In-Store Assembly',
+    price: '$40.00',
+    description: 'Another option is to have us assemble your frame in our store for you to pick up and take home. You can also pick up your mattress in its original box or we can unbox for you to carry out (tied up vertically and wrapped in plastic). We will help you carry out and load your purchases into your vehicle. A full-sized pickup truck or van is recommended for transporting an assembled frame and/or mattress. Our fee for this service is $40.00, with a 24-hour notice required.',
+    icon: 'build',
+  },
+  {
+    _id: 'whiteglove',
+    title: 'Premium White Glove Service',
+    price: '$60.00 + delivery',
+    description: 'A final option is to have us assemble/set up your frame in your home by our professional, courteous delivery personnel to your room of choice. This includes applying Grip Strips to your frame, putting your mattress protector and/or cover on your mattress, reviewing and demonstrating converting your frame or cabinet, final performance inspections, and removing all packaging and clean up area. Our fee for this service is $60.00, plus delivery rate based on the mileage from our store to your home.',
+    icon: 'star',
+  },
+];
+
+const INTRO_TEXT = 'At Carolina Futons, we don\'t add the cost of assembly and delivery into our prices, which means that you don\'t pay for services you don\'t need. Instead, we offer service levels to meet your individual needs. All of our frames come with a pack of Grip Strips to keep your mattress in place, at no additional charge. We\'ll also be here to answer any questions you might have after you take your purchase home regarding assembly and/or mechanics of your frame.';
+
+const DELIVERY_RATES = {
+  minimumCharge: '$25.00',
+  minimumRadius: '10-mile',
+  note: 'Contact us for rates or input your zip code when adding items to your cart for pricing.',
+};
+
+/**
+ * Get the intro paragraph text for the Getting It Home page.
+ * @returns {string}
+ */
+export function getIntroText() {
+  return INTRO_TEXT;
+}
+
+/**
+ * Get all service tiers with IDs, titles, prices, and descriptions.
+ * @returns {Array<{_id: string, title: string, price: string, description: string, icon: string}>}
+ */
+export function getServiceTiers() {
+  return SERVICE_TIERS;
+}
+
+/**
+ * Get delivery rate information.
+ * @returns {{minimumCharge: string, minimumRadius: string, note: string}}
+ */
+export function getDeliveryRates() {
+  return DELIVERY_RATES;
+}

--- a/tests/deliveryHelpers.test.js
+++ b/tests/deliveryHelpers.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getIntroText,
+  getServiceTiers,
+  getDeliveryRates,
+} from '../src/public/deliveryHelpers.js';
+
+// ── getIntroText ──────────────────────────────────────────────────────
+
+describe('getIntroText', () => {
+  it('returns a non-empty string', () => {
+    const text = getIntroText();
+    expect(typeof text).toBe('string');
+    expect(text.length).toBeGreaterThan(50);
+  });
+
+  it('mentions not adding delivery costs to prices', () => {
+    const text = getIntroText();
+    expect(text).toContain("don't add the cost of assembly and delivery");
+  });
+
+  it('mentions Grip Strips included free', () => {
+    const text = getIntroText();
+    expect(text).toContain('Grip Strips');
+    expect(text).toContain('no additional charge');
+  });
+});
+
+// ── getServiceTiers ───────────────────────────────────────────────────
+
+describe('getServiceTiers', () => {
+  it('returns exactly 4 service tiers', () => {
+    const tiers = getServiceTiers();
+    expect(tiers).toHaveLength(4);
+  });
+
+  it('each tier has required fields', () => {
+    const tiers = getServiceTiers();
+    tiers.forEach(tier => {
+      expect(tier).toHaveProperty('_id');
+      expect(tier).toHaveProperty('title');
+      expect(tier).toHaveProperty('price');
+      expect(tier).toHaveProperty('description');
+      expect(tier).toHaveProperty('icon');
+    });
+  });
+
+  it('all tier IDs are unique', () => {
+    const tiers = getServiceTiers();
+    const ids = tiers.map(t => t._id);
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it('first tier is Do It Yourself (free)', () => {
+    const tiers = getServiceTiers();
+    expect(tiers[0].title).toBe('Do It Yourself');
+    expect(tiers[0].price).toBe('Free');
+  });
+
+  it('second tier is Home Drop Off', () => {
+    const tiers = getServiceTiers();
+    expect(tiers[1].title).toBe('Home Drop Off');
+  });
+
+  it('third tier is In-Store Assembly at $40', () => {
+    const tiers = getServiceTiers();
+    expect(tiers[2].title).toBe('In-Store Assembly');
+    expect(tiers[2].price).toContain('$40');
+  });
+
+  it('fourth tier is Premium White Glove Service at $60+', () => {
+    const tiers = getServiceTiers();
+    expect(tiers[3].title).toBe('Premium White Glove Service');
+    expect(tiers[3].price).toContain('$60');
+  });
+
+  it('all descriptions are non-empty strings', () => {
+    const tiers = getServiceTiers();
+    tiers.forEach(tier => {
+      expect(typeof tier.description).toBe('string');
+      expect(tier.description.length).toBeGreaterThan(20);
+    });
+  });
+
+  it('white glove tier mentions Grip Strips and clean up', () => {
+    const tiers = getServiceTiers();
+    const whiteGlove = tiers[3];
+    expect(whiteGlove.description).toContain('Grip Strips');
+    expect(whiteGlove.description).toContain('clean up');
+  });
+});
+
+// ── getDeliveryRates ──────────────────────────────────────────────────
+
+describe('getDeliveryRates', () => {
+  it('returns minimum charge of $25', () => {
+    const rates = getDeliveryRates();
+    expect(rates.minimumCharge).toContain('$25');
+  });
+
+  it('returns 10-mile minimum radius', () => {
+    const rates = getDeliveryRates();
+    expect(rates.minimumRadius).toContain('10');
+  });
+
+  it('has a note about contacting for rates', () => {
+    const rates = getDeliveryRates();
+    expect(rates.note).toContain('Contact us');
+  });
+});

--- a/tests/gettingItHome.test.js
+++ b/tests/gettingItHome.test.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '',
+    src: '',
+    alt: '',
+    html: '',
+    data: [],
+    style: { color: '', backgroundColor: '' },
+    accessibility: { ariaLabel: '', role: '' },
+    background: { src: '' },
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(),
+    expand: vi.fn(),
+    scrollTo: vi.fn(),
+    postMessage: vi.fn(),
+    onClick: vi.fn(),
+    onChange: vi.fn(),
+    onItemReady: vi.fn(),
+    onReady: vi.fn(() => Promise.resolve()),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Mock Backend Modules ────────────────────────────────────────────
+
+vi.mock('public/pageSeo.js', () => ({
+  initPageSeo: vi.fn(),
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  initBackToTop: vi.fn(),
+  isMobile: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('public/a11yHelpers.js', () => ({
+  makeClickable: vi.fn((el, handler, opts) => {
+    el.onClick(handler);
+    if (opts?.ariaLabel) {
+      try { el.accessibility.ariaLabel = opts.ariaLabel; } catch (e) {}
+    }
+  }),
+  announce: vi.fn(),
+}));
+
+vi.mock('public/deliveryHelpers.js', async () => {
+  const actual = await vi.importActual('../src/public/deliveryHelpers.js');
+  return actual;
+});
+
+vi.mock('backend/seoHelpers.web', () => ({
+  getBusinessSchema: vi.fn().mockResolvedValue(null),
+}));
+
+// ── Load Page ──────────────────────────────────────────────────────
+
+beforeEach(() => {
+  elements.clear();
+  onReadyHandler = null;
+  vi.resetModules();
+});
+
+describe('Getting It Home Page', () => {
+  beforeEach(async () => {
+    await import('../src/pages/Getting It Home.js');
+  });
+
+  it('registers an onReady handler', () => {
+    expect(onReadyHandler).toBeInstanceOf(Function);
+  });
+
+  describe('page initialization', () => {
+    it('tracks page view event', async () => {
+      await onReadyHandler();
+      const { trackEvent } = await import('public/engagementTracker');
+      expect(trackEvent).toHaveBeenCalledWith('page_view', expect.objectContaining({ page: 'getting-it-home' }));
+    });
+
+    it('initializes page SEO', async () => {
+      await onReadyHandler();
+      const { initPageSeo } = await import('public/pageSeo.js');
+      expect(initPageSeo).toHaveBeenCalledWith('getting-it-home');
+    });
+
+    it('initializes back to top button', async () => {
+      await onReadyHandler();
+      const { initBackToTop } = await import('public/mobileHelpers');
+      expect(initBackToTop).toHaveBeenCalled();
+    });
+  });
+
+  describe('intro section', () => {
+    it('sets intro text on the intro element', async () => {
+      await onReadyHandler();
+      const intro = getEl('#deliveryIntro');
+      expect(intro.text).toContain("don't add the cost");
+    });
+  });
+
+  describe('service tiers', () => {
+    it('populates service tier repeater with 4 items', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#serviceTierRepeater');
+      expect(repeater.data).toHaveLength(4);
+    });
+
+    it('sets onItemReady callback on repeater', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#serviceTierRepeater');
+      expect(repeater.onItemReady).toHaveBeenCalled();
+    });
+
+    it('onItemReady sets tier title, price, and description', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#serviceTierRepeater');
+      const itemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const $item = (sel) => getEl(`_item_${sel}`);
+      const tierData = {
+        _id: 'diy',
+        title: 'Do It Yourself',
+        price: 'Free',
+        description: 'Test description for DIY tier',
+        icon: 'wrench',
+      };
+
+      itemReadyCb($item, tierData);
+
+      expect(getEl('_item_#tierTitle').text).toBe('Do It Yourself');
+      expect(getEl('_item_#tierPrice').text).toBe('Free');
+      expect(getEl('_item_#tierDescription').text).toBe('Test description for DIY tier');
+    });
+
+    it('repeater has accessible label', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#serviceTierRepeater');
+      expect(repeater.accessibility.ariaLabel).toContain('service');
+    });
+  });
+
+  describe('delivery rates', () => {
+    it('sets minimum delivery charge text', async () => {
+      await onReadyHandler();
+      const chargeEl = getEl('#deliveryMinCharge');
+      expect(chargeEl.text).toContain('$25');
+    });
+
+    it('sets delivery rate note', async () => {
+      await onReadyHandler();
+      const noteEl = getEl('#deliveryRateNote');
+      expect(noteEl.text).toContain('Contact us');
+    });
+  });
+
+  describe('navigation links', () => {
+    it('wires FAQ link click handler', async () => {
+      await onReadyHandler();
+      const faqLink = getEl('#deliveryFaqLink');
+      expect(faqLink.onClick).toHaveBeenCalled();
+    });
+
+    it('wires contact link click handler', async () => {
+      await onReadyHandler();
+      const contactLink = getEl('#deliveryContactLink');
+      expect(contactLink.onClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -215,6 +215,8 @@ export default defineConfig({
       'public/performanceHelpers': path.resolve(__dirname, 'src/public/performanceHelpers.js'),
       'public/aboutContactHelpers.js': path.resolve(__dirname, 'src/public/aboutContactHelpers.js'),
       'public/aboutContactHelpers': path.resolve(__dirname, 'src/public/aboutContactHelpers.js'),
+      'public/deliveryHelpers.js': path.resolve(__dirname, 'src/public/deliveryHelpers.js'),
+      'public/deliveryHelpers': path.resolve(__dirname, 'src/public/deliveryHelpers.js'),
       'public/faqHelpers.js': path.resolve(__dirname, 'src/public/faqHelpers.js'),
       'public/faqHelpers': path.resolve(__dirname, 'src/public/faqHelpers.js'),
       'public/models3d.js': path.resolve(__dirname, 'src/public/models3d.js'),


### PR DESCRIPTION
## Summary
- New "Getting It Home" page with delivery and assembly service information
- 4 service tiers: DIY (free), Home Drop Off, In-Store Assembly ($40), White Glove ($60+)
- Content sourced from production site via Playwright
- `deliveryHelpers.js` module with content data, `Getting It Home.js` page code

## TDD approach
- Tests written first, verified red, then implementation to green
- 15 unit tests for content helpers (getIntroText, getServiceTiers, getDeliveryRates)
- 13 integration tests for page initialization (SEO, tracking, repeater, nav links)

## Test plan
- [x] 28 new tests pass
- [x] Full suite: 12,492 tests pass
- [ ] Visual verification in Wix Studio needed (element IDs need mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)