### PR TITLE
test(cf-ptcov): handler behavior tests for Fullscreen, Cart, Blog Post pages

### DIFF
--- a/tests/blogPostPage.test.js
+++ b/tests/blogPostPage.test.js
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '', src: '', alt: '', value: '', label: '',
+    options: [], data: [],
+    style: { color: '' },
+    accessibility: {},
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(), expand: vi.fn(),
+    scrollTo: vi.fn(), postMessage: vi.fn(),
+    onClick: vi.fn(), onChange: vi.fn(),
+    onItemReady: vi.fn(), onItemClicked: vi.fn(),
+    onReady: vi.fn(() => Promise.resolve()),
+    focus: vi.fn(),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Mock Post Data ──────────────────────────────────────────────────
+
+const mockPost = {
+  slug: 'futon-care-guide',
+  title: 'How to Care for Your Futon',
+  excerpt: 'A comprehensive guide to futon maintenance, cleaning, and longevity tips for keeping your futon in great shape for years.',
+  category: 'Care Tips',
+  publishDate: '2026-01-15',
+  coverImage: 'https://img/futon-care.jpg',
+  heroImage: 'https://img/futon-care-hero.jpg',
+  author: 'Carolina Futons',
+};
+
+const mockRelatedPosts = [
+  { slug: 'choosing-right-mattress', title: 'Choosing the Right Mattress', category: 'Buying Guide', excerpt: 'Short guide to mattress selection.' },
+  { slug: 'futon-vs-sofa-bed', title: 'Futon vs Sofa Bed', category: 'Comparisons', excerpt: 'Compare futons and sofa beds side by side.' },
+];
+
+// ── Mock Backend Modules ────────────────────────────────────────────
+
+vi.mock('backend/seoHelpers.web', () => ({
+  getBlogArticleSchema: vi.fn().mockResolvedValue('{"@type":"Article"}'),
+  getBlogFaqSchema: vi.fn().mockResolvedValue(null),
+  getPageTitle: vi.fn().mockResolvedValue('How to Care for Your Futon | Carolina Futons Blog'),
+  getCanonicalUrl: vi.fn().mockResolvedValue('https://www.carolinafutons.com/blog/futon-care-guide'),
+  getPageMetaDescription: vi.fn().mockResolvedValue('A comprehensive guide...'),
+}));
+
+vi.mock('backend/pinterestRichPins.web', () => ({
+  getGuidePinData: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+vi.mock('backend/blogContent', () => ({
+  getBlogPost: vi.fn((slug) => slug === 'futon-care-guide' ? mockPost : null),
+  getAllBlogPosts: vi.fn().mockReturnValue([mockPost, ...mockRelatedPosts]),
+}));
+
+vi.mock('wix-location-frontend', () => ({
+  default: { path: ['blog', 'futon-care-guide'], to: vi.fn() },
+  to: vi.fn(),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  initBackToTop: vi.fn(),
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('public/ga4Tracking', () => ({
+  fireCustomEvent: vi.fn(),
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+  makeClickable: vi.fn((el, handler, opts) => {
+    el._clickHandler = handler;
+    el._a11yOpts = opts;
+  }),
+}));
+
+vi.mock('public/blogHelpers', () => ({
+  estimateReadingTime: vi.fn().mockReturnValue(5),
+  formatPublishDate: vi.fn().mockReturnValue('January 15, 2026'),
+  buildAuthorBio: vi.fn().mockReturnValue({
+    name: 'Carolina Futons',
+    description: 'Family-owned furniture store since 1991.',
+    location: 'Hendersonville, NC',
+    established: '1991',
+  }),
+  buildShareUrls: vi.fn().mockReturnValue({
+    facebook: 'https://facebook.com/share?u=test',
+    pinterest: 'https://pinterest.com/pin/create?url=test',
+    twitter: 'https://twitter.com/intent/tweet?url=test',
+    email: 'mailto:?subject=test',
+  }),
+  getRelatedPosts: vi.fn().mockReturnValue(mockRelatedPosts),
+}));
+
+vi.mock('public/pageSeo.js', () => ({
+  initPageSeo: vi.fn(),
+}));
+
+vi.mock('wix-window-frontend', () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock('wix-seo-frontend', () => ({
+  head: { setMetaTag: vi.fn() },
+}));
+
+const { trackEvent } = await import('public/engagementTracker');
+const { fireCustomEvent } = await import('public/ga4Tracking');
+const { makeClickable } = await import('public/a11yHelpers');
+const { estimateReadingTime, buildAuthorBio, getRelatedPosts } = await import('public/blogHelpers');
+const { getBlogArticleSchema } = await import('backend/seoHelpers.web');
+const { initPageSeo } = await import('public/pageSeo.js');
+
+// ── Import Page ─────────────────────────────────────────────────────
+
+describe('Blog Post Page', () => {
+  beforeAll(async () => {
+    await import('../src/pages/Blog Post.js');
+  });
+
+  beforeEach(() => {
+    elements.clear();
+    vi.clearAllMocks();
+    getRelatedPosts.mockReturnValue(mockRelatedPosts);
+  });
+
+  // ── onReady basics ──────────────────────────────────────────────
+
+  describe('onReady', () => {
+    it('tracks page_view for blog_post', async () => {
+      await onReadyHandler();
+      expect(trackEvent).toHaveBeenCalledWith('page_view', { page: 'blog_post' });
+    });
+
+    it('fires GA4 blog_post_view with slug and category', async () => {
+      await onReadyHandler();
+      expect(fireCustomEvent).toHaveBeenCalledWith('blog_post_view', {
+        slug: 'futon-care-guide',
+        category: 'Care Tips',
+      });
+    });
+
+    it('calls initPageSeo with blogPost type and post data', async () => {
+      await onReadyHandler();
+      expect(initPageSeo).toHaveBeenCalledWith('blogPost', {
+        name: 'How to Care for Your Futon',
+        slug: 'futon-care-guide',
+        image: 'https://img/futon-care.jpg',
+      });
+    });
+  });
+
+  // ── Reading Time Badge ──────────────────────────────────────────
+
+  describe('reading time badge', () => {
+    it('displays reading time in minutes', async () => {
+      await onReadyHandler();
+      expect(getEl('#postReadTime').text).toBe('5 min read');
+    });
+
+    it('displays formatted publish date', async () => {
+      await onReadyHandler();
+      expect(getEl('#postDate').text).toBe('January 15, 2026');
+    });
+
+    it('displays post category', async () => {
+      await onReadyHandler();
+      expect(getEl('#postCategory').text).toBe('Care Tips');
+    });
+  });
+
+  // ── Author Bio ──────────────────────────────────────────────────
+
+  describe('author bio', () => {
+    it('sets author name, description, and location', async () => {
+      await onReadyHandler();
+      expect(getEl('#authorName').text).toBe('Carolina Futons');
+      expect(getEl('#authorDescription').text).toBe('Family-owned furniture store since 1991.');
+      expect(getEl('#authorLocation').text).toBe('Hendersonville, NC');
+    });
+
+    it('sets established year', async () => {
+      await onReadyHandler();
+      expect(getEl('#authorEstablished').text).toBe('Est. 1991');
+    });
+
+    it('expands author bio section', async () => {
+      await onReadyHandler();
+      expect(getEl('#authorBioSection').expand).toHaveBeenCalled();
+    });
+  });
+
+  // ── Social Share Buttons ────────────────────────────────────────
+
+  describe('social share buttons', () => {
+    it('registers makeClickable on all 4 share buttons', async () => {
+      await onReadyHandler();
+      const registeredEls = makeClickable.mock.calls.map(c => c[0]);
+      expect(registeredEls).toContain(getEl('#postShareFacebook'));
+      expect(registeredEls).toContain(getEl('#postSharePinterest'));
+      expect(registeredEls).toContain(getEl('#postShareTwitter'));
+      expect(registeredEls).toContain(getEl('#postShareEmail'));
+    });
+
+    it('sets correct ARIA labels on share buttons', async () => {
+      await onReadyHandler();
+      const fbCall = makeClickable.mock.calls.find(c => c[0] === getEl('#postShareFacebook'));
+      expect(fbCall[2].ariaLabel).toBe('Share on Facebook (opens in new window)');
+
+      const emailCall = makeClickable.mock.calls.find(c => c[0] === getEl('#postShareEmail'));
+      expect(emailCall[2].ariaLabel).toBe('Share via email');
+    });
+  });
+
+  // ── Related Posts ───────────────────────────────────────────────
+
+  describe('related posts', () => {
+    it('populates relatedPostsRepeater with related post data', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#relatedPostsRepeater');
+      expect(repeater.data).toHaveLength(2);
+      expect(repeater.data[0]._id).toBe('choosing-right-mattress');
+      expect(repeater.data[1]._id).toBe('futon-vs-sofa-bed');
+    });
+
+    it('expands relatedPostsSection when related posts exist', async () => {
+      await onReadyHandler();
+      expect(getEl('#relatedPostsSection').expand).toHaveBeenCalled();
+    });
+
+    it('collapses relatedPostsSection when no related posts', async () => {
+      getRelatedPosts.mockReturnValue([]);
+      await onReadyHandler();
+      expect(getEl('#relatedPostsSection').collapse).toHaveBeenCalled();
+    });
+
+    it('onItemReady sets title, category, and reading time', async () => {
+      // Pre-create repeater element before onReady so it persists
+      const repeater = getEl('#relatedPostsRepeater');
+      await onReadyHandler();
+      const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+
+      onItemReadyCb($item, mockRelatedPosts[0]);
+
+      expect($item('#relatedTitle').text).toBe('Choosing the Right Mattress');
+      expect($item('#relatedCategory').text).toBe('Buying Guide');
+    });
+
+    it('onItemReady registers makeClickable for navigation', async () => {
+      const repeater = getEl('#relatedPostsRepeater');
+      await onReadyHandler();
+      const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+
+      onItemReadyCb($item, mockRelatedPosts[0]);
+
+      const linkCall = makeClickable.mock.calls.find(c => c[0] === $item('#relatedPostLink'));
+      expect(linkCall).toBeDefined();
+      expect(linkCall[2].ariaLabel).toBe('Read related: Choosing the Right Mattress');
+    });
+  });
+
+  // ── SEO Schema ──────────────────────────────────────────────────
+
+  describe('SEO schema injection', () => {
+    it('posts article schema to postSeoSchema element', async () => {
+      await onReadyHandler();
+      expect(getBlogArticleSchema).toHaveBeenCalledWith(mockPost);
+      expect(getEl('#postSeoSchema').postMessage).toHaveBeenCalled();
+      const msg = getEl('#postSeoSchema').postMessage.mock.calls[0][0];
+      expect(msg).toContain('application/ld+json');
+      expect(msg).toContain('Article');
+    });
+  });
+});

--- a/tests/cartPageHandlers.test.js
+++ b/tests/cartPageHandlers.test.js
@@ -1,0 +1,457 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '', src: '', alt: '', value: '', label: '',
+    options: [], data: [],
+    style: { color: '', backgroundColor: '', fontWeight: '' },
+    accessibility: {},
+    hidden: false,
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(), expand: vi.fn(),
+    scrollTo: vi.fn(), postMessage: vi.fn(),
+    onClick: vi.fn(), onChange: vi.fn(),
+    onItemReady: vi.fn(), onItemClicked: vi.fn(),
+    onReady: vi.fn(() => Promise.resolve()),
+    setFilter: vi.fn(), setSort: vi.fn(),
+    focus: vi.fn(),
+    disable: vi.fn(), enable: vi.fn(),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Mock Backend Modules ────────────────────────────────────────────
+
+const mockCart = {
+  lineItems: [
+    { _id: 'li-1', productId: 'prod-1', name: 'Asheville Futon', price: 599, quantity: 1, mediaItem: { src: 'https://img/ash.jpg' } },
+    { _id: 'li-2', productId: 'prod-2', name: 'Futon Mattress', price: 199, quantity: 2, mediaItem: { src: 'https://img/mat.jpg' } },
+  ],
+  totals: { subtotal: 997, shipping: 0, total: 997 },
+  appliedCoupon: null,
+};
+
+vi.mock('backend/productRecommendations.web', () => ({
+  getCompletionSuggestions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('backend/financingCalc.web', () => ({
+  getCartFinancing: vi.fn().mockResolvedValue({ success: false }),
+}));
+
+vi.mock('public/galleryHelpers', () => ({
+  getRecentlyViewed: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('public/cartService', () => ({
+  getCurrentCart: vi.fn().mockResolvedValue(mockCart),
+  addToCart: vi.fn(),
+  updateCartItemQuantity: vi.fn().mockResolvedValue({}),
+  removeCartItem: vi.fn().mockResolvedValue({}),
+  onCartChanged: vi.fn(),
+  getShippingProgress: vi.fn().mockReturnValue({ remaining: 50, progressPct: 50, qualifies: false }),
+  getTierProgress: vi.fn().mockReturnValue({
+    tier: { label: (r) => `Add $${r} for 5% off` },
+    remaining: 100,
+    progressPct: 20,
+  }),
+  FREE_SHIPPING_THRESHOLD: 100000,
+  MIN_QUANTITY: 1,
+  MAX_QUANTITY: 10,
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  initBackToTop: vi.fn(),
+  collapseOnMobile: vi.fn(),
+  limitForViewport: vi.fn((items) => items),
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('public/ga4Tracking', () => ({
+  fireViewCart: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+  makeClickable: vi.fn((el, handler, opts) => {
+    el._clickHandler = handler;
+    el._a11yOpts = opts;
+  }),
+}));
+
+vi.mock('public/cartStyles.js', () => ({
+  getCartItemStyles: vi.fn().mockReturnValue({ nameColor: '#333', priceColor: '#666', removeColor: '#e74c3c' }),
+  getProgressBarStyles: vi.fn().mockReturnValue({ trackColor: '#eee', fillColor: '#4CAF50', textColor: '#333' }),
+  getEmptyCartStyles: vi.fn().mockReturnValue({ headingColor: '#3A2518', messageColor: '#666' }),
+  getCheckoutButtonStyles: vi.fn().mockReturnValue({ background: '#E8845C', textColor: '#fff' }),
+  getQuantitySpinnerStyles: vi.fn().mockReturnValue({ buttonColor: '#5B8FA8', valueColor: '#333' }),
+}));
+
+vi.mock('public/crossSellWidget.js', () => ({
+  buildRoomBundles: vi.fn().mockReturnValue([]),
+  initCrossSellWidget: vi.fn(),
+}));
+
+vi.mock('public/SaveForLater.js', () => ({
+  saveForLater: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('public/cartDeliveryEstimate.js', () => ({
+  initCartDeliveryEstimate: vi.fn().mockResolvedValue(undefined),
+  updateCartDeliveryEstimate: vi.fn(),
+}));
+
+vi.mock('public/CouponCodeInput.js', () => ({
+  initCouponCodeInput: vi.fn(),
+}));
+
+vi.mock('public/pageSeo.js', () => ({
+  initPageSeo: vi.fn(),
+}));
+
+vi.mock('wix-location-frontend', () => ({
+  to: vi.fn(),
+}));
+
+const { getCurrentCart, updateCartItemQuantity, removeCartItem, onCartChanged } = await import('public/cartService');
+const { trackEvent } = await import('public/engagementTracker');
+const { announce } = await import('public/a11yHelpers');
+const { saveForLater } = await import('public/SaveForLater.js');
+const { initPageSeo } = await import('public/pageSeo.js');
+
+// ── Import Page ─────────────────────────────────────────────────────
+
+describe('Cart Page — handler behavior', () => {
+  beforeAll(async () => {
+    await import('../src/pages/Cart Page.js');
+  });
+
+  beforeEach(() => {
+    elements.clear();
+    vi.clearAllMocks();
+    getCurrentCart.mockResolvedValue(mockCart);
+  });
+
+  // ── onReady ─────────────────────────────────────────────────────
+
+  describe('onReady', () => {
+    it('calls initPageSeo with cart', async () => {
+      await onReadyHandler();
+      expect(initPageSeo).toHaveBeenCalledWith('cart');
+    });
+
+    it('tracks page_view with item count for populated cart', async () => {
+      await onReadyHandler();
+      expect(trackEvent).toHaveBeenCalledWith('page_view', { page: 'cart', itemCount: 2 });
+    });
+  });
+
+  // ── Empty cart state ────────────────────────────────────────────
+
+  describe('empty cart state', () => {
+    beforeEach(() => {
+      getCurrentCart.mockResolvedValue({ lineItems: [], totals: { subtotal: 0 } });
+    });
+
+    it('expands emptyCartSection when cart is empty', async () => {
+      await onReadyHandler();
+      expect(getEl('#emptyCartSection').expand).toHaveBeenCalled();
+    });
+
+    it('sets empty cart title text', async () => {
+      await onReadyHandler();
+      expect(getEl('#emptyCartTitle').text).toBe('Your cart is empty');
+    });
+
+    it('sets empty cart title role to heading', async () => {
+      await onReadyHandler();
+      expect(getEl('#emptyCartTitle').accessibility.role).toBe('heading');
+    });
+
+    it('sets continue shopping button styling', async () => {
+      await onReadyHandler();
+      expect(getEl('#continueShoppingBtn').style.backgroundColor).toBe('#E8845C');
+      expect(getEl('#continueShoppingBtn').style.color).toBe('#fff');
+    });
+
+    it('collapses suggestions, recent, and financing sections', async () => {
+      await onReadyHandler();
+      expect(getEl('#suggestionsSection').collapse).toHaveBeenCalled();
+      expect(getEl('#cartRecentSection').collapse).toHaveBeenCalled();
+      expect(getEl('#cartFinancingSection').collapse).toHaveBeenCalled();
+    });
+
+    it('tracks page_view with empty=true', async () => {
+      await onReadyHandler();
+      expect(trackEvent).toHaveBeenCalledWith('page_view', { page: 'cart', empty: true });
+    });
+  });
+
+  // ── Quantity controls ───────────────────────────────────────────
+
+  describe('quantity controls — minus button', () => {
+    async function getItemReadyCb() {
+      await onReadyHandler();
+      return getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+    }
+
+    function createItemScope() {
+      const itemElements = new Map();
+      return (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+    }
+
+    it('decreases quantity and calls updateCartItemQuantity', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '3';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const minusClickCb = $item('#qtyMinus').onClick.mock.calls[0][0];
+      await minusClickCb();
+
+      expect(updateCartItemQuantity).toHaveBeenCalledWith('li-1', 2);
+    });
+
+    it('updates quantity display after decrease', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '3';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const minusClickCb = $item('#qtyMinus').onClick.mock.calls[0][0];
+      await minusClickCb();
+
+      expect($item('#qtyInput').value).toBe('2');
+    });
+
+    it('announces quantity change to screen readers', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '3';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const minusClickCb = $item('#qtyMinus').onClick.mock.calls[0][0];
+      await minusClickCb();
+
+      expect(announce).toHaveBeenCalledWith($w, 'Asheville Futon quantity updated to 2');
+    });
+
+    it('does NOT decrease below MIN_QUANTITY (1)', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '1';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const minusClickCb = $item('#qtyMinus').onClick.mock.calls[0][0];
+      await minusClickCb();
+
+      expect(updateCartItemQuantity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('quantity controls — plus button', () => {
+    async function getItemReadyCb() {
+      await onReadyHandler();
+      return getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+    }
+
+    function createItemScope() {
+      const itemElements = new Map();
+      return (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+    }
+
+    it('increases quantity and calls updateCartItemQuantity', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '2';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const plusClickCb = $item('#qtyPlus').onClick.mock.calls[0][0];
+      await plusClickCb();
+
+      expect(updateCartItemQuantity).toHaveBeenCalledWith('li-1', 3);
+    });
+
+    it('does NOT increase above MAX_QUANTITY (10)', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '10';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const plusClickCb = $item('#qtyPlus').onClick.mock.calls[0][0];
+      await plusClickCb();
+
+      expect(updateCartItemQuantity).not.toHaveBeenCalled();
+    });
+
+    it('updates ariaValueNow after increase', async () => {
+      const cb = await getItemReadyCb();
+      const $item = createItemScope();
+      $item('#qtyInput').value = '2';
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const plusClickCb = $item('#qtyPlus').onClick.mock.calls[0][0];
+      await plusClickCb();
+
+      expect($item('#qtyInput').accessibility.ariaValueNow).toBe(3);
+    });
+  });
+
+  // ── Remove item ─────────────────────────────────────────────────
+
+  describe('remove item from cart', () => {
+    it('calls removeCartItem with item ID', async () => {
+      await onReadyHandler();
+      const cb = getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const removeClickCb = $item('#removeItem').onClick.mock.calls[0][0];
+      await removeClickCb();
+
+      expect(removeCartItem).toHaveBeenCalledWith('li-1');
+    });
+
+    it('announces removal to screen readers', async () => {
+      await onReadyHandler();
+      const cb = getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      cb($item, { _id: 'li-1', name: 'Asheville Futon', price: 599 });
+
+      const removeClickCb = $item('#removeItem').onClick.mock.calls[0][0];
+      await removeClickCb();
+
+      expect(announce).toHaveBeenCalledWith($w, 'Asheville Futon removed from cart');
+    });
+  });
+
+  // ── Save for later ──────────────────────────────────────────────
+
+  describe('save for later', () => {
+    async function clickSaveForLater(itemData) {
+      await onReadyHandler();
+      const cb = getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      cb($item, itemData);
+      const saveCb = $item('#saveForLaterBtn').onClick.mock.calls[0][0];
+      await saveCb();
+      return $item;
+    }
+
+    it('calls saveForLater with item data', async () => {
+      await clickSaveForLater({ _id: 'li-1', productId: 'prod-1', name: 'Asheville Futon', price: 599, mediaItem: { src: 'img.jpg' } });
+      expect(saveForLater).toHaveBeenCalledWith({
+        _id: 'li-1',
+        productId: 'prod-1',
+        name: 'Asheville Futon',
+        price: 599,
+        image: 'img.jpg',
+      });
+    });
+
+    it('announces success when save succeeds', async () => {
+      saveForLater.mockResolvedValue({ success: true });
+      await clickSaveForLater({ _id: 'li-1', productId: 'prod-1', name: 'Asheville Futon', price: 599, mediaItem: { src: 'img.jpg' } });
+      expect(announce).toHaveBeenCalledWith($w, 'Asheville Futon saved to your wishlist');
+    });
+
+    it('announces login prompt when not authenticated', async () => {
+      saveForLater.mockResolvedValue({ success: false, reason: 'not_authenticated' });
+      await clickSaveForLater({ _id: 'li-1', productId: 'prod-1', name: 'Asheville Futon', price: 599, mediaItem: { src: 'img.jpg' } });
+      expect(announce).toHaveBeenCalledWith($w, 'Please log in to save items for later');
+    });
+
+    it('disables save button before calling saveForLater', async () => {
+      await onReadyHandler();
+      const cb = getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      cb($item, { _id: 'li-1', productId: 'prod-1', name: 'Test', price: 100, mediaItem: { src: 'i.jpg' } });
+      const saveCb = $item('#saveForLaterBtn').onClick.mock.calls[0][0];
+      await saveCb();
+      expect($item('#saveForLaterBtn').disable).toHaveBeenCalled();
+    });
+  });
+
+  // ── ARIA attributes ─────────────────────────────────────────────
+
+  describe('ARIA attributes on cart items', () => {
+    it('sets ariaLabel on qtyMinus, qtyPlus, and removeItem', async () => {
+      await onReadyHandler();
+      const cb = getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      cb($item, { _id: 'li-1', name: 'Sedona Futon', price: 799 });
+
+      expect($item('#qtyMinus').accessibility.ariaLabel).toBe('Decrease quantity of Sedona Futon');
+      expect($item('#qtyPlus').accessibility.ariaLabel).toBe('Increase quantity of Sedona Futon');
+      expect($item('#removeItem').accessibility.ariaLabel).toBe('Remove Sedona Futon from cart');
+    });
+
+    it('sets spinbutton role on qtyInput', async () => {
+      await onReadyHandler();
+      const cb = getEl('#cartItemsRepeater').onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      cb($item, { _id: 'li-1', name: 'Test', price: 100 });
+
+      expect($item('#qtyInput').accessibility.role).toBe('spinbutton');
+      expect($item('#qtyInput').accessibility.ariaValueMin).toBe(1);
+      expect($item('#qtyInput').accessibility.ariaValueMax).toBe(10);
+    });
+  });
+
+  // ── Cart change listener ────────────────────────────────────────
+
+  describe('cart change listener', () => {
+    it('registers onCartChanged callback', async () => {
+      await onReadyHandler();
+      expect(onCartChanged).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/fullscreenPageHandlers.test.js
+++ b/tests/fullscreenPageHandlers.test.js
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+// ── $w Mock Infrastructure ──────────────────────────────────────────
+
+const elements = new Map();
+
+function createMockElement() {
+  return {
+    text: '', src: '', alt: '', value: '', label: '',
+    options: [], data: [],
+    style: { color: '', fontWeight: '' },
+    accessibility: {},
+    hidden: false,
+    show: vi.fn(() => Promise.resolve()),
+    hide: vi.fn(() => Promise.resolve()),
+    collapse: vi.fn(), expand: vi.fn(),
+    scrollTo: vi.fn(), postMessage: vi.fn(),
+    onClick: vi.fn(), onChange: vi.fn(),
+    onItemReady: vi.fn(), onItemClicked: vi.fn(),
+    onPlay: vi.fn(), onPause: vi.fn(), onEnded: vi.fn(),
+    play: vi.fn(),
+    onReady: vi.fn(() => Promise.resolve()),
+    setFilter: vi.fn(), setSort: vi.fn(),
+    focus: vi.fn(),
+  };
+}
+
+function getEl(sel) {
+  if (!elements.has(sel)) elements.set(sel, createMockElement());
+  return elements.get(sel);
+}
+
+let onReadyHandler = null;
+globalThis.$w = Object.assign(
+  (sel) => getEl(sel),
+  { onReady: (fn) => { onReadyHandler = fn; } }
+);
+
+// ── Mock Backend Modules ────────────────────────────────────────────
+
+vi.mock('wix-data', () => ({
+  default: {
+    query: vi.fn(),
+    filter: vi.fn(() => ({
+      contains: vi.fn((field, value) => ({ _field: field, _value: value })),
+    })),
+  },
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+  trackGalleryInteraction: vi.fn(),
+}));
+
+vi.mock('public/designTokens.js', () => ({
+  typography: { h2: { weight: 700 }, body: { weight: 400 } },
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+  makeClickable: vi.fn((el, handler, opts) => {
+    el._clickHandler = handler;
+    el._a11yOpts = opts;
+  }),
+}));
+
+vi.mock('public/mobileHelpers', () => ({
+  initBackToTop: vi.fn(),
+  collapseOnMobile: vi.fn(),
+}));
+
+vi.mock('wix-location-frontend', () => ({
+  to: vi.fn(),
+}));
+
+const { trackEvent, trackGalleryInteraction } = await import('public/engagementTracker');
+const { announce, makeClickable } = await import('public/a11yHelpers');
+const wixData = (await import('wix-data')).default;
+
+// ── Import Page ─────────────────────────────────────────────────────
+
+describe('Fullscreen Page — handler behavior', () => {
+  beforeAll(async () => {
+    await import('../src/pages/Fullscreen Page.js');
+  });
+
+  beforeEach(() => {
+    elements.clear();
+    vi.clearAllMocks();
+  });
+
+  // ── playVideo behavior ──────────────────────────────────────────
+
+  describe('playVideo — via thumbnail click', () => {
+    async function clickVideoThumb(videoData) {
+      await onReadyHandler();
+      const repeater = getEl('#videosRepeater');
+      const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
+
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+
+      onItemReadyCb($item, videoData);
+
+      // Invoke the click handler registered via makeClickable on #videoThumb
+      const thumbEl = $item('#videoThumb');
+      thumbEl._clickHandler();
+    }
+
+    it('sets videoPlayer src to the video URL', async () => {
+      await clickVideoThumb({ title: 'Asheville Demo', thumbnail: 't.jpg', videoUrl: 'https://cdn/asheville.mp4', category: 'futon' });
+      expect(getEl('#videoPlayer').src).toBe('https://cdn/asheville.mp4');
+    });
+
+    it('calls player.play()', async () => {
+      await clickVideoThumb({ title: 'Asheville Demo', thumbnail: 't.jpg', videoUrl: 'https://cdn/asheville.mp4' });
+      expect(getEl('#videoPlayer').play).toHaveBeenCalled();
+    });
+
+    it('tracks video_play via trackGalleryInteraction', async () => {
+      await clickVideoThumb({ title: 'Asheville Demo', thumbnail: 't.jpg', videoUrl: 'https://cdn/asheville.mp4' });
+      expect(trackGalleryInteraction).toHaveBeenCalledWith('video_play');
+    });
+
+    it('tracks video_play event with title and category', async () => {
+      await clickVideoThumb({ title: 'Asheville Demo', thumbnail: 't.jpg', videoUrl: 'https://cdn/asheville.mp4', category: 'futon' });
+      expect(trackEvent).toHaveBeenCalledWith('video_play', { title: 'Asheville Demo', category: 'futon' });
+    });
+
+    it('shows videoProductLink when productSlug is present', async () => {
+      await clickVideoThumb({ title: 'Asheville', thumbnail: 't.jpg', videoUrl: 'v.mp4', productSlug: 'asheville-futon' });
+      expect(getEl('#videoProductLink').show).toHaveBeenCalled();
+    });
+
+    it('does not show videoProductLink when productSlug is absent', async () => {
+      await clickVideoThumb({ title: 'Intro Video', thumbnail: 't.jpg', videoUrl: 'intro.mp4' });
+      expect(getEl('#videoProductLink').show).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── videoProductLink navigation ─────────────────────────────────
+
+  describe('videoProductLink — navigation to product page', () => {
+    it('navigates to product page using stored slug on click', async () => {
+      const wixLocation = await import('wix-location-frontend');
+
+      await onReadyHandler();
+
+      // First play a video with a productSlug to set currentVideoProductSlug
+      const repeater = getEl('#videosRepeater');
+      const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      onItemReadyCb($item, { title: 'Sedona', thumbnail: 't.jpg', videoUrl: 'v.mp4', productSlug: 'sedona-futon' });
+      $item('#videoThumb')._clickHandler();
+
+      // Now click the product link
+      const productLink = getEl('#videoProductLink');
+      productLink._clickHandler();
+
+      // Wait for dynamic import to resolve
+      await new Promise(r => setTimeout(r, 10));
+
+      expect(wixLocation.to).toHaveBeenCalledWith('/product-page/sedona-futon');
+    });
+  });
+
+  // ── onPlay/onPause/onEnded handler behavior ─────────────────────
+
+  describe('video player event handler behavior', () => {
+    it('onPlay hides videoOverlay with fade animation', async () => {
+      await onReadyHandler();
+      const player = getEl('#videoPlayer');
+      const onPlayCb = player.onPlay.mock.calls[0][0];
+      onPlayCb();
+      expect(getEl('#videoOverlay').hide).toHaveBeenCalledWith('fade', { duration: 300 });
+    });
+
+    it('onPause shows videoOverlay with fade animation', async () => {
+      await onReadyHandler();
+      const player = getEl('#videoPlayer');
+      const onPauseCb = player.onPause.mock.calls[0][0];
+      onPauseCb();
+      expect(getEl('#videoOverlay').show).toHaveBeenCalledWith('fade', { duration: 300 });
+    });
+
+    it('onEnded shows both videoOverlay and videoShopCTA', async () => {
+      await onReadyHandler();
+      const player = getEl('#videoPlayer');
+      const onEndedCb = player.onEnded.mock.calls[0][0];
+      onEndedCb();
+      expect(getEl('#videoOverlay').show).toHaveBeenCalledWith('fade', { duration: 300 });
+      expect(getEl('#videoShopCTA').show).toHaveBeenCalledWith('fade', { duration: 400 });
+    });
+  });
+
+  // ── filterVideosByCategory ──────────────────────────────────────
+
+  describe('filterVideosByCategory — via filter button click', () => {
+    it('clicking "All" filter clears dataset filter', async () => {
+      await onReadyHandler();
+      const allBtn = getEl('#videoFilterAll');
+      allBtn._clickHandler();
+      expect(getEl('#videosDataset').setFilter).toHaveBeenCalled();
+      expect(wixData.filter).toHaveBeenCalled();
+    });
+
+    it('clicking "Futons" filter sets contains filter on category', async () => {
+      await onReadyHandler();
+      const futonBtn = getEl('#videoFilterFutons');
+      futonBtn._clickHandler();
+      expect(getEl('#videosDataset').setFilter).toHaveBeenCalled();
+    });
+
+    it('clicking filter announces the active filter to screen readers', async () => {
+      await onReadyHandler();
+      const murphyBtn = getEl('#videoFilterMurphy');
+      murphyBtn._clickHandler();
+      expect(announce).toHaveBeenCalledWith($w, 'Showing filter murphy bed videos');
+    });
+
+    it('clicking filter bolds the active button and unbolds others', async () => {
+      await onReadyHandler();
+      const futonBtn = getEl('#videoFilterFutons');
+      futonBtn._clickHandler();
+
+      expect(getEl('#videoFilterFutons').style.fontWeight).toBe('700');
+      expect(getEl('#videoFilterAll').style.fontWeight).toBe('400');
+      expect(getEl('#videoFilterMurphy').style.fontWeight).toBe('400');
+      expect(getEl('#videoFilterPlatform').style.fontWeight).toBe('400');
+    });
+
+    it('clicking filter sets ariaPressed on active button only', async () => {
+      await onReadyHandler();
+      const platformBtn = getEl('#videoFilterPlatform');
+      platformBtn._clickHandler();
+
+      expect(getEl('#videoFilterPlatform').accessibility.ariaPressed).toBe(true);
+      expect(getEl('#videoFilterAll').accessibility.ariaPressed).toBe(false);
+      expect(getEl('#videoFilterFutons').accessibility.ariaPressed).toBe(false);
+      expect(getEl('#videoFilterMurphy').accessibility.ariaPressed).toBe(false);
+    });
+  });
+
+  // ── onItemReady — edge cases ──────────────────────────────────────
+
+  describe('onItemReady — edge cases', () => {
+    async function setupItemReady(itemData) {
+      await onReadyHandler();
+      const repeater = getEl('#videosRepeater');
+      const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
+      const itemElements = new Map();
+      const $item = (sel) => {
+        if (!itemElements.has(sel)) itemElements.set(sel, createMockElement());
+        return itemElements.get(sel);
+      };
+      onItemReadyCb($item, itemData);
+      return $item;
+    }
+
+    it('hides category badge when category is not provided', async () => {
+      const $item = await setupItemReady({ title: 'Intro', thumbnail: 't.jpg' });
+      // Badge show should NOT be called when no category
+      expect($item('#videoCategoryBadge').show).not.toHaveBeenCalled();
+    });
+
+    it('does not set duration when duration is not provided', async () => {
+      const $item = await setupItemReady({ title: 'Test', thumbnail: 't.jpg' });
+      expect($item('#videoDuration').text).toBe('');
+    });
+
+    it('sets alt text with brand suffix', async () => {
+      const $item = await setupItemReady({ title: 'Maricopa Demo', thumbnail: 't.jpg' });
+      expect($item('#videoThumb').alt).toBe('Maricopa Demo product demo video - Carolina Futons');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 59 page-level handler behavior tests across 3 previously untested pages
- **Fullscreen Page** (18 tests): `playVideo()` behavior (src, tracking, product link), `filterVideosByCategory()` dataset logic, video overlay show/hide handlers, `onItemReady` edge cases
- **Cart Page** (24 tests): qty +/- with MIN/MAX boundary guards, `removeCartItem`, `saveForLater` (success + not_authenticated), empty cart state, ARIA spinbutton/live regions
- **Blog Post** (17 tests): reading time badge, author bio rendering, social share button wiring, related posts repeater + navigation, SEO schema injection, GA4 tracking
- Closes coverage gaps flagged by pr-test-analyzer on PR #318

## Test plan
- [x] All 59 new tests pass
- [x] Full test suite passes (321 files, 12,472 tests)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)