### PR TITLE
fix: announcement bar with full showroom address + phone

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -211,10 +211,10 @@ function initEnhancedNavigation() {
 async function initAnnouncementBar() {
   const messages = [
     // 'Free Shipping on Orders Over $999!', // Disabled: free shipping currently inactive
-    'Visit Our Showroom: Wed–Sat 10–5, Hendersonville NC',
+    'Visit Our Showroom: Wed–Sat 10–5 | 824 Locust St, Hendersonville NC | (828) 252-9449',
     'Over 700 Fabric Swatches Available In-Store',
     'Request FREE fabric swatches — shipped to your door!',
-    'Family Owned Since 1991 — Now Carolina Futons',
+    'Family Owned Since 1991 — Carolina Futons',
   ];
 
   // Prepend active flash sale messages for urgency


### PR DESCRIPTION
## Summary
- Update showroom message to include full address and phone: `Visit Our Showroom: Wed–Sat 10–5 | 824 Locust St, Hendersonville NC | (828) 252-9449`
- Remove "Now" from family tagline
- Editor ds changes get overwritten by Velo rotation code — fix must be in masterPage.js

## Test plan
- [x] masterPage.test.js: 120 tests pass
- [ ] Verify on staging after merge+publish: announcement bar rotates with new text

🤖 Generated with [Claude Code](https://claude.com/claude-code)