### PR TITLE
feat(CF-sdlo): CI guard for test import path conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Audit dependencies
         run: npm audit --audit-level=high || true
 
+      - name: Check for external repo import paths in tests
+        run: |
+          # CF-sdlo: Prevent imports from sibling repos (e.g. ../carolina-futons-stage3-velo/)
+          # Tests must use vitest aliases (backend/*, public/*) or relative ../src/ paths.
+          if grep -rn "from ['\"].*carolina-futons-stage3\|from ['\"].*carolina-futons-mobile" tests/ --include='*.js' --include='*.ts'; then
+            echo "::error::Found external repo import paths in tests. Use vitest aliases or ../src/ relative paths instead."
+            exit 1
+          fi
+
       - name: Run tests
         run: npm test
 

--- a/MASTER-HOOKUP.md
+++ b/MASTER-HOOKUP.md
@@ -1465,7 +1465,32 @@ If you need to verify the code works before deploying, run from the repo root:
 npx vitest run
 ```
 
-**Current status:** 12,993+ tests across 326 files — all passing, zero failures.
+**Current status:** 13,237+ tests across 345 files — all passing, zero failures.
+
+### Test Import Conventions (CF-sdlo)
+
+Tests must **never** import from sibling repos (e.g., `../carolina-futons-stage3-velo/`). CI will reject PRs with external repo paths.
+
+**Allowed import patterns:**
+
+| Pattern | Example | When to use |
+|---------|---------|-------------|
+| Vitest alias | `import from 'backend/batchAltText.web'` | Backend/public modules (preferred) |
+| Relative to repo | `import from '../src/backend/foo.web.js'` | When alias doesn't exist yet |
+| Mock path | `import from 'wix-data'` | Wix platform modules (auto-aliased) |
+
+**Forbidden patterns:**
+
+| Pattern | Why |
+|---------|-----|
+| `../carolina-futons-stage3-velo/...` | Breaks CI — path doesn't exist in checkout |
+| `../../some-other-repo/...` | Same — external repos aren't available |
+| Absolute paths (`/Users/...`) | Machine-specific, breaks everywhere |
+
+**Adding a new alias:** If your test can't resolve a Wix-style import, add the alias to `vitest.config.js` in the `resolve.alias` block. Follow the existing pattern:
+```js
+'backend/myModule.web': path.resolve(__dirname, 'src/backend/myModule.web.js'),
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds CI step that rejects PRs with imports from sibling repos (`carolina-futons-stage3-velo`, `carolina-futons-mobile`) in test files
- Documents test import conventions in MASTER-HOOKUP.md (allowed vs forbidden patterns, how to add aliases)
- Fixes: CF-sdlo (prevent stage3-velo local path leaks, ref PR #325 incident)

## Test plan
- [x] Grep guard passes on current codebase (no false positives)
- [x] Full test suite: 13,237 tests passing
- [x] Guard correctly catches `from '../carolina-futons-stage3-velo/...'` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)