### PR TITLE
fix(css): tame inflated collection card headings on homepage

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -353,6 +353,23 @@ h4.font_4,
 
 
 /* ═══════════════════════════════════════════════════════════════════════
+   6b. HOMEPAGE COLLECTIONS — "SHOP BY COLLECTIONS" card headings
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Wix responsive system inflates collection card headings to ~66px.
+   Force readable size with high specificity via [id$=] suffix match. */
+[id$="ly76uqq8"] .wixui-rich-text h3,
+[id$="ly76uqq8"] h3.font_3,
+[id$="ly76uqq8"] .wixui-rich-text__text {
+  font-size: 20px !important;
+  line-height: 1.3 !important;
+  font-weight: 600 !important;
+  color: var(--cf-white) !important;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.5) !important;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════
    7. HOMEPAGE GALLERIES — "NEW IN" and "BEST SELLERS"
    ═══════════════════════════════════════════════════════════════════════ */
 


### PR DESCRIPTION
## Summary
- SHOP BY COLLECTIONS h3 headings rendered at ~66px (Wix responsive inflation), causing text overflow and overlap with card images
- Added targeted CSS with `[id$=]` suffix match to force `20px` readable size
- White text with text-shadow for contrast against card images

## Before
Collection card text ("FUTON FRAMES", "MURPHY CABINET BEDS") wraps vertically in a narrow column, overlapping images.

## After
Clean 20px headings readable over card images.

## Test plan
- [ ] Verify on live site after CSS push to stage3-velo
- [ ] Check mobile breakpoint rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)