### PR TITLE
fix: WCAG AA contrast — swap cf-blue text to cf-blue-dark + focus-visible (hq-lw2i)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,7 +134,7 @@ h4.font_4,
 }
 
 .horizontal-menu__item-label:hover {
-  color: var(--cf-blue) !important;
+  color: var(--cf-blue-dark) !important;
 }
 
 .vertical-menu__item-label {
@@ -244,7 +244,7 @@ h4.font_4,
 [data-hook="sr-product-item-price-to-pay"] {
   font-size: 15px !important;
   font-weight: 700 !important;
-  color: var(--cf-blue) !important;
+  color: var(--cf-blue-dark) !important;
 }
 
 [data-hook="product-item-product-details"] {
@@ -314,7 +314,7 @@ h4.font_4,
 [data-hook="formatted-primary-price"] {
   font-size: 24px !important;
   font-weight: 700 !important;
-  color: var(--cf-blue) !important;
+  color: var(--cf-blue-dark) !important;
 }
 
 [data-hook="product-description"] {
@@ -486,6 +486,16 @@ h4.font_4,
 
 
 /* ═══════════════════════════════════════════════════════════════════════
+   9b. FOCUS INDICATORS — WCAG 2.1 AA keyboard accessibility
+   ═══════════════════════════════════════════════════════════════════════ */
+
+*:focus-visible {
+  outline: 3px solid var(--cf-blue-dark) !important;
+  outline-offset: 2px !important;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════
    10. BLOG PAGE
    ═══════════════════════════════════════════════════════════════════════ */
 
@@ -510,7 +520,7 @@ h4.font_4,
 [data-hook="read-more-link"] {
   font-size: 14px !important;
   font-weight: 600 !important;
-  color: var(--cf-blue) !important;
+  color: var(--cf-blue-dark) !important;
 }
 
 
@@ -660,7 +670,7 @@ h4.font_4,
 /* Links */
 .rich-text a,
 .rich-text__text a {
-  color: var(--cf-blue) !important;
+  color: var(--cf-blue-dark) !important;
 }
 
 .rich-text a:hover {

--- a/tests/wcagContrastFix.test.js
+++ b/tests/wcagContrastFix.test.js
@@ -1,0 +1,121 @@
+/**
+ * @file wcagContrastFix.test.js
+ * @description TDD tests for hq-lw2i: WCAG AA contrast fix.
+ *
+ * Verifies:
+ * 1. CSS text/link uses of --cf-blue are replaced with --cf-blue-dark for contrast
+ * 2. Global focus-visible CSS rule exists
+ * 3. Design token mountainBlue is not used for normal-size text on white/light backgrounds
+ *
+ * WCAG AA requirements:
+ * - Normal text (< 18px or < 14px bold): 4.5:1 contrast ratio
+ * - Large text (>= 18px or >= 14px bold): 3:1 contrast ratio
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+// ── Contrast ratio calculator ────────────────────────────────────────
+
+function sRGBtoLinear(c) {
+  c = c / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function luminance(hex) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return 0.2126 * sRGBtoLinear(r) + 0.7152 * sRGBtoLinear(g) + 0.0722 * sRGBtoLinear(b);
+}
+
+function contrastRatio(hex1, hex2) {
+  const l1 = luminance(hex1);
+  const l2 = luminance(hex2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// ── CSS color token values (from :root in global.css) ────────────────
+
+const CF_BLUE = '#5B8FA8';
+const CF_BLUE_DARK = '#3D6B80';
+const CF_WHITE = '#FFFFFF';
+const CF_GRAY_LIGHT = '#F0F4F8';
+
+// ── 1. Token contrast verification ──────────────────────────────────
+
+describe('WCAG AA: cf-blue-dark passes for normal text', () => {
+  it('cf-blue-dark on white passes AA normal text (4.5:1)', () => {
+    const ratio = contrastRatio(CF_BLUE_DARK, CF_WHITE);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('cf-blue-dark on gray-light passes AA normal text (4.5:1)', () => {
+    const ratio = contrastRatio(CF_BLUE_DARK, CF_GRAY_LIGHT);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('cf-blue (#5B8FA8) fails AA normal text on white — this is why we fix it', () => {
+    const ratio = contrastRatio(CF_BLUE, CF_WHITE);
+    expect(ratio).toBeLessThan(4.5);
+  });
+
+  it('cf-blue (#5B8FA8) fails AA normal text on gray-light', () => {
+    const ratio = contrastRatio(CF_BLUE, CF_GRAY_LIGHT);
+    expect(ratio).toBeLessThan(4.5);
+  });
+});
+
+// ── 2. CSS audit: text/link color uses cf-blue-dark, not cf-blue ────
+
+describe('WCAG AA: global.css text/link colors use --cf-blue-dark', () => {
+  const css = readFileSync('src/styles/global.css', 'utf-8');
+
+  // These are CSS rules where color (not background-color) was set to var(--cf-blue).
+  // After the fix, they should use var(--cf-blue-dark) instead.
+  const textColorRules = [
+    { desc: 'nav hover link color', pattern: /\.horizontal-menu__item-label:hover[\s\S]*?color:\s*var\(--cf-blue-dark\)/m },
+    { desc: 'product item price color', pattern: /\[data-hook="product-item-price-to-pay"\][\s\S]*?color:\s*var\(--cf-blue-dark\)/m },
+    { desc: 'product page price color', pattern: /\[data-hook="product-price"\][\s\S]*?color:\s*var\(--cf-blue-dark\)/m },
+    { desc: 'blog read-more link color', pattern: /\[data-hook="read-more-link"\][\s\S]*?color:\s*var\(--cf-blue-dark\)/m },
+    { desc: 'rich-text link color', pattern: /\.rich-text a[\s\S]*?color:\s*var\(--cf-blue-dark\)/m },
+  ];
+
+  for (const { desc, pattern } of textColorRules) {
+    it(`${desc} uses var(--cf-blue-dark)`, () => {
+      expect(css).toMatch(pattern);
+    });
+  }
+
+  // Verify no text color rules still use var(--cf-blue) (excluding background-color and hover bg)
+  it('no text "color: var(--cf-blue)" remains in CSS (excluding background-color)', () => {
+    // Extract all lines with "color: var(--cf-blue)" that are NOT "background-color:"
+    const lines = css.split('\n');
+    const textColorBlueLines = lines.filter(line => {
+      const trimmed = line.trim();
+      return trimmed.match(/^color:\s*var\(--cf-blue\)/) && !trimmed.startsWith('background-color');
+    });
+    expect(textColorBlueLines).toEqual([]);
+  });
+});
+
+// ── 3. CSS audit: focus-visible rule exists ─────────────────────────
+
+describe('WCAG AA: global.css includes focus-visible styles', () => {
+  const css = readFileSync('src/styles/global.css', 'utf-8');
+
+  it('has a :focus-visible rule', () => {
+    expect(css).toMatch(/:focus-visible/);
+  });
+
+  it('focus-visible rule includes outline property', () => {
+    // Match a :focus-visible block that contains an outline declaration
+    expect(css).toMatch(/:focus-visible[\s\S]*?outline.*:/m);
+  });
+
+  it('focus-visible rule uses brand color (--cf-blue or --cf-blue-dark)', () => {
+    expect(css).toMatch(/:focus-visible[\s\S]*?var\(--cf-blue(?:-dark)?\)/m);
+  });
+});


### PR DESCRIPTION
## Summary
- Swap 5 text/link `color: var(--cf-blue)` rules to `var(--cf-blue-dark)` in global.css for WCAG AA compliance
- Add global `*:focus-visible` outline rule for keyboard accessibility
- 13 new TDD tests verifying contrast ratios and CSS rules

## Contrast Ratios (Before → After)

| Element | Before | After | WCAG AA |
|---------|--------|-------|---------|
| Prices on white | 3.54:1 FAIL | 5.81:1 PASS | 4.5:1 required |
| Links on white | 3.54:1 FAIL | 5.81:1 PASS | 4.5:1 required |
| Links on gray-light | 3.20:1 FAIL | 5.27:1 PASS | 4.5:1 required |

## What Changed
- Nav hover link color (line 137)
- Product grid price color (line 247)
- Product page price color (line 317)
- Blog "read more" link color (line 520)
- Rich-text link color (line 670)
- NEW: focus-visible rule (section 9b)

## What Was NOT Changed
- Button backgrounds (add-to-cart, checkout, submit) — separate phase
- Design tokens in sharedTokens.js
- SVG illustrations (decorative)

## Test plan
- [x] 13 new TDD tests in tests/wcagContrastFix.test.js
- [x] Full suite: 13,393 tests pass (352 files), 0 regressions
- [ ] Visual verification: prices, links, nav hover use darker blue
- [ ] Keyboard tab through page: focus rings visible on all interactive elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)