### PR TITLE
fix: WCAG touch targets + prefers-reduced-motion + min font size (hq-hnzj)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -393,7 +393,7 @@ h4.font_4,
 
 [data-hook="product-item-ribbon"],
 [class*="ribbon"] {
-  font-size: 11px !important;
+  font-size: 12px !important;
   font-weight: 600 !important;
 }
 
@@ -861,6 +861,61 @@ h4.font_4,
     padding: 12px 16px !important;
   }
 
+  /* Nav links — 44px touch target */
+  .horizontal-menu__item-label {
+    min-height: 44px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+  }
+
+  /* Footer links — 44px touch target */
+  .footer a {
+    min-height: 44px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+  }
+
+  /* Filter options — 44px touch target */
+  [data-hook="filter-title"],
+  [data-hook="filter-full-title"] {
+    min-height: 44px !important;
+    display: flex !important;
+    align-items: center !important;
+  }
+
+  /* Sort dropdown — 44px touch target */
+  [data-hook="sort-floating-dropdown"] {
+    min-height: 44px !important;
+  }
+
+  /* Cart icon — 44px touch target */
+  [data-hook="cart-icon-button"] {
+    min-height: 44px !important;
+    min-width: 44px !important;
+  }
+
+  /* Search button — 44px touch target */
+  .search-button__label {
+    min-height: 44px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+  }
+
+  /* Breadcrumb links — 44px touch target */
+  [data-hook="extended-gallery-breadcrumbs"] a,
+  [data-hook="extended-gallery-breadcrumbs"] {
+    min-height: 44px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+  }
+
+  /* Mobile menu links — 44px touch target */
+  .mobile-menu a {
+    min-height: 44px !important;
+    display: flex !important;
+    align-items: center !important;
+  }
+
   /* Cart page — compact text for narrow screens */
   [data-hook="cart-widget-item-name"],
   [data-hook="CartItemDataHook.Name"],
@@ -947,5 +1002,22 @@ h4.font_4,
 
   [data-hook="ricos-viewer"] h3 {
     font-size: 16px !important;
+  }
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════
+   20. REDUCED MOTION — respect user preference (WCAG 2.3.3)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/tests/wcagTouchMotion.test.js
+++ b/tests/wcagTouchMotion.test.js
@@ -1,0 +1,113 @@
+/**
+ * @file wcagTouchMotion.test.js
+ * @description TDD tests for hq-hnzj: 44px touch targets + prefers-reduced-motion.
+ *
+ * Verifies:
+ * 1. All interactive elements at 480px have min-height: 44px (WCAG 2.5.5 AAA / 2.5.8 AA)
+ * 2. A prefers-reduced-motion media query exists to disable/reduce animations
+ * 3. Minimum font sizes are enforced (no sub-12px text)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+const css = readFileSync('src/styles/global.css', 'utf-8');
+
+// Extract the @media (max-width: 480px) block for touch target checks
+function extractMobileBlock(cssText) {
+  const marker = '@media (max-width: 480px)';
+  const idx = cssText.indexOf(marker);
+  if (idx === -1) return '';
+  // Find the matching closing brace
+  let depth = 0;
+  let start = -1;
+  for (let i = idx; i < cssText.length; i++) {
+    if (cssText[i] === '{') {
+      if (start === -1) start = i;
+      depth++;
+    } else if (cssText[i] === '}') {
+      depth--;
+      if (depth === 0) return cssText.slice(start + 1, i);
+    }
+  }
+  return '';
+}
+
+const mobileBlock = extractMobileBlock(css);
+
+// ── 1. Touch targets at 480px ───────────────────────────────────────
+
+describe('WCAG: 44px touch targets at mobile breakpoint (480px)', () => {
+  it('has a @media (max-width: 480px) block', () => {
+    expect(mobileBlock.length).toBeGreaterThan(0);
+  });
+
+  const touchTargetSelectors = [
+    { desc: 'nav links', pattern: /\.horizontal-menu__item-label[\s\S]*?min-height:\s*44px/ },
+    { desc: 'footer links', pattern: /\.footer\s+a[\s\S]*?min-height:\s*44px/ },
+    { desc: 'filter options', pattern: /\[data-hook="filter-(?:title|full-title)"\][\s\S]*?min-height:\s*44px/ },
+    { desc: 'sort dropdown', pattern: /\[data-hook="sort-floating-dropdown"\][\s\S]*?min-height:\s*44px/ },
+    { desc: 'cart icon', pattern: /\[data-hook="cart-icon-button"\][\s\S]*?min-height:\s*44px/ },
+    { desc: 'search button', pattern: /\.search-button[\s\S]*?min-height:\s*44px/ },
+    { desc: 'breadcrumb links', pattern: /\[data-hook="extended-gallery-breadcrumbs"\][\s\S]*?min-height:\s*44px/ },
+    { desc: 'mobile menu links', pattern: /\.mobile-menu\s+a[\s\S]*?min-height:\s*44px/ },
+  ];
+
+  for (const { desc, pattern } of touchTargetSelectors) {
+    it(`${desc} have min-height: 44px`, () => {
+      expect(mobileBlock).toMatch(pattern);
+    });
+  }
+
+  // Verify existing touch targets still present
+  it('primary action buttons still have min-height: 44px', () => {
+    expect(mobileBlock).toMatch(/\[data-hook="add-to-cart"\][\s\S]*?min-height:\s*44px/);
+  });
+});
+
+// ── 2. prefers-reduced-motion ───────────────────────────────────────
+
+describe('WCAG: prefers-reduced-motion media query', () => {
+  it('has a @media (prefers-reduced-motion: reduce) block', () => {
+    expect(css).toMatch(/@media\s*\(\s*prefers-reduced-motion:\s*reduce\s*\)/);
+  });
+
+  it('reduces or disables transitions', () => {
+    const motionBlock = extractReducedMotionBlock(css);
+    expect(motionBlock).toMatch(/transition.*(?:none|0s)/i);
+  });
+
+  it('reduces or disables animations', () => {
+    const motionBlock = extractReducedMotionBlock(css);
+    expect(motionBlock).toMatch(/animation.*(?:none|0s)/i);
+  });
+});
+
+function extractReducedMotionBlock(cssText) {
+  const marker = 'prefers-reduced-motion';
+  const idx = cssText.indexOf(marker);
+  if (idx === -1) return '';
+  let depth = 0;
+  let start = -1;
+  for (let i = idx; i < cssText.length; i++) {
+    if (cssText[i] === '{') {
+      if (start === -1) start = i;
+      depth++;
+    } else if (cssText[i] === '}') {
+      depth--;
+      if (depth === 0) return cssText.slice(start + 1, i);
+    }
+  }
+  return '';
+}
+
+// ── 3. Minimum font sizes ───────────────────────────────────────────
+
+describe('WCAG: minimum font sizes (no sub-12px interactive text)', () => {
+  it('product ribbon font is at least 12px', () => {
+    // [data-hook="product-item-ribbon"] should be >= 12px
+    const ribbonMatch = css.match(/\[data-hook="product-item-ribbon"\][\s\S]*?font-size:\s*(\d+)px/);
+    expect(ribbonMatch).not.toBeNull();
+    expect(parseInt(ribbonMatch[1], 10)).toBeGreaterThanOrEqual(12);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 44px min-height touch targets for 8 interactive element types at 480px breakpoint
- Add `@media (prefers-reduced-motion: reduce)` to disable all animations/transitions
- Bump product ribbon font from 11px to 12px minimum

## Touch Targets Added (480px)

| Element | Selector | Change |
|---------|----------|--------|
| Nav links | `.horizontal-menu__item-label` | min-height: 44px |
| Footer links | `.footer a` | min-height: 44px |
| Filter options | `[data-hook="filter-title/full-title"]` | min-height: 44px |
| Sort dropdown | `[data-hook="sort-floating-dropdown"]` | min-height: 44px |
| Cart icon | `[data-hook="cart-icon-button"]` | min-height + min-width: 44px |
| Search button | `.search-button__label` | min-height: 44px |
| Breadcrumbs | `[data-hook="extended-gallery-breadcrumbs"]` | min-height: 44px |
| Mobile menu | `.mobile-menu a` | min-height: 44px |

## Reduced Motion
```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0s !important;
    transition-duration: 0s !important;
    scroll-behavior: auto !important;
  }
}
```

## Test plan
- [x] 14 new TDD tests in `tests/wcagTouchMotion.test.js`
- [x] Full suite: 13,407 tests pass (353 files), 0 regressions
- [ ] Mobile viewport (480px): verify all interactive elements have adequate tap area
- [ ] Enable "Reduce motion" in OS settings: verify no animations play

🤖 Generated with [Claude Code](https://claude.com/claude-code)