### PR TITLE
docs: v0.7.0 release notes

### DIFF
--- a/docs/releases/RELEASE-v0.7.0.md
+++ b/docs/releases/RELEASE-v0.7.0.md
@@ -1,0 +1,44 @@
+# Release v0.7.0
+
+**Date:** 2026-03-14
+**Since:** v0.6.0 (2026-03-14)
+**PRs merged:** 4
+
+## Highlights
+
+- WCAG AA contrast fix: cf-blue (#5B8FA8) swapped to cf-blue-dark (#3D6B80) for all text uses — passes 5.81:1 ratio (hq-lw2i)
+- Accessibility: 44px touch targets at mobile breakpoint, prefers-reduced-motion support, 14px min font (hq-hnzj)
+- Performance: critical/deferred section splits for LCP, removed blocking masterPage schema await (hq-r3ie)
+- Product Page polish: empty catches replaced with console.warn for debuggability (hq-nrf3)
+- Test suite: 354 files, 13,426 tests passing (up from 13,380)
+
+---
+
+## Fixes (3)
+
+| PR | Title |
+|----|-------|
+| #336 | WCAG AA contrast — swap cf-blue text to cf-blue-dark + focus-visible (hq-lw2i) |
+| #337 | Product Page polish — replace empty catches with console.warn (hq-nrf3) |
+| #339 | WCAG touch targets + prefers-reduced-motion + min font size (hq-hnzj) |
+
+## Performance (1)
+
+| PR | Title |
+|----|-------|
+| #338 | Optimize critical/deferred section splits and remove blocking await (hq-r3ie) |
+
+---
+
+## Stats
+
+| Metric | v0.6.0 | v0.7.0 |
+|--------|--------|--------|
+| Test files | 351 | 354 |
+| Tests | 13,380 | 13,426 |
+| PRs | 25 | 4 |
+
+## Contributors
+
+- Dallas crew (bishop, burke, ripley, hicks) — accessibility, performance, polish
+- miquella — coordination, release management


### PR DESCRIPTION
## Summary
- Add v0.7.0 release notes covering 4 PRs since v0.6.0
- WCAG AA contrast, touch targets, prefers-reduced-motion, performance, Product Page polish
- 13,426 tests passing (354 files)

## Test plan
- [x] All 13,426 tests passing on main
- [ ] Merge this PR, then tag v0.7.0 and create GitHub Release
- [ ] Sync to prod repo (stage3-velo) with clean release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)