### PR TITLE
fix(hq-r3ie): add error logging for schema injection

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -60,7 +60,7 @@ $w.onReady(async function () {
   injectCanonicalUrl();
   initScrollDepthTracking();
   deferInit(() => import('public/tikTokPixel').then(m => m.initTikTokPixel()));
-  injectBusinessSchema();
+  injectBusinessSchema().catch(e => console.warn('[masterPage] Schema injection failed:', e.message));
 
   // Live chat widget — async loaded, 2s delay to avoid impacting page speed
   setTimeout(() => {
@@ -397,7 +397,7 @@ async function injectBusinessSchema() {
       $w('#businessSchemaHtml').postMessage(schema);
     }
   } catch (e) {
-    // Schema injection is non-critical
+    console.warn('[masterPage] BusinessSchema injection failed:', e.message);
   }
 
   // WebSite schema with SearchAction for sitelinks searchbox eligibility
@@ -407,7 +407,7 @@ async function injectBusinessSchema() {
       $w('#websiteSchemaHtml').postMessage(websiteSchema);
     }
   } catch (e) {
-    // WebSite schema is non-critical
+    console.warn('[masterPage] WebSiteSchema injection failed:', e.message);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace empty catch blocks in `injectBusinessSchema()` with `console.warn` so SEO schema failures are visible in dev tools
- Add `.catch()` at the call site to prevent unhandled promise rejection (function is now fire-and-forget per PR #338)

## Context
Bishop flagged the empty catch blocks during PR #338 review. This follow-up addresses that feedback.

## Test plan
- [x] masterPage.test.js and performanceFixes.test.js passing
- [x] No functional changes — logging only

🤖 Generated with [Claude Code](https://claude.com/claude-code)