### PR TITLE
refactor: extract http-functions helpers + 28 tests

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -12,74 +12,7 @@ import wixData from 'wix-data';
 import { colors } from 'public/sharedTokens';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { getEnhancedCatalogFields, exportCustomerAudienceData } from 'backend/facebookCatalog.web';
-
-// ── Security Helpers ──────────────────────────────────────────────────
-
-/**
- * Constant-time string comparison to prevent timing attacks on secret keys.
- * @param {string} a
- * @param {string} b
- * @returns {boolean}
- */
-function timingSafeEqual(a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string') return false;
-  if (a.length !== b.length) return false;
-  let result = 0;
-  for (let i = 0; i < a.length; i++) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return result === 0;
-}
-
-/**
- * Decode HTML entities to prevent entity-encoded XSS in feed outputs.
- * Handles numeric (&#60;), hex (&#x3c;), and named (&lt;) entities.
- * @param {string} str
- * @returns {string}
- */
-function decodeHtmlEntities(str) {
-  if (!str) return '';
-  return str
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(dec))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#039;|&apos;/g, "'");
-}
-
-/**
- * Strip HTML tags AND decode entities, then remove any remaining tags
- * that were hidden inside entities. Safe for feed text fields.
- * @param {string} html
- * @returns {string}
- */
-function stripHtmlSafe(html) {
-  if (!html) return '';
-  // First pass: strip visible tags
-  let text = html.replace(/<[^>]*>/g, '');
-  // Decode entities that may contain hidden markup
-  text = decodeHtmlEntities(text);
-  // Second pass: strip any tags that were entity-encoded
-  text = text.replace(/<[^>]*>/g, '');
-  return text;
-}
-
-/**
- * Escape special XML characters for safe inclusion in XML documents.
- * @param {string} str
- * @returns {string}
- */
-function escapeXml(str) {
-  if (!str) return '';
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
+import { timingSafeEqual, decodeHtmlEntities, stripHtmlSafe, escapeXml } from 'backend/utils/httpHelpers';
 
 /**
  * Fetch all products from the Stores/Products collection, paginating

--- a/src/backend/utils/httpHelpers.js
+++ b/src/backend/utils/httpHelpers.js
@@ -1,0 +1,71 @@
+/**
+ * @module httpHelpers
+ * Pure utility functions for HTTP function security and data sanitization.
+ * Extracted from http-functions.js for testability.
+ */
+
+/**
+ * Constant-time string comparison to prevent timing attacks on secret keys.
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+export function timingSafeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+/**
+ * Decode HTML entities to prevent entity-encoded XSS in feed outputs.
+ * Handles numeric (&#60;), hex (&#x3c;), and named (&lt;) entities.
+ * @param {string} str
+ * @returns {string}
+ */
+export function decodeHtmlEntities(str) {
+  if (!str) return '';
+  return str
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(dec))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;|&apos;/g, "'");
+}
+
+/**
+ * Strip HTML tags AND decode entities, then remove any remaining tags
+ * that were hidden inside entities. Safe for feed text fields.
+ * @param {string} html
+ * @returns {string}
+ */
+export function stripHtmlSafe(html) {
+  if (!html) return '';
+  // First pass: strip visible tags
+  let text = html.replace(/<[^>]*>/g, '');
+  // Decode entities that may contain hidden markup
+  text = decodeHtmlEntities(text);
+  // Second pass: strip any tags that were entity-encoded
+  text = text.replace(/<[^>]*>/g, '');
+  return text;
+}
+
+/**
+ * Escape special XML characters for safe inclusion in XML documents.
+ * @param {string} str
+ * @returns {string}
+ */
+export function escapeXml(str) {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/tests/httpHelpers.test.js
+++ b/tests/httpHelpers.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  timingSafeEqual,
+  decodeHtmlEntities,
+  stripHtmlSafe,
+  escapeXml,
+} from '../src/backend/utils/httpHelpers.js';
+
+// ── timingSafeEqual ─────────────────────────────────────────────────
+
+describe('timingSafeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeEqual('secret123', 'secret123')).toBe(true);
+  });
+
+  it('returns false for different strings of same length', () => {
+    expect(timingSafeEqual('secret123', 'secret124')).toBe(false);
+  });
+
+  it('returns false for different length strings', () => {
+    expect(timingSafeEqual('short', 'longer-string')).toBe(false);
+  });
+
+  it('returns false for empty vs non-empty', () => {
+    expect(timingSafeEqual('', 'notempty')).toBe(false);
+  });
+
+  it('returns true for both empty', () => {
+    expect(timingSafeEqual('', '')).toBe(true);
+  });
+
+  it('returns false for non-string inputs', () => {
+    expect(timingSafeEqual(null, 'test')).toBe(false);
+    expect(timingSafeEqual('test', undefined)).toBe(false);
+    expect(timingSafeEqual(123, 123)).toBe(false);
+    expect(timingSafeEqual(null, null)).toBe(false);
+  });
+
+  it('handles unicode strings', () => {
+    expect(timingSafeEqual('café', 'café')).toBe(true);
+    expect(timingSafeEqual('café', 'cafe')).toBe(false);
+  });
+});
+
+// ── decodeHtmlEntities ──────────────────────────────────────────────
+
+describe('decodeHtmlEntities', () => {
+  it('decodes numeric entities', () => {
+    expect(decodeHtmlEntities('&#60;script&#62;')).toBe('<script>');
+  });
+
+  it('decodes hex entities', () => {
+    expect(decodeHtmlEntities('&#x3c;script&#x3e;')).toBe('<script>');
+  });
+
+  it('decodes named entities', () => {
+    expect(decodeHtmlEntities('&lt;div&gt;&amp;&quot;&apos;')).toBe('<div>&"\'');
+  });
+
+  it('decodes &#039; apostrophe variant', () => {
+    expect(decodeHtmlEntities("it&#039;s")).toBe("it's");
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(decodeHtmlEntities('')).toBe('');
+    expect(decodeHtmlEntities(null)).toBe('');
+    expect(decodeHtmlEntities(undefined)).toBe('');
+  });
+
+  it('passes through plain text unchanged', () => {
+    expect(decodeHtmlEntities('Hello World')).toBe('Hello World');
+  });
+
+  it('handles mixed entities and plain text', () => {
+    expect(decodeHtmlEntities('Price: &lt;$500 &amp; free shipping')).toBe('Price: <$500 & free shipping');
+  });
+});
+
+// ── stripHtmlSafe ───────────────────────────────────────────────────
+
+describe('stripHtmlSafe', () => {
+  it('strips simple HTML tags', () => {
+    expect(stripHtmlSafe('<p>Hello</p>')).toBe('Hello');
+  });
+
+  it('strips nested tags', () => {
+    expect(stripHtmlSafe('<div><b>Bold</b> text</div>')).toBe('Bold text');
+  });
+
+  it('strips entity-encoded tags (double-encoded XSS defense)', () => {
+    expect(stripHtmlSafe('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe('alert(1)');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(stripHtmlSafe('')).toBe('');
+    expect(stripHtmlSafe(null)).toBe('');
+    expect(stripHtmlSafe(undefined)).toBe('');
+  });
+
+  it('handles mixed content', () => {
+    const input = '<p>Solid hardwood &amp; certified foam</p>';
+    expect(stripHtmlSafe(input)).toBe('Solid hardwood & certified foam');
+  });
+
+  it('handles self-closing tags', () => {
+    expect(stripHtmlSafe('Line 1<br/>Line 2')).toBe('Line 1Line 2');
+  });
+});
+
+// ── escapeXml ───────────────────────────────────────────────────────
+
+describe('escapeXml', () => {
+  it('escapes ampersand', () => {
+    expect(escapeXml('A & B')).toBe('A &amp; B');
+  });
+
+  it('escapes angle brackets', () => {
+    expect(escapeXml('<tag>')).toBe('&lt;tag&gt;');
+  });
+
+  it('escapes quotes', () => {
+    expect(escapeXml('He said "hello"')).toBe('He said &quot;hello&quot;');
+  });
+
+  it('escapes apostrophes', () => {
+    expect(escapeXml("it's")).toBe("it&apos;s");
+  });
+
+  it('escapes all special chars together', () => {
+    expect(escapeXml('<a href="url">A & B\'s</a>')).toBe(
+      '&lt;a href=&quot;url&quot;&gt;A &amp; B&apos;s&lt;/a&gt;'
+    );
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(escapeXml('')).toBe('');
+    expect(escapeXml(null)).toBe('');
+    expect(escapeXml(undefined)).toBe('');
+  });
+
+  it('passes through safe text unchanged', () => {
+    expect(escapeXml('Hello World 123')).toBe('Hello World 123');
+  });
+
+  it('handles product descriptions with special chars', () => {
+    expect(escapeXml('8" Futon Mattress — Full & Queen')).toBe(
+      '8&quot; Futon Mattress — Full &amp; Queen'
+    );
+  });
+});

--- a/tests/securityPiiGdpr.test.js
+++ b/tests/securityPiiGdpr.test.js
@@ -19,6 +19,7 @@ const FB_CATALOG = join(BACKEND_DIR, 'facebookCatalog.web.js');
 const RETURNS_SERVICE = join(BACKEND_DIR, 'returnsService.web.js');
 const SANITIZE = join(BACKEND_DIR, 'utils', 'sanitize.js');
 const EMAIL_AUTOMATION = join(BACKEND_DIR, 'emailAutomation.web.js');
+const HTTP_HELPERS = join(BACKEND_DIR, 'utils', 'httpHelpers.js');
 
 function readFile(path) {
   return readFileSync(path, 'utf-8');
@@ -75,11 +76,17 @@ describe('Security: timingSafeEqual implementation', () => {
   });
 
   it('source code uses XOR-based constant-time comparison', () => {
-    const src = readFile(HTTP_FUNCTIONS);
+    const src = readFile(HTTP_HELPERS);
     // Must use XOR (^) for constant-time comparison
     expect(src).toMatch(/charCodeAt\(i\)\s*\^\s*\w+\.charCodeAt\(i\)/);
     // Must use OR (|) to accumulate differences
     expect(src).toMatch(/result\s*\|=\s*/);
+  });
+
+  it('http-functions imports timingSafeEqual from httpHelpers', () => {
+    const src = readFile(HTTP_FUNCTIONS);
+    expect(src).toContain("import { timingSafeEqual");
+    expect(src).toContain("from 'backend/utils/httpHelpers'");
   });
 });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -84,6 +84,7 @@ export default defineConfig({
       'backend/utils/mediaHelpers': path.resolve(__dirname, 'src/backend/utils/mediaHelpers.js'),
       'backend/utils/errorHandler': path.resolve(__dirname, 'src/backend/utils/errorHandler.js'),
       'backend/utils/safeParse': path.resolve(__dirname, 'src/backend/utils/safeParse.js'),
+      'backend/utils/httpHelpers': path.resolve(__dirname, 'src/backend/utils/httpHelpers.js'),
       'backend/assemblyGuides.web': path.resolve(__dirname, 'src/backend/assemblyGuides.web.js'),
       'backend/errorMonitoring.web': path.resolve(__dirname, 'src/backend/errorMonitoring.web.js'),
       'backend/liveChat.web': path.resolve(__dirname, 'src/backend/liveChat.web.js'),


### PR DESCRIPTION
## Summary
- Extract `timingSafeEqual`, `decodeHtmlEntities`, `stripHtmlSafe`, `escapeXml` from `http-functions.js` into `backend/utils/httpHelpers.js`
- Add 28 dedicated tests covering all edge cases (timing attacks, entity-encoded XSS, XML escaping)
- Update `securityPiiGdpr.test.js` to verify extraction and import chain
- Add vitest alias for new module

## Test plan
- [x] All 13,455 tests passing (355 files, +29 new tests)
- [x] Security PII/GDPR tests pass with updated source assertions
- [x] httpHelpers tests cover: nulls, unicode, XSS vectors, entity encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)