### PR TITLE
fix: sanitize secret key names from error logs

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -172,7 +172,7 @@ export const triggerWelcomeSequence = webMethod(
       if (existing.items.length > 0) return { success: false, queued: 0 };
 
       let discountCode = '';
-      try { discountCode = await getSecret('WELCOME_DISCOUNT_CODE'); } catch (e) { console.error('[emailAutomation] Failed to retrieve WELCOME_DISCOUNT_CODE:', e.message); }
+      try { discountCode = await getSecret('WELCOME_DISCOUNT_CODE'); } catch (e) { console.error('[emailAutomation] Failed to load welcome discount:', e.message); }
 
       const abVariant = selectABVariant();
       const abData = SEQUENCES.welcome.abVariants[abVariant] || {};
@@ -309,7 +309,7 @@ export const triggerAbandonedCartRecovery = webMethod(
 
       let cartsProcessed = 0;
       let discountCode = '';
-      try { discountCode = await getSecret('RECOVERY_DISCOUNT_CODE'); } catch (e) { console.error('[emailAutomation] Failed to retrieve RECOVERY_DISCOUNT_CODE for cart recovery:', e.message); }
+      try { discountCode = await getSecret('RECOVERY_DISCOUNT_CODE'); } catch (e) { console.error('[emailAutomation] Failed to load cart recovery discount:', e.message); }
 
       for (const cart of result.items) {
         if (!cart.buyerEmail || !validateEmail(cart.buyerEmail)) continue;
@@ -410,7 +410,7 @@ export const triggerReengagement = webMethod(
         if (alreadySent.items.length > 0) continue;
 
         let discountCode = '';
-        try { discountCode = await getSecret('RECOVERY_DISCOUNT_CODE'); } catch (e) { console.error('[emailAutomation] Failed to retrieve RECOVERY_DISCOUNT_CODE for reengagement:', e.message); }
+        try { discountCode = await getSecret('RECOVERY_DISCOUNT_CODE'); } catch (e) { console.error('[emailAutomation] Failed to load reengagement discount:', e.message); }
 
         await queueEmail({
           templateId: SEQUENCES.reengagement.steps[0].templateId,


### PR DESCRIPTION
## Summary
- Remove explicit secret key names (WELCOME_DISCOUNT_CODE, RECOVERY_DISCOUNT_CODE) from console.error messages in emailAutomation.web.js
- Prevents metadata leakage of secret names in backend logs
- Found during routine security audit (Stilgar standing order)
- Replaces PR #343 (which accidentally included release notes)

## Test plan
- [x] All 13,426 tests passing
- [x] No behavioral change — only log message text updated
- [x] 5-agent review completed on original PR #343 — no blockers found

🤖 Generated with [Claude Code](https://claude.com/claude-code)