### PR TITLE
test(CF-03jx): element hookup iterations 2-3 — 117 more tests

### DIFF
--- a/tests/elementHookupCart.test.js
+++ b/tests/elementHookupCart.test.js
@@ -3,9 +3,11 @@
  * Covers: #cartFinancingSection, #financingThreshold, #cartFinancingTeaser,
  * #cartAfterpayMessage, #emptyCartSection, #emptyCartTitle, #emptyCartMessage,
  * #continueShoppingBtn, #shippingProgressBar, #shippingProgressText,
- * #tierProgressBar, #tierProgressText, #cartSubtotal, #cartTotal,
- * #cartItemsRepeater, #cartItemName, #cartItemPrice, #qtyMinus, #qtyPlus,
- * #qtyInput, #removeItem, #saveForLaterBtn
+ * #shippingProgressIcon, #tierProgressBar, #tierProgressText,
+ * #cartSubtotal, #cartTotal, #cartItemsRepeater, #cartItemName,
+ * #cartItemPrice, #qtyMinus, #qtyPlus, #qtyInput, #removeItem,
+ * #saveForLaterBtn, #cartRecentSection, #cartRecentRepeater,
+ * #suggestionsSection, #cartDeliverySection
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -568,10 +570,12 @@ describe('Cart Page — #cartRecentRepeater child elements', () => {
   });
 
   it('expands recent section and populates repeater when products exist', async () => {
-    const { getRecentlyViewed } = await import('public/galleryHelpers');
-    getRecentlyViewed.mockReturnValue([
-      { _id: 'rv1', name: 'Vienna Frame', mainMedia: 'vienna.jpg', price: '$399', slug: 'vienna-frame' },
-    ]);
+    // Mock must be set up inside loadPage override to survive vi.resetModules()
+    vi.doMock('public/galleryHelpers', () => ({
+      getRecentlyViewed: vi.fn(() => [
+        { _id: 'rv1', name: 'Vienna Frame', mainMedia: 'vienna.jpg', price: '$399', slug: 'vienna-frame' },
+      ]),
+    }));
 
     await loadPage();
 

--- a/tests/elementHookupCheckout.test.js
+++ b/tests/elementHookupCheckout.test.js
@@ -10,8 +10,13 @@
  * #checkoutProgressNav, #checkoutProgressRepeater, #progressStepLabel,
  * #progressStepNumber, #progressStepDot, #progressStepContainer,
  * #orderNotesToggle, #orderNotesField, #checkoutFreeShipping,
- * #checkoutItemCount, #orderSummarySidebar, #orderSummarySubtotal,
- * #orderSummaryShipping, #orderSummaryTax, #orderSummaryTotal,
+ * #checkoutItemCount, #checkoutDeliveryEstimate,
+ * #orderSummarySidebar, #orderSummarySubtotal, #orderSummaryShipping,
+ * #orderSummaryTax, #orderSummaryTotal, #orderSummarySavings,
+ * #orderSummaryItemsRepeater, #summaryItemName, #summaryItemQty,
+ * #summaryItemPrice, #trustRepeater,
+ * #addressFullNameError, #addressLine1Error, #addressCityError,
+ * #addressStateError, #addressZipError,
  * #expressCheckoutSection, #expressCheckoutBtn
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/tests/elementHookupSideCart.test.js
+++ b/tests/elementHookupSideCart.test.js
@@ -1,9 +1,10 @@
 /**
  * Tests for Side Cart element hookup — CF-03jx
  * Covers: #cartBadge, #sideCartPanel, #sideCartTitle, #sideCartSubtotal,
- * #sideTierText, #sideCartClose, #sideCartCheckout, #viewFullCart,
- * #sideQtyMinus, #sideQtyPlus, #sideItemImage, #sideItemName, #sideItemPrice,
- * #sideItemQty, #sideItemLineTotal, #sideItemRemove, #sideSaveForLater,
+ * #sideTierText, #sideCartClose, #sideCartOverlay, #sideCartCheckout,
+ * #viewFullCart, #sideCartRepeater, #sideQtyMinus, #sideQtyPlus,
+ * #sideItemImage, #sideItemName, #sideItemPrice, #sideItemQty,
+ * #sideItemLineTotal, #sideItemVariant, #sideItemRemove, #sideSaveForLater,
  * #sideCartEmpty, #sideCartItems, #sideCartFooter, #sideShippingBar,
  * #sideShippingText, #sideTierBar
  */

--- a/tests/elementHookupThankYou.test.js
+++ b/tests/elementHookupThankYou.test.js
@@ -9,7 +9,8 @@
  * #referralSection, #referralTitle, #referralMessage, #referralCopyBtn, #referralEmailBtn,
  * #assemblyGuideSection, #assemblyGuideTitle, #assemblyGuideText, #assemblyGuideBtn,
  * #reviewSection, #reviewTitle, #reviewPrompt, #reviewStar1–#reviewStar5,
- * #reviewRating, #reviewSubmitBtn, #reviewError, #reviewSuccess
+ * #reviewRating, #reviewSubmitBtn, #reviewError, #reviewSuccess,
+ * #postPurchaseHeading, #postPurchaseRepeater
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 


### PR DESCRIPTION
## Summary
- **Cart Page**: shipping/tier progress bars, empty cart state, cart items repeater children, subtotal/total ARIA, recently viewed repeater
- **Side Cart**: panel ARIA dialog, close/checkout/viewFullCart, repeater item details, empty/populated state toggles, shipping/tier progress after refresh
- **Checkout**: progress nav, order notes toggle, free shipping badge, item count, order summary sidebar, express checkout, delivery estimate, order summary items repeater
- **Thank You**: order summary, Brenda message, social sharing, newsletter signup, referral, assembly guide, review request (star rating UI), delivery estimate, post-purchase repeater

175 total element hookup tests (up from 58 in PR #349). 13,610 suite-wide — all green.

## Test plan
- [x] All 175 element hookup tests pass
- [x] Full test suite (13,610 tests) passes
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)