### PR TITLE
docs(CF-ltuu): live site image cross-reference

### DIFF
--- a/docs/live-site-crossref.json
+++ b/docs/live-site-crossref.json
@@ -6,9 +6,9 @@
     "totalLiveProducts": 88,
     "totalCatalogProducts": 88,
     "finding": "Live Wix site product images are IDENTICAL to catalog-MASTER.json. No additional photos exist on the live site beyond what the catalog already contains.",
-    "mattressFinding": "All 8 mattress products match exactly. Mattresses remain photo-deficient (avg 1.1 imgs). Mesa 1000/3000/5000 and Pulsar have only 1 image each. New photos must be sourced externally.",
+    "mattressFinding": "All 8 products named 'Mattress' match exactly (listed in mattressComparison). The 'mattresses' catalog category also contains 6 additional futon frames with 1 image each — these are category mismatches, not actual mattresses. All remain photo-deficient. New photos must be sourced externally.",
     "murphyFinding": "All 9 Murphy cabinet beds match exactly (3-14 images each). Murphy beds are well-photographed.",
-    "recommendation": "Photo gaps identified in photo-audit.json (39 products below 3-image minimum, 67 images needed) cannot be filled from the Wix media manager. Need manufacturer photos or new photography."
+    "recommendation": "Photo gaps identified in content/photo-audit.json (39 products below 3-image minimum, 67 images needed) cannot be filled from the Wix media manager. Need manufacturer photos or new photography."
   },
   "mattressComparison": [
     {


### PR DESCRIPTION
## Summary
- Cross-referenced all 88 Wix Stores products via REST API against catalog-MASTER.json
- **Finding: live site images are identical to catalog** — no additional photos in Wix media manager
- Mattress photos confirmed deficient (avg 1.1/product per photo-audit), must source externally
- Murphy cabinet beds well-photographed (3-14 images each, all synced)

## Test plan
- [ ] Verify docs/live-site-crossref.json is valid JSON
- [ ] Cross-check a few mattress/Murphy products against live Wix dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)