### PR TITLE
test: deepen ProductOptions + ups-shipping coverage

### DIFF
--- a/tests/productOptions.test.js
+++ b/tests/productOptions.test.js
@@ -100,6 +100,127 @@ describe('ProductOptions', () => {
       await handleCustomVariantChange($w, state);
       expect(updateStickyPrice).toHaveBeenCalled();
     });
+
+    it('returns early when both size and finish are empty', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockClear();
+      $w('#sizeDropdown').value = '';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect(getProductVariants).not.toHaveBeenCalled();
+    });
+
+    it('queries with only size when finish is empty', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockClear();
+      $w('#sizeDropdown').value = 'Queen';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect(getProductVariants).toHaveBeenCalledWith('prod-1', { Size: 'Queen' });
+    });
+
+    it('does not update display when no variants returned', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      // Price should remain unchanged
+      expect($w('#productPrice').text).toBe('');
+    });
+
+    it('handles API error gracefully', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockRejectedValueOnce(new Error('Network fail'));
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      // Should not throw
+      await expect(handleCustomVariantChange($w, state)).resolves.toBeUndefined();
+    });
+
+    it('shows call-for-price text for $0 products', async () => {
+      state.product = { ...state.product, price: 0 };
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([{
+        variant: { price: 0 }, inStock: true, imageSrc: null, mediaItems: [],
+      }]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#productPrice').text).toBe('Call for Pricing \u2014 (828) 327-8030');
+    });
+
+    it('updates stock badge to In Stock', async () => {
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#stockStatus').text).toBe('In Stock');
+    });
+
+    it('updates stock badge to Special Order when out of stock', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([{
+        variant: { price: 599 }, inStock: false, imageSrc: null, mediaItems: [],
+      }]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#stockStatus').text).toBe('Special Order');
+    });
+
+    it('shows compare price when variant has one', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([{
+        variant: { price: 599, comparePrice: 799 }, inStock: true, imageSrc: null, mediaItems: [],
+      }]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#productComparePrice').text).toBe('$799.00');
+      expect($w('#productComparePrice').show).toHaveBeenCalled();
+    });
+
+    it('hides compare price when variant lacks one', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([{
+        variant: { price: 599 }, inStock: true, imageSrc: null, mediaItems: [],
+      }]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#productComparePrice').hide).toHaveBeenCalled();
+    });
+
+    it('updates main image and alt text on variant with imageSrc', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([{
+        variant: { price: 599 }, inStock: true,
+        imageSrc: 'https://example.com/natural.jpg',
+        label: 'Natural',
+        mediaItems: [],
+      }]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#productMainImage').src).toBe('https://example.com/natural.jpg');
+      expect($w('#productMainImage').alt).toContain('Natural');
+    });
+
+    it('updates gallery items when variant has mediaItems', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValueOnce([{
+        variant: { price: 599 }, inStock: true, imageSrc: null,
+        mediaItems: [
+          { src: 'https://example.com/a.jpg', alt: 'Angle A' },
+          { src: 'https://example.com/b.jpg', alt: 'Angle B' },
+        ],
+      }]);
+      $w('#sizeDropdown').value = 'Full';
+      $w('#finishDropdown').value = '';
+      await handleCustomVariantChange($w, state);
+      expect($w('#productGallery').items).toHaveLength(2);
+      expect($w('#productGallery').items[0].type).toBe('image');
+    });
   });
 
   describe('initSwatchSelector', () => {
@@ -131,6 +252,91 @@ describe('ProductOptions', () => {
       await initSwatchSelector($w, state);
       expect($w('#swatchSection').collapse).toHaveBeenCalled();
     });
+
+    it('collapses swatch section when product is null', async () => {
+      state.product = null;
+      await initSwatchSelector($w, state);
+      expect($w('#swatchSection').collapse).toHaveBeenCalled();
+    });
+
+    it('registers onClick on swatchViewAll button', async () => {
+      await initSwatchSelector($w, state);
+      expect($w('#swatchViewAll').onClick).toHaveBeenCalled();
+    });
+
+    it('registers onClick on swatchRequestLink', async () => {
+      await initSwatchSelector($w, state);
+      expect($w('#swatchRequestLink').onClick).toHaveBeenCalled();
+    });
+
+    it('collapses on backend error', async () => {
+      const { getProductSwatches } = await import('backend/swatchService.web');
+      getProductSwatches.mockRejectedValueOnce(new Error('Backend down'));
+      await initSwatchSelector($w, state);
+      expect($w('#swatchSection').collapse).toHaveBeenCalled();
+    });
+
+    it('sets swatch grid data with _id fallback', async () => {
+      const { getProductSwatches } = await import('backend/swatchService.web');
+      getProductSwatches.mockResolvedValueOnce([
+        { swatchName: 'No ID Swatch', colorHex: '#FF0000' },
+      ]);
+      await initSwatchSelector($w, state);
+      expect($w('#swatchGrid').data[0]._id).toBe('swatch-0');
+    });
+
+    it('renders swatch grid with onItemReady callback', async () => {
+      await initSwatchSelector($w, state);
+      expect($w('#swatchGrid').onItemReady).toHaveBeenCalled();
+      // Simulate onItemReady callback
+      const callback = $w('#swatchGrid').onItemReady.mock.calls[0][0];
+      const $item = create$w();
+      const itemData = { _id: 'sw-1', swatchName: 'Ocean Blue', swatchImage: 'https://example.com/sw1.jpg' };
+      callback($item, itemData);
+      expect($item('#swatchThumb').src).toBe('https://example.com/sw1.jpg');
+      expect($item('#swatchLabel').text).toBe('Ocean Blue');
+    });
+
+    it('renders swatch grid item with colorHex fallback when no image', async () => {
+      await initSwatchSelector($w, state);
+      const callback = $w('#swatchGrid').onItemReady.mock.calls[0][0];
+      const $item = create$w();
+      const itemData = { _id: 'sw-3', swatchName: 'Red', colorHex: '#FF0000' };
+      callback($item, itemData);
+      expect($item('#swatchThumb').style.backgroundColor).toBe('#FF0000');
+    });
+
+    it('highlights selected swatch in grid', async () => {
+      state.selectedSwatchId = 'sw-1';
+      await initSwatchSelector($w, state);
+      const callback = $w('#swatchGrid').onItemReady.mock.calls[0][0];
+      const $item = create$w();
+      callback($item, { _id: 'sw-1', swatchName: 'Ocean Blue', swatchImage: 'https://example.com/sw1.jpg' });
+      expect($item('#swatchThumb').style.borderColor).toBe('#1e3a5f'); // mountainBlue
+      expect($item('#swatchThumb').style.borderWidth).toBe('3px');
+    });
+
+    it('does not highlight unselected swatch in grid', async () => {
+      state.selectedSwatchId = 'sw-1';
+      await initSwatchSelector($w, state);
+      const callback = $w('#swatchGrid').onItemReady.mock.calls[0][0];
+      const $item = create$w();
+      callback($item, { _id: 'sw-2', swatchName: 'Forest Green', swatchImage: 'https://example.com/sw2.jpg' });
+      expect($item('#swatchThumb').style.borderWidth).toBe('1px');
+    });
+
+    it('registers color filter onChange that re-fetches swatches', async () => {
+      await initSwatchSelector($w, state);
+      expect($w('#swatchColorFilter').onChange).toHaveBeenCalled();
+    });
+
+    it('capitalizes family names in filter options', async () => {
+      await initSwatchSelector($w, state);
+      const opts = $w('#swatchColorFilter').options;
+      expect(opts[1].label).toBe('Blue');
+      expect(opts[2].label).toBe('Green');
+      expect(opts[3].label).toBe('Neutral');
+    });
   });
 
   describe('selectSwatch', () => {
@@ -143,6 +349,40 @@ describe('ProductOptions', () => {
       $w('#finishDropdown').options = [{ label: 'Natural', value: 'natural' }];
       await selectSwatch($w, state, { _id: 'sw-1', swatchName: 'Ocean Blue', colorHex: '#2244AA' });
       expect($w('#swatchTintOverlay').style.backgroundColor).toBe('#2244AA');
+    });
+
+    it('triggers variant change when swatch matches finish option', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockClear();
+      $w('#finishDropdown').options = [
+        { label: 'Ocean Blue', value: 'ocean-blue' },
+        { label: 'Natural', value: 'natural' },
+      ];
+      $w('#sizeDropdown').value = 'Full';
+      await selectSwatch($w, state, { _id: 'sw-1', swatchName: 'Ocean Blue', colorHex: '#2244AA' });
+      expect($w('#finishDropdown').value).toBe('ocean-blue');
+      expect(getProductVariants).toHaveBeenCalled();
+    });
+
+    it('refreshes grid data to update selection visuals', async () => {
+      $w('#swatchGrid').data = [
+        { _id: 'sw-1', swatchName: 'Ocean Blue' },
+        { _id: 'sw-2', swatchName: 'Forest Green' },
+      ];
+      await selectSwatch($w, state, { _id: 'sw-1', swatchName: 'Ocean Blue', colorHex: '#2244AA' });
+      // Grid data should be a new array reference (spread copy)
+      expect($w('#swatchGrid').data).toHaveLength(2);
+    });
+
+    it('sets tint overlay opacity to 0.25', async () => {
+      await selectSwatch($w, state, { _id: 'sw-1', swatchName: 'Ocean Blue', colorHex: '#2244AA' });
+      expect($w('#swatchTintOverlay').style.opacity).toBe(0.25);
+    });
+
+    it('does not apply tint when colorHex is null', async () => {
+      await selectSwatch($w, state, { _id: 'sw-1', swatchName: 'Custom', colorHex: null });
+      // Overlay should not have been modified
+      expect($w('#swatchTintOverlay').show).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/ups-shipping.test.js
+++ b/tests/ups-shipping.test.js
@@ -195,6 +195,119 @@ describe('getUPSRates', () => {
     expect(rates[0].title).toBe('UPS Ground');
     expect(rates[0].estimatedDelivery).toBeTruthy();
   });
+
+  it('caps packages array at 20', async () => {
+    const manyPackages = Array.from({ length: 25 }, (_, i) => ({
+      length: 48, width: 30, height: 12, weight: 50, description: `Pkg ${i}`,
+    }));
+    const rates = await getUPSRates(
+      { postalCode: '28801', city: 'Asheville', state: 'NC', country: 'US' },
+      manyPackages,
+      500,
+    );
+    // Should still succeed (capped internally)
+    expect(rates.length).toBeGreaterThan(0);
+  });
+
+  it('handles non-array packages gracefully', async () => {
+    const rates = await getUPSRates(
+      { postalCode: '28801', city: 'Asheville', state: 'NC', country: 'US' },
+      null,
+      500,
+    );
+    expect(rates.length).toBeGreaterThan(0);
+  });
+
+  it('uses default dimensions when package dimensions missing', async () => {
+    const rates = await getUPSRates(
+      { postalCode: '28801', city: 'Asheville', state: 'NC', country: 'US' },
+      [{}], // No dimensions
+      500,
+    );
+    expect(rates.length).toBeGreaterThan(0);
+  });
+
+  it('returns fallback rates for West Coast postal codes', async () => {
+    __setHandler(() => { throw new Error('Network error'); });
+    const rates = await getUPSRates(
+      { postalCode: '90210' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(rates[0].cost).toBe(79.99);
+  });
+
+  it('returns fallback rates for Northeast postal codes', async () => {
+    __setHandler(() => { throw new Error('Network error'); });
+    const rates = await getUPSRates(
+      { postalCode: '10001' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(rates[0].cost).toBe(59.99);
+  });
+
+  it('returns fallback rates for Southeast postal codes', async () => {
+    __setHandler(() => { throw new Error('Network error'); });
+    const rates = await getUPSRates(
+      { postalCode: '30301' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(rates[0].cost).toBe(39.99);
+  });
+
+  it('fallback includes ground and 2nd day options', async () => {
+    __setHandler(() => { throw new Error('Network error'); });
+    const rates = await getUPSRates(
+      { postalCode: '28801' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(rates).toHaveLength(2);
+    expect(rates[0].code).toBe('ups-ground-est');
+    expect(rates[1].code).toBe('ups-2day-est');
+    expect(rates[1].cost).toBe(rates[0].cost + 40);
+  });
+
+  it('maps unknown service codes to generic name', async () => {
+    __setHandler((url) => {
+      if (url.includes('/oauth/token')) {
+        return { ok: true, async json() { return { access_token: 'tok', expires_in: '3600' }; }, async text() { return ''; } };
+      }
+      if (url.includes('/rating/')) {
+        return {
+          ok: true,
+          async json() {
+            return {
+              RateResponse: {
+                RatedShipment: [{
+                  Service: { Code: '99' },
+                  TotalCharges: { MonetaryValue: '199.99', CurrencyCode: 'USD' },
+                }],
+              },
+            };
+          },
+          async text() { return ''; },
+        };
+      }
+      return { ok: true, async json() { return {}; }, async text() { return ''; } };
+    });
+    const rates = await getUPSRates(
+      { postalCode: '28801', city: 'Asheville', state: 'NC', country: 'US' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(rates[0].title).toBe('UPS Service 99');
+    expect(rates[0].estimatedDelivery).toBe('Contact for estimate');
+  });
+
+  it('handles null destinationAddress in fallback path', async () => {
+    __setHandler(() => { throw new Error('Network error'); });
+    const rates = await getUPSRates(null, [{ weight: 50 }], 500);
+    expect(rates.length).toBeGreaterThan(0);
+    expect(rates[0].isEstimate).toBe(true);
+  });
 });
 
 // ── createShipment ─────────────────────────────────────────────────
@@ -248,6 +361,90 @@ describe('createShipment', () => {
       packages: [{ length: 48, width: 30, height: 12, weight: 50 }],
     });
 
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('creates return label when returnLabel is true', async () => {
+    const result = await createShipment({
+      orderId: '10043',
+      recipientName: 'Jane Smith',
+      recipientPhone: '8285551234',
+      addressLine1: '123 Main St',
+      city: 'Asheville',
+      state: 'NC',
+      postalCode: '28801',
+      country: 'US',
+      serviceCode: '03',
+      returnLabel: true,
+      packages: [{ length: 80, width: 40, height: 12, weight: 85, description: 'Return Futon Frame' }],
+    });
+    expect(result.success).toBe(true);
+    expect(result.trackingNumber).toBeTruthy();
+  });
+
+  it('defaults to Ground service when serviceCode not provided', async () => {
+    const result = await createShipment({
+      orderId: '10044',
+      recipientName: 'Bob',
+      addressLine1: '456 Oak Ave',
+      city: 'Denver',
+      state: 'CO',
+      postalCode: '80201',
+      packages: [{ length: 48, width: 30, height: 12, weight: 50 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('handles missing optional addressLine2', async () => {
+    const result = await createShipment({
+      orderId: '10045',
+      recipientName: 'Alice',
+      addressLine1: '789 Pine St',
+      city: 'Portland',
+      state: 'OR',
+      postalCode: '97201',
+      packages: [{ length: 48, width: 30, height: 12, weight: 50 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('includes billing weight in response', async () => {
+    const result = await createShipment({
+      orderId: '10046',
+      recipientName: 'Jane',
+      addressLine1: '123 Main St',
+      city: 'Asheville',
+      state: 'NC',
+      postalCode: '28801',
+      packages: [{ length: 80, width: 40, height: 12, weight: 85 }],
+    });
+    expect(result.billingWeight).toBe('85');
+  });
+
+  it('handles invalid response structure', async () => {
+    __setHandler((url) => {
+      if (url.includes('/oauth/token')) {
+        return { ok: true, async json() { return { access_token: 'tok', expires_in: '3600' }; }, async text() { return ''; } };
+      }
+      if (url.includes('/shipments/')) {
+        return {
+          ok: true,
+          async json() { return { ShipmentResponse: {} }; },
+          async text() { return ''; },
+        };
+      }
+      return { ok: true, async json() { return {}; }, async text() { return ''; } };
+    });
+    const result = await createShipment({
+      orderId: '10047',
+      recipientName: 'Test',
+      addressLine1: '1 St',
+      city: 'X',
+      state: 'NC',
+      postalCode: '28801',
+      packages: [{ length: 48, width: 30, height: 12, weight: 50 }],
+    });
     expect(result.success).toBe(false);
     expect(result.error).toBeTruthy();
   });
@@ -317,6 +514,81 @@ describe('trackShipment', () => {
     const result = await trackShipment(null);
     expect(result.success).toBe(false);
     expect(result.error).toBe('Invalid tracking number format');
+  });
+
+  it('rejects tracking number that is too long', async () => {
+    const result = await trackShipment('A'.repeat(36));
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Invalid tracking number format');
+  });
+
+  it('strips special characters from tracking number', async () => {
+    // 1Z-999-AA1-0123-4567-84 should be cleaned to 1Z999AA10123456784
+    const result = await trackShipment('1Z-999-AA1-0123-4567-84');
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('In Transit');
+  });
+
+  it('returns error when no tracking info found', async () => {
+    __setHandler((url) => {
+      if (url.includes('/oauth/token')) {
+        return { ok: true, async json() { return { access_token: 'tok', expires_in: '3600' }; }, async text() { return ''; } };
+      }
+      if (url.includes('/track/')) {
+        return {
+          ok: true,
+          async json() { return { trackResponse: { shipment: [] } }; },
+          async text() { return ''; },
+        };
+      }
+      return { ok: true, async json() { return {}; }, async text() { return ''; } };
+    });
+    const result = await trackShipment('1Z999AA10123456784');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No tracking information found');
+  });
+
+  it('includes weight in tracking response', async () => {
+    const result = await trackShipment('1Z999AA10123456784');
+    expect(result.weight).toBe('85');
+  });
+
+  it('formats activity location from city, state, country', async () => {
+    const result = await trackShipment('1Z999AA10123456784');
+    expect(result.activities[0].location).toBe('Hendersonville, NC, US');
+  });
+
+  it('handles activity with partial location data', async () => {
+    __setHandler((url) => {
+      if (url.includes('/oauth/token')) {
+        return { ok: true, async json() { return { access_token: 'tok', expires_in: '3600' }; }, async text() { return ''; } };
+      }
+      if (url.includes('/track/')) {
+        return {
+          ok: true,
+          async json() {
+            return {
+              trackResponse: {
+                shipment: [{
+                  package: [{
+                    currentStatus: { description: 'Delivered', code: 'DL' },
+                    deliveryDate: [],
+                    weight: { weight: '85' },
+                    activity: [
+                      { status: { description: 'Delivered' }, location: { address: { city: 'Asheville' } }, date: '20250620', time: '140000' },
+                    ],
+                  }],
+                }],
+              },
+            };
+          },
+          async text() { return ''; },
+        };
+      }
+      return { ok: true, async json() { return {}; }, async text() { return ''; } };
+    });
+    const result = await trackShipment('1Z999AA10123456784');
+    expect(result.activities[0].location).toBe('Asheville');
   });
 });
 
@@ -421,6 +693,31 @@ describe('validateAddress', () => {
     expect(result.error).toBe('validation unavailable');
   });
 
+  it('returns invalid with no candidates for NoCandidatesIndicator', async () => {
+    __setHandler((url) => {
+      if (url.includes('/oauth/token')) {
+        return { ok: true, async json() { return { access_token: 'tok', expires_in: '3600' }; }, async text() { return ''; } };
+      }
+      if (url.includes('/addressvalidation/')) {
+        return {
+          ok: true,
+          async json() { return { XAVResponse: { NoCandidatesIndicator: '' } }; },
+          async text() { return ''; },
+        };
+      }
+      return { ok: true, async json() { return {}; }, async text() { return ''; } };
+    });
+    const result = await validateAddress({
+      addressLine1: '99999 Fake St',
+      city: 'Nowhere',
+      state: 'XX',
+      postalCode: '00000',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.ambiguous).toBe(false);
+    expect(result.candidates).toHaveLength(0);
+  });
+
   it('returns invalid with unavailable flag on unrecognized response format', async () => {
     __setHandler((url) => {
       if (url.includes('/oauth/token')) {
@@ -471,5 +768,29 @@ describe('getPackageDimensions', () => {
     const dims = getPackageDimensions('something-else');
     expect(dims.length).toBe(48);
     expect(dims.weight).toBe(50);
+  });
+
+  it('returns futon-mattress dimensions', () => {
+    const dims = getPackageDimensions('futon-mattress');
+    expect(dims.length).toBe(78);
+    expect(dims.weight).toBe(55);
+  });
+
+  it('returns platform-bed dimensions', () => {
+    const dims = getPackageDimensions('platform-bed');
+    expect(dims.length).toBe(80);
+    expect(dims.weight).toBe(70);
+  });
+
+  it('returns casegoods dimensions', () => {
+    const dims = getPackageDimensions('casegoods');
+    expect(dims.length).toBe(36);
+    expect(dims.weight).toBe(45);
+  });
+
+  it('returns accessory dimensions', () => {
+    const dims = getPackageDimensions('accessory');
+    expect(dims.length).toBe(24);
+    expect(dims.weight).toBe(15);
   });
 });


### PR DESCRIPTION
## Summary
- **ProductOptions.js**: 12 → 39 tests (+27). Covers variant display (price, stock badge, compare price, gallery update, call-for-price), swatch grid rendering (image vs colorHex, selection highlight, filter options), error handling, and selectSwatch variant matching
- **ups-shipping.web.js**: 20 → 46 tests (+26). Covers return label creation, package array cap at 20, all regional fallback tiers, unknown service codes, NoCandidatesIndicator, tracking number sanitization, invalid response handling, and all package dimension categories
- Full suite: 12,806 tests passing across 326 files

## Test plan
- [x] `npx vitest run tests/productOptions.test.js` — 39/39 passing
- [x] `npx vitest run tests/ups-shipping.test.js` — 46/46 passing
- [x] Full suite `npx vitest run` — 12,806/12,806 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)