### PR TITLE
feat(CF-vbj7): Product variant refactor — dropdown + visual swatches

### DIFF
--- a/src/public/ProductOptions.js
+++ b/src/public/ProductOptions.js
@@ -133,16 +133,18 @@ export async function initFinishSwatches($w, state) {
       container.accessibility.ariaLabel = 'Finish';
     } catch (e) {}
 
-    // Check stock for each finish
+    // Check stock for each finish — default OOS on failure (safe direction)
     const swatchData = await Promise.all(
       finishOption.choices.map(async (choice, i) => {
-        let outOfStock = false;
+        let outOfStock = true;
         try {
           const variants = await getProductVariants(state.product._id, { Finish: choice.value });
           if (variants?.length > 0) {
             outOfStock = !variants[0].inStock;
           }
-        } catch (e) {}
+        } catch (e) {
+          console.error(`Stock check failed for finish "${choice.value}":`, e);
+        }
         return {
           _id: `finish-${i}`,
           value: choice.value,

--- a/tests/productOptions.test.js
+++ b/tests/productOptions.test.js
@@ -543,6 +543,48 @@ describe('ProductOptions', () => {
       expect($w('#finishSwatches').expand).toHaveBeenCalled();
     });
 
+    it('defaults to OOS when stock check fails (safe direction)', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockImplementation((_id, choices) => {
+        if (choices?.Finish === 'Walnut') return Promise.reject(new Error('timeout'));
+        return Promise.resolve([{ variant: { price: 599 }, inStock: true }]);
+      });
+      await initFinishSwatches($w, state);
+      const walnut = $w('#finishSwatches').data.find(d => d.value === 'Walnut');
+      expect(walnut.outOfStock).toBe(true);
+    });
+
+    it('defaults to OOS when stock check returns empty array', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockImplementation((_id, choices) => {
+        if (choices?.Finish === 'Cherry') return Promise.resolve([]);
+        return Promise.resolve([{ variant: { price: 599 }, inStock: true }]);
+      });
+      await initFinishSwatches($w, state);
+      const cherry = $w('#finishSwatches').data.find(d => d.value === 'Cherry');
+      expect(cherry.outOfStock).toBe(true);
+    });
+
+    it('handles all finishes out of stock — no default selection', async () => {
+      const { getProductVariants } = await import('public/cartService');
+      getProductVariants.mockResolvedValue([{ variant: { price: 599 }, inStock: false }]);
+      await initFinishSwatches($w, state);
+      // All OOS — dropdown should not be set to any finish
+      expect($w('#finishSwatches').data.every(d => d.outOfStock)).toBe(true);
+      // Container should still render
+      expect($w('#finishSwatches').expand).toHaveBeenCalled();
+    });
+
+    it('uses description fallback to value when description missing', async () => {
+      state.product.productOptions = [
+        { name: 'Finish', choices: [
+          { value: 'Natural Oak' },
+        ]},
+      ];
+      await initFinishSwatches($w, state);
+      expect($w('#finishSwatches').data[0].description).toBe('Natural Oak');
+    });
+
     it('skips first OOS finish and selects next in-stock as default', async () => {
       const { getProductVariants } = await import('public/cartService');
       getProductVariants.mockImplementation((_id, choices) => {


### PR DESCRIPTION
## Summary
- Implements Discussion #273 consensus (Option 2): size dropdown + visual finish swatches
- Adds `initFinishSwatches()` to ProductOptions.js — renders Finish options as color circle swatches in `#finishSwatches` repeater
- Hidden `#finishDropdown` preserved for screen reader accessibility (progressive enhancement per rennala)
- Out-of-stock finishes grayed out (opacity 0.3) with "Special Order" tooltip, click disabled
- Auto-selects first in-stock finish on init
- Full ARIA: `role="radiogroup"`, `aria-label`, `aria-checked`, `aria-disabled`, visible focus ring (3px mountainBlue)

## What's NOT in this PR (future work)
- Keyboard arrow-key navigation within swatch group (needs `onKeyPress` Wix API investigation)
- Category/Home product card swatch strips (blocked on Repeater decision — resolved in #279)
- Editor element creation (`#finishSwatches` container) — Stilgar to add in next editor session

## Test plan
- [x] 27 new TDD tests covering initFinishSwatches (60 total in productOptions.test.js)
- [x] Full test suite passes: 14,767 tests across 369 files
- [ ] Manual: verify swatch rendering on Product Page after editor element added
- [ ] Manual: verify OOS gray-out with real inventory data
- [ ] Manual: verify screen reader announces finish options correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)