### PR TITLE
docs(CF-7eop): Codecov integration audit — badge + report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Carolina Futons
 
+[![codecov](https://codecov.io/gh/DreadPirateRobertz/carolina-futons/graph/badge.svg)](https://codecov.io/gh/DreadPirateRobertz/carolina-futons)
+
 E-commerce website for Carolina Futons, built on the Wix Velo platform. Handcrafted mountain furniture with a Blue Ridge aesthetic — futons, sofas, mattresses, and accessories.
 
 Live site: [carolinafutons.com](https://www.carolinafutons.com)
@@ -8,7 +10,7 @@ Live site: [carolinafutons.com](https://www.carolinafutons.com)
 
 **v0.5.0 deployed** to stage3-velo. v0.4.1 released (security hardening). v0.4.0 released (color scheme shift). Running on My Site 3 (Wix Studio Furniture Store #3563 template).
 
-- 12,993 tests passing across 331 test files
+- 16,658 tests passing across 409 test files
 - 191 backend files, 41 pages, 232 public utilities
 - 71.9% element connectivity (595/827 IDs wired)
 - Category card photos now set in Wix Dashboard

--- a/docs/reports/codecov-audit.md
+++ b/docs/reports/codecov-audit.md
@@ -1,0 +1,41 @@
+# Codecov Integration Audit — CF-7eop
+
+**Date**: 2026-03-16
+**Auditor**: godfrey
+
+## Summary
+
+Codecov is fully operational on the `carolina-futons` repo. PR comment bot posts coverage diffs, reports upload successfully, and tokens are configured in both repos.
+
+## Findings
+
+### carolina-futons (main repo)
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| CODECOV_TOKEN in GitHub Secrets | Pass | Set and active |
+| CI uploads coverage (Node 20) | Pass | `codecov/codecov-action@v5` with `flags: unit` |
+| Nightly CI uploads coverage | Pass | `flags: nightly` in nightly-integration job |
+| Codecov bot posts PR comments | Pass | Verified on PRs #380, #381 |
+| Coverage thresholds configured | Pass | lines 70%, branches 60%, functions 70% |
+| `fail_ci_if_error: false` | Info | Coverage upload failure won't block CI |
+| README badge | Added | `codecov.io/gh/DreadPirateRobertz/carolina-futons` |
+
+### carolina-futons-stage3-velo (production repo)
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| CODECOV_TOKEN in GitHub Secrets | Pass | `CODECOV_TOKEN` set (separate from `CODECOV_TOKEN_STAGE3_VELO`) |
+| CI runs | Fail | CI failing on recent runs (build/config issue, not Codecov-specific) |
+| Coverage reporting | Unknown | Cannot verify until CI passes |
+
+## Recommendations
+
+1. **Stage3-velo CI**: Fix the build failures — coverage can't upload if CI fails before the coverage step.
+2. **Coverage thresholds**: Consider raising from 70% to 80% as test count grows (currently 16,658 tests).
+3. **Dashboard link**: https://app.codecov.io/gh/DreadPirateRobertz/carolina-futons
+
+## Actions Taken
+
+- Added Codecov badge to README.md
+- Updated test count in README (12,993 → 16,658 across 409 files)


### PR DESCRIPTION
## Summary
- Add Codecov coverage badge to README
- Update test count (12,993 → 16,658 tests across 409 files)
- Audit report: Codecov fully operational on main repo, stage3-velo CI failing (non-Codecov issue)

## Test plan
- [ ] Verify badge renders on GitHub repo page
- [ ] Confirm CI passes with no changes to workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)