### PR TITLE
feat(CF-8bbu): AI product recommendations carousel — Customers Also Love

### DIFF
--- a/src/backend/productRecommendations.web.js
+++ b/src/backend/productRecommendations.web.js
@@ -692,3 +692,87 @@ function formatProduct(item) {
     productOptions: item.productOptions || [],
   };
 }
+
+// ── getRecommendations ─────────────────────────────────────────────
+// In-memory cache: key=productId → {products, expires}. 30-min TTL.
+// Per-instance (serverless cold starts reset cache — acceptable trade-off).
+const _recCache = new Map();
+const REC_CACHE_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Get "Customers Also Love" recommendations for a product.
+ * Scores candidates by collection overlap (2pts each) + price band ±20% (1pt).
+ * Results ranked by overlap score, cached 30min per productId.
+ *
+ * @param {string} productId - Source product ID
+ * @param {number} [limit=6] - Max recommendations to return
+ * @returns {Promise<{success: boolean, products: Array}>}
+ * @permission Anyone
+ */
+export const getRecommendations = webMethod(
+  Permissions.Anyone,
+  async (productId, limit = 6) => {
+    try {
+      const pid = validateId(productId);
+      if (!pid) return { success: false, products: [] };
+
+      const safeLimit = Math.max(1, Math.min(12, Math.round(limit)));
+
+      // Return cached result if still fresh
+      const cached = _recCache.get(pid);
+      if (cached && cached.expires > Date.now()) {
+        return { success: true, products: cached.products.slice(0, safeLimit) };
+      }
+
+      // Load source product
+      const source = await wixData.get('Stores/Products', pid);
+      if (!source) return { success: false, products: [] };
+
+      const sourceCollections = Array.isArray(source.collections)
+        ? source.collections
+        : source.collections ? [source.collections] : [];
+
+      const sourcePrice = source.price || 0;
+      const minPrice = sourcePrice * 0.8;
+      const maxPrice = sourcePrice * 1.2;
+
+      // Fetch candidates: products sharing ≥1 collection, exclude source + call-for-price
+      let candidates = [];
+      if (sourceCollections.length > 0) {
+        const collResult = await wixData.query('Stores/Products')
+          .hasSome('collections', sourceCollections)
+          .ne('_id', pid)
+          .gt('price', CALL_FOR_PRICE_THRESHOLD)
+          .limit(50)
+          .find();
+        candidates = collResult.items;
+      }
+
+      // Score each candidate: 2pts per shared collection, +1 if in price band
+      const scored = candidates.map(item => {
+        const itemColls = Array.isArray(item.collections)
+          ? item.collections
+          : item.collections ? [item.collections] : [];
+        const sharedColls = itemColls.filter(c => sourceCollections.includes(c)).length;
+        const inPriceBand = item.price >= minPrice && item.price <= maxPrice ? 1 : 0;
+        return { item, score: sharedColls * 2 + inPriceBand };
+      });
+
+      // Sort by score descending, format for return
+      const ranked = scored
+        .sort((a, b) => b.score - a.score)
+        .map(({ item }) => formatProduct(item));
+
+      // Cache full ranked list (up to 12) to serve different limit values
+      _recCache.set(pid, { products: ranked.slice(0, 12), expires: Date.now() + REC_CACHE_TTL_MS });
+
+      return { success: true, products: ranked.slice(0, safeLimit) };
+    } catch (err) {
+      console.error('[productRecommendations] getRecommendations error:', err);
+      return { success: false, products: [] };
+    }
+  }
+);
+
+/** @testing Clear the recommendations cache. */
+export function __resetRecCache() { _recCache.clear(); }

--- a/src/public/ProductRecommendations.js
+++ b/src/public/ProductRecommendations.js
@@ -1,0 +1,108 @@
+/**
+ * @module ProductRecommendations
+ * @description "Customers Also Love" carousel for the Product Detail Page.
+ *
+ * Editor elements:
+ *   #recommendationsSection (Section) — wraps the entire carousel
+ *   #recommendationsTitle (Text) — "Customers Also Love"
+ *   #recommendationsRepeater (Repeater) — product cards
+ *     ↳ #recProductImage (Image), #recProductName (Text), #recProductPrice (Text)
+ *     ↳ #recAddToCartBtn (Button), #recViewBtn (Button)
+ *
+ * CF-8bbu: AI product recommendations carousel
+ */
+import { getRecommendations } from 'backend/productRecommendations.web';
+import { isCallForPrice, CALL_FOR_PRICE_TEXT } from 'public/productPageUtils.js';
+import { makeClickable } from 'public/a11yHelpers.js';
+
+/**
+ * Initialize the "Customers Also Love" recommendations carousel on the PDP.
+ * Collapses #recommendationsSection if no recommendations are returned.
+ *
+ * @param {Function} $w - Wix Velo selector
+ * @param {{ product: Object }} state - Page state with product data
+ * @returns {Promise<void>}
+ */
+export async function initRecommendationsCarousel($w, state) {
+  try {
+    const productId = state?.product?._id;
+    if (!productId) {
+      _collapseSection($w);
+      return;
+    }
+
+    const { success, products } = await getRecommendations(productId, 6);
+
+    if (!success || !products || products.length === 0) {
+      _collapseSection($w);
+      return;
+    }
+
+    _populateCarousel($w, products);
+  } catch (e) {
+    console.warn('[ProductRecommendations] initRecommendationsCarousel failed:', e?.message ?? e);
+    _collapseSection($w);
+  }
+}
+
+function _collapseSection($w) {
+  try { $w('#recommendationsSection').collapse(); } catch (e) {
+    console.warn('[ProductRecommendations] section collapse failed:', e?.message ?? e);
+  }
+}
+
+function _populateCarousel($w, products) {
+  try {
+    $w('#recommendationsRepeater').data = products.map(p => ({
+      _id: p._id,
+      name: p.name,
+      slug: p.slug,
+      price: p.price,
+      formattedPrice: p.formattedPrice,
+      mainMedia: p.mainMedia,
+    }));
+
+    $w('#recommendationsRepeater').onItemReady(($item, itemData) => {
+      try { $item('#recProductName').text = itemData.name || ''; } catch (e) {
+        console.warn('[ProductRecommendations] recProductName set failed:', e?.message ?? e);
+      }
+      try {
+        $item('#recProductPrice').text = isCallForPrice(itemData)
+          ? CALL_FOR_PRICE_TEXT
+          : (itemData.formattedPrice || '');
+      } catch (e) {
+        console.warn('[ProductRecommendations] recProductPrice set failed:', e?.message ?? e);
+      }
+      try {
+        if (itemData.mainMedia) $item('#recProductImage').src = itemData.mainMedia;
+      } catch (e) {
+        console.warn('[ProductRecommendations] recProductImage set failed:', e?.message ?? e);
+      }
+
+      const url = `/product-page/${itemData.slug}`;
+
+      try {
+        makeClickable($item('#recProductImage'), url, { ariaLabel: `View ${itemData.name}` });
+      } catch (e) {
+        console.warn('[ProductRecommendations] recProductImage click wiring failed:', e?.message ?? e);
+      }
+
+      try {
+        $item('#recViewBtn').onClick(() => {
+          try {
+            import('wix-location-frontend').then(m => {
+              (m.default?.to ?? m.to)?.(url);
+            }).catch(e => console.warn('[ProductRecommendations] navigation failed:', e?.message ?? e));
+          } catch (e) {
+            console.warn('[ProductRecommendations] recViewBtn onClick failed:', e?.message ?? e);
+          }
+        });
+      } catch (e) {
+        console.warn('[ProductRecommendations] recViewBtn wiring failed:', e?.message ?? e);
+      }
+    });
+  } catch (e) {
+    console.warn('[ProductRecommendations] populateCarousel failed:', e?.message ?? e);
+    _collapseSection($w);
+  }
+}

--- a/tests/getRecommendations.test.js
+++ b/tests/getRecommendations.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests for getRecommendations — CF-8bbu "Customers Also Love" carousel.
+ * Covers: input validation, scoring (collection overlap + price band),
+ * limit clamping, cache behavior, and error handling.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __seed } from './__mocks__/wix-data.js';
+import { allProducts, futonFrame, futonMattress, murphyBed, platformBed } from './fixtures/products.js';
+
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+const { getRecommendations, __resetRecCache } = await import('../src/backend/productRecommendations.web.js');
+
+beforeEach(() => {
+  __seed('Stores/Products', allProducts);
+  __resetRecCache();
+});
+
+describe('getRecommendations — input validation', () => {
+  it('returns success:false for null productId', async () => {
+    const result = await getRecommendations(null);
+    expect(result.success).toBe(false);
+    expect(result.products).toEqual([]);
+  });
+
+  it('returns success:false for invalid productId (injection attempt)', async () => {
+    const result = await getRecommendations('DROP TABLE;--');
+    expect(result.success).toBe(false);
+    expect(result.products).toEqual([]);
+  });
+
+  it('returns success:false for unknown productId', async () => {
+    const result = await getRecommendations('does-not-exist-xyz');
+    expect(result.success).toBe(false);
+    expect(result.products).toEqual([]);
+  });
+});
+
+describe('getRecommendations — limit clamping', () => {
+  it('clamps limit to minimum of 1', async () => {
+    const result = await getRecommendations(futonFrame._id, 0);
+    expect(result.success).toBe(true);
+    expect(result.products.length).toBeGreaterThanOrEqual(0);
+    expect(result.products.length).toBeLessThanOrEqual(1);
+  });
+
+  it('clamps limit to maximum of 12', async () => {
+    const result = await getRecommendations(futonFrame._id, 100);
+    expect(result.success).toBe(true);
+    expect(result.products.length).toBeLessThanOrEqual(12);
+  });
+
+  it('rounds fractional limit', async () => {
+    const result = await getRecommendations(futonFrame._id, 3.7);
+    expect(result.success).toBe(true);
+    expect(result.products.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('getRecommendations — scoring', () => {
+  it('excludes the source product from results', async () => {
+    const result = await getRecommendations(futonFrame._id, 6);
+    expect(result.success).toBe(true);
+    result.products.forEach(p => expect(p._id).not.toBe(futonFrame._id));
+  });
+
+  it('returns products sharing a collection', async () => {
+    // futonFrame is in 'futon-frames'; should find other futon-frames products
+    const result = await getRecommendations(futonFrame._id, 6);
+    expect(result.success).toBe(true);
+    // At minimum should return something if there are other futon-frames in allProducts
+    if (result.products.length > 0) {
+      expect(result.products[0]._id).toBeTruthy();
+    }
+  });
+
+  it('returns products array on success', async () => {
+    const result = await getRecommendations(futonFrame._id, 6);
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.products)).toBe(true);
+    result.products.forEach(p => {
+      expect(p).toHaveProperty('_id');
+      expect(p).toHaveProperty('name');
+      expect(p).toHaveProperty('price');
+    });
+  });
+});
+
+describe('getRecommendations — caching', () => {
+  it('returns same results on second call (cache hit)', async () => {
+    const first = await getRecommendations(futonFrame._id, 6);
+    const second = await getRecommendations(futonFrame._id, 6);
+    expect(second.success).toBe(first.success);
+    expect(second.products.map(p => p._id)).toEqual(first.products.map(p => p._id));
+  });
+
+  it('serves different limits from same cache', async () => {
+    const large = await getRecommendations(futonFrame._id, 6);
+    const small = await getRecommendations(futonFrame._id, 2);
+    expect(small.products.length).toBeLessThanOrEqual(2);
+    if (large.products.length >= 2) {
+      expect(small.products[0]._id).toBe(large.products[0]._id);
+    }
+  });
+
+  it('clears cache and re-fetches after __resetRecCache', async () => {
+    await getRecommendations(futonFrame._id, 6);
+    __resetRecCache();
+    const fresh = await getRecommendations(futonFrame._id, 6);
+    expect(fresh.success).toBe(true);
+  });
+});
+
+describe('getRecommendations — error handling', () => {
+  it('returns success:false and empty products array on db error', async () => {
+    __seed('Stores/Products', []); // empty — source product not found
+    __resetRecCache();
+    const result = await getRecommendations(futonFrame._id, 6);
+    // source product not found → success:false
+    expect(result.success).toBe(false);
+    expect(result.products).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Re-implementation of CF-8bbu (closes #564 which was 109 commits stale).

- **Backend**: `getRecommendations()` webMethod in `productRecommendations.web.js`
  - Scores candidates by collection overlap (2pts each) + price band ±20% (1pt)
  - 30-min in-memory TTL cache per productId (up to 12 results cached)
  - Excludes source product + call-for-price items
  - Validates productId via `validateId`
  - `__resetRecCache()` exported for testing

- **Frontend**: `src/public/ProductRecommendations.js`
  - `initRecommendationsCarousel($w, state)` — wires #recommendationsRepeater on PDP
  - Graceful degradation: collapses #recommendationsSection if no results
  - All operations wrapped in try/catch

## Test plan
- [ ] 13 tests in `tests/getRecommendations.test.js` — all pass
- [ ] input validation (null, injection, unknown)
- [ ] limit clamping (min 1, max 12, fractional rounding)
- [ ] source product exclusion
- [ ] cache hit + limit serving from cache
- [ ] cache reset
- [ ] graceful not-found handling
- [ ] Full suite green

🤖 Generated with [Claude Code](https://claude.ai/code)