### PR TITLE
feat(CF-rw9g): P0 rate limiting — emailService sendEmail + swatch methods

### DIFF
--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -26,6 +26,71 @@ import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 
+// ── Rate Limiting (CF-rw9g) ──────────────────────────────────────────
+// CMS collection: EmailRateLimit (key, count, windowStart)
+// Pattern: same as newsletterService._checkRateLimit
+
+export const EMAIL_RATE_LIMIT_MAX = 3;
+export const EMAIL_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Check and record a rate-limit attempt for email operations.
+ * Allows up to EMAIL_RATE_LIMIT_MAX calls per EMAIL_RATE_LIMIT_WINDOW_MS per key.
+ * Fails open on DB errors.
+ *
+ * @param {string} key - Normalized identifier (email).
+ * @param {Object} [opts]
+ * @param {number} [opts.now] - Timestamp override for testing.
+ * @returns {Promise<{allowed: boolean, reason?: string}>}
+ */
+export async function _checkEmailRateLimit(key, opts = {}) {
+  const now = (opts && opts.now != null) ? opts.now : Date.now();
+  try {
+    const cleanKey = sanitize(key, 254).toLowerCase();
+
+    const existing = await wixData.query('EmailRateLimit')
+      .eq('key', cleanKey)
+      .limit(1)
+      .find();
+
+    if (existing.items.length === 0) {
+      await wixData.insert('EmailRateLimit', {
+        key: cleanKey,
+        count: 1,
+        windowStart: new Date(now),
+      });
+      return { allowed: true };
+    }
+
+    const record = existing.items[0];
+    const windowAge = now - new Date(record.windowStart).getTime();
+
+    if (windowAge > EMAIL_RATE_LIMIT_WINDOW_MS) {
+      await wixData.update('EmailRateLimit', {
+        ...record,
+        count: 1,
+        windowStart: new Date(now),
+      });
+      return { allowed: true };
+    }
+
+    if (record.count >= EMAIL_RATE_LIMIT_MAX) {
+      return { allowed: false, reason: 'rate_limited' };
+    }
+
+    await wixData.update('EmailRateLimit', {
+      ...record,
+      count: record.count + 1,
+    });
+    return { allowed: true };
+  } catch (err) {
+    console.warn('[emailService] Rate limit check failed, allowing request:', err?.message);
+    return { allowed: true };
+  }
+}
+
+const RATE_LIMIT_MESSAGE = 'Too many requests. Please try again later.';
+
 /**
  * Send a contact form submission to the store owner via triggered email.
  * Also saves the submission to the `ContactSubmissions` CMS collection.
@@ -54,6 +119,12 @@ export const sendEmail = webMethod(
 
       if (!validateEmail(cleanEmail)) {
         return { success: false, message: 'Invalid email address.' };
+      }
+
+      // CF-rw9g: Rate limit per email — 3 calls/hour
+      const rateCheck = await _checkEmailRateLimit(cleanEmail);
+      if (!rateCheck.allowed) {
+        return { success: false, message: RATE_LIMIT_MESSAGE };
       }
 
       // Retrieve the site owner's Wix contact ID from Secrets Manager.
@@ -128,6 +199,12 @@ export const submitSwatchRequest = webMethod(
 
       if (!validateEmail(cleanEmail)) {
         return { success: false, message: 'Invalid email address.' };
+      }
+
+      // CF-rw9g: Rate limit per email — 3 calls/hour (shared with sendEmail)
+      const rateCheck = await _checkEmailRateLimit(cleanEmail);
+      if (!rateCheck.allowed) {
+        return { success: false, message: RATE_LIMIT_MESSAGE };
       }
 
       const siteOwnerContactId = await getSecret('SITE_OWNER_CONTACT_ID');
@@ -215,6 +292,13 @@ export const sendSwatchConfirmationEmail = webMethod(
     try {
       if (!contactId) {
         return { success: false, message: 'Customer contact ID is required.' };
+      }
+
+      // CF-rw9g: Rate limit per email or contactId — 3 calls/hour
+      const rateLimitKey = email ? sanitize(email, 254).toLowerCase() : sanitize(contactId, 254);
+      const rateCheck = await _checkEmailRateLimit(rateLimitKey);
+      if (!rateCheck.allowed) {
+        return { success: false, message: RATE_LIMIT_MESSAGE };
       }
 
       const cleanName = sanitize(name, 200);

--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -332,7 +332,7 @@ export const sendSwatchConfirmationEmail = webMethod(
       return { success: true };
     } catch (err) {
       console.error('Error sending swatch confirmation email:', err);
-      return { success: false };
+      return { success: false, message: 'Failed to send confirmation email.' };
     }
   }
 );

--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -38,6 +38,10 @@ export const EMAIL_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
  * Allows up to EMAIL_RATE_LIMIT_MAX calls per EMAIL_RATE_LIMIT_WINDOW_MS per key.
  * Fails open on DB errors.
  *
+ * Known gap: query-check-update is not atomic (Wix Data lacks conditional updates).
+ * Concurrent requests may exceed the limit by 1-2 under high concurrency.
+ * Acceptable for email spam prevention — not a billing or auth boundary.
+ *
  * @param {string} key - Normalized identifier (email).
  * @param {Object} [opts]
  * @param {number} [opts.now] - Timestamp override for testing.
@@ -295,7 +299,8 @@ export const sendSwatchConfirmationEmail = webMethod(
       }
 
       // CF-rw9g: Rate limit per email or contactId — 3 calls/hour
-      const rateLimitKey = email ? sanitize(email, 254).toLowerCase() : sanitize(contactId, 254);
+      // Pass raw values — _checkEmailRateLimit handles sanitization internally
+      const rateLimitKey = email || contactId;
       const rateCheck = await _checkEmailRateLimit(rateLimitKey);
       if (!rateCheck.allowed) {
         return { success: false, message: RATE_LIMIT_MESSAGE };

--- a/tests/emailServiceDeepen.test.js
+++ b/tests/emailServiceDeepen.test.js
@@ -347,7 +347,7 @@ describe('sendSwatchConfirmationEmail', () => {
       swatchNames: ['Velvet'],
       productName: 'Monterey',
     });
-    expect(res).toEqual({ success: false });
+    expect(res).toEqual({ success: false, message: 'Failed to send confirmation email.' });
   });
 });
 

--- a/tests/emailServiceDeepen.test.js
+++ b/tests/emailServiceDeepen.test.js
@@ -84,9 +84,10 @@ describe('sendEmail', () => {
     const inserted = [];
     __onInsert((col, item) => inserted.push({ col, item }));
     await sendEmail(validForm);
-    expect(inserted).toHaveLength(1);
-    expect(inserted[0].col).toBe('ContactSubmissions');
-    expect(inserted[0].item).toMatchObject({
+    // CF-rw9g: rate limit also inserts to EmailRateLimit, so filter for ContactSubmissions
+    const contactInserts = inserted.filter(i => i.col === 'ContactSubmissions');
+    expect(contactInserts).toHaveLength(1);
+    expect(contactInserts[0].item).toMatchObject({
       name: 'Jane Doe',
       email: 'jane@example.com',
       phone: '828-555-1234',
@@ -94,7 +95,7 @@ describe('sendEmail', () => {
       message: 'Do you ship to Alaska?',
       status: 'new',
     });
-    expect(inserted[0].item.submittedAt).toBeInstanceOf(Date);
+    expect(contactInserts[0].item.submittedAt).toBeInstanceOf(Date);
   });
 
   it('rejects invalid email with { success: false }', async () => {

--- a/tests/emailServiceRateLimit.test.js
+++ b/tests/emailServiceRateLimit.test.js
@@ -1,0 +1,285 @@
+/**
+ * CF-rw9g: Email service rate limiting tests (TDD — tests first)
+ *
+ * Verifies that sendEmail, submitSwatchRequest, and sendSwatchConfirmationEmail
+ * enforce rate limits per the newsletterService pattern: 3 calls/hour per email key.
+ *
+ * CMS collection: EmailRateLimit (key, count, windowStart)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── CMS Mock ──────────────────────────────────────────────────────────
+
+let _collections = {};
+
+function __seed(collection, items) {
+  _collections[collection] = items.map((item, i) => ({ _id: `id-${i}`, ...item }));
+}
+
+vi.mock('wix-data', () => ({
+  default: {
+    query: (col) => {
+      const items = _collections[col] || [];
+      return {
+        eq: (field, value) => ({
+          limit: () => ({
+            find: async () => ({
+              items: items.filter(i => i[field] === value),
+            }),
+          }),
+        }),
+      };
+    },
+    insert: async (col, item) => {
+      if (!_collections[col]) _collections[col] = [];
+      const record = { _id: `id-${Date.now()}`, ...item };
+      _collections[col].push(record);
+      return record;
+    },
+    update: async (col, item) => {
+      if (!_collections[col]) _collections[col] = [];
+      const idx = _collections[col].findIndex(i => i._id === item._id);
+      if (idx >= 0) _collections[col][idx] = item;
+      return item;
+    },
+  },
+}));
+
+vi.mock('wix-crm-backend', () => ({
+  triggeredEmails: {
+    emailContact: vi.fn(async () => {}),
+  },
+  contacts: {
+    queryContacts: () => ({
+      eq: () => ({
+        limit: () => ({
+          find: async () => ({ items: [] }),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('wix-secrets-backend', () => ({
+  getSecret: vi.fn(async () => 'owner-contact-123'),
+}));
+
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => null) },
+}));
+
+vi.mock('backend/utils/sanitize', async () => {
+  const actual = await vi.importActual('../src/backend/utils/sanitize.js');
+  return actual;
+});
+
+// ── Import Module ─────────────────────────────────────────────────────
+
+import {
+  sendEmail,
+  submitSwatchRequest,
+  sendSwatchConfirmationEmail,
+  EMAIL_RATE_LIMIT_MAX,
+  EMAIL_RATE_LIMIT_WINDOW_MS,
+  _checkEmailRateLimit,
+} from '../src/backend/emailService.web.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const validContactForm = {
+  name: 'Test User',
+  email: 'test@example.com',
+  phone: '828-555-0100',
+  subject: 'Test Subject',
+  message: 'This is a test message for rate limit testing.',
+};
+
+const validSwatchRequest = {
+  name: 'Test User',
+  email: 'test@example.com',
+  address: '123 Main St, Asheville NC 28801',
+  productId: 'prod-123',
+  productName: 'Eureka Futon',
+  swatchNames: ['Navy', 'Charcoal'],
+};
+
+const validSwatchConfirmation = {
+  contactId: 'contact-abc',
+  name: 'Test User',
+  email: 'test@example.com',
+  swatchNames: ['Navy'],
+  productName: 'Eureka Futon',
+};
+
+// ── Setup ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  _collections = {};
+  vi.clearAllMocks();
+});
+
+// ── Rate Limit Constants ─────────────────────────────────────────────
+
+describe('rate limit constants', () => {
+  it('exports EMAIL_RATE_LIMIT_MAX as 3', () => {
+    expect(EMAIL_RATE_LIMIT_MAX).toBe(3);
+  });
+
+  it('exports EMAIL_RATE_LIMIT_WINDOW_MS as 1 hour', () => {
+    expect(EMAIL_RATE_LIMIT_WINDOW_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+// ── _checkEmailRateLimit ─────────────────────────────────────────────
+
+describe('_checkEmailRateLimit', () => {
+  it('allows first request for a new key', async () => {
+    const result = await _checkEmailRateLimit('user@example.com');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('allows up to 3 requests within the window', async () => {
+    const now = Date.now();
+    for (let i = 0; i < 3; i++) {
+      const result = await _checkEmailRateLimit('user@example.com', { now });
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it('blocks the 4th request within the window', async () => {
+    const now = Date.now();
+    for (let i = 0; i < 3; i++) {
+      await _checkEmailRateLimit('user@example.com', { now });
+    }
+    const result = await _checkEmailRateLimit('user@example.com', { now });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('rate_limited');
+  });
+
+  it('resets the window after expiry', async () => {
+    const now = Date.now();
+    // Use up the limit
+    for (let i = 0; i < 3; i++) {
+      await _checkEmailRateLimit('user@example.com', { now });
+    }
+    // 4th blocked
+    const blocked = await _checkEmailRateLimit('user@example.com', { now });
+    expect(blocked.allowed).toBe(false);
+
+    // Advance past window (1 hour + 1 ms)
+    const afterWindow = now + EMAIL_RATE_LIMIT_WINDOW_MS + 1;
+    const result = await _checkEmailRateLimit('user@example.com', { now: afterWindow });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('tracks different keys independently', async () => {
+    const now = Date.now();
+    // Fill up limit for user A
+    for (let i = 0; i < 3; i++) {
+      await _checkEmailRateLimit('a@example.com', { now });
+    }
+    const blockedA = await _checkEmailRateLimit('a@example.com', { now });
+    expect(blockedA.allowed).toBe(false);
+
+    // User B should still be allowed
+    const resultB = await _checkEmailRateLimit('b@example.com', { now });
+    expect(resultB.allowed).toBe(true);
+  });
+
+  it('normalizes email key to lowercase', async () => {
+    const now = Date.now();
+    await _checkEmailRateLimit('User@Example.COM', { now });
+    await _checkEmailRateLimit('user@example.com', { now });
+    await _checkEmailRateLimit('USER@EXAMPLE.COM', { now });
+    // All count toward same key — 4th should be blocked
+    const result = await _checkEmailRateLimit('user@example.com', { now });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('fails open on DB error', async () => {
+    // Seed broken state that will cause query to fail
+    _collections = null; // Force error in mock
+    const result = await _checkEmailRateLimit('user@example.com');
+    expect(result.allowed).toBe(true);
+    _collections = {}; // Restore
+  });
+});
+
+// ── sendEmail rate limiting ──────────────────────────────────────────
+
+describe('sendEmail rate limiting', () => {
+  it('allows a valid email send within limit', async () => {
+    const result = await sendEmail(validContactForm);
+    expect(result.success).toBe(true);
+  });
+
+  it('blocks email send after rate limit exceeded', async () => {
+    const now = Date.now();
+    // Exhaust the limit by sending 3 emails
+    for (let i = 0; i < 3; i++) {
+      await sendEmail(validContactForm);
+    }
+    // 4th should be rate limited
+    const result = await sendEmail(validContactForm);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/too many|rate|try again/i);
+  });
+
+  it('still validates email before rate limiting', async () => {
+    const result = await sendEmail({ ...validContactForm, email: 'not-an-email' });
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/invalid email/i);
+  });
+});
+
+// ── submitSwatchRequest rate limiting ────────────────────────────────
+
+describe('submitSwatchRequest rate limiting', () => {
+  it('allows a valid swatch request within limit', async () => {
+    const result = await submitSwatchRequest(validSwatchRequest);
+    expect(result.success).toBe(true);
+  });
+
+  it('blocks swatch request after rate limit exceeded', async () => {
+    for (let i = 0; i < 3; i++) {
+      await submitSwatchRequest(validSwatchRequest);
+    }
+    const result = await submitSwatchRequest(validSwatchRequest);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/too many|rate|try again/i);
+  });
+});
+
+// ── sendSwatchConfirmationEmail rate limiting ────────────────────────
+
+describe('sendSwatchConfirmationEmail rate limiting', () => {
+  it('allows a valid confirmation email within limit', async () => {
+    const result = await sendSwatchConfirmationEmail(validSwatchConfirmation);
+    expect(result.success).toBe(true);
+  });
+
+  it('blocks confirmation email after rate limit exceeded', async () => {
+    for (let i = 0; i < 3; i++) {
+      await sendSwatchConfirmationEmail(validSwatchConfirmation);
+    }
+    const result = await sendSwatchConfirmationEmail(validSwatchConfirmation);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/too many|rate|try again/i);
+  });
+});
+
+// ── Cross-method rate limiting ───────────────────────────────────────
+
+describe('cross-method rate limiting', () => {
+  it('shares rate limit across sendEmail and submitSwatchRequest for same email', async () => {
+    // 2 sendEmail + 1 submitSwatchRequest = 3 (limit)
+    await sendEmail(validContactForm);
+    await sendEmail(validContactForm);
+    await submitSwatchRequest(validSwatchRequest);
+
+    // 4th call (any method) should be blocked
+    const result = await sendEmail(validContactForm);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/too many|rate|try again/i);
+  });
+});

--- a/tests/emailServiceRateLimit.test.js
+++ b/tests/emailServiceRateLimit.test.js
@@ -172,6 +172,17 @@ describe('_checkEmailRateLimit', () => {
     expect(result.allowed).toBe(true);
   });
 
+  it('still blocks at exact window boundary (strict >)', async () => {
+    const now = Date.now();
+    for (let i = 0; i < 3; i++) {
+      await _checkEmailRateLimit('user@example.com', { now });
+    }
+    // At exactly the window boundary (not past it) — should still be blocked
+    const atBoundary = now + EMAIL_RATE_LIMIT_WINDOW_MS;
+    const result = await _checkEmailRateLimit('user@example.com', { now: atBoundary });
+    expect(result.allowed).toBe(false);
+  });
+
   it('tracks different keys independently', async () => {
     const now = Date.now();
     // Fill up limit for user A

--- a/tests/emailServiceRateLimit.test.js
+++ b/tests/emailServiceRateLimit.test.js
@@ -266,6 +266,16 @@ describe('sendSwatchConfirmationEmail rate limiting', () => {
     expect(result.success).toBe(false);
     expect(result.message).toMatch(/too many|rate|try again/i);
   });
+
+  it('uses contactId as rate limit key when email is absent', async () => {
+    const noEmailParams = { contactId: 'contact-xyz', name: 'Test', swatchNames: ['Navy'], productName: 'Futon' };
+    for (let i = 0; i < 3; i++) {
+      await sendSwatchConfirmationEmail(noEmailParams);
+    }
+    const result = await sendSwatchConfirmationEmail(noEmailParams);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/too many|rate|try again/i);
+  });
 });
 
 // ── Cross-method rate limiting ───────────────────────────────────────
@@ -279,6 +289,17 @@ describe('cross-method rate limiting', () => {
 
     // 4th call (any method) should be blocked
     const result = await sendEmail(validContactForm);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/too many|rate|try again/i);
+  });
+
+  it('shares rate limit across all 3 methods for same email', async () => {
+    await sendEmail(validContactForm);
+    await submitSwatchRequest(validSwatchRequest);
+    await sendSwatchConfirmationEmail(validSwatchConfirmation);
+
+    // 4th call via any method should be blocked
+    const result = await submitSwatchRequest(validSwatchRequest);
     expect(result.success).toBe(false);
     expect(result.message).toMatch(/too many|rate|try again/i);
   });


### PR DESCRIPTION
## Summary
- Added `_checkEmailRateLimit()` to `emailService.web.js` — 3 calls/hour per email key
- Applied to all 3 `Permissions.Anyone` email methods: `sendEmail`, `submitSwatchRequest`, `sendSwatchConfirmationEmail`
- CMS collection: `EmailRateLimit` (key, count, windowStart)
- Fails open on DB errors (same pattern as newsletterService)
- Cross-method shared limit: sendEmail + submitSwatchRequest count toward same key

## Test plan
- [x] 17 new TDD tests in `tests/emailServiceRateLimit.test.js`
- [x] 89 total email tests pass (4 files, 0 regressions)
- [x] Rate limit enforcement: 4th call blocked
- [x] Window reset after 1 hour
- [x] Key independence (different emails tracked separately)
- [x] Case normalization (USER@Example.COM = user@example.com)
- [x] Fail-open on DB error
- [x] Cross-method shared limits

## Bead
CF-rw9g (P0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)