### PR TITLE
fix(CF-lk0c): applyPromoCode fail-close on missing rateLimitKey — remove anonymous bucket

### DIFF
--- a/src/backend/promotionsEngine.web.js
+++ b/src/backend/promotionsEngine.web.js
@@ -199,8 +199,13 @@ export const applyPromoCode = webMethod(
         return { success: false, error: 'Cart items are required' };
       }
 
-      // Rate limit: 10 attempts/hour per key (IP in production) to block enumeration
-      const rateLimitKey = (opts && opts.rateLimitKey) ? String(opts.rateLimitKey) : 'anonymous';
+      // Rate limit: 10 attempts/hour per caller-supplied key (memberId or email).
+      // Fail-close on missing key — a shared 'anonymous' bucket would exhaust after
+      // 10 calls and block all unauthenticated users simultaneously.
+      const rateLimitKey = opts && opts.rateLimitKey ? String(opts.rateLimitKey).trim() : '';
+      if (!rateLimitKey) {
+        return { success: false, error: 'A valid session identifier is required to apply a promo code.' };
+      }
       const rateCheck = await _checkPromoRateLimit(rateLimitKey, { now: opts && opts.rateLimitNow });
       if (!rateCheck.allowed) {
         return { success: false, error: 'Too many promo code attempts. Please try again later.' };

--- a/src/backend/promotionsEngine.web.js
+++ b/src/backend/promotionsEngine.web.js
@@ -187,7 +187,7 @@ export const validatePromoCode = webMethod(
  * @param {string} code - The promo code
  * @param {Array<{_id: string, name?: string, price: number, quantity: number, category?: string}>} cartItems
  * @param {Object} [opts] - Injectable overrides (for testability)
- * @param {string} [opts.rateLimitKey] - Rate limit bucket key (e.g. visitor IP from frontend)
+ * @param {string} opts.rateLimitKey - Caller's memberId or email; required for rate limiting (fail-close if missing)
  * @param {number} [opts.rateLimitNow] - Timestamp override for rate limit testing
  * @returns {Promise<Object>}
  */

--- a/tests/promotionsEngine.test.js
+++ b/tests/promotionsEngine.test.js
@@ -164,7 +164,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('SAVE10', cartItems);
+    const result = await applyPromoCode('SAVE10', cartItems, { rateLimitKey: 'test-user' });
     expect(result.success).toBe(true);
     // subtotal: 499 + (299*2) = 1097, 10% off = 109.70
     expect(result.discount).toBe(109.7);
@@ -181,7 +181,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('FLAT50', cartItems);
+    const result = await applyPromoCode('FLAT50', cartItems, { rateLimitKey: 'test-user' });
     expect(result.success).toBe(true);
     expect(result.discount).toBe(50);
     expect(result.subtotalAfterDiscount).toBe(1047);
@@ -196,7 +196,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('FREESHIP', cartItems);
+    const result = await applyPromoCode('FREESHIP', cartItems, { rateLimitKey: 'test-user' });
     expect(result.success).toBe(true);
     expect(result.discount).toBe(0);
     expect(result.freeShipping).toBe(true);
@@ -211,7 +211,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('BIG', [{ _id: 'x', price: 100, quantity: 1 }]);
+    const result = await applyPromoCode('BIG', [{ _id: 'x', price: 100, quantity: 1 }], { rateLimitKey: 'test-user' });
     expect(result.success).toBe(true);
     expect(result.valid).toBe(false);
     expect(result.reason).toMatch(/minimum/i);
@@ -226,7 +226,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('HUGE', [{ _id: 'x', price: 50, quantity: 1 }]);
+    const result = await applyPromoCode('HUGE', [{ _id: 'x', price: 50, quantity: 1 }], { rateLimitKey: 'test-user' });
     expect(result.success).toBe(true);
     expect(result.discount).toBe(50);
     expect(result.subtotalAfterDiscount).toBe(0);
@@ -241,7 +241,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('FRAMES15', cartItems);
+    const result = await applyPromoCode('FRAMES15', cartItems, { rateLimitKey: 'test-user' });
     expect(result.success).toBe(true);
     // Only frame (499) gets 15% off = 74.85
     expect(result.discount).toBe(74.85);
@@ -259,20 +259,20 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    await applyPromoCode('TRACK', cartItems);
+    await applyPromoCode('TRACK', cartItems, { rateLimitKey: 'test-user' });
     expect(updated).not.toBeNull();
     expect(updated.col).toBe('PromoCodes');
     expect(updated.item.usesCount).toBe(6);
   });
 
   it('rejects empty cart', async () => {
-    const result = await applyPromoCode('ANY', []);
+    const result = await applyPromoCode('ANY', [], { rateLimitKey: 'test-user' });
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/cart/i);
   });
 
   it('rejects null cart', async () => {
-    const result = await applyPromoCode('ANY', null);
+    const result = await applyPromoCode('ANY', null, { rateLimitKey: 'test-user' });
     expect(result.success).toBe(false);
   });
 
@@ -285,7 +285,7 @@ describe('applyPromoCode', () => {
       applicableProducts: '',
     }]);
 
-    const result = await applyPromoCode('ALL', cartItems);
+    const result = await applyPromoCode('ALL', cartItems, { rateLimitKey: 'test-user' });
     expect(result.discount).toBeLessThanOrEqual(1097);
     expect(result.subtotalAfterDiscount).toBe(0);
   });

--- a/tests/promotionsEngineDeep.test.js
+++ b/tests/promotionsEngineDeep.test.js
@@ -193,18 +193,18 @@ describe('validatePromoCode — deep edge cases', () => {
 
 describe('applyPromoCode — deep edge cases', () => {
   it('rejects empty cart', async () => {
-    const result = await applyPromoCode('SAVE10', []);
+    const result = await applyPromoCode('SAVE10', [], { rateLimitKey: 'test-user' });
     expect(result.success).toBe(false);
     expect(result.error).toContain('Cart items');
   });
 
   it('rejects null cart', async () => {
-    const result = await applyPromoCode('SAVE10', null);
+    const result = await applyPromoCode('SAVE10', null, { rateLimitKey: 'test-user' });
     expect(result.success).toBe(false);
   });
 
   it('rejects non-array cart', async () => {
-    const result = await applyPromoCode('SAVE10', 'not-array');
+    const result = await applyPromoCode('SAVE10', 'not-array', { rateLimitKey: 'test-user' });
     expect(result.success).toBe(false);
   });
 
@@ -212,7 +212,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 20 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: 2 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.valid).toBe(true);
     expect(result.discount).toBe(40); // 200 * 20%
     expect(result.subtotalAfterDiscount).toBe(160);
@@ -222,7 +222,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'fixed', value: 25 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: 1 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.discount).toBe(25);
     expect(result.subtotalAfterDiscount).toBe(75);
   });
@@ -231,7 +231,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'fixed', value: 500 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 50, quantity: 1 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.discount).toBe(50);
     expect(result.subtotalAfterDiscount).toBe(0);
   });
@@ -240,7 +240,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'freeShipping', value: 0 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: 1 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.discount).toBe(0);
     expect(result.freeShipping).toBe(true);
     expect(result.discountType).toBe('freeShipping');
@@ -251,7 +251,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ minSubtotal: 100 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 50, quantity: 1 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.valid).toBe(false);
     expect(result.reason).toContain('Minimum order');
   });
@@ -259,7 +259,7 @@ describe('applyPromoCode — deep edge cases', () => {
   it('limits cart items to 50', async () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 10 })]);
     const items = Array.from({ length: 60 }, (_, i) => ({ _id: `p${i}`, price: 1, quantity: 1 }));
-    const result = await applyPromoCode('SAVE10', items);
+    const result = await applyPromoCode('SAVE10', items, { rateLimitKey: 'test-user' });
     // Only first 50 items should count: subtotal = 50
     expect(result.discount).toBe(5); // 50 * 10%
   });
@@ -268,7 +268,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 10 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 0, quantity: 5 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.discount).toBe(0);
   });
 
@@ -276,7 +276,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 10 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: -50, quantity: 1 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     // Math.max(0, -50) = 0
     expect(result.discount).toBe(0);
   });
@@ -285,7 +285,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 10 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: 200 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     // qty clamped to 99: subtotal = 100*99 = 9900, discount = 990
     expect(result.discount).toBe(990);
   });
@@ -294,7 +294,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 10 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: NaN },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     // Number(NaN) || 1 = 1, Math.max(1, 1) = 1
     expect(result.discount).toBe(10); // 100 * 10%
   });
@@ -304,7 +304,7 @@ describe('applyPromoCode — deep edge cases', () => {
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: 1, category: 'futons' },
       { _id: 'p2', price: 200, quantity: 1, category: 'beds' },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     // Only futons eligible: 100 * 50% = 50
     expect(result.discount).toBe(50);
     // Subtotal is 300, after discount = 250
@@ -316,7 +316,7 @@ describe('applyPromoCode — deep edge cases', () => {
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 100, quantity: 1 },
       { _id: 'p2', price: 200, quantity: 1 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     // Fixed discount is min(subtotal, 30) = 30
     expect(result.discount).toBe(30);
   });
@@ -325,7 +325,7 @@ describe('applyPromoCode — deep edge cases', () => {
     __seed('PromoCodes', [makePromo({ type: 'percentage', value: 100 })]);
     const result = await applyPromoCode('SAVE10', [
       { _id: 'p1', price: 75, quantity: 2 },
-    ]);
+    ], { rateLimitKey: 'test-user' });
     expect(result.discount).toBe(150);
     expect(result.subtotalAfterDiscount).toBe(0);
   });
@@ -335,7 +335,7 @@ describe('applyPromoCode — deep edge cases', () => {
     let updated = null;
     __onUpdate((col, data) => { if (col === 'PromoCodes') updated = data; });
 
-    await applyPromoCode('SAVE10', [{ _id: 'p1', price: 100, quantity: 1 }]);
+    await applyPromoCode('SAVE10', [{ _id: 'p1', price: 100, quantity: 1 }], { rateLimitKey: 'test-user' });
     expect(updated.usesCount).toBe(4);
   });
 });

--- a/tests/promotionsEngineDeepen.test.js
+++ b/tests/promotionsEngineDeepen.test.js
@@ -45,7 +45,7 @@ describe('applyPromoCode — category/product restrictions', () => {
       cartItem({ _id: 'a', price: 100, category: 'futons' }),
       cartItem({ _id: 'b', price: 200, category: 'pillows' }),
     ];
-    const r = await applyPromoCode('TEST20', cart);
+    const r = await applyPromoCode('TEST20', cart, { rateLimitKey: 'test-user' });
     expect(r.valid).toBe(true);
     // 20% of 100 (futons only) = 20
     expect(r.discount).toBe(20);
@@ -58,7 +58,7 @@ describe('applyPromoCode — category/product restrictions', () => {
       cartItem({ _id: 'prod-A', price: 50, category: 'futons' }),
       cartItem({ _id: 'prod-B', price: 150, category: 'futons' }),
     ];
-    const r = await applyPromoCode('TEST20', cart);
+    const r = await applyPromoCode('TEST20', cart, { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(10); // 20% of 50
     expect(r.subtotalAfterDiscount).toBe(190);
   });
@@ -71,7 +71,7 @@ describe('applyPromoCode — category/product restrictions', () => {
     const cart = [
       cartItem({ _id: 'prod-A', price: 80, category: 'futons' }),
     ];
-    const r = await applyPromoCode('TEST20', cart);
+    const r = await applyPromoCode('TEST20', cart, { rateLimitKey: 'test-user' });
     // prod-A matches product list even though category is futons not pillows
     expect(r.discount).toBe(16); // 20% of 80
   });
@@ -84,7 +84,7 @@ describe('applyPromoCode — category/product restrictions', () => {
     const cart = [
       cartItem({ _id: 'prod-A', price: 60, category: 'futons' }),
     ];
-    const r = await applyPromoCode('TEST20', cart);
+    const r = await applyPromoCode('TEST20', cart, { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(12); // 20% of 60
   });
 
@@ -98,7 +98,7 @@ describe('applyPromoCode — category/product restrictions', () => {
       cartItem({ _id: 'acc-1', price: 30, quantity: 1, category: 'accessories' }),
       cartItem({ _id: 'p1', price: 50, quantity: 1, category: 'pillows' }),
     ];
-    const r = await applyPromoCode('TEST20', cart);
+    const r = await applyPromoCode('TEST20', cart, { rateLimitKey: 'test-user' });
     // eligible: futons 200*2=400 + acc-1 30 = 430
     // 20% of 430 = 86
     expect(r.discount).toBe(86);
@@ -112,7 +112,7 @@ describe('applyPromoCode — category/product restrictions', () => {
 describe('applyPromoCode — freeShipping', () => {
   it('returns discount:0 and freeShipping:true', async () => {
     __seed('PromoCodes', [activePromo({ type: 'freeShipping', value: 0 })]);
-    const r = await applyPromoCode('TEST20', [cartItem()]);
+    const r = await applyPromoCode('TEST20', [cartItem()], { rateLimitKey: 'test-user' });
     expect(r.valid).toBe(true);
     expect(r.discount).toBe(0);
     expect(r.freeShipping).toBe(true);
@@ -124,7 +124,7 @@ describe('applyPromoCode — freeShipping', () => {
     __seed('PromoCodes', [activePromo({ type: 'freeShipping', value: 0 })]);
     let updated = null;
     __onUpdate((col, item) => { if (col === 'PromoCodes') updated = item; });
-    await applyPromoCode('TEST20', [cartItem()]);
+    await applyPromoCode('TEST20', [cartItem()], { rateLimitKey: 'test-user' });
     expect(updated).not.toBeNull();
     expect(updated.usesCount).toBe(1);
   });
@@ -135,14 +135,14 @@ describe('applyPromoCode — freeShipping', () => {
 describe('applyPromoCode — fixed discount', () => {
   it('applies fixed dollar amount', async () => {
     __seed('PromoCodes', [activePromo({ type: 'fixed', value: 15 })]);
-    const r = await applyPromoCode('TEST20', [cartItem({ price: 100 })]);
+    const r = await applyPromoCode('TEST20', [cartItem({ price: 100 })], { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(15);
     expect(r.subtotalAfterDiscount).toBe(85);
   });
 
   it('caps fixed discount at subtotal (cannot go negative)', async () => {
     __seed('PromoCodes', [activePromo({ type: 'fixed', value: 500 })]);
-    const r = await applyPromoCode('TEST20', [cartItem({ price: 50 })]);
+    const r = await applyPromoCode('TEST20', [cartItem({ price: 50 })], { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(50);
     expect(r.subtotalAfterDiscount).toBe(0);
   });
@@ -153,7 +153,7 @@ describe('applyPromoCode — fixed discount', () => {
 describe('applyPromoCode — minSubtotal', () => {
   it('rejects when subtotal below minimum', async () => {
     __seed('PromoCodes', [activePromo({ minSubtotal: 200 })]);
-    const r = await applyPromoCode('TEST20', [cartItem({ price: 50 })]);
+    const r = await applyPromoCode('TEST20', [cartItem({ price: 50 })], { rateLimitKey: 'test-user' });
     expect(r.valid).toBe(false);
     expect(r.reason).toContain('$200');
     expect(r.reason).toContain('Minimum');
@@ -161,7 +161,7 @@ describe('applyPromoCode — minSubtotal', () => {
 
   it('accepts when subtotal meets minimum exactly', async () => {
     __seed('PromoCodes', [activePromo({ minSubtotal: 100 })]);
-    const r = await applyPromoCode('TEST20', [cartItem({ price: 100 })]);
+    const r = await applyPromoCode('TEST20', [cartItem({ price: 100 })], { rateLimitKey: 'test-user' });
     expect(r.valid).toBe(true);
     expect(r.discount).toBe(20);
   });
@@ -172,13 +172,13 @@ describe('applyPromoCode — minSubtotal', () => {
 describe('applyPromoCode — empty cart', () => {
   it('returns error for empty cartItems array', async () => {
     __seed('PromoCodes', [activePromo()]);
-    const r = await applyPromoCode('TEST20', []);
+    const r = await applyPromoCode('TEST20', [], { rateLimitKey: 'test-user' });
     expect(r.success).toBe(false);
     expect(r.error).toBeTruthy();
   });
 
   it('returns error for null cartItems', async () => {
-    const r = await applyPromoCode('TEST20', null);
+    const r = await applyPromoCode('TEST20', null, { rateLimitKey: 'test-user' });
     expect(r.success).toBe(false);
   });
 });
@@ -436,7 +436,7 @@ describe('round2 precision via applyPromoCode', () => {
   it('avoids floating point artifacts on percentage discount', async () => {
     // 33.33% of $99.99 = 33.326667 → should round to 33.33
     __seed('PromoCodes', [activePromo({ value: 33.33 })]);
-    const r = await applyPromoCode('TEST20', [cartItem({ price: 99.99 })]);
+    const r = await applyPromoCode('TEST20', [cartItem({ price: 99.99 })], { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(33.33);
     // Verify no floating artifacts (e.g. 33.330000000000004)
     expect(String(r.discount)).toMatch(/^\d+(\.\d{1,2})?$/);
@@ -452,14 +452,14 @@ describe('round2 precision via applyPromoCode', () => {
       cartItem({ _id: 'b', price: 33.33 }),
       cartItem({ _id: 'c', price: 33.33 }),
     ];
-    const r = await applyPromoCode('TEST20', cart);
+    const r = await applyPromoCode('TEST20', cart, { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(10);
     expect(r.subtotalAfterDiscount).toBe(89.99);
   });
 
   it('fixed discount subtotalAfterDiscount has no floating artifacts', async () => {
     __seed('PromoCodes', [activePromo({ type: 'fixed', value: 10.01 })]);
-    const r = await applyPromoCode('TEST20', [cartItem({ price: 33.33 })]);
+    const r = await applyPromoCode('TEST20', [cartItem({ price: 33.33 })], { rateLimitKey: 'test-user' });
     expect(r.discount).toBe(10.01);
     expect(r.subtotalAfterDiscount).toBe(23.32);
   });

--- a/tests/rateLimiting.test.js
+++ b/tests/rateLimiting.test.js
@@ -127,16 +127,22 @@ describe('applyPromoCode — rate limiting', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('uses anonymous key when rateLimitKey is not provided', async () => {
-    const inserted = [];
-    __onInsert((col, item) => inserted.push({ col, item }));
-    __seed('PromoCodes', []);
+  it('fails-close (returns error) when rateLimitKey is not provided', async () => {
+    const result = await applyPromoCode('SAVE10', validCart);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/session identifier/i);
+  });
 
-    await applyPromoCode('BADCODE', validCart);
+  it('fails-close when rateLimitKey is empty string', async () => {
+    const result = await applyPromoCode('SAVE10', validCart, { rateLimitKey: '' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/session identifier/i);
+  });
 
-    const rlInserts = inserted.filter(i => i.col === 'PromoRateLimits');
-    expect(rlInserts).toHaveLength(1);
-    expect(rlInserts[0].item.key).toBe('anonymous');
+  it('fails-close when rateLimitKey is whitespace only', async () => {
+    const result = await applyPromoCode('SAVE10', validCart, { rateLimitKey: '   ' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/session identifier/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- Removes `'anonymous'` fallback bucket from `applyPromoCode` rate limiter
- Now fails-close with error response when `rateLimitKey` is missing or whitespace
- 3 new tests: missing key, empty string, whitespace — all return failure
- ~43 existing test calls updated with `rateLimitKey: 'test-user'`

Fixes code review finding on #609 (score 80): shared anonymous bucket enabled trivial DoS — any 10 calls exhausted the shared limit for all users.

Fixes: CF-lk0c

🤖 Generated with [Claude Code](https://claude.ai/code)