### PR TITLE
feat(CF-cm3e3): Klarna HTTP functions — checkout + confirm proxy

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -20,6 +20,7 @@ import { getEnhancedCatalogFields, exportCustomerAudienceData } from 'backend/fa
 import { timingSafeEqual, decodeHtmlEntities, stripHtmlSafe, escapeXml } from 'backend/utils/httpHelpers';
 import { CLUSTERS, SITE_URL } from 'backend/utils/topicClusterData';
 import { listBundles, getBundleBySlug, addBundleToCart } from 'backend/bundleDeals.web';
+import { createKlarnaSession, readKlarnaOrder } from 'backend/klarnaService.web';
 
 /**
  * Fetch all products from the Stores/Products collection, paginating
@@ -1636,5 +1637,84 @@ export async function post_answerQuestion(request) {
   } catch (err) {
     console.error('HTTP function error (post_answerQuestion):', err);
     return serverError({ body: JSON.stringify({ error: 'Internal server error' }), headers: JSON_HEADERS });
+  }
+}
+
+// ── Klarna Checkout Proxy ─────────────────────────────────────────────
+//
+// POST /_functions/klarna/checkout — create a Klarna session; returns redirect URL
+// POST /_functions/klarna/confirm  — read a completed Klarna order
+//
+// Both paths are served by post_klarna; request.path[0] determines the action.
+// Mobile's WixClient calls these to drive the Klarna WebView redirect flow.
+export async function post_klarna(request) {
+  const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+  const sub = Array.isArray(request.path) && request.path[0];
+
+  if (sub !== 'checkout' && sub !== 'confirm') {
+    return badRequest({
+      body: JSON.stringify({ error: 'Invalid path: expected /checkout or /confirm' }),
+      headers: JSON_HEADERS,
+    });
+  }
+
+  // Parse body
+  let body;
+  try {
+    const text = await request.body.text();
+    body = JSON.parse(text);
+  } catch (_) {
+    return badRequest({
+      body: JSON.stringify({ error: 'Invalid JSON body' }),
+      headers: JSON_HEADERS,
+    });
+  }
+
+  try {
+    if (sub === 'checkout') {
+      const { lineItems, totals } = body;
+
+      if (!Array.isArray(lineItems) || lineItems.length === 0) {
+        return badRequest({
+          body: JSON.stringify({ error: 'lineItems must be a non-empty array' }),
+          headers: JSON_HEADERS,
+        });
+      }
+      if (!totals || typeof totals.total !== 'number' || totals.total <= 0) {
+        return badRequest({
+          body: JSON.stringify({ error: 'totals.total must be a positive number' }),
+          headers: JSON_HEADERS,
+        });
+      }
+
+      const result = await createKlarnaSession(lineItems, totals);
+      return ok({ body: JSON.stringify(result), headers: JSON_HEADERS });
+    }
+
+    // sub === 'confirm'
+    const { klarnaOrderId } = body;
+
+    if (typeof klarnaOrderId !== 'string' || !klarnaOrderId) {
+      return badRequest({
+        body: JSON.stringify({ error: 'klarnaOrderId must be a non-empty string' }),
+        headers: JSON_HEADERS,
+      });
+    }
+    // Reject IDs containing path traversal or control characters
+    if (/[^a-zA-Z0-9_\-]/.test(klarnaOrderId)) {
+      return badRequest({
+        body: JSON.stringify({ error: 'klarnaOrderId contains invalid characters' }),
+        headers: JSON_HEADERS,
+      });
+    }
+
+    const result = await readKlarnaOrder(klarnaOrderId);
+    return ok({ body: JSON.stringify(result), headers: JSON_HEADERS });
+  } catch (err) {
+    console.error(`HTTP function error (post_klarna/${sub}):`, err);
+    return serverError({
+      body: JSON.stringify({ error: 'Internal server error' }),
+      headers: JSON_HEADERS,
+    });
   }
 }

--- a/src/backend/klarnaService.web.js
+++ b/src/backend/klarnaService.web.js
@@ -1,0 +1,160 @@
+/**
+ * @module klarnaService
+ * @description Server-side proxy for the Klarna Checkout API.
+ *
+ * Exposes two operations consumed by post_klarna in http-functions.js:
+ *   - createKlarnaSession: creates a Klarna checkout order and returns the
+ *     redirect URL for the mobile WebView flow.
+ *   - readKlarnaOrder: reads a completed Klarna checkout order for confirmation.
+ *
+ * Credentials (KLARNA_API_USERNAME, KLARNA_API_PASSWORD, KLARNA_API_ENV) are
+ * loaded from Wix Secrets Manager on each call — never hardcoded.
+ *
+ * Amounts: all monetary values are in cents (integer), matching Klarna's wire
+ * format. Callers must not pass dollar floats.
+ */
+
+import { fetch } from 'wix-fetch';
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const KLARNA_BASE_URLS = {
+  playground: 'https://api.playground.klarna.com',
+  production: 'https://api.na.klarna.com',
+};
+
+const MERCHANT_URLS = {
+  terms: 'https://www.carolinafutons.com/terms',
+  checkout: 'https://www.carolinafutons.com/checkout',
+  confirmation: 'https://www.carolinafutons.com/order-confirmation',
+  push: 'https://www.carolinafutons.com/_functions/klarna/push',
+};
+
+// ── Credentials ───────────────────────────────────────────────────────
+
+async function loadCredentials() {
+  const { getSecret } = await import('wix-secrets-backend');
+  const [username, password, env] = await Promise.all([
+    getSecret('KLARNA_API_USERNAME'),
+    getSecret('KLARNA_API_PASSWORD'),
+    getSecret('KLARNA_API_ENV').catch(() => 'production'),
+  ]);
+  const baseUrl = KLARNA_BASE_URLS[env] ?? KLARNA_BASE_URLS.production;
+  const auth = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+  return { baseUrl, auth };
+}
+
+// ── API helpers ───────────────────────────────────────────────────────
+
+async function klarnaPost(path, body) {
+  const { baseUrl, auth } = await loadCredentials();
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': auth,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    throw new KlarnaApiError(
+      errBody.error_code ?? `HTTP ${res.status}`,
+      res.status,
+    );
+  }
+  return res.json();
+}
+
+async function klarnaGet(path) {
+  const { baseUrl, auth } = await loadCredentials();
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'GET',
+    headers: { 'Authorization': auth },
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    throw new KlarnaApiError(
+      errBody.error_code ?? `HTTP ${res.status}`,
+      res.status,
+    );
+  }
+  return res.json();
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Create a Klarna checkout session.
+ *
+ * @param {Array<{name: string, quantity: number, unitPrice: number}>} lineItems
+ * @param {{subtotal: number, shipping: number, tax: number, total: number}} totals
+ *   All values in cents.
+ * @returns {Promise<{klarnaOrderId: string, redirectUrl: string}>}
+ */
+export async function createKlarnaSession(lineItems, totals) {
+  const order_lines = lineItems.map((item) => ({
+    type: 'physical',
+    name: item.name,
+    quantity: item.quantity,
+    unit_price: item.unitPrice,
+    tax_rate: 0,
+    total_amount: item.unitPrice * item.quantity,
+    total_discount_amount: 0,
+    total_tax_amount: 0,
+  }));
+
+  // Add shipping as a separate order line if non-zero
+  if (totals.shipping > 0) {
+    order_lines.push({
+      type: 'shipping_fee',
+      name: 'Shipping',
+      quantity: 1,
+      unit_price: totals.shipping,
+      tax_rate: 0,
+      total_amount: totals.shipping,
+      total_discount_amount: 0,
+      total_tax_amount: 0,
+    });
+  }
+
+  const data = await klarnaPost('/checkout/v3/orders', {
+    purchase_country: 'US',
+    purchase_currency: 'USD',
+    locale: 'en-US',
+    order_amount: totals.total,
+    order_tax_amount: totals.tax,
+    order_lines,
+    merchant_urls: MERCHANT_URLS,
+  });
+
+  return {
+    klarnaOrderId: data.order_id,
+    redirectUrl: data.order_url,
+  };
+}
+
+/**
+ * Read a Klarna checkout order by ID (used to confirm completion).
+ *
+ * @param {string} klarnaOrderId
+ * @returns {Promise<{klarnaOrderId: string, status: string, amount: number}>}
+ */
+export async function readKlarnaOrder(klarnaOrderId) {
+  const data = await klarnaGet(`/checkout/v3/orders/${encodeURIComponent(klarnaOrderId)}`);
+  return {
+    klarnaOrderId: data.order_id,
+    status: data.status,
+    amount: data.order_amount,
+  };
+}
+
+// ── Error type ────────────────────────────────────────────────────────
+
+export class KlarnaApiError extends Error {
+  constructor(message, httpStatus) {
+    super(message);
+    this.name = 'KlarnaApiError';
+    this.httpStatus = httpStatus;
+  }
+}

--- a/tests/klarnaHttpFunctions.test.js
+++ b/tests/klarnaHttpFunctions.test.js
@@ -1,0 +1,342 @@
+/**
+ * Tests for Klarna HTTP functions
+ *
+ * Covers POST /_functions/klarna/checkout and /_functions/klarna/confirm.
+ * Both are served by post_klarna(request), dispatched on request.path[0].
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __setSecrets, __reset as resetSecrets } from './__mocks__/wix-secrets-backend.js';
+import { __setHandler, __reset as resetFetch } from './__mocks__/wix-fetch.js';
+import { post_klarna } from '../src/backend/http-functions.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const KLARNA_CREDS = {
+  KLARNA_API_USERNAME: 'PK12345_abc',
+  KLARNA_API_PASSWORD: 's3cr3t',
+  KLARNA_API_ENV: 'playground',
+};
+
+const sampleLineItems = [
+  { name: 'Eureka Futon Frame', quantity: 1, unitPrice: 49900 },
+  { name: 'Moonshadow Mattress', quantity: 2, unitPrice: 34900 },
+];
+
+const sampleTotals = {
+  subtotal: 119700,
+  shipping: 4900,
+  tax: 8379,
+  total: 132979,
+};
+
+function makeCheckoutRequest(body = {}) {
+  const payload = JSON.stringify({ lineItems: sampleLineItems, totals: sampleTotals, ...body });
+  return {
+    path: ['checkout'],
+    body: {
+      text: async () => payload,
+      json: async () => JSON.parse(payload),
+    },
+    headers: {},
+  };
+}
+
+function makeConfirmRequest(body = {}) {
+  const payload = JSON.stringify({ klarnaOrderId: 'korder-abc-123', ...body });
+  return {
+    path: ['confirm'],
+    body: {
+      text: async () => payload,
+      json: async () => JSON.parse(payload),
+    },
+    headers: {},
+  };
+}
+
+const klarnaCheckoutResponse = {
+  order_id: 'korder-abc-123',
+  order_url: 'https://checkout.klarna.com/eu1/checkout/korder-abc-123',
+  status: 'checkout_incomplete',
+};
+
+const klarnaOrderResponse = {
+  order_id: 'korder-abc-123',
+  status: 'checkout_complete',
+  order_amount: 132979,
+  purchase_currency: 'USD',
+};
+
+// ── Setup ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetSecrets();
+  resetFetch();
+  __setSecrets(KLARNA_CREDS);
+});
+
+// ── path routing ─────────────────────────────────────────────────────
+
+describe('post_klarna — routing', () => {
+  it('returns 400 for unknown sub-path', async () => {
+    __setHandler(() => ({ ok: true, json: async () => klarnaCheckoutResponse }));
+    const req = { path: ['unknown'], body: { text: async () => '{}' }, headers: {} };
+    const result = await post_klarna(req);
+    expect(result.status).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toMatch(/unknown path|invalid/i);
+  });
+
+  it('returns 400 when path is missing', async () => {
+    const req = { path: [], body: { text: async () => '{}' }, headers: {} };
+    const result = await post_klarna(req);
+    expect(result.status).toBe(400);
+  });
+});
+
+// ── checkout ─────────────────────────────────────────────────────────
+
+describe('post_klarna — checkout (/_functions/klarna/checkout)', () => {
+  it('returns 200 with klarnaOrderId and redirectUrl on success', async () => {
+    __setHandler(() => ({
+      ok: true,
+      json: async () => klarnaCheckoutResponse,
+    }));
+    const result = await post_klarna(makeCheckoutRequest());
+    expect(result.status).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.klarnaOrderId).toBe('korder-abc-123');
+    expect(body.redirectUrl).toBe('https://checkout.klarna.com/eu1/checkout/korder-abc-123');
+  });
+
+  it('calls Klarna checkout API with correct auth header', async () => {
+    let capturedUrl, capturedOptions;
+    __setHandler((url, opts) => {
+      capturedUrl = url;
+      capturedOptions = opts;
+      return { ok: true, json: async () => klarnaCheckoutResponse };
+    });
+    await post_klarna(makeCheckoutRequest());
+    expect(capturedUrl).toContain('/checkout/v3/orders');
+    expect(capturedOptions.method).toBe('POST');
+    const expected = 'Basic ' + Buffer.from('PK12345_abc:s3cr3t').toString('base64');
+    expect(capturedOptions.headers['Authorization']).toBe(expected);
+  });
+
+  it('uses playground URL when KLARNA_API_ENV=playground', async () => {
+    let capturedUrl;
+    __setHandler((url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => klarnaCheckoutResponse };
+    });
+    await post_klarna(makeCheckoutRequest());
+    expect(capturedUrl).toContain('api.playground.klarna.com');
+  });
+
+  it('uses production URL when KLARNA_API_ENV=production', async () => {
+    __setSecrets({ KLARNA_API_ENV: 'production' });
+    let capturedUrl;
+    __setHandler((url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => klarnaCheckoutResponse };
+    });
+    await post_klarna(makeCheckoutRequest());
+    expect(capturedUrl).toContain('api.na.klarna.com');
+    expect(capturedUrl).not.toContain('playground');
+  });
+
+  it('converts dollar totals to Klarna cents (×100)', async () => {
+    let capturedBody;
+    __setHandler((url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => klarnaCheckoutResponse };
+    });
+    // totals.total = 132979 cents already in the fixture — but our http function
+    // receives totals in cents (as stored internally) and passes them to Klarna
+    await post_klarna(makeCheckoutRequest());
+    expect(capturedBody.order_amount).toBe(sampleTotals.total);
+    expect(capturedBody.order_tax_amount).toBe(sampleTotals.tax);
+  });
+
+  it('includes all line items in Klarna order_lines', async () => {
+    let capturedBody;
+    __setHandler((url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => klarnaCheckoutResponse };
+    });
+    await post_klarna(makeCheckoutRequest());
+    // sampleTotals.shipping > 0, so a shipping line is appended
+    expect(capturedBody.order_lines).toHaveLength(sampleLineItems.length + 1);
+    expect(capturedBody.order_lines[0].name).toBe('Eureka Futon Frame');
+    expect(capturedBody.order_lines[0].quantity).toBe(1);
+    expect(capturedBody.order_lines[0].unit_price).toBe(49900);
+  });
+
+  it('sets purchase_country=US and purchase_currency=USD', async () => {
+    let capturedBody;
+    __setHandler((url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => klarnaCheckoutResponse };
+    });
+    await post_klarna(makeCheckoutRequest());
+    expect(capturedBody.purchase_country).toBe('US');
+    expect(capturedBody.purchase_currency).toBe('USD');
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      path: ['checkout'],
+      body: { text: async () => 'not-json' },
+      headers: {},
+    };
+    const result = await post_klarna(req);
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 400 when lineItems is missing', async () => {
+    const result = await post_klarna(makeCheckoutRequest({ lineItems: undefined }));
+    expect(result.status).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toMatch(/lineItems/i);
+  });
+
+  it('returns 400 when lineItems is empty', async () => {
+    const result = await post_klarna(makeCheckoutRequest({ lineItems: [] }));
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 400 when totals is missing', async () => {
+    const result = await post_klarna(makeCheckoutRequest({ totals: undefined }));
+    expect(result.status).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toMatch(/totals/i);
+  });
+
+  it('returns 400 when total is not a positive number', async () => {
+    const result = await post_klarna(makeCheckoutRequest({ totals: { ...sampleTotals, total: -1 } }));
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 500 when Klarna API is unavailable (secrets missing)', async () => {
+    resetSecrets();
+    __setSecrets({ KLARNA_API_USERNAME: 'u', KLARNA_API_PASSWORD: 'p' }); // no ENV
+    __setHandler(() => { throw new Error('Network failure'); });
+    const result = await post_klarna(makeCheckoutRequest());
+    expect(result.status).toBe(500);
+  });
+
+  it('returns 500 when Klarna returns non-ok response', async () => {
+    __setHandler(() => ({
+      ok: false,
+      status: 401,
+      json: async () => ({ error_code: 'UNAUTHORIZED' }),
+    }));
+    const result = await post_klarna(makeCheckoutRequest());
+    expect(result.status).toBe(500);
+  });
+
+  it('returns 500 when credentials secret is missing', async () => {
+    resetSecrets();
+    const result = await post_klarna(makeCheckoutRequest());
+    expect(result.status).toBe(500);
+  });
+
+  it('returns no-store Cache-Control header', async () => {
+    __setHandler(() => ({ ok: true, json: async () => klarnaCheckoutResponse }));
+    const result = await post_klarna(makeCheckoutRequest());
+    expect(result.headers['Cache-Control']).toBe('no-store');
+  });
+});
+
+// ── confirm ──────────────────────────────────────────────────────────
+
+describe('post_klarna — confirm (/_functions/klarna/confirm)', () => {
+  it('returns 200 with klarnaOrderId and status on success', async () => {
+    __setHandler(() => ({
+      ok: true,
+      json: async () => klarnaOrderResponse,
+    }));
+    const result = await post_klarna(makeConfirmRequest());
+    expect(result.status).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.klarnaOrderId).toBe('korder-abc-123');
+    expect(body.status).toBe('checkout_complete');
+  });
+
+  it('calls Klarna order-read endpoint with correct order ID', async () => {
+    let capturedUrl;
+    __setHandler((url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => klarnaOrderResponse };
+    });
+    await post_klarna(makeConfirmRequest());
+    expect(capturedUrl).toContain('korder-abc-123');
+    expect(capturedUrl).toContain('/checkout/v3/orders/');
+  });
+
+  it('uses correct auth header on confirm', async () => {
+    let capturedOptions;
+    __setHandler((url, opts) => {
+      capturedOptions = opts;
+      return { ok: true, json: async () => klarnaOrderResponse };
+    });
+    await post_klarna(makeConfirmRequest());
+    const expected = 'Basic ' + Buffer.from('PK12345_abc:s3cr3t').toString('base64');
+    expect(capturedOptions.headers['Authorization']).toBe(expected);
+  });
+
+  it('returns 400 when klarnaOrderId is missing', async () => {
+    const result = await post_klarna(makeConfirmRequest({ klarnaOrderId: undefined }));
+    expect(result.status).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toMatch(/klarnaOrderId/i);
+  });
+
+  it('returns 400 when klarnaOrderId is not a non-empty string', async () => {
+    const result = await post_klarna(makeConfirmRequest({ klarnaOrderId: '' }));
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = {
+      path: ['confirm'],
+      body: { text: async () => '{bad json' },
+      headers: {},
+    };
+    const result = await post_klarna(req);
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 500 when Klarna returns non-ok on confirm', async () => {
+    __setHandler(() => ({
+      ok: false,
+      status: 404,
+      json: async () => ({ error_code: 'ORDER_NOT_FOUND' }),
+    }));
+    const result = await post_klarna(makeConfirmRequest());
+    expect(result.status).toBe(500);
+  });
+
+  it('returns 500 when credentials are missing on confirm', async () => {
+    resetSecrets();
+    const result = await post_klarna(makeConfirmRequest());
+    expect(result.status).toBe(500);
+  });
+
+  it('returns no-store Cache-Control on confirm', async () => {
+    __setHandler(() => ({ ok: true, json: async () => klarnaOrderResponse }));
+    const result = await post_klarna(makeConfirmRequest());
+    expect(result.headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('sanitizes klarnaOrderId — rejects IDs with path traversal characters', async () => {
+    const result = await post_klarna(makeConfirmRequest({ klarnaOrderId: '../../../etc/passwd' }));
+    expect(result.status).toBe(400);
+  });
+
+  it('returns order amount from Klarna response', async () => {
+    __setHandler(() => ({ ok: true, json: async () => klarnaOrderResponse }));
+    const result = await post_klarna(makeConfirmRequest());
+    const body = JSON.parse(result.body);
+    expect(body.amount).toBe(132979);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /_functions/klarna/checkout` — creates a Klarna checkout session and returns `{ klarnaOrderId, redirectUrl }` for the mobile WebView flow
- Adds `POST /_functions/klarna/confirm` — reads a completed Klarna order by ID and returns `{ klarnaOrderId, status, amount }`
- Both paths served by `post_klarna(request)` dispatching on `request.path[0]` (Wix HTTP function path routing pattern)
- New `klarnaService.web.js` handles Klarna API calls: Basic auth from Wix Secrets Manager (`KLARNA_API_USERNAME`, `KLARNA_API_PASSWORD`, `KLARNA_API_ENV`), playground vs NA production URL, shipping as a separate `shipping_fee` order line
- Input validation: non-empty lineItems array, positive totals.total, klarnaOrderId sanitized against path traversal characters
- 29 TDD tests — routing, checkout happy path, confirm happy path, auth header, URL selection (playground/production), input validation, error handling

## Test plan

- [ ] `vitest run tests/klarnaHttpFunctions.test.js` — 29/29 pass
- [ ] `vitest run tests/httpFunctions.test.js` — 154/154 pass (no regression)
- [ ] Secrets `KLARNA_API_USERNAME`, `KLARNA_API_PASSWORD`, `KLARNA_API_ENV` must be added to Wix Secrets Manager before going live
- [ ] Mobile team (CF-cm3e3 cross-rig dep) to wire WixClient calls to `/_functions/klarna/checkout` and `/_functions/klarna/confirm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)