### PR TITLE
test(CF-nmbr): fix exitIntentCapture Node20 flake — replace vi.doMock with mockImplementationOnce

### DIFF
--- a/tests/exitIntentCapture.test.js
+++ b/tests/exitIntentCapture.test.js
@@ -349,9 +349,10 @@ describe('submitExitCapture', () => {
   });
 
   it('handles backend import failure gracefully', async () => {
-    vi.doMock('backend/newsletterService.web', () => {
-      throw new Error('Module not found');
-    });
+    // vi.doMock with a throwing factory is unreliable on Node 20 (cached module
+    // prevents re-evaluation). Simulate the same catch path by making the first
+    // backend call throw — submitExitCapture wraps everything in try/catch.
+    mockSubscribe.mockImplementationOnce(() => { throw new Error('Module not found'); });
     const result = await submitExitCapture('user@test.com');
     expect(result.success).toBe(false);
     expect(result.error).toBe('submission_failed');


### PR DESCRIPTION
## Summary
Fixes persistent Node 20 CI failure: `exitIntentCapture > handles backend import failure gracefully`

**Root cause**: `vi.doMock()` with a throwing factory is unreliable on Node 20. Once `backend/newsletterService.web` is cached from earlier tests in the same file, the `doMock` override is ignored and the cached working mock is returned → `success: true` instead of expected `submission_failed`.

**Fix**: Replace `vi.doMock` throw with `mockSubscribe.mockImplementationOnce(() => { throw })`. This tests the same `catch` path in `submitExitCapture` and works consistently on Node 18/20/22.

Fixes: CF-nmbr

🤖 Generated with [Claude Code](https://claude.ai/code)