### PR TITLE
feat(hq-dd6g): batch Wix catalog rename — apply CF marketing names to 16 products

### DIFF
--- a/src/backend/catalogNameUpdate.web.js
+++ b/src/backend/catalogNameUpdate.web.js
@@ -1,0 +1,98 @@
+/**
+ * @module catalogNameUpdate
+ * @description Batch-rename Wix catalog products to CF marketing names.
+ *
+ * Mapping confirmed via cross-team product name review on 2026-03-21.
+ * Run from admin dashboard or via Wix backend function.
+ *
+ * @requires wix-web-module
+ * @requires wix-stores-backend
+ */
+import { Permissions, webMethod } from 'wix-web-module';
+import { products } from 'wix-stores-backend';
+
+/**
+ * Mapping from OtisBed/Wix current product names to CF marketing names.
+ * Keys are exact current product names as they appear in the Wix catalog.
+ */
+export const CF_NAME_MAP = {
+  // Futons
+  'Gemini': 'The Gemini Full Futon',
+  'Gemini II': 'The Gemini Queen Futon',
+  'Chandler': 'The Chandler Full Futon',
+  'Mesa': 'The Mesa Full Futon',
+  'Mesa 5000': 'The Mesa Queen Futon',
+  'Yuma': 'The Yuma Full Futon',
+  'Prescott': 'The Prescott Full Futon',
+  'Sedona': 'The Sedona Queen Futon',
+  'Flagstaff': 'The Flagstaff Twin Futon',
+  'Tucson': 'The Tucson Loveseat Futon',
+  // Murphy Beds
+  'Vail': 'The Vail Queen Murphy Cabinet Bed',
+  'Aspen': 'The Aspen Full Murphy Cabinet',
+  'Breckenridge': 'The Breckenridge Queen Bookcase Murphy',
+  'Telluride': 'The Telluride Twin Cabinet Bed',
+  'Durango': 'The Durango Queen Desk Murphy',
+  'Silverton': 'The Silverton Full Storage Murphy',
+};
+
+/**
+ * Batch-rename all catalog products with CF marketing names.
+ * Skips products whose names are not in CF_NAME_MAP.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.dryRun=false] - Preview changes without writing.
+ * @returns {Promise<{updated: number, skipped: number, errors: string[], changes: Array<{from: string, to: string, id: string}>}>}
+ */
+export const runCatalogNameUpdate = webMethod(
+  Permissions.Admin,
+  async (opts = {}) => {
+    const { dryRun = false } = opts;
+    const results = { updated: 0, skipped: 0, errors: [], changes: [] };
+
+    try {
+      let allProducts = [];
+      let skip = 0;
+      const limit = 100;
+
+      // Paginate through all products (Wix cap: 100 per query)
+      while (true) {
+        const query = await products.queryProducts()
+          .skip(skip)
+          .limit(limit)
+          .find();
+
+        allProducts = allProducts.concat(query.items);
+        if (query.items.length < limit) break;
+        skip += limit;
+      }
+
+      for (const product of allProducts) {
+        const currentName = product.name;
+        const newName = CF_NAME_MAP[currentName];
+
+        if (!newName) {
+          results.skipped++;
+          continue;
+        }
+
+        results.changes.push({ id: product._id, from: currentName, to: newName });
+
+        if (!dryRun) {
+          try {
+            await products.updateProductFields(product._id, { name: newName });
+            results.updated++;
+          } catch (err) {
+            results.errors.push(`${currentName} (${product._id}): ${err.message}`);
+          }
+        } else {
+          results.updated++;
+        }
+      }
+    } catch (err) {
+      results.errors.push(`Query failed: ${err.message}`);
+    }
+
+    return results;
+  }
+);

--- a/tests/catalogNameUpdate.test.js
+++ b/tests/catalogNameUpdate.test.js
@@ -1,0 +1,273 @@
+/**
+ * @file catalogNameUpdate.test.js
+ * @description Tests for src/backend/catalogNameUpdate.web.js (hq-dd6g).
+ *
+ * Covers:
+ *  - CF_NAME_MAP: all 16 entries present, keys and values non-empty
+ *  - runCatalogNameUpdate: dry run lists changes without writing
+ *  - runCatalogNameUpdate: live run calls updateProductFields for matched products
+ *  - runCatalogNameUpdate: skips products not in the map
+ *  - runCatalogNameUpdate: captures per-product update errors without aborting
+ *  - runCatalogNameUpdate: handles query failure gracefully
+ *  - runCatalogNameUpdate: paginates when product count exceeds 100
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Capture webMethod permission for security assertion ──────────────────────
+// vi.mock is hoisted above let declarations — use vi.hoisted() so the ref is
+// available when the factory runs.
+
+const { capturedPermission } = vi.hoisted(() => ({ capturedPermission: { value: null } }));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Anyone: 'Anyone', SiteMember: 'SiteMember', Admin: 'Admin' },
+  webMethod: (perm, fn) => { capturedPermission.value = perm; return fn; },
+}));
+
+// ── Mock wix-stores-backend ──────────────────────────────────────────────────
+
+let _productPages = [];
+
+vi.mock('wix-stores-backend', () => ({
+  products: {
+    queryProducts: vi.fn(() => {
+      let _skip = 0;
+      let _limit = 100;
+      const builder = {
+        skip: vi.fn((n) => { _skip = n; return builder; }),
+        limit: vi.fn((n) => { _limit = n; return builder; }),
+        find: vi.fn(async () => {
+          // Return the page corresponding to the current skip
+          const pageIndex = _skip / _limit;
+          const page = _productPages[pageIndex] ?? [];
+          return { items: page };
+        }),
+      };
+      return builder;
+    }),
+    updateProductFields: vi.fn(async () => {}),
+  },
+}));
+
+import { products as storeMock } from 'wix-stores-backend';
+import { CF_NAME_MAP, runCatalogNameUpdate } from '../src/backend/catalogNameUpdate.web.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeProduct(id, name) {
+  return { _id: id, name };
+}
+
+beforeEach(() => {
+  _productPages = [];
+  storeMock.queryProducts.mockClear();
+  storeMock.updateProductFields.mockClear();
+});
+
+// ── Permission guard ─────────────────────────────────────────────────────────
+
+describe('runCatalogNameUpdate — permission', () => {
+  it('is restricted to Admin (not Anyone or SiteMember)', () => {
+    expect(capturedPermission.value).toBe('Admin');
+  });
+});
+
+// ── CF_NAME_MAP ──────────────────────────────────────────────────────────────
+
+describe('CF_NAME_MAP', () => {
+  it('contains exactly 16 entries', () => {
+    expect(Object.keys(CF_NAME_MAP)).toHaveLength(16);
+  });
+
+  it('all keys are non-empty strings', () => {
+    for (const key of Object.keys(CF_NAME_MAP)) {
+      expect(typeof key).toBe('string');
+      expect(key.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(CF_NAME_MAP)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('contains futon entries', () => {
+    expect(CF_NAME_MAP['Gemini']).toBe('The Gemini Full Futon');
+    expect(CF_NAME_MAP['Gemini II']).toBe('The Gemini Queen Futon');
+    expect(CF_NAME_MAP['Chandler']).toBe('The Chandler Full Futon');
+    expect(CF_NAME_MAP['Mesa']).toBe('The Mesa Full Futon');
+    expect(CF_NAME_MAP['Mesa 5000']).toBe('The Mesa Queen Futon');
+    expect(CF_NAME_MAP['Yuma']).toBe('The Yuma Full Futon');
+    expect(CF_NAME_MAP['Prescott']).toBe('The Prescott Full Futon');
+    expect(CF_NAME_MAP['Sedona']).toBe('The Sedona Queen Futon');
+    expect(CF_NAME_MAP['Flagstaff']).toBe('The Flagstaff Twin Futon');
+    expect(CF_NAME_MAP['Tucson']).toBe('The Tucson Loveseat Futon');
+  });
+
+  it('contains murphy bed entries', () => {
+    expect(CF_NAME_MAP['Vail']).toBe('The Vail Queen Murphy Cabinet Bed');
+    expect(CF_NAME_MAP['Aspen']).toBe('The Aspen Full Murphy Cabinet');
+    expect(CF_NAME_MAP['Breckenridge']).toBe('The Breckenridge Queen Bookcase Murphy');
+    expect(CF_NAME_MAP['Telluride']).toBe('The Telluride Twin Cabinet Bed');
+    expect(CF_NAME_MAP['Durango']).toBe('The Durango Queen Desk Murphy');
+    expect(CF_NAME_MAP['Silverton']).toBe('The Silverton Full Storage Murphy');
+  });
+});
+
+// ── runCatalogNameUpdate — dry run ───────────────────────────────────────────
+
+describe('runCatalogNameUpdate — dry run', () => {
+  it('lists changes without calling updateProductFields', async () => {
+    _productPages = [
+      [makeProduct('prod-1', 'Gemini'), makeProduct('prod-2', 'Vail')],
+    ];
+
+    const result = await runCatalogNameUpdate({ dryRun: true });
+
+    expect(result.updated).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(storeMock.updateProductFields).not.toHaveBeenCalled();
+  });
+
+  it('populates changes array with from/to/id', async () => {
+    _productPages = [
+      [makeProduct('prod-1', 'Mesa')],
+    ];
+
+    const result = await runCatalogNameUpdate({ dryRun: true });
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toEqual({
+      id: 'prod-1',
+      from: 'Mesa',
+      to: 'The Mesa Full Futon',
+    });
+  });
+
+  it('skips unknown products in dry run', async () => {
+    _productPages = [
+      [makeProduct('prod-1', 'Unknown Product'), makeProduct('prod-2', 'Gemini')],
+    ];
+
+    const result = await runCatalogNameUpdate({ dryRun: true });
+
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0].from).toBe('Gemini');
+  });
+});
+
+// ── runCatalogNameUpdate — live run ─────────────────────────────────────────
+
+describe('runCatalogNameUpdate — live run', () => {
+  it('calls updateProductFields for each matched product', async () => {
+    _productPages = [
+      [
+        makeProduct('prod-1', 'Gemini'),
+        makeProduct('prod-2', 'Vail'),
+        makeProduct('prod-3', 'Unknown'),
+      ],
+    ];
+
+    const result = await runCatalogNameUpdate();
+
+    expect(storeMock.updateProductFields).toHaveBeenCalledTimes(2);
+    expect(storeMock.updateProductFields).toHaveBeenCalledWith('prod-1', { name: 'The Gemini Full Futon' });
+    expect(storeMock.updateProductFields).toHaveBeenCalledWith('prod-2', { name: 'The Vail Queen Murphy Cabinet Bed' });
+    expect(result.updated).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns correct changes array on live run', async () => {
+    _productPages = [
+      [makeProduct('prod-a', 'Chandler')],
+    ];
+
+    const result = await runCatalogNameUpdate();
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toEqual({
+      id: 'prod-a',
+      from: 'Chandler',
+      to: 'The Chandler Full Futon',
+    });
+  });
+
+  it('skips products not in the map and does not call update for them', async () => {
+    _productPages = [
+      [makeProduct('prod-x', 'Not In Map'), makeProduct('prod-y', 'Also Unknown')],
+    ];
+
+    const result = await runCatalogNameUpdate();
+
+    expect(storeMock.updateProductFields).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(2);
+    expect(result.updated).toBe(0);
+  });
+
+  it('captures per-product update errors without aborting the batch', async () => {
+    _productPages = [
+      [makeProduct('prod-1', 'Gemini'), makeProduct('prod-2', 'Mesa')],
+    ];
+
+    // First update succeeds, second throws
+    storeMock.updateProductFields
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('API timeout'));
+
+    const result = await runCatalogNameUpdate();
+
+    expect(result.updated).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Mesa');
+    expect(result.errors[0]).toContain('API timeout');
+  });
+
+  it('handles query failure gracefully and returns error', async () => {
+    storeMock.queryProducts.mockImplementationOnce(() => ({
+      skip: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      find: vi.fn().mockRejectedValueOnce(new Error('DB unavailable')),
+    }));
+
+    const result = await runCatalogNameUpdate();
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Query failed');
+    expect(result.updated).toBe(0);
+  });
+
+  it('paginates when product count equals page size (100)', async () => {
+    // Page 0: 100 products (exactly at limit — triggers another page)
+    const page0 = Array.from({ length: 100 }, (_, i) =>
+      makeProduct(`prod-${i}`, i === 0 ? 'Gemini' : `Unknown-${i}`)
+    );
+    // Page 1: fewer than 100 — signals end of results
+    const page1 = [makeProduct('prod-100', 'Vail')];
+
+    _productPages = [page0, page1];
+
+    const result = await runCatalogNameUpdate();
+
+    // 2 matched across 2 pages
+    expect(result.updated).toBe(2);
+    expect(storeMock.updateProductFields).toHaveBeenCalledWith('prod-0', { name: 'The Gemini Full Futon' });
+    expect(storeMock.updateProductFields).toHaveBeenCalledWith('prod-100', { name: 'The Vail Queen Murphy Cabinet Bed' });
+  });
+
+  it('empty catalog returns zero counts and no errors', async () => {
+    _productPages = [[]];
+
+    const result = await runCatalogNameUpdate();
+
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(result.changes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `runCatalogNameUpdate` — a `Permissions.Admin` webMethod that batch-renames Wix catalog products to CF marketing names confirmed by Dallas (hq-2o1s, 2026-03-21)
- `CF_NAME_MAP`: 16 OtisBed → CF name mappings (10 futons, 6 murphy beds)
- Supports `dryRun` mode: lists changes without writing to catalog
- Paginates all products (Wix cap: 100/query), handles >100 products safely
- Per-product error isolation: one `updateProductFields` failure does not abort the batch

## Test plan

- [x] `CF_NAME_MAP` completeness — 16 entries, all futon + murphy keys/values correct
- [x] Dry run — changes listed, `updateProductFields` never called
- [x] Live run — `updateProductFields` called with correct id + name per matched product
- [x] Skips unknown products
- [x] Per-product error captured in `errors[]`, batch continues
- [x] Query failure returns error in result without throwing
- [x] Pagination — 100-product page triggers second query, results combined
- [x] Empty catalog — returns zero counts, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)