### PR TITLE
feat(cf-y2l3): Trade-In / Trade-Up program

### DIFF
--- a/src/backend/tradeInService.web.js
+++ b/src/backend/tradeInService.web.js
@@ -1,0 +1,361 @@
+/**
+ * @module tradeInService
+ * @description Trade-In / Trade-Up program backend.
+ *
+ * Customers submit their old furniture (futon frame, mattress, murphy bed, etc.)
+ * and receive an estimated store credit range. Staff confirm in-store condition
+ * and issue the actual credit via storeCreditService.
+ *
+ * @setup (manual steps required)
+ * CMS collections:
+ *   TradeInRequests (
+ *     requestId Text indexed, email Text, name Text, phone Text,
+ *     productType Text, condition Text, description Text,
+ *     photoUrls Text (JSON array), estimatedCredit Number,
+ *     status Text: 'pending'|'confirmed'|'declined'|'expired',
+ *     staffNotes Text, actualCondition Text, creditId Text,
+ *     createdAt Date, updatedAt Date
+ *   )
+ *   TradeInRateLimit (email Text, count Number, windowStart Date)
+ * Secrets: none required — uses existing ANTHROPIC_API_KEY indirectly via storeCreditService
+ *
+ * @note Condition credit values are starting points — Stilgar to confirm final numbers.
+ */
+
+import { Permissions, webMethod } from 'wix-web-module';
+import wixData from 'wix-data';
+import { sanitize, validateEmail, validateId } from 'backend/utils/sanitize';
+
+const TRADE_IN_REQUESTS = 'TradeInRequests';
+const RATE_LIMIT_COLLECTION = 'TradeInRateLimit';
+
+// Rate limiting: max 3 submissions per email per 24h
+const RATE_LIMIT_MAX = 3;
+const RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// Requests expire after 30 days if not confirmed
+const REQUEST_EXPIRY_DAYS = 30;
+
+// Credit ranges by product type and condition.
+// Each value is the BASE credit amount. A ±15% range is shown to customers
+// to reflect that final assessment happens in-store.
+// Values in dollars — Stilgar to confirm before go-live.
+export const CONDITION_MATRIX = {
+  'futon-frame':   { good: 75,  fair: 50,  poor: 25 },
+  'futon-mattress':{ good: 40,  fair: 25,  poor: 0  }, // poor = hygiene, no credit
+  'murphy-bed':    { good: 100, fair: 65,  poor: 30 },
+  'platform-bed':  { good: 80,  fair: 55,  poor: 25 },
+  'sofa':          { good: 60,  fair: 40,  poor: 15 },
+};
+
+export const VALID_PRODUCT_TYPES = Object.keys(CONDITION_MATRIX);
+export const VALID_CONDITIONS = ['good', 'fair', 'poor'];
+
+/** Credit range shown to customers: base ±15%, floored at 0. */
+export function creditRange(base) {
+  if (base <= 0) return { min: 0, max: 0 };
+  const delta = Math.round(base * 0.15);
+  return { min: Math.max(0, base - delta), max: base + delta };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function checkRateLimit(email, nowMs = Date.now()) {
+  try {
+    const res = await wixData.query(RATE_LIMIT_COLLECTION)
+      .eq('email', email)
+      .limit(1)
+      .find();
+    const record = res.items[0] || null;
+
+    if (!record) {
+      await wixData.insert(RATE_LIMIT_COLLECTION, {
+        email,
+        count: 1,
+        windowStart: new Date(nowMs),
+      });
+      return { allowed: true };
+    }
+
+    const windowAge = nowMs - new Date(record.windowStart).getTime();
+    if (windowAge > RATE_LIMIT_WINDOW_MS) {
+      await wixData.update(RATE_LIMIT_COLLECTION, {
+        ...record,
+        count: 1,
+        windowStart: new Date(nowMs),
+      });
+      return { allowed: true };
+    }
+
+    if (record.count >= RATE_LIMIT_MAX) {
+      return { allowed: false, reason: 'rate_limited' };
+    }
+
+    await wixData.update(RATE_LIMIT_COLLECTION, { ...record, count: record.count + 1 });
+    return { allowed: true };
+  } catch (err) {
+    console.warn('[tradeInService] rate limit check failed, allowing request:', err?.message);
+    return { allowed: true }; // Fail open
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public webMethods
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the estimated store credit range for a given product type and condition.
+ * Returns { eligible: false } for unsupported product types.
+ * Returns { eligible: true, min, max, base } when credit is available.
+ * Returns { eligible: true, min: 0, max: 0, ineligible: true } for poor-condition mattresses.
+ *
+ * @param {string} productType
+ * @param {string} condition — 'good' | 'fair' | 'poor'
+ */
+export const estimateTradeIn = webMethod(
+  Permissions.Anyone,
+  async (productType, condition) => {
+    const type = sanitize(productType || '', 50).toLowerCase();
+    const cond = sanitize(condition || '', 20).toLowerCase();
+
+    if (!VALID_PRODUCT_TYPES.includes(type)) {
+      return { eligible: false };
+    }
+    if (!VALID_CONDITIONS.includes(cond)) {
+      return { eligible: false, error: 'invalid_condition' };
+    }
+
+    const base = CONDITION_MATRIX[type][cond];
+    const { min, max } = creditRange(base);
+    return { eligible: true, min, max, base, productType: type, condition: cond };
+  }
+);
+
+/**
+ * Submit a trade-in request.
+ * Anyone can submit — no login required (pre-sale / in-store flow).
+ *
+ * @param {Object} data
+ * @param {string} data.name
+ * @param {string} data.email
+ * @param {string} [data.phone]
+ * @param {string} data.productType
+ * @param {string} data.condition
+ * @param {string} [data.description]
+ * @param {string[]} [data.photoUrls]
+ * @returns {{ success: boolean, requestId?: string, estimatedCredit?: number, error?: string }}
+ */
+export const submitTradeInRequest = webMethod(
+  Permissions.Anyone,
+  async (data) => {
+    if (!data || typeof data !== 'object') {
+      return { success: false, error: 'invalid_request' };
+    }
+
+    const name = sanitize(data.name || '', 100);
+    const email = sanitize(data.email || '', 254).toLowerCase();
+    const phone = sanitize(data.phone || '', 30);
+    const productType = sanitize(data.productType || '', 50).toLowerCase();
+    const condition = sanitize(data.condition || '', 20).toLowerCase();
+    const description = sanitize(data.description || '', 1000);
+
+    // Validate photo URLs — accept only Wix media URLs or empty
+    let photoUrls = [];
+    if (Array.isArray(data.photoUrls)) {
+      const { isWixMediaUrl } = await import('backend/utils/sanitize');
+      photoUrls = data.photoUrls
+        .slice(0, 5) // max 5 photos
+        .filter(u => typeof u === 'string' && isWixMediaUrl(u));
+    }
+
+    if (!name) return { success: false, error: 'name_required' };
+    if (!validateEmail(email)) return { success: false, error: 'invalid_email' };
+    if (!VALID_PRODUCT_TYPES.includes(productType)) return { success: false, error: 'invalid_product_type' };
+    if (!VALID_CONDITIONS.includes(condition)) return { success: false, error: 'invalid_condition' };
+
+    // Rate limit by email
+    const rl = await checkRateLimit(email);
+    if (!rl.allowed) return { success: false, error: 'rate_limited' };
+
+    const base = CONDITION_MATRIX[productType][condition];
+    const { min, max } = creditRange(base);
+    const estimatedCredit = base;
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + REQUEST_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+
+    // Generate a short human-readable request ID (TI-XXXXXXXX)
+    const requestId = 'TI-' + Math.random().toString(36).slice(2, 10).toUpperCase();
+
+    try {
+      await wixData.insert(TRADE_IN_REQUESTS, {
+        requestId,
+        email,
+        name,
+        phone,
+        productType,
+        condition,
+        description,
+        photoUrls: JSON.stringify(photoUrls),
+        estimatedCredit,
+        estimatedMin: min,
+        estimatedMax: max,
+        status: 'pending',
+        staffNotes: '',
+        actualCondition: '',
+        creditId: '',
+        createdAt: now,
+        updatedAt: now,
+        expiresAt,
+      });
+    } catch (err) {
+      console.error('[tradeInService] insert failed:', err?.message);
+      return { success: false, error: 'submission_failed' };
+    }
+
+    return { success: true, requestId, estimatedCredit, estimatedMin: min, estimatedMax: max };
+  }
+);
+
+/**
+ * Look up a trade-in request by requestId and email (for status checking).
+ * Email verification prevents enumeration.
+ *
+ * @param {string} requestId
+ * @param {string} email
+ */
+export const getTradeInRequest = webMethod(
+  Permissions.Anyone,
+  async (requestId, email) => {
+    const cleanId = sanitize(requestId || '', 20);
+    const cleanEmail = sanitize(email || '', 254).toLowerCase();
+
+    if (!cleanId || !validateEmail(cleanEmail)) {
+      return { success: false, error: 'invalid_request' };
+    }
+
+    try {
+      const res = await wixData.query(TRADE_IN_REQUESTS)
+        .eq('requestId', cleanId)
+        .eq('email', cleanEmail)
+        .limit(1)
+        .find();
+
+      if (!res.items.length) return { success: false, error: 'not_found' };
+
+      const r = res.items[0];
+      return {
+        success: true,
+        request: {
+          requestId: r.requestId,
+          productType: r.productType,
+          condition: r.condition,
+          status: r.status,
+          estimatedMin: r.estimatedMin,
+          estimatedMax: r.estimatedMax,
+          createdAt: r.createdAt,
+          expiresAt: r.expiresAt,
+        },
+      };
+    } catch (err) {
+      console.error('[tradeInService] lookup failed:', err?.message);
+      return { success: false, error: 'lookup_failed' };
+    }
+  }
+);
+
+/**
+ * Staff confirmation: verify item in-store, set actual condition, issue store credit.
+ *
+ * @param {string} requestId
+ * @param {string} actualCondition — 'good' | 'fair' | 'poor' | 'declined'
+ * @param {string} [staffNotes]
+ */
+export const confirmTradeIn = webMethod(
+  Permissions.Admin,
+  async (requestId, actualCondition, staffNotes = '') => {
+    const cleanId = sanitize(requestId || '', 20);
+    const cond = sanitize(actualCondition || '', 20).toLowerCase();
+    const notes = sanitize(staffNotes || '', 500);
+
+    if (!cleanId) return { success: false, error: 'invalid_request_id' };
+
+    const declined = cond === 'declined';
+    if (!declined && !VALID_CONDITIONS.includes(cond)) {
+      return { success: false, error: 'invalid_condition' };
+    }
+
+    let record;
+    try {
+      const res = await wixData.query(TRADE_IN_REQUESTS)
+        .eq('requestId', cleanId)
+        .limit(1)
+        .find();
+      record = res.items[0];
+    } catch (err) {
+      console.error('[tradeInService] confirmTradeIn query failed:', err?.message);
+      return { success: false, error: 'lookup_failed' };
+    }
+
+    if (!record) return { success: false, error: 'not_found' };
+    if (record.status !== 'pending') {
+      return { success: false, error: 'already_processed', status: record.status };
+    }
+
+    const now = new Date();
+
+    if (declined) {
+      await wixData.update(TRADE_IN_REQUESTS, {
+        ...record,
+        status: 'declined',
+        actualCondition: 'declined',
+        staffNotes: notes,
+        updatedAt: now,
+      });
+      return { success: true, status: 'declined' };
+    }
+
+    // Issue store credit via storeCreditService
+    const base = CONDITION_MATRIX[record.productType]?.[cond] ?? 0;
+
+    if (base <= 0) {
+      // No credit (e.g., poor-condition mattress)
+      await wixData.update(TRADE_IN_REQUESTS, {
+        ...record,
+        status: 'confirmed',
+        actualCondition: cond,
+        staffNotes: notes,
+        updatedAt: now,
+      });
+      return { success: true, status: 'confirmed', creditAmount: 0 };
+    }
+
+    let creditId = '';
+    try {
+      const { issueStoreCredit } = await import('backend/storeCreditService.web');
+      const creditResult = await issueStoreCredit({
+        memberId: record.memberId || record.email, // email fallback for non-members
+        amount: base,
+        reason: 'promotion',
+        orderReference: cleanId,
+      });
+      creditId = creditResult?.creditId || '';
+    } catch (err) {
+      console.error('[tradeInService] credit issuance failed:', err?.message);
+      return { success: false, error: 'credit_issuance_failed' };
+    }
+
+    await wixData.update(TRADE_IN_REQUESTS, {
+      ...record,
+      status: 'confirmed',
+      actualCondition: cond,
+      staffNotes: notes,
+      creditId,
+      updatedAt: now,
+    });
+
+    return { success: true, status: 'confirmed', creditAmount: base, creditId };
+  }
+);

--- a/src/backend/tradeInService.web.js
+++ b/src/backend/tradeInService.web.js
@@ -9,23 +9,25 @@
  * @setup (manual steps required)
  * CMS collections:
  *   TradeInRequests (
- *     requestId Text indexed, email Text, name Text, phone Text,
+ *     requestId Text — ADD UNIQUE INDEX on this field in the CMS editor,
+ *     email Text, name Text, phone Text,
  *     productType Text, condition Text, description Text,
  *     photoUrls Text (JSON array), estimatedCredit Number,
  *     estimatedMin Number, estimatedMax Number,
- *     status Text: 'pending'|'confirmed'|'declined'|'expired',
+ *     status Text: 'pending'|'processing'|'confirmed'|'declined'|'expired',
  *     staffNotes Text, actualCondition Text, creditId Text,
  *     createdAt Date, updatedAt Date, expiresAt Date
  *   )
- *   TradeInRateLimit (email Text, count Number, windowStart Date)
- * Secrets: none required — uses existing ANTHROPIC_API_KEY indirectly via storeCreditService
+ *   TradeInRateLimit (email Text — ADD UNIQUE INDEX on email, count Number, windowStart Date)
+ * Secrets: none required — uses existing credit system via storeCreditService
  *
- * @note Condition credit values are starting points — Stilgar to confirm final numbers.
+ * @note TODO: confirm final credit values before go-live.
  */
 
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateEmail, validateId, isWixMediaUrl } from 'backend/utils/sanitize';
+import { randomUUID } from 'crypto';
 
 const TRADE_IN_REQUESTS = 'TradeInRequests';
 const RATE_LIMIT_COLLECTION = 'TradeInRateLimit';
@@ -40,7 +42,7 @@ const REQUEST_EXPIRY_DAYS = 30;
 // Credit ranges by product type and condition.
 // Each value is the BASE credit amount. A ±15% range is shown to customers
 // to reflect that final assessment happens in-store.
-// Values in dollars — Stilgar to confirm before go-live.
+// Values in dollars — TODO: confirm final credit values before go-live.
 export const CONDITION_MATRIX = {
   'futon-frame':   { good: 75,  fair: 50,  poor: 25 },
   'futon-mattress':{ good: 40,  fair: 25,  poor: 0  }, // poor = hygiene, no credit
@@ -63,6 +65,13 @@ export function creditRange(base) {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Rate-limit check for trade-in submissions.
+ * Uses a retry pattern to handle concurrent inserts: if two requests arrive
+ * simultaneously and both see no existing record, the second insert will
+ * fail (unique email constraint). We catch that and re-query to enforce
+ * the limit correctly rather than failing open with a bad count.
+ */
 async function checkRateLimit(email, nowMs = Date.now()) {
   try {
     const res = await wixData.query(RATE_LIMIT_COLLECTION)
@@ -72,12 +81,36 @@ async function checkRateLimit(email, nowMs = Date.now()) {
     const record = res.items[0] || null;
 
     if (!record) {
-      await wixData.insert(RATE_LIMIT_COLLECTION, {
-        email,
-        count: 1,
-        windowStart: new Date(nowMs),
-      });
-      return { allowed: true };
+      try {
+        await wixData.insert(RATE_LIMIT_COLLECTION, {
+          email,
+          count: 1,
+          windowStart: new Date(nowMs),
+        });
+        return { allowed: true };
+      } catch (_insertErr) {
+        // Concurrent request inserted first — re-fetch and apply limit check
+        try {
+          const retryRes = await wixData.query(RATE_LIMIT_COLLECTION)
+            .eq('email', email)
+            .limit(1)
+            .find();
+          const retryRecord = retryRes.items[0];
+          if (!retryRecord) return { allowed: true };
+          if (retryRecord.count >= RATE_LIMIT_MAX) {
+            return { allowed: false, reason: 'rate_limited' };
+          }
+          await wixData.update(RATE_LIMIT_COLLECTION, {
+            ...retryRecord,
+            count: retryRecord.count + 1,
+          });
+          return { allowed: true };
+        } catch (_retryErr) {
+          // Fail open — better to allow than silently block on a DB hiccup
+          console.error('[tradeInService] rate limit retry failed:', _retryErr);
+          return { allowed: true };
+        }
+      }
     }
 
     const windowAge = nowMs - new Date(record.windowStart).getTime();
@@ -186,8 +219,8 @@ export const submitTradeInRequest = webMethod(
     const now = new Date();
     const expiresAt = new Date(now.getTime() + REQUEST_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
 
-    // Generate a short human-readable request ID (TI-XXXXXXXX)
-    const requestId = 'TI-' + Math.random().toString(36).slice(2, 10).toUpperCase();
+    // Use UUID for collision-safe request IDs
+    const requestId = 'TI-' + randomUUID().replace(/-/g, '').slice(0, 12).toUpperCase();
 
     try {
       await wixData.insert(TRADE_IN_REQUESTS, {
@@ -269,18 +302,27 @@ export const getTradeInRequest = webMethod(
 /**
  * Staff confirmation: verify item in-store, set actual condition, issue store credit.
  *
+ * IDOR note: requires both requestId AND customer email so staff cannot accidentally
+ * confirm the wrong person's trade-in from a bare ID.
+ *
+ * Double-issue protection: sets status to 'processing' before calling issueStoreCredit.
+ * A concurrent or retry call will see status !== 'pending' and abort cleanly.
+ *
  * @param {string} requestId
+ * @param {string} customerEmail — must match the email on the original request
  * @param {string} actualCondition — 'good' | 'fair' | 'poor' | 'declined'
  * @param {string} [staffNotes]
  */
 export const confirmTradeIn = webMethod(
   Permissions.Admin,
-  async (requestId, actualCondition, staffNotes = '') => {
+  async (requestId, customerEmail, actualCondition, staffNotes = '') => {
     const cleanId = sanitize(requestId || '', 20);
+    const cleanEmail = sanitize(customerEmail || '', 254).toLowerCase();
     const cond = sanitize(actualCondition || '', 20).toLowerCase();
     const notes = sanitize(staffNotes || '', 500);
 
     if (!cleanId) return { success: false, error: 'invalid_request_id' };
+    if (!validateEmail(cleanEmail)) return { success: false, error: 'invalid_email' };
 
     const declined = cond === 'declined';
     if (!declined && !VALID_CONDITIONS.includes(cond)) {
@@ -291,6 +333,7 @@ export const confirmTradeIn = webMethod(
     try {
       const res = await wixData.query(TRADE_IN_REQUESTS)
         .eq('requestId', cleanId)
+        .eq('email', cleanEmail)
         .limit(1)
         .find();
       record = res.items[0];
@@ -342,6 +385,20 @@ export const confirmTradeIn = webMethod(
       return { success: true, status: 'confirmed', creditAmount: 0 };
     }
 
+    // Mark as 'processing' BEFORE issuing credit to prevent double-issue on retry.
+    // If a concurrent confirmTradeIn call arrives, it will see status='processing'
+    // (not 'pending') and return already_processed.
+    try {
+      await wixData.update(TRADE_IN_REQUESTS, {
+        ...record,
+        status: 'processing',
+        updatedAt: now,
+      });
+    } catch (err) {
+      console.error('[tradeInService] confirmTradeIn processing-lock failed:', err?.message);
+      return { success: false, error: 'update_failed' };
+    }
+
     let creditId = '';
     try {
       const { issueStoreCredit } = await import('backend/storeCreditService.web');
@@ -369,7 +426,7 @@ export const confirmTradeIn = webMethod(
     } catch (err) {
       // Credit was already issued — log prominently for manual reconciliation.
       // Do NOT return an error to the caller (credit is real), but flag for ops.
-      console.error('[tradeInService] confirmTradeIn CMS update failed after credit issued — MANUAL RECONCILIATION REQUIRED:', { requestId: cleanId, creditId, err: err?.message });
+      console.error('[tradeInService] CMS update failed after credit issued — MANUAL RECONCILIATION REQUIRED:', { requestId: cleanId, creditId, err: err?.message });
     }
 
     return { success: true, status: 'confirmed', creditAmount: base, creditId };

--- a/src/backend/tradeInService.web.js
+++ b/src/backend/tradeInService.web.js
@@ -12,9 +12,10 @@
  *     requestId Text indexed, email Text, name Text, phone Text,
  *     productType Text, condition Text, description Text,
  *     photoUrls Text (JSON array), estimatedCredit Number,
+ *     estimatedMin Number, estimatedMax Number,
  *     status Text: 'pending'|'confirmed'|'declined'|'expired',
  *     staffNotes Text, actualCondition Text, creditId Text,
- *     createdAt Date, updatedAt Date
+ *     createdAt Date, updatedAt Date, expiresAt Date
  *   )
  *   TradeInRateLimit (email Text, count Number, windowStart Date)
  * Secrets: none required — uses existing ANTHROPIC_API_KEY indirectly via storeCreditService
@@ -24,7 +25,7 @@
 
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
-import { sanitize, validateEmail, validateId } from 'backend/utils/sanitize';
+import { sanitize, validateEmail, validateId, isWixMediaUrl } from 'backend/utils/sanitize';
 
 const TRADE_IN_REQUESTS = 'TradeInRequests';
 const RATE_LIMIT_COLLECTION = 'TradeInRateLimit';
@@ -96,7 +97,7 @@ async function checkRateLimit(email, nowMs = Date.now()) {
     await wixData.update(RATE_LIMIT_COLLECTION, { ...record, count: record.count + 1 });
     return { allowed: true };
   } catch (err) {
-    console.warn('[tradeInService] rate limit check failed, allowing request:', err?.message);
+    console.error('[tradeInService] rate limit check failed, allowing request:', err);
     return { allowed: true }; // Fail open
   }
 }
@@ -109,7 +110,7 @@ async function checkRateLimit(email, nowMs = Date.now()) {
  * Get the estimated store credit range for a given product type and condition.
  * Returns { eligible: false } for unsupported product types.
  * Returns { eligible: true, min, max, base } when credit is available.
- * Returns { eligible: true, min: 0, max: 0, ineligible: true } for poor-condition mattresses.
+ * Returns { eligible: true, min: 0, max: 0, base: 0 } for zero-value conditions (e.g., poor mattress).
  *
  * @param {string} productType
  * @param {string} condition — 'good' | 'fair' | 'poor'
@@ -164,7 +165,6 @@ export const submitTradeInRequest = webMethod(
     // Validate photo URLs — accept only Wix media URLs or empty
     let photoUrls = [];
     if (Array.isArray(data.photoUrls)) {
-      const { isWixMediaUrl } = await import('backend/utils/sanitize');
       photoUrls = data.photoUrls
         .slice(0, 5) // max 5 photos
         .filter(u => typeof u === 'string' && isWixMediaUrl(u));
@@ -307,13 +307,18 @@ export const confirmTradeIn = webMethod(
     const now = new Date();
 
     if (declined) {
-      await wixData.update(TRADE_IN_REQUESTS, {
-        ...record,
-        status: 'declined',
-        actualCondition: 'declined',
-        staffNotes: notes,
-        updatedAt: now,
-      });
+      try {
+        await wixData.update(TRADE_IN_REQUESTS, {
+          ...record,
+          status: 'declined',
+          actualCondition: 'declined',
+          staffNotes: notes,
+          updatedAt: now,
+        });
+      } catch (err) {
+        console.error('[tradeInService] confirmTradeIn declined-update failed:', err?.message);
+        return { success: false, error: 'update_failed' };
+      }
       return { success: true, status: 'declined' };
     }
 
@@ -322,13 +327,18 @@ export const confirmTradeIn = webMethod(
 
     if (base <= 0) {
       // No credit (e.g., poor-condition mattress)
-      await wixData.update(TRADE_IN_REQUESTS, {
-        ...record,
-        status: 'confirmed',
-        actualCondition: cond,
-        staffNotes: notes,
-        updatedAt: now,
-      });
+      try {
+        await wixData.update(TRADE_IN_REQUESTS, {
+          ...record,
+          status: 'confirmed',
+          actualCondition: cond,
+          staffNotes: notes,
+          updatedAt: now,
+        });
+      } catch (err) {
+        console.error('[tradeInService] confirmTradeIn zero-credit-update failed:', err?.message);
+        return { success: false, error: 'update_failed' };
+      }
       return { success: true, status: 'confirmed', creditAmount: 0 };
     }
 
@@ -347,14 +357,20 @@ export const confirmTradeIn = webMethod(
       return { success: false, error: 'credit_issuance_failed' };
     }
 
-    await wixData.update(TRADE_IN_REQUESTS, {
-      ...record,
-      status: 'confirmed',
-      actualCondition: cond,
-      staffNotes: notes,
-      creditId,
-      updatedAt: now,
-    });
+    try {
+      await wixData.update(TRADE_IN_REQUESTS, {
+        ...record,
+        status: 'confirmed',
+        actualCondition: cond,
+        staffNotes: notes,
+        creditId,
+        updatedAt: now,
+      });
+    } catch (err) {
+      // Credit was already issued — log prominently for manual reconciliation.
+      // Do NOT return an error to the caller (credit is real), but flag for ops.
+      console.error('[tradeInService] confirmTradeIn CMS update failed after credit issued — MANUAL RECONCILIATION REQUIRED:', { requestId: cleanId, creditId, err: err?.message });
+    }
 
     return { success: true, status: 'confirmed', creditAmount: base, creditId };
   }

--- a/src/pages/Trade In.js
+++ b/src/pages/Trade In.js
@@ -1,0 +1,317 @@
+/**
+ * Trade In.js — Customer-facing Trade-In / Trade-Up page.
+ *
+ * Flow:
+ * 1. Customer selects product type + condition → live estimate shown
+ * 2. Customer fills contact info + optional description + photo upload
+ * 3. Submit → confirmation panel with request ID shown
+ * 4. Status lookup by request ID + email
+ *
+ * Wix elements:
+ *   #tradeInTitle, #tradeInSubtitle
+ *   #productTypeDropdown, #conditionDropdown
+ *   #estimateSection, #estimateText, #estimateRange
+ *   #nameInput, #emailInput, #phoneInput, #descriptionInput
+ *   #photoUpload
+ *   #submitTradeInBtn
+ *   #errorText
+ *   #confirmationSection, #confirmationRequestId, #confirmationEstimate
+ *   #statusSection, #statusRequestIdInput, #statusEmailInput, #checkStatusBtn
+ *   #statusResult
+ */
+
+import { estimateTradeIn, submitTradeInRequest, getTradeInRequest } from 'backend/tradeInService.web';
+import { buildConditionOptions, formatEstimateText } from 'public/TradeInWidget.js';
+import { announce } from 'public/a11yHelpers.js';
+import { trackEvent } from 'public/engagementTracker';
+import { sanitizeText } from 'public/validators';
+
+let _submitting = false;
+
+$w.onReady(async function () {
+  initPage();
+  initEstimateForm();
+  initSubmitForm();
+  initStatusLookup();
+  prefillFromQueryParams();
+  trackEvent('page_view', { page: 'trade_in' });
+});
+
+// ── Initialization ───────────────────────────────────────────────────
+
+function initPage() {
+  try { $w('#tradeInTitle').text = 'Trade In & Trade Up'; } catch (_) {}
+  try {
+    $w('#tradeInSubtitle').text =
+      'Bring your old futon, mattress, or cabinet bed to our Hendersonville showroom ' +
+      'and put its value toward something new. Get an instant credit estimate below.';
+  } catch (_) {}
+
+  try { $w('#estimateSection').hide(); } catch (_) {}
+  try { $w('#confirmationSection').hide(); } catch (_) {}
+  try { $w('#errorText').hide(); } catch (_) {}
+}
+
+function initEstimateForm() {
+  const conditions = buildConditionOptions();
+
+  try {
+    $w('#productTypeDropdown').options = [
+      { label: 'Futon Frame', value: 'futon-frame' },
+      { label: 'Futon Mattress', value: 'futon-mattress' },
+      { label: 'Murphy Cabinet Bed', value: 'murphy-bed' },
+      { label: 'Platform Bed', value: 'platform-bed' },
+      { label: 'Sofa', value: 'sofa' },
+    ];
+    $w('#productTypeDropdown').placeholder = 'Select item type…';
+    $w('#productTypeDropdown').accessibility.ariaLabel = 'Type of item to trade in';
+  } catch (_) {}
+
+  try {
+    $w('#conditionDropdown').options = conditions.map(c => ({ label: c.label, value: c.value }));
+    $w('#conditionDropdown').placeholder = 'Select condition…';
+    $w('#conditionDropdown').accessibility.ariaLabel = 'Condition of item to trade in';
+  } catch (_) {}
+
+  try {
+    $w('#productTypeDropdown').onChange(() => fetchEstimate());
+    $w('#conditionDropdown').onChange(() => fetchEstimate());
+  } catch (_) {}
+}
+
+function initSubmitForm() {
+  try { $w('#nameInput').accessibility.ariaLabel = 'Your name'; } catch (_) {}
+  try { $w('#emailInput').accessibility.ariaLabel = 'Your email address'; } catch (_) {}
+  try { $w('#phoneInput').accessibility.ariaLabel = 'Your phone number (optional)'; } catch (_) {}
+  try {
+    $w('#descriptionInput').accessibility.ariaLabel =
+      'Describe your item — brand, age, any known issues';
+  } catch (_) {}
+
+  try {
+    $w('#submitTradeInBtn').onClick(() => handleSubmit());
+    $w('#submitTradeInBtn').label = 'Submit Trade-In Request';
+  } catch (_) {}
+}
+
+function initStatusLookup() {
+  try { $w('#statusRequestIdInput').accessibility.ariaLabel = 'Trade-in request ID (e.g. TI-ABCD1234)'; } catch (_) {}
+  try { $w('#statusEmailInput').accessibility.ariaLabel = 'Email address used in your request'; } catch (_) {}
+  try { $w('#checkStatusBtn').onClick(() => handleStatusLookup()); } catch (_) {}
+  try { $w('#statusSection').hide(); } catch (_) {}
+
+  try {
+    $w('#showStatusLookupBtn').onClick(() => {
+      try { $w('#statusSection').show(); } catch (_) {}
+    });
+  } catch (_) {}
+}
+
+function prefillFromQueryParams() {
+  try {
+    const { query } = wixLocation;
+    if (query?.type) {
+      try { $w('#productTypeDropdown').value = query.type; } catch (_) {}
+    }
+    if (query?.condition) {
+      try { $w('#conditionDropdown').value = query.condition; } catch (_) {}
+    }
+    if (query?.type && query?.condition) fetchEstimate();
+  } catch (_) {}
+}
+
+// ── Live Estimate ────────────────────────────────────────────────────
+
+async function fetchEstimate() {
+  let productType, condition;
+  try {
+    productType = $w('#productTypeDropdown').value;
+    condition = $w('#conditionDropdown').value;
+  } catch (_) { return; }
+
+  if (!productType || !condition) return;
+
+  try { $w('#estimateSection').show(); } catch (_) {}
+  try { $w('#estimateText').text = 'Calculating…'; } catch (_) {}
+  try { $w('#estimateRange').hide(); } catch (_) {}
+
+  try {
+    const result = await estimateTradeIn(productType, condition);
+
+    if (!result.eligible) {
+      try { $w('#estimateText').text = 'This item type is not eligible for trade-in.'; } catch (_) {}
+      return;
+    }
+
+    const rangeText = formatEstimateText(result);
+    try { $w('#estimateText').text = rangeText; } catch (_) {}
+    try { $w('#estimateRange').show(); } catch (_) {}
+    announce(rangeText);
+    trackEvent('trade_in_estimate_viewed', { productType, condition, min: result.min, max: result.max });
+  } catch (err) {
+    try { $w('#estimateText').text = 'Could not load estimate — please try again.'; } catch (_) {}
+  }
+}
+
+// ── Form Submission ──────────────────────────────────────────────────
+
+async function handleSubmit() {
+  if (_submitting) return;
+
+  let name, email, phone, description;
+  try {
+    name = sanitizeText($w('#nameInput').value || '');
+    email = sanitizeText($w('#emailInput').value || '');
+    phone = sanitizeText($w('#phoneInput').value || '');
+    description = sanitizeText($w('#descriptionInput').value || '');
+  } catch (_) { return; }
+
+  // Client-side validation
+  if (!name.trim()) {
+    showError('Please enter your name.');
+    try { $w('#nameInput').focus(); } catch (_) {}
+    return;
+  }
+  if (!email.trim() || !email.includes('@')) {
+    showError('Please enter a valid email address.');
+    try { $w('#emailInput').focus(); } catch (_) {}
+    return;
+  }
+
+  let productType, condition;
+  try {
+    productType = $w('#productTypeDropdown').value;
+    condition = $w('#conditionDropdown').value;
+  } catch (_) {}
+
+  if (!productType) {
+    showError('Please select the type of item you want to trade in.');
+    return;
+  }
+  if (!condition) {
+    showError('Please select the condition of your item.');
+    return;
+  }
+
+  // Collect photo URLs if uploader present
+  let photoUrls = [];
+  try {
+    const files = $w('#photoUpload').value;
+    if (Array.isArray(files)) {
+      photoUrls = files
+        .map(f => f.fileUrl || f.url || '')
+        .filter(Boolean)
+        .slice(0, 5);
+    }
+  } catch (_) {}
+
+  _submitting = true;
+  try { $w('#submitTradeInBtn').disable(); } catch (_) {}
+  try { $w('#submitTradeInBtn').label = 'Submitting…'; } catch (_) {}
+  hideError();
+
+  try {
+    const result = await submitTradeInRequest({
+      name, email, phone, productType, condition, description, photoUrls,
+    });
+
+    if (!result.success) {
+      const messages = {
+        name_required:        'Please enter your name.',
+        invalid_email:        'Please enter a valid email address.',
+        invalid_product_type: 'Please select a valid item type.',
+        invalid_condition:    'Please select a valid condition.',
+        rate_limited:         'Too many requests — please wait 24 hours before submitting again.',
+        submission_failed:    'Submission failed — please try again.',
+      };
+      showError(messages[result.error] || 'Something went wrong. Please try again.');
+      return;
+    }
+
+    showConfirmation(result);
+    trackEvent('trade_in_submitted', {
+      productType,
+      condition,
+      estimatedCredit: result.estimatedCredit,
+      requestId: result.requestId,
+    });
+  } catch (err) {
+    showError('Submission failed — please try again.');
+  } finally {
+    _submitting = false;
+    try { $w('#submitTradeInBtn').enable(); } catch (_) {}
+    try { $w('#submitTradeInBtn').label = 'Submit Trade-In Request'; } catch (_) {}
+  }
+}
+
+// ── Status Lookup ────────────────────────────────────────────────────
+
+async function handleStatusLookup() {
+  let requestId, email;
+  try {
+    requestId = ($w('#statusRequestIdInput').value || '').trim().toUpperCase();
+    email = ($w('#statusEmailInput').value || '').trim();
+  } catch (_) { return; }
+
+  if (!requestId || !email) {
+    try { $w('#statusResult').text = 'Please enter your request ID and email.'; } catch (_) {}
+    return;
+  }
+
+  try { $w('#statusResult').text = 'Looking up…'; } catch (_) {}
+
+  try {
+    const result = await getTradeInRequest(requestId, email);
+    if (!result.success) {
+      const msg = result.error === 'not_found'
+        ? 'No request found for that ID and email.'
+        : 'Lookup failed — please try again.';
+      try { $w('#statusResult').text = msg; } catch (_) {}
+      return;
+    }
+
+    const { request } = result;
+    const statusLabels = {
+      pending:   'Pending — bring your item to our showroom at 824 Locust St, Hendersonville.',
+      confirmed: `Confirmed — $${request.estimatedMin ?? 0}–$${request.estimatedMax ?? 0} store credit issued.`,
+      declined:  'Declined — item did not meet trade-in criteria.',
+      expired:   'Expired — request is older than 30 days.',
+    };
+    const statusText = statusLabels[request.status] || request.status;
+    try { $w('#statusResult').text = statusText; } catch (_) {}
+    announce(statusText);
+  } catch (err) {
+    try { $w('#statusResult').text = 'Lookup failed — please try again.'; } catch (_) {}
+  }
+}
+
+// ── UI Helpers ───────────────────────────────────────────────────────
+
+function showConfirmation(result) {
+  try { $w('#tradeInForm').hide(); } catch (_) {}
+  try { $w('#estimateSection').hide(); } catch (_) {}
+
+  try {
+    $w('#confirmationSection').show();
+    $w('#confirmationRequestId').text = `Your request ID: ${result.requestId}`;
+    const rangeText = result.estimatedMin !== undefined && result.estimatedMax !== undefined
+      ? `$${result.estimatedMin}–$${result.estimatedMax}`
+      : `$${result.estimatedCredit}`;
+    $w('#confirmationEstimate').text =
+      `Estimated credit: ${rangeText} (confirmed in-store upon item inspection).`;
+  } catch (_) {}
+
+  announce(`Trade-in request submitted. Your request ID is ${result.requestId}.`);
+}
+
+function showError(message) {
+  try {
+    $w('#errorText').text = message;
+    $w('#errorText').show();
+  } catch (_) {}
+  announce(message);
+}
+
+function hideError() {
+  try { $w('#errorText').hide(); } catch (_) {}
+}

--- a/src/public/TradeInWidget.js
+++ b/src/public/TradeInWidget.js
@@ -1,0 +1,181 @@
+/**
+ * @module TradeInWidget
+ * @description Pure functions for the Trade-In CTA widget shown on eligible PDPs.
+ *
+ * No Wix API calls — all side effects handled by the page module which calls
+ * these functions and applies returned state to Wix elements.
+ *
+ * Elements expected on PDP:
+ *   #tradeInBanner     — collapsed strip showing trade-in CTA
+ *   #tradeInEstimate   — inline credit range estimate text
+ *   #tradeInCtaBtn     — "Start Trade-In" button
+ *   #tradeInConditionDropdown — condition selector (if shown inline)
+ */
+
+/** Product types eligible for trade-in. Mirrors VALID_PRODUCT_TYPES in tradeInService. */
+export const ELIGIBLE_PRODUCT_TYPES = [
+  'futon-frame',
+  'futon-mattress',
+  'murphy-bed',
+  'platform-bed',
+  'sofa',
+];
+
+/** Map from Wix product category slug to trade-in product type. */
+const CATEGORY_TO_TRADE_IN_TYPE = {
+  'futon-frames':    'futon-frame',
+  'futon-mattresses':'futon-mattress',
+  'murphy-beds':     'murphy-bed',
+  'platform-beds':   'platform-bed',
+  'sofas':           'sofa',
+};
+
+/**
+ * Returns the trade-in product type for a given product category slug,
+ * or null if the category is not eligible.
+ *
+ * @param {string|null|undefined} categorySlug
+ * @returns {string|null}
+ */
+export function getTradeInType(categorySlug) {
+  if (typeof categorySlug !== 'string' || !categorySlug.trim()) return null;
+  return CATEGORY_TO_TRADE_IN_TYPE[categorySlug.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Whether the widget should be shown for the given trade-in type.
+ *
+ * @param {string|null} tradeInType
+ * @returns {boolean}
+ */
+export function isEligible(tradeInType) {
+  return ELIGIBLE_PRODUCT_TYPES.includes(tradeInType ?? '');
+}
+
+/**
+ * Build the banner text for the PDP widget.
+ * Shown to all visitors regardless of whether they have an old item.
+ *
+ * @param {string|null} tradeInType
+ * @returns {string}
+ */
+export function buildBannerText(tradeInType) {
+  if (!isEligible(tradeInType)) return '';
+  const typeLabels = {
+    'futon-frame':    'futon frame',
+    'futon-mattress': 'futon mattress',
+    'murphy-bed':     'murphy bed',
+    'platform-bed':   'platform bed',
+    'sofa':           'sofa',
+  };
+  const label = typeLabels[tradeInType] || 'furniture';
+  return `Trade in your old ${label} for store credit toward this purchase.`;
+}
+
+/**
+ * Format a credit estimate range for display.
+ *
+ * @param {{ min: number, max: number, base: number }} estimate
+ * @returns {string}  e.g. "Worth $64–$86 in store credit"
+ */
+export function formatEstimateText(estimate) {
+  if (!estimate || typeof estimate !== 'object') return '';
+  const { min, max } = estimate;
+  if (min <= 0 && max <= 0) return 'No credit available for this condition.';
+  if (min === max) return `Worth $${min} in store credit`;
+  return `Worth $${min}–$${max} in store credit`;
+}
+
+/**
+ * Build the condition dropdown options.
+ *
+ * @returns {Array<{ value: string, label: string, description: string }>}
+ */
+export function buildConditionOptions() {
+  return [
+    {
+      value: 'good',
+      label: 'Good',
+      description: 'Minimal wear, no tears or stains, fully functional.',
+    },
+    {
+      value: 'fair',
+      label: 'Fair',
+      description: 'Some visible wear, minor cosmetic issues, still functional.',
+    },
+    {
+      value: 'poor',
+      label: 'Poor',
+      description: 'Heavy wear, structural issues, or significant cosmetic damage.',
+    },
+  ];
+}
+
+/**
+ * Widget state when the product is not eligible for trade-in.
+ *
+ * @returns {{ bannerVisible: boolean }}
+ */
+export function buildHiddenState() {
+  return { bannerVisible: false };
+}
+
+/**
+ * Widget state when the product is eligible but no estimate has been fetched.
+ *
+ * @param {string} tradeInType
+ * @returns {{ bannerVisible: boolean, bannerText: string, estimateVisible: boolean }}
+ */
+export function buildIdleState(tradeInType) {
+  return {
+    bannerVisible: true,
+    bannerText: buildBannerText(tradeInType),
+    estimateVisible: false,
+  };
+}
+
+/**
+ * Widget state while fetching an estimate.
+ *
+ * @returns {{ estimateVisible: boolean, estimateText: string, ctaDisabled: boolean }}
+ */
+export function buildLoadingState() {
+  return {
+    estimateVisible: true,
+    estimateText: 'Calculating estimate…',
+    ctaDisabled: true,
+  };
+}
+
+/**
+ * Widget state after a successful estimate fetch.
+ *
+ * @param {{ min: number, max: number, base: number }} estimate
+ * @returns {{ estimateVisible: boolean, estimateText: string, ctaDisabled: boolean, ctaLabel: string }}
+ */
+export function buildEstimateState(estimate) {
+  const estimateText = formatEstimateText(estimate);
+  const noCredit = estimate.max <= 0;
+  return {
+    estimateVisible: true,
+    estimateText,
+    ctaDisabled: noCredit,
+    ctaLabel: noCredit ? 'No credit available' : 'Start Trade-In →',
+  };
+}
+
+/**
+ * Build the Trade-In page URL with pre-filled query params.
+ *
+ * @param {string} tradeInType
+ * @param {string} [condition]
+ * @returns {string}
+ */
+export function buildTradeInUrl(tradeInType, condition = '') {
+  const base = '/trade-in';
+  const params = new URLSearchParams();
+  if (tradeInType) params.set('type', tradeInType);
+  if (condition) params.set('condition', condition);
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
+}

--- a/src/public/TradeInWidget.js
+++ b/src/public/TradeInWidget.js
@@ -21,6 +21,15 @@ export const ELIGIBLE_PRODUCT_TYPES = [
   'sofa',
 ];
 
+/** Display labels for each trade-in product type (used in banner copy). */
+const TYPE_LABELS = {
+  'futon-frame':    'futon frame',
+  'futon-mattress': 'futon mattress',
+  'murphy-bed':     'murphy bed',
+  'platform-bed':   'platform bed',
+  'sofa':           'sofa',
+};
+
 /** Map from Wix product category slug to trade-in product type. */
 const CATEGORY_TO_TRADE_IN_TYPE = {
   'futon-frames':    'futon-frame',
@@ -49,7 +58,7 @@ export function getTradeInType(categorySlug) {
  * @returns {boolean}
  */
 export function isEligible(tradeInType) {
-  return ELIGIBLE_PRODUCT_TYPES.includes(tradeInType ?? '');
+  return ELIGIBLE_PRODUCT_TYPES.includes(tradeInType);
 }
 
 /**
@@ -61,14 +70,7 @@ export function isEligible(tradeInType) {
  */
 export function buildBannerText(tradeInType) {
   if (!isEligible(tradeInType)) return '';
-  const typeLabels = {
-    'futon-frame':    'futon frame',
-    'futon-mattress': 'futon mattress',
-    'murphy-bed':     'murphy bed',
-    'platform-bed':   'platform bed',
-    'sofa':           'sofa',
-  };
-  const label = typeLabels[tradeInType] || 'furniture';
+  const label = TYPE_LABELS[tradeInType] || 'furniture';
   return `Trade in your old ${label} for store credit toward this purchase.`;
 }
 

--- a/tests/tradeInService.test.js
+++ b/tests/tradeInService.test.js
@@ -1,0 +1,356 @@
+/**
+ * @file tradeInService.test.js
+ * @description Tests for tradeInService.web.js — Trade-In / Trade-Up backend.
+ *
+ * Covers:
+ *  - estimateTradeIn: valid/invalid product types and conditions, credit matrix, ranges
+ *  - submitTradeInRequest: validation, rate limiting, CMS insert, requestId format
+ *  - getTradeInRequest: lookup, email verification, not found
+ *  - confirmTradeIn: staff confirmation, credit issuance, decline, already-processed guard
+ *  - creditRange: base calculation, floor at zero
+ *  - CONDITION_MATRIX shape
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  __reset as resetData,
+  __seed,
+  __onInsert,
+  __onUpdate,
+  __setInsertError,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+import {
+  estimateTradeIn,
+  submitTradeInRequest,
+  getTradeInRequest,
+  confirmTradeIn,
+  creditRange,
+  CONDITION_MATRIX,
+  VALID_PRODUCT_TYPES,
+  VALID_CONDITIONS,
+} from '../src/backend/tradeInService.web.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-03-28T15:00:00Z'));
+  resetData();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// creditRange
+// ---------------------------------------------------------------------------
+
+describe('creditRange', () => {
+  it('returns min=0 max=0 for base <= 0', () => {
+    expect(creditRange(0)).toEqual({ min: 0, max: 0 });
+    expect(creditRange(-10)).toEqual({ min: 0, max: 0 });
+  });
+
+  it('returns ±15% range for positive base', () => {
+    const { min, max } = creditRange(100);
+    expect(min).toBe(85);
+    expect(max).toBe(115);
+  });
+
+  it('floors min at 0', () => {
+    // base=5, delta=1 → min=4, max=6
+    const { min } = creditRange(5);
+    expect(min).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns symmetric range for futon-frame good ($75)', () => {
+    const { min, max } = creditRange(75);
+    expect(min).toBe(64); // 75 - round(75*0.15)=11
+    expect(max).toBe(86);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CONDITION_MATRIX
+// ---------------------------------------------------------------------------
+
+describe('CONDITION_MATRIX', () => {
+  it('covers all VALID_PRODUCT_TYPES', () => {
+    for (const type of VALID_PRODUCT_TYPES) {
+      expect(CONDITION_MATRIX).toHaveProperty(type);
+    }
+  });
+
+  it('covers all VALID_CONDITIONS for each type', () => {
+    for (const type of VALID_PRODUCT_TYPES) {
+      for (const cond of VALID_CONDITIONS) {
+        expect(typeof CONDITION_MATRIX[type][cond]).toBe('number');
+      }
+    }
+  });
+
+  it('futon-mattress poor has 0 credit (hygiene)', () => {
+    expect(CONDITION_MATRIX['futon-mattress']['poor']).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// estimateTradeIn
+// ---------------------------------------------------------------------------
+
+describe('estimateTradeIn', () => {
+  it('returns { eligible: false } for unknown product type', async () => {
+    const result = await estimateTradeIn('dishwasher', 'good');
+    expect(result).toEqual({ eligible: false });
+  });
+
+  it('returns { eligible: false, error: invalid_condition } for bad condition', async () => {
+    const result = await estimateTradeIn('futon-frame', 'mint');
+    expect(result).toMatchObject({ eligible: false, error: 'invalid_condition' });
+  });
+
+  it('returns estimate with min/max/base for futon-frame good', async () => {
+    const result = await estimateTradeIn('futon-frame', 'good');
+    expect(result.eligible).toBe(true);
+    expect(result.base).toBe(75);
+    expect(result.min).toBeLessThan(result.base);
+    expect(result.max).toBeGreaterThan(result.base);
+  });
+
+  it('returns min=0 max=0 for futon-mattress poor (hygiene)', async () => {
+    const result = await estimateTradeIn('futon-mattress', 'poor');
+    expect(result.eligible).toBe(true);
+    expect(result.min).toBe(0);
+    expect(result.max).toBe(0);
+  });
+
+  it('sanitizes and lowercases inputs', async () => {
+    const result = await estimateTradeIn('  Futon-Frame  ', '  GOOD  ');
+    expect(result.eligible).toBe(true);
+  });
+
+  it('returns correct productType and condition in response', async () => {
+    const result = await estimateTradeIn('murphy-bed', 'fair');
+    expect(result.productType).toBe('murphy-bed');
+    expect(result.condition).toBe('fair');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitTradeInRequest — validation
+// ---------------------------------------------------------------------------
+
+describe('submitTradeInRequest — validation', () => {
+  it('returns invalid_request for non-object input', async () => {
+    const result = await submitTradeInRequest(null);
+    expect(result).toEqual({ success: false, error: 'invalid_request' });
+  });
+
+  it('returns name_required when name is empty', async () => {
+    const result = await submitTradeInRequest({
+      name: '', email: 'a@b.com', productType: 'futon-frame', condition: 'good',
+    });
+    expect(result).toEqual({ success: false, error: 'name_required' });
+  });
+
+  it('returns invalid_email for malformed email', async () => {
+    const result = await submitTradeInRequest({
+      name: 'Alice', email: 'not-an-email', productType: 'futon-frame', condition: 'good',
+    });
+    expect(result).toEqual({ success: false, error: 'invalid_email' });
+  });
+
+  it('returns invalid_product_type for unknown type', async () => {
+    const result = await submitTradeInRequest({
+      name: 'Alice', email: 'a@b.com', productType: 'blender', condition: 'good',
+    });
+    expect(result).toEqual({ success: false, error: 'invalid_product_type' });
+  });
+
+  it('returns invalid_condition for unknown condition', async () => {
+    const result = await submitTradeInRequest({
+      name: 'Alice', email: 'a@b.com', productType: 'futon-frame', condition: 'excellent',
+    });
+    expect(result).toEqual({ success: false, error: 'invalid_condition' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitTradeInRequest — happy path
+// ---------------------------------------------------------------------------
+
+const validRequest = {
+  name: 'Alice Futon',
+  email: 'alice@example.com',
+  productType: 'futon-frame',
+  condition: 'good',
+};
+
+describe('submitTradeInRequest — happy path', () => {
+  it('inserts a TradeInRequests record on success', async () => {
+    const inserted = [];
+    __onInsert((col, r) => { if (col === 'TradeInRequests') inserted.push(r); });
+    await submitTradeInRequest(validRequest);
+    expect(inserted.length).toBe(1);
+    expect(inserted[0].productType).toBe('futon-frame');
+    expect(inserted[0].condition).toBe('good');
+    expect(inserted[0].status).toBe('pending');
+  });
+
+  it('returns success with requestId starting TI-', async () => {
+    const result = await submitTradeInRequest(validRequest);
+    expect(result.success).toBe(true);
+    expect(result.requestId).toMatch(/^TI-[A-Z0-9]+$/);
+  });
+
+  it('returns estimatedCredit matching the condition matrix', async () => {
+    const result = await submitTradeInRequest(validRequest);
+    expect(result.estimatedCredit).toBe(CONDITION_MATRIX['futon-frame']['good']);
+  });
+
+  it('returns estimatedMin and estimatedMax in response', async () => {
+    const result = await submitTradeInRequest(validRequest);
+    expect(result.estimatedMin).toBeLessThan(result.estimatedCredit);
+    expect(result.estimatedMax).toBeGreaterThan(result.estimatedCredit);
+  });
+
+  it('returns submission_failed when CMS insert throws', async () => {
+    __setInsertError('TradeInRequests', new Error('db error'));
+    const result = await submitTradeInRequest(validRequest);
+    expect(result).toEqual({ success: false, error: 'submission_failed' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitTradeInRequest — rate limiting
+// ---------------------------------------------------------------------------
+
+describe('submitTradeInRequest — rate limiting', () => {
+  it('allows up to 3 submissions per email in 24h', async () => {
+    for (let i = 0; i < 3; i++) {
+      const r = await submitTradeInRequest(validRequest);
+      expect(r.success).toBe(true);
+    }
+  });
+
+  it('blocks the 4th submission within 24h', async () => {
+    for (let i = 0; i < 3; i++) {
+      await submitTradeInRequest(validRequest);
+    }
+    const result = await submitTradeInRequest(validRequest);
+    expect(result).toEqual({ success: false, error: 'rate_limited' });
+  });
+
+  it('resets rate limit after 24h window', async () => {
+    for (let i = 0; i < 3; i++) {
+      await submitTradeInRequest(validRequest);
+    }
+    // Advance past the 24h window
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+    const result = await submitTradeInRequest(validRequest);
+    expect(result.success).toBe(true);
+  });
+
+  it('allows request when rate limit DB query fails (fail-open)', async () => {
+    __setQueryError('TradeInRateLimit', new Error('db error'));
+    const result = await submitTradeInRequest(validRequest);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTradeInRequest
+// ---------------------------------------------------------------------------
+
+function makeTradeInRecord(overrides = {}) {
+  return {
+    _id: 'rec-1',
+    requestId: 'TI-ABCD1234',
+    email: 'alice@example.com',
+    name: 'Alice',
+    productType: 'futon-frame',
+    condition: 'good',
+    status: 'pending',
+    estimatedMin: 64,
+    estimatedMax: 86,
+    createdAt: new Date('2026-03-28T10:00:00Z'),
+    expiresAt: new Date('2026-04-27T10:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('getTradeInRequest', () => {
+  it('returns not_found when no match exists', async () => {
+    const result = await getTradeInRequest('TI-ABCD1234', 'alice@example.com');
+    expect(result).toEqual({ success: false, error: 'not_found' });
+  });
+
+  it('returns not_found when email does not match', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord()]);
+    const result = await getTradeInRequest('TI-ABCD1234', 'other@example.com');
+    expect(result).toEqual({ success: false, error: 'not_found' });
+  });
+
+  it('returns request details on valid lookup', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord()]);
+    const result = await getTradeInRequest('TI-ABCD1234', 'alice@example.com');
+    expect(result.success).toBe(true);
+    expect(result.request.requestId).toBe('TI-ABCD1234');
+    expect(result.request.status).toBe('pending');
+    expect(result.request.estimatedMin).toBe(64);
+  });
+
+  it('returns invalid_request for empty requestId', async () => {
+    const result = await getTradeInRequest('', 'alice@example.com');
+    expect(result).toMatchObject({ success: false, error: 'invalid_request' });
+  });
+
+  it('returns invalid_request for invalid email', async () => {
+    const result = await getTradeInRequest('TI-ABCD1234', 'not-email');
+    expect(result).toMatchObject({ success: false, error: 'invalid_request' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// confirmTradeIn
+// ---------------------------------------------------------------------------
+
+describe('confirmTradeIn', () => {
+  it('returns not_found when requestId does not exist', async () => {
+    const result = await confirmTradeIn('TI-NONEXIST', 'good');
+    expect(result).toEqual({ success: false, error: 'not_found' });
+  });
+
+  it('returns already_processed for non-pending request', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ status: 'confirmed' })]);
+    const result = await confirmTradeIn('TI-ABCD1234', 'good');
+    expect(result).toMatchObject({ success: false, error: 'already_processed', status: 'confirmed' });
+  });
+
+  it('returns invalid_condition for unknown condition', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord()]);
+    const result = await confirmTradeIn('TI-ABCD1234', 'excellent');
+    expect(result).toEqual({ success: false, error: 'invalid_condition' });
+  });
+
+  it('updates status to declined when declined', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord()]);
+    const updated = [];
+    __onUpdate((col, r) => { if (col === 'TradeInRequests') updated.push(r); });
+    const result = await confirmTradeIn('TI-ABCD1234', 'declined', 'Poor structural condition');
+    expect(result).toEqual({ success: true, status: 'declined' });
+    expect(updated[0].status).toBe('declined');
+    expect(updated[0].staffNotes).toBe('Poor structural condition');
+  });
+
+  it('returns creditAmount: 0 for poor-condition mattress (no credit)', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-mattress', condition: 'poor' })]);
+    const result = await confirmTradeIn('TI-ABCD1234', 'poor');
+    expect(result).toMatchObject({ success: true, status: 'confirmed', creditAmount: 0 });
+  });
+
+  it('returns invalid_request_id for empty requestId', async () => {
+    const result = await confirmTradeIn('', 'good');
+    expect(result).toEqual({ success: false, error: 'invalid_request_id' });
+  });
+});

--- a/tests/tradeInService.test.js
+++ b/tests/tradeInService.test.js
@@ -19,7 +19,14 @@ import {
   __onUpdate,
   __setInsertError,
   __setQueryError,
+  __setUpdateError,
 } from './__mocks__/wix-data.js';
+
+// Mock storeCreditService so confirmTradeIn can be tested without a live credit system.
+const mockIssueStoreCredit = vi.fn();
+vi.mock('backend/storeCreditService.web', () => ({
+  issueStoreCredit: (...args) => mockIssueStoreCredit(...args),
+}));
 import {
   estimateTradeIn,
   submitTradeInRequest,
@@ -35,6 +42,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2026-03-28T15:00:00Z'));
   resetData();
+  mockIssueStoreCredit.mockResolvedValue({ creditId: 'cred-test-123' });
 });
 
 afterEach(() => {
@@ -352,5 +360,108 @@ describe('confirmTradeIn', () => {
   it('returns invalid_request_id for empty requestId', async () => {
     const result = await confirmTradeIn('', 'good');
     expect(result).toEqual({ success: false, error: 'invalid_request_id' });
+  });
+
+  it('issues store credit and updates CMS on happy path', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-frame', condition: 'good' })]);
+    const updated = [];
+    __onUpdate((col, r) => { if (col === 'TradeInRequests') updated.push(r); });
+
+    const result = await confirmTradeIn('TI-ABCD1234', 'good', 'Looks great');
+
+    expect(result).toMatchObject({ success: true, status: 'confirmed', creditAmount: 75, creditId: 'cred-test-123' });
+    expect(mockIssueStoreCredit).toHaveBeenCalledWith(expect.objectContaining({
+      amount: 75,
+      reason: 'promotion',
+      orderReference: 'TI-ABCD1234',
+    }));
+    expect(updated[0].status).toBe('confirmed');
+    expect(updated[0].creditId).toBe('cred-test-123');
+    expect(updated[0].staffNotes).toBe('Looks great');
+  });
+
+  it('returns credit_issuance_failed when issueStoreCredit throws', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-frame', condition: 'good' })]);
+    mockIssueStoreCredit.mockRejectedValue(new Error('credit service down'));
+
+    const result = await confirmTradeIn('TI-ABCD1234', 'good');
+
+    expect(result).toEqual({ success: false, error: 'credit_issuance_failed' });
+  });
+
+  it('returns success even when post-credit CMS update fails (credit already issued)', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-frame', condition: 'good' })]);
+    __setUpdateError('TradeInRequests', new Error('db write failed'));
+
+    const result = await confirmTradeIn('TI-ABCD1234', 'good');
+
+    // Credit was issued — return success despite CMS failure
+    expect(result).toMatchObject({ success: true, status: 'confirmed', creditAmount: 75 });
+  });
+
+  it('returns update_failed when declined CMS update throws', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord()]);
+    __setUpdateError('TradeInRequests', new Error('db error'));
+
+    const result = await confirmTradeIn('TI-ABCD1234', 'declined');
+    expect(result).toEqual({ success: false, error: 'update_failed' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTradeInRequest — error path
+// ---------------------------------------------------------------------------
+
+describe('getTradeInRequest — error path', () => {
+  it('returns lookup_failed when wixData query throws', async () => {
+    __setQueryError('TradeInRequests', new Error('db error'));
+    const result = await getTradeInRequest('TI-ABCD1234', 'alice@example.com');
+    expect(result).toEqual({ success: false, error: 'lookup_failed' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitTradeInRequest — photo URL filtering
+// ---------------------------------------------------------------------------
+
+describe('submitTradeInRequest — photo URL filtering', () => {
+  it('filters out non-Wix media URLs', async () => {
+    const inserted = [];
+    __onInsert((col, r) => { if (col === 'TradeInRequests') inserted.push(r); });
+
+    await submitTradeInRequest({
+      ...validRequest,
+      photoUrls: [
+        'wix:image://v1/abc123.jpg/img.jpg', // valid Wix media
+        'https://evil.com/bad.jpg',           // invalid
+        'javascript:alert(1)',                // invalid
+        'wix:image://v1/def456.png/img.png', // valid
+      ],
+    });
+
+    const stored = JSON.parse(inserted[0].photoUrls);
+    expect(stored).toHaveLength(2);
+    expect(stored.every(u => u.startsWith('wix:'))).toBe(true);
+  });
+
+  it('allows an empty photoUrls array', async () => {
+    const result = await submitTradeInRequest({ ...validRequest, photoUrls: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('handles missing photoUrls field gracefully', async () => {
+    const result = await submitTradeInRequest(validRequest); // no photoUrls
+    expect(result.success).toBe(true);
+  });
+
+  it('caps photo list at 5', async () => {
+    const inserted = [];
+    __onInsert((col, r) => { if (col === 'TradeInRequests') inserted.push(r); });
+
+    const sixPhotos = Array.from({ length: 6 }, (_, i) => `wix:image://v1/img${i}.jpg/img.jpg`);
+    await submitTradeInRequest({ ...validRequest, photoUrls: sixPhotos });
+
+    const stored = JSON.parse(inserted[0].photoUrls);
+    expect(stored).toHaveLength(5);
   });
 });

--- a/tests/tradeInService.test.js
+++ b/tests/tradeInService.test.js
@@ -205,10 +205,10 @@ describe('submitTradeInRequest — happy path', () => {
     expect(inserted[0].status).toBe('pending');
   });
 
-  it('returns success with requestId starting TI-', async () => {
+  it('returns success with collision-safe UUID-based requestId', async () => {
     const result = await submitTradeInRequest(validRequest);
     expect(result.success).toBe(true);
-    expect(result.requestId).toMatch(/^TI-[A-Z0-9]+$/);
+    expect(result.requestId).toMatch(/^TI-[A-F0-9]{12}$/);
   });
 
   it('returns estimatedCredit matching the condition matrix', async () => {
@@ -323,21 +323,45 @@ describe('getTradeInRequest', () => {
 // confirmTradeIn
 // ---------------------------------------------------------------------------
 
+const ADMIN_EMAIL = 'alice@example.com'; // matches makeTradeInRecord default
+
 describe('confirmTradeIn', () => {
+  it('returns invalid_request_id for empty requestId', async () => {
+    const result = await confirmTradeIn('', ADMIN_EMAIL, 'good');
+    expect(result).toEqual({ success: false, error: 'invalid_request_id' });
+  });
+
+  it('returns invalid_email for missing customerEmail', async () => {
+    const result = await confirmTradeIn('TI-ABCD1234', '', 'good');
+    expect(result).toEqual({ success: false, error: 'invalid_email' });
+  });
+
   it('returns not_found when requestId does not exist', async () => {
-    const result = await confirmTradeIn('TI-NONEXIST', 'good');
+    const result = await confirmTradeIn('TI-NONEXIST', ADMIN_EMAIL, 'good');
+    expect(result).toEqual({ success: false, error: 'not_found' });
+  });
+
+  it('returns not_found when email does not match (IDOR prevention)', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord()]);
+    const result = await confirmTradeIn('TI-ABCD1234', 'staff-typo@example.com', 'good');
     expect(result).toEqual({ success: false, error: 'not_found' });
   });
 
   it('returns already_processed for non-pending request', async () => {
     __seed('TradeInRequests', [makeTradeInRecord({ status: 'confirmed' })]);
-    const result = await confirmTradeIn('TI-ABCD1234', 'good');
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'good');
     expect(result).toMatchObject({ success: false, error: 'already_processed', status: 'confirmed' });
+  });
+
+  it('returns already_processed for processing status (concurrent retry blocked)', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ status: 'processing' })]);
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'good');
+    expect(result).toMatchObject({ success: false, error: 'already_processed', status: 'processing' });
   });
 
   it('returns invalid_condition for unknown condition', async () => {
     __seed('TradeInRequests', [makeTradeInRecord()]);
-    const result = await confirmTradeIn('TI-ABCD1234', 'excellent');
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'excellent');
     expect(result).toEqual({ success: false, error: 'invalid_condition' });
   });
 
@@ -345,7 +369,7 @@ describe('confirmTradeIn', () => {
     __seed('TradeInRequests', [makeTradeInRecord()]);
     const updated = [];
     __onUpdate((col, r) => { if (col === 'TradeInRequests') updated.push(r); });
-    const result = await confirmTradeIn('TI-ABCD1234', 'declined', 'Poor structural condition');
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'declined', 'Poor structural condition');
     expect(result).toEqual({ success: true, status: 'declined' });
     expect(updated[0].status).toBe('declined');
     expect(updated[0].staffNotes).toBe('Poor structural condition');
@@ -353,13 +377,8 @@ describe('confirmTradeIn', () => {
 
   it('returns creditAmount: 0 for poor-condition mattress (no credit)', async () => {
     __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-mattress', condition: 'poor' })]);
-    const result = await confirmTradeIn('TI-ABCD1234', 'poor');
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'poor');
     expect(result).toMatchObject({ success: true, status: 'confirmed', creditAmount: 0 });
-  });
-
-  it('returns invalid_request_id for empty requestId', async () => {
-    const result = await confirmTradeIn('', 'good');
-    expect(result).toEqual({ success: false, error: 'invalid_request_id' });
   });
 
   it('issues store credit and updates CMS on happy path', async () => {
@@ -367,7 +386,7 @@ describe('confirmTradeIn', () => {
     const updated = [];
     __onUpdate((col, r) => { if (col === 'TradeInRequests') updated.push(r); });
 
-    const result = await confirmTradeIn('TI-ABCD1234', 'good', 'Looks great');
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'good', 'Looks great');
 
     expect(result).toMatchObject({ success: true, status: 'confirmed', creditAmount: 75, creditId: 'cred-test-123' });
     expect(mockIssueStoreCredit).toHaveBeenCalledWith(expect.objectContaining({
@@ -375,35 +394,44 @@ describe('confirmTradeIn', () => {
       reason: 'promotion',
       orderReference: 'TI-ABCD1234',
     }));
-    expect(updated[0].status).toBe('confirmed');
-    expect(updated[0].creditId).toBe('cred-test-123');
-    expect(updated[0].staffNotes).toBe('Looks great');
+    // First update: processing lock. Second update: confirmed with creditId.
+    const confirmUpdate = updated.find(r => r.status === 'confirmed');
+    expect(confirmUpdate.creditId).toBe('cred-test-123');
+    expect(confirmUpdate.staffNotes).toBe('Looks great');
+  });
+
+  it('sets processing status before credit issuance (double-issue lock)', async () => {
+    __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-frame', condition: 'good' })]);
+    const updated = [];
+    __onUpdate((col, r) => { if (col === 'TradeInRequests') updated.push(r); });
+
+    await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'good');
+
+    expect(updated[0].status).toBe('processing'); // processing lock first
+    expect(updated[1].status).toBe('confirmed');  // then confirmed
   });
 
   it('returns credit_issuance_failed when issueStoreCredit throws', async () => {
     __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-frame', condition: 'good' })]);
     mockIssueStoreCredit.mockRejectedValue(new Error('credit service down'));
 
-    const result = await confirmTradeIn('TI-ABCD1234', 'good');
-
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'good');
     expect(result).toEqual({ success: false, error: 'credit_issuance_failed' });
   });
 
-  it('returns success even when post-credit CMS update fails (credit already issued)', async () => {
+  it('returns update_failed when processing-lock CMS update throws', async () => {
     __seed('TradeInRequests', [makeTradeInRecord({ productType: 'futon-frame', condition: 'good' })]);
-    __setUpdateError('TradeInRequests', new Error('db write failed'));
+    __setUpdateError('TradeInRequests', new Error('db error'));
 
-    const result = await confirmTradeIn('TI-ABCD1234', 'good');
-
-    // Credit was issued — return success despite CMS failure
-    expect(result).toMatchObject({ success: true, status: 'confirmed', creditAmount: 75 });
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'good');
+    expect(result).toEqual({ success: false, error: 'update_failed' });
   });
 
   it('returns update_failed when declined CMS update throws', async () => {
     __seed('TradeInRequests', [makeTradeInRecord()]);
     __setUpdateError('TradeInRequests', new Error('db error'));
 
-    const result = await confirmTradeIn('TI-ABCD1234', 'declined');
+    const result = await confirmTradeIn('TI-ABCD1234', ADMIN_EMAIL, 'declined');
     expect(result).toEqual({ success: false, error: 'update_failed' });
   });
 });

--- a/tests/tradeInWidget.test.js
+++ b/tests/tradeInWidget.test.js
@@ -1,0 +1,219 @@
+/**
+ * @file tradeInWidget.test.js
+ * @description Unit tests for TradeInWidget.js — pure PDP widget helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getTradeInType,
+  isEligible,
+  buildBannerText,
+  formatEstimateText,
+  buildConditionOptions,
+  buildHiddenState,
+  buildIdleState,
+  buildLoadingState,
+  buildEstimateState,
+  buildTradeInUrl,
+  ELIGIBLE_PRODUCT_TYPES,
+} from '../src/public/TradeInWidget.js';
+
+// ---------------------------------------------------------------------------
+// getTradeInType
+// ---------------------------------------------------------------------------
+
+describe('getTradeInType', () => {
+  it('maps futon-frames to futon-frame', () => {
+    expect(getTradeInType('futon-frames')).toBe('futon-frame');
+  });
+
+  it('maps futon-mattresses to futon-mattress', () => {
+    expect(getTradeInType('futon-mattresses')).toBe('futon-mattress');
+  });
+
+  it('maps murphy-beds to murphy-bed', () => {
+    expect(getTradeInType('murphy-beds')).toBe('murphy-bed');
+  });
+
+  it('returns null for unknown category', () => {
+    expect(getTradeInType('blenders')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(getTradeInType('')).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(getTradeInType(null)).toBeNull();
+    expect(getTradeInType(undefined)).toBeNull();
+  });
+
+  it('trims and lowercases category slug', () => {
+    expect(getTradeInType('  Futon-Frames  ')).toBe('futon-frame');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEligible
+// ---------------------------------------------------------------------------
+
+describe('isEligible', () => {
+  it('returns true for all ELIGIBLE_PRODUCT_TYPES', () => {
+    for (const type of ELIGIBLE_PRODUCT_TYPES) {
+      expect(isEligible(type)).toBe(true);
+    }
+  });
+
+  it('returns false for null', () => {
+    expect(isEligible(null)).toBe(false);
+  });
+
+  it('returns false for unknown type', () => {
+    expect(isEligible('dishwasher')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBannerText
+// ---------------------------------------------------------------------------
+
+describe('buildBannerText', () => {
+  it('includes the item label for eligible types', () => {
+    const text = buildBannerText('futon-frame');
+    expect(text).toContain('futon frame');
+    expect(text).toContain('store credit');
+  });
+
+  it('returns empty string for ineligible type', () => {
+    expect(buildBannerText('dishwasher')).toBe('');
+  });
+
+  it('returns empty string for null', () => {
+    expect(buildBannerText(null)).toBe('');
+  });
+
+  it('uses generic "furniture" label for unknown but mapped type', () => {
+    // If a type is in ELIGIBLE_PRODUCT_TYPES but not in typeLabels, falls back to "furniture"
+    // This is a defensive test — all current types are mapped
+    const text = buildBannerText('futon-mattress');
+    expect(text).toContain('futon mattress');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatEstimateText
+// ---------------------------------------------------------------------------
+
+describe('formatEstimateText', () => {
+  it('returns range string for valid estimate', () => {
+    expect(formatEstimateText({ min: 64, max: 86, base: 75 }))
+      .toBe('Worth $64–$86 in store credit');
+  });
+
+  it('returns single value string when min === max', () => {
+    expect(formatEstimateText({ min: 50, max: 50, base: 50 }))
+      .toBe('Worth $50 in store credit');
+  });
+
+  it('returns no-credit message when max is 0', () => {
+    expect(formatEstimateText({ min: 0, max: 0, base: 0 }))
+      .toBe('No credit available for this condition.');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(formatEstimateText(null)).toBe('');
+    expect(formatEstimateText(undefined)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildConditionOptions
+// ---------------------------------------------------------------------------
+
+describe('buildConditionOptions', () => {
+  it('returns 3 conditions', () => {
+    expect(buildConditionOptions()).toHaveLength(3);
+  });
+
+  it('includes good, fair, poor values', () => {
+    const values = buildConditionOptions().map(c => c.value);
+    expect(values).toContain('good');
+    expect(values).toContain('fair');
+    expect(values).toContain('poor');
+  });
+
+  it('each option has label and description', () => {
+    for (const opt of buildConditionOptions()) {
+      expect(typeof opt.label).toBe('string');
+      expect(typeof opt.description).toBe('string');
+      expect(opt.label.length).toBeGreaterThan(0);
+      expect(opt.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State builders
+// ---------------------------------------------------------------------------
+
+describe('buildHiddenState', () => {
+  it('returns bannerVisible: false', () => {
+    expect(buildHiddenState()).toEqual({ bannerVisible: false });
+  });
+});
+
+describe('buildIdleState', () => {
+  it('returns bannerVisible: true with banner text', () => {
+    const state = buildIdleState('futon-frame');
+    expect(state.bannerVisible).toBe(true);
+    expect(state.bannerText).toContain('futon frame');
+    expect(state.estimateVisible).toBe(false);
+  });
+});
+
+describe('buildLoadingState', () => {
+  it('returns ctaDisabled: true and loading text', () => {
+    const state = buildLoadingState();
+    expect(state.ctaDisabled).toBe(true);
+    expect(state.estimateText).toContain('Calculating');
+  });
+});
+
+describe('buildEstimateState', () => {
+  it('returns estimate text and enabled CTA for credit-bearing estimate', () => {
+    const state = buildEstimateState({ min: 64, max: 86, base: 75 });
+    expect(state.estimateVisible).toBe(true);
+    expect(state.estimateText).toContain('$64');
+    expect(state.ctaDisabled).toBe(false);
+    expect(state.ctaLabel).toContain('Trade-In');
+  });
+
+  it('disables CTA when estimate has zero max (no credit)', () => {
+    const state = buildEstimateState({ min: 0, max: 0, base: 0 });
+    expect(state.ctaDisabled).toBe(true);
+    expect(state.ctaLabel).toContain('No credit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTradeInUrl
+// ---------------------------------------------------------------------------
+
+describe('buildTradeInUrl', () => {
+  it('returns /trade-in with type and condition params', () => {
+    const url = buildTradeInUrl('futon-frame', 'good');
+    expect(url).toContain('/trade-in');
+    expect(url).toContain('type=futon-frame');
+    expect(url).toContain('condition=good');
+  });
+
+  it('returns /trade-in with only type when condition is empty', () => {
+    const url = buildTradeInUrl('futon-frame', '');
+    expect(url).toContain('type=futon-frame');
+    expect(url).not.toContain('condition=');
+  });
+
+  it('returns /trade-in with no params when both are empty', () => {
+    expect(buildTradeInUrl('', '')).toBe('/trade-in');
+  });
+});


### PR DESCRIPTION
## Summary

- **`src/backend/tradeInService.web.js`** — `estimateTradeIn` (Anyone), `submitTradeInRequest` (Anyone), `getTradeInRequest` (Anyone), `confirmTradeIn` (Admin). Condition matrix with ±15% customer-facing range, rate limiting (3/email/24h), duplicate prevention, credit issuance via `storeCreditService`.
- **`src/public/TradeInWidget.js`** — pure PDP widget helpers: `getTradeInType` (category slug → trade-in type), `isEligible`, `buildBannerText`, `formatEstimateText`, state builders (hidden/idle/loading/estimate), `buildTradeInUrl`.
- **`src/pages/Trade In.js`** — customer form: live estimate on dropdown change, contact info + photo upload, submission, confirmation panel with requestId, status lookup by requestId + email.

## Flow

1. Visitor opens `/trade-in` (or clicks CTA from PDP via `TradeInWidget`)
2. Selects product type + condition → live credit estimate shown ($min–$max)
3. Fills name/email/phone/description + optional photos → submits
4. Receives request ID (e.g. `TI-ABCD1234`) + confirmation message
5. Brings item to store — staff confirms condition in dashboard, issues store credit via `confirmTradeIn`
6. Status checkable anytime at `/trade-in` by request ID + email

## Condition matrix (starting values — Stilgar to confirm)

| Type | Good | Fair | Poor |
|---|---|---|---|
| Futon frame | $75 | $50 | $25 |
| Futon mattress | $40 | $25 | $0 (hygiene) |
| Murphy bed | $100 | $65 | $30 |
| Platform bed | $80 | $55 | $25 |
| Sofa | $60 | $40 | $15 |

Shown to customers as ±15% range. Final credit confirmed in-store.

## CMS setup required (manual)
- `TradeInRequests`: requestId, email, name, phone, productType, condition, description, photoUrls, estimatedCredit, estimatedMin, estimatedMax, status, staffNotes, actualCondition, creditId, createdAt, updatedAt, expiresAt
- `TradeInRateLimit`: email, count, windowStart

## Test plan
- [x] creditRange ±15% math, floor at zero
- [x] CONDITION_MATRIX covers all types/conditions, mattress-poor is $0
- [x] estimateTradeIn: valid/invalid types, hygiene zero, sanitization
- [x] submitTradeInRequest: validation (name, email, type, condition), CMS insert, rate limiting (3/day, reset after 24h, fail-open)
- [x] getTradeInRequest: lookup, email mismatch → not_found, invalid inputs
- [x] confirmTradeIn: not_found, already_processed, decline, poor-mattress zero credit
- [x] TradeInWidget: all state builders, URL builder, condition options
- [x] 67 tests passing

Closes cf-y2l3

Generated with Claude Code