### PR TITLE
feat(CF-rw9i.1): 'Share your room' UGC photo submit CTA on PDP

### DIFF
--- a/EDITOR_HOOKUP_GUIDE.html
+++ b/EDITOR_HOOKUP_GUIDE.html
@@ -1621,6 +1621,52 @@ Right column:
         ["priceDropNotifySuccess","Text","Success confirmation — hidden by default"],
         ["priceDropNotifyError","Text","Inline error message — hidden by default"]
       ]},
+      { name: "Share Your Room CTA", impl: `<h4>📸 Implementation — "Share Your Room" UGC Submit CTA (Product Page)</h4>
+<p><strong>CF-rw9i.1</strong>: Adds a "Share your room" button on the PDP that opens an inline photo-submission modal. Members upload a photo, choose a room type, optionally add a caption, then submit for moderation. Calls <code>submitUGCPhoto</code> from <code>ugcService.web.js</code>. Non-members see a sign-in prompt instead of the upload form.</p>
+<div class="layer-diagram">LAYOUT:
+  #shareYourRoomBtn        (Button — "Share your room" CTA, always visible)
+  #shareYourRoomOverlay    (Box — full-screen dimmed overlay, collapsed by default)
+  #shareYourRoomModal      (Box — modal container, collapsed by default)
+    ├─ #shareYourRoomClose   (Button — "×" close, top-right)
+    ├─ #shareYourRoomLoginPrompt (Box — sign-in message, collapsed for members)
+    ├─ #shareYourRoomForm    (Section — form controls, hides on success)
+    │    ├─ #shareYourRoomUpload   (UploadButton — fileType=Image)
+    │    ├─ #shareYourRoomPreview  (Image — collapsed until file chosen)
+    │    ├─ #shareYourRoomRoomType (Dropdown — 5 room types)
+    │    ├─ #shareYourRoomCaption  (TextInput — optional, max 300 chars)
+    │    ├─ #shareYourRoomValidation (Text — error messages, collapsed by default)
+    │    └─ #shareYourRoomSubmitBtn (Button — "Submit photo", disabled until upload+roomType set)
+    └─ #shareYourRoomSuccess (Section — "Thanks! Your photo will appear after review.", collapsed by default)
+</div>
+<ul>
+  <li><strong>#shareYourRoomBtn</strong>: Button — "Share your room". Visible to all visitors. Opens modal on click.</li>
+  <li><strong>#shareYourRoomOverlay</strong>: Box — dimmed background overlay. Click closes modal. Collapsed by default.</li>
+  <li><strong>#shareYourRoomModal</strong>: Box — modal wrapper. Collapsed by default. Expand on CTA click.</li>
+  <li><strong>#shareYourRoomClose</strong>: Button — "×". Collapses modal + overlay.</li>
+  <li><strong>#shareYourRoomLoginPrompt</strong>: Box — "Please sign in to share your room." Shown to guests, collapsed for members.</li>
+  <li><strong>#shareYourRoomForm</strong>: Section — contains upload + form. Collapses on successful submit.</li>
+  <li><strong>#shareYourRoomUpload</strong>: UploadButton — fileType must be "Image". Required.</li>
+  <li><strong>#shareYourRoomPreview</strong>: Image — collapsed until upload succeeds. Src set to uploaded URL.</li>
+  <li><strong>#shareYourRoomRoomType</strong>: Dropdown — options auto-populated (Living Room, Bedroom, Office, Dorm, Porch).</li>
+  <li><strong>#shareYourRoomCaption</strong>: TextInput — optional caption, max 300 chars.</li>
+  <li><strong>#shareYourRoomValidation</strong>: Text — inline validation errors. Collapsed by default.</li>
+  <li><strong>#shareYourRoomSubmitBtn</strong>: Button — "Submit photo". Disabled until both upload URL and room type are present.</li>
+  <li><strong>#shareYourRoomSuccess</strong>: Section — success confirmation. Collapsed by default; expanded after submit.</li>
+</ul>`, elements: [
+        ["shareYourRoomBtn","Button","Share your room CTA — always visible"],
+        ["shareYourRoomOverlay","Box","Dimmed overlay — collapsed by default; click closes modal"],
+        ["shareYourRoomModal","Box","Modal container — collapsed by default"],
+        ["shareYourRoomClose","Button","Close × button inside modal"],
+        ["shareYourRoomLoginPrompt","Box","Sign-in prompt for guests — collapsed for members"],
+        ["shareYourRoomForm","Section","Form controls wrapper — collapses on success"],
+        ["shareYourRoomUpload","UploadButton","Photo upload — fileType=Image"],
+        ["shareYourRoomPreview","Image","Preview of uploaded photo — collapsed until upload done"],
+        ["shareYourRoomRoomType","Dropdown","Room type selector — 5 options auto-populated"],
+        ["shareYourRoomCaption","TextInput","Optional caption — max 300 chars"],
+        ["shareYourRoomValidation","Text","Inline validation/error — collapsed by default"],
+        ["shareYourRoomSubmitBtn","Button","Submit photo — disabled until upload+roomType set"],
+        ["shareYourRoomSuccess","Section","Success message — collapsed by default"]
+      ]},
       { name: "Q&A Section", impl: `<h4>❓ Implementation — Customer Q&A Widget (Product Page)</h4>
 <p><strong>CF-q7nt / CF-qa8c</strong>: Replaces retired <code>ProductQA.js</code> (which used <code>#qa*</code> IDs). All new element nicknames use the <code>#qna*</code> prefix. Backend: <code>productQA.web.js</code> → <em>ProductQuestions</em> CMS collection.</p>
 <div class="layer-diagram">LAYOUT:

--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -239,6 +239,8 @@ async function initProductPage() {
       { name: 'swatchRequestFlow', init: async () => { const m = await import('public/SwatchRequestFlow.js'); m.initSwatchRequestFlow($w, state); }, critical: false },
       // CF-uits: Room Planner CTA — links to /room-planner with product preloaded
       { name: 'roomPlannerCTA', init: async () => { const m = await import('public/roomPlannerCTA.js'); m.initRoomPlannerCTA($w, state); }, critical: false },
+      // CF-rw9i.1: 'Share your room' UGC photo submit CTA
+      { name: 'shareYourRoom', init: async () => { const m = await import('public/ShareYourRoom.js'); m.initShareYourRoomCTA($w, state); }, critical: false },
       // CF-ac80 (S1) / CF-1792 (S3): Showroom CTA + QR mode banner
       { name: 'showroomCTA', init: async () => { const m = await import('backend/showroomService.web.js'); await initShowroomCTA($w, state, m); }, critical: false },
       // CF-9fv2: Gift product button — adds gift card to cart for current product

--- a/src/public/ShareYourRoom.js
+++ b/src/public/ShareYourRoom.js
@@ -1,0 +1,280 @@
+/**
+ * ShareYourRoom.js — "Share your room" UGC photo submit CTA on the PDP.
+ *
+ * Wires a "Share your room" button on the Product Detail Page that expands an
+ * inline photo-submission modal. Members upload a photo, pick a room type,
+ * optionally add a caption, then submit — calling submitUGCPhoto from the
+ * UGC service. Non-members see the modal in a disabled/sign-in-prompt state.
+ *
+ * Editor element IDs required on the Product Page:
+ *   #shareYourRoomBtn          — CTA trigger button (visible to all)
+ *   #shareYourRoomModal        — Container/box that wraps the modal (collapsed by default)
+ *   #shareYourRoomOverlay      — Full-screen overlay behind modal (for click-to-close)
+ *   #shareYourRoomClose        — Close (×) button inside modal
+ *   #shareYourRoomUpload       — Wix UploadButton element (fileType = 'Image')
+ *   #shareYourRoomPreview      — Image element (hidden until file chosen)
+ *   #shareYourRoomRoomType     — Dropdown element for room type selection
+ *   #shareYourRoomCaption      — TextInput for optional caption
+ *   #shareYourRoomSubmitBtn    — Submit button
+ *   #shareYourRoomForm         — Section containing form controls (collapsed on success)
+ *   #shareYourRoomSuccess      — Success confirmation section (collapsed by default)
+ *   #shareYourRoomValidation   — Text element for inline validation/error messages
+ *   #shareYourRoomLoginPrompt  — Section shown to non-members (collapsed for members)
+ *
+ * @module public/ShareYourRoom
+ * @requires backend/ugcService.web
+ * @requires public/a11yHelpers
+ * @requires public/engagementTracker
+ */
+import { submitUGCPhoto } from 'backend/ugcService.web';
+import { announce } from 'public/a11yHelpers';
+import { trackEvent } from 'public/engagementTracker';
+
+const VALID_ROOM_TYPES = [
+  { value: 'living-room', label: 'Living Room' },
+  { value: 'bedroom',     label: 'Bedroom' },
+  { value: 'office',      label: 'Office' },
+  { value: 'dorm',        label: 'Dorm' },
+  { value: 'porch',       label: 'Porch' },
+];
+
+// ── Module state ──────────────────────────────────────────────────────────────
+
+let _uploadedFileUrl = null;  // Wix media URL after successful upload
+let _isOpen = false;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Wire up the "Share your room" CTA on the Product Detail Page.
+ *
+ * @param {Function} $w - Wix element selector
+ * @param {Object}   state - PDP state object
+ * @param {Object}   [state.product] - Current product
+ * @param {string}   [state.product._id] - Product ID (pre-fills submission)
+ * @param {string}   [state.product.name] - Product name (pre-fills submission)
+ * @param {boolean}  [state.isLoggedIn] - Whether the current visitor is a member
+ */
+export function initShareYourRoomCTA($w, state) {
+  // Reset upload state on every PDP load
+  _uploadedFileUrl = null;
+  _isOpen = false;
+
+  const product = (state && state.product) || {};
+
+  // Populate room type dropdown options
+  try {
+    $w('#shareYourRoomRoomType').options = VALID_ROOM_TYPES.map(rt => ({
+      label: rt.label,
+      value: rt.value,
+    }));
+  } catch (e) { /* element may not exist yet */ }
+
+  // Collapse modal + success sections on init
+  try { $w('#shareYourRoomModal').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomSuccess').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomValidation').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomPreview').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomLoginPrompt').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomSubmitBtn').disable(); } catch (e) {}
+
+  // CTA button → open modal
+  try {
+    $w('#shareYourRoomBtn').onClick(() => openModal($w, state));
+  } catch (e) {
+    console.warn('[ShareYourRoom] #shareYourRoomBtn not found');
+  }
+
+  // Close via overlay or × button
+  try { $w('#shareYourRoomOverlay').onClick(() => closeModal($w)); } catch (e) {}
+  try { $w('#shareYourRoomClose').onClick(() => closeModal($w)); } catch (e) {}
+
+  // Upload button — handle file selection + upload
+  try {
+    $w('#shareYourRoomUpload').fileType = 'Image';
+    $w('#shareYourRoomUpload').onChange(() => handleUploadChange($w));
+  } catch (e) {
+    console.warn('[ShareYourRoom] #shareYourRoomUpload not found');
+  }
+
+  // Room type dropdown — refresh submit button state
+  try {
+    $w('#shareYourRoomRoomType').onChange(() => refreshSubmitState($w));
+  } catch (e) {}
+
+  // Submit button
+  try {
+    $w('#shareYourRoomSubmitBtn').onClick(() =>
+      handleSubmit($w, product)
+    );
+  } catch (e) {
+    console.warn('[ShareYourRoom] #shareYourRoomSubmitBtn not found');
+  }
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+function openModal($w, state) {
+  _isOpen = true;
+  _uploadedFileUrl = null;
+
+  // Reset form to clean state
+  try { $w('#shareYourRoomForm').expand(); } catch (e) {}
+  try { $w('#shareYourRoomSuccess').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomValidation').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomPreview').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomCaption').value = ''; } catch (e) {}
+  try { $w('#shareYourRoomRoomType').value = undefined; } catch (e) {}
+  try { $w('#shareYourRoomSubmitBtn').disable(); } catch (e) {}
+
+  // Show login prompt for non-members, hide for members
+  const isLoggedIn = state && state.isLoggedIn;
+  try {
+    if (isLoggedIn) {
+      $w('#shareYourRoomLoginPrompt').collapse();
+    } else {
+      $w('#shareYourRoomLoginPrompt').expand();
+      try { $w('#shareYourRoomUpload').disable(); } catch (e2) {}
+    }
+  } catch (e) {}
+
+  try { $w('#shareYourRoomModal').expand(); } catch (e) {}
+  try { $w('#shareYourRoomOverlay').expand(); } catch (e) {}
+
+  announce('Share your room photo dialog opened');
+  trackEvent('ugc_modal_open', {
+    productId: state && state.product && state.product._id,
+  });
+}
+
+function closeModal($w) {
+  _isOpen = false;
+  try { $w('#shareYourRoomModal').collapse(); } catch (e) {}
+  try { $w('#shareYourRoomOverlay').collapse(); } catch (e) {}
+  announce('Share your room dialog closed');
+}
+
+async function handleUploadChange($w) {
+  _uploadedFileUrl = null;
+  refreshSubmitState($w);
+
+  let files;
+  try {
+    files = $w('#shareYourRoomUpload').value;
+  } catch (e) {
+    return;
+  }
+
+  if (!files || files.length === 0) return;
+
+  try {
+    $w('#shareYourRoomSubmitBtn').disable();
+    const uploaded = await $w('#shareYourRoomUpload').startUpload();
+    if (uploaded && uploaded.url) {
+      _uploadedFileUrl = uploaded.url;
+      try {
+        $w('#shareYourRoomPreview').src = uploaded.url;
+        $w('#shareYourRoomPreview').expand();
+      } catch (e2) {}
+      refreshSubmitState($w);
+    }
+  } catch (err) {
+    showValidation($w, 'Upload failed. Please try again.');
+    console.error('[ShareYourRoom] Upload error:', err);
+  }
+}
+
+function refreshSubmitState($w) {
+  let roomTypeSelected = false;
+  try {
+    const val = $w('#shareYourRoomRoomType').value;
+    roomTypeSelected = Boolean(val);
+  } catch (e) {}
+
+  const ready = Boolean(_uploadedFileUrl) && roomTypeSelected;
+  try {
+    if (ready) {
+      $w('#shareYourRoomSubmitBtn').enable();
+    } else {
+      $w('#shareYourRoomSubmitBtn').disable();
+    }
+  } catch (e) {}
+}
+
+async function handleSubmit($w, product) {
+  hideValidation($w);
+
+  const roomType = getRoomType($w);
+  if (!roomType) {
+    showValidation($w, 'Please select a room type.');
+    return;
+  }
+
+  if (!_uploadedFileUrl) {
+    showValidation($w, 'Please upload a photo first.');
+    return;
+  }
+
+  let caption = '';
+  try { caption = ($w('#shareYourRoomCaption').value || '').trim(); } catch (e) {}
+
+  try { $w('#shareYourRoomSubmitBtn').disable(); } catch (e) {}
+
+  try {
+    const result = await submitUGCPhoto({
+      photoUrl:    _uploadedFileUrl,
+      roomType,
+      caption,
+      productId:   product._id   || null,
+      productName: product.name  || null,
+    });
+
+    if (result && result.success) {
+      try { $w('#shareYourRoomForm').collapse(); } catch (e) {}
+      try { $w('#shareYourRoomSuccess').expand(); } catch (e) {}
+      announce('Photo submitted! It will appear in the gallery after review.');
+      trackEvent('ugc_photo_submitted', {
+        roomType,
+        productId: product._id,
+        hasCaption: Boolean(caption),
+      });
+    } else {
+      const msg = (result && result.error) || 'Submission failed. Please try again.';
+      showValidation($w, msg);
+      try { $w('#shareYourRoomSubmitBtn').enable(); } catch (e) {}
+    }
+  } catch (err) {
+    console.error('[ShareYourRoom] Submit error:', err);
+    showValidation($w, 'An error occurred. Please try again.');
+    try { $w('#shareYourRoomSubmitBtn').enable(); } catch (e) {}
+  }
+}
+
+function getRoomType($w) {
+  try {
+    return $w('#shareYourRoomRoomType').value || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function showValidation($w, message) {
+  try {
+    $w('#shareYourRoomValidation').text = message;
+    $w('#shareYourRoomValidation').expand();
+    announce(message);
+  } catch (e) {}
+}
+
+function hideValidation($w) {
+  try { $w('#shareYourRoomValidation').collapse(); } catch (e) {}
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+/** Exposed for unit tests only. */
+export const _VALID_ROOM_TYPES = VALID_ROOM_TYPES;
+export { openModal as _openModal, closeModal as _closeModal };
+export function _getUploadedUrl() { return _uploadedFileUrl; }
+export function _setUploadedUrl(url) { _uploadedFileUrl = url; }
+export function _isModalOpen() { return _isOpen; }

--- a/tests/crossSellModule.test.js
+++ b/tests/crossSellModule.test.js
@@ -64,6 +64,7 @@ const { getRelatedProducts, getSameCollection, getBundleSuggestion } =
   await import('backend/productRecommendations.web');
 const { addToCart } = await import('public/cartService');
 const { makeClickable } = await import('public/a11yHelpers.js');
+const { to: wixTo } = await import('wix-location-frontend');
 
 const { loadRelatedProducts, loadCollectionProducts, initBundleSection } =
   await import('../src/public/product/crossSell.js');
@@ -263,6 +264,99 @@ describe('initBundleSection', () => {
     expect(addToCart).toHaveBeenCalledWith('p1', 1);
     expect(addToCart).toHaveBeenCalledWith('b1', 1);
     expect(firstCallCount).toBe(2);
+  });
+});
+
+describe('loadCollectionProducts — onItemReady coverage', () => {
+  beforeEach(() => { elements.clear(); vi.clearAllMocks(); });
+
+  it('onItemReady sets image src/alt, name, and price', async () => {
+    const products = [{ _id: 'c1', name: 'Coll Prod', mainMedia: 'c.jpg', formattedPrice: '$75', slug: 'cp' }];
+    getSameCollection.mockResolvedValue(products);
+    await loadCollectionProducts($w, { _id: 'p1', collections: ['futons'] });
+
+    const callback = getEl('#collectionRepeater').onItemReady.mock.calls[0][0];
+    const itemEls = new Map();
+    const $item = (sel) => {
+      if (!itemEls.has(sel)) itemEls.set(sel, createMockElement());
+      return itemEls.get(sel);
+    };
+    callback($item, products[0]);
+
+    expect($item('#collectionImage').src).toBe('c.jpg');
+    expect($item('#collectionName').text).toBe('Coll Prod');
+  });
+
+  it('navigateToProduct onClick calls wix-location-frontend to()', async () => {
+    const products = [{ _id: 'c1', name: 'C', mainMedia: 'c.jpg', formattedPrice: '$50', slug: 'coll-slug' }];
+    getSameCollection.mockResolvedValue(products);
+    await loadCollectionProducts($w, { _id: 'p1', collections: ['futons'] });
+
+    const callback = getEl('#collectionRepeater').onItemReady.mock.calls[0][0];
+    const itemEls = new Map();
+    const $item = (sel) => {
+      if (!itemEls.has(sel)) itemEls.set(sel, createMockElement());
+      return itemEls.get(sel);
+    };
+    callback($item, products[0]);
+
+    // Trigger the onClick registered on the image
+    const onClickFn = $item('#collectionImage').onClick.mock.calls[0][0];
+    onClickFn();
+    await new Promise(r => setTimeout(r, 0)); // flush dynamic import chain
+
+    expect(wixTo).toHaveBeenCalledWith('/product-page/coll-slug');
+  });
+});
+
+describe('loadRelatedProducts — navigation coverage', () => {
+  beforeEach(() => { elements.clear(); vi.clearAllMocks(); });
+
+  it('navigateToProduct passed to makeClickable calls wix-location-frontend to()', async () => {
+    const products = [{ _id: 'r1', name: 'R', mainMedia: 'i.jpg', formattedPrice: '$50', slug: 'rel-slug' }];
+    getRelatedProducts.mockResolvedValue(products);
+    await loadRelatedProducts($w, { _id: 'p1', collections: ['c1'] });
+
+    const callback = getEl('#relatedRepeater').onItemReady.mock.calls[0][0];
+    const itemEls = new Map();
+    const $item = (sel) => {
+      if (!itemEls.has(sel)) itemEls.set(sel, createMockElement());
+      return itemEls.get(sel);
+    };
+    callback($item, products[0]);
+
+    // makeClickable receives navigateToProduct as its second arg
+    const navigateFn = makeClickable.mock.calls[0][1];
+    navigateFn();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(wixTo).toHaveBeenCalledWith('/product-page/rel-slug');
+  });
+});
+
+describe('initBundleSection — navigation and error coverage', () => {
+  beforeEach(() => { elements.clear(); vi.clearAllMocks(); });
+
+  it('navigateToBundle onClick calls wix-location-frontend to()', async () => {
+    getBundleSuggestion.mockResolvedValue({
+      product: { _id: 'b1', name: 'B', mainMedia: 'b.jpg', slug: 'bundle-slug' },
+      bundlePrice: 100, savings: 20,
+    });
+    await initBundleSection($w, { _id: 'p1' });
+
+    const navigateFn = getEl('#bundleImage').onClick.mock.calls[0][0];
+    navigateFn();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(wixTo).toHaveBeenCalledWith('/product-page/bundle-slug');
+  });
+
+  it('logs error when getBundleSuggestion throws (outer catch)', async () => {
+    getBundleSuggestion.mockRejectedValue(new Error('fetch failed'));
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await initBundleSection($w, { _id: 'p1' });
+    expect(spy).toHaveBeenCalledWith('Error loading bundle section:', expect.any(Error));
+    spy.mockRestore();
   });
 });
 

--- a/tests/shareYourRoom.test.js
+++ b/tests/shareYourRoom.test.js
@@ -395,11 +395,64 @@ describe('ShareYourRoom', () => {
     );
   });
 
+  // ── room type onChange → refreshSubmitState ─────────────────────────────────
+
+  it('room type onChange triggers refreshSubmitState (enables submit when url + type present)', async () => {
+    const roomTypeEl = mockEl({ value: 'bedroom' });
+    const submitEl = mockEl();
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      if (sel === '#shareYourRoomSubmitBtn') return submitEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/abc.jpg'); // pre-set upload URL
+
+    // Trigger the arrow function registered to room type onChange
+    const onChangeFn = roomTypeEl.onChange.mock.calls[0][0];
+    onChangeFn();
+
+    expect(submitEl.enable).toHaveBeenCalled();
+  });
+
+  // ── getRoomType catch branch ──────────────────────────────────────────────
+
+  it('handles getRoomType when $w throws for roomType selector', async () => {
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') throw new Error('element not found');
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/abc.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    // getRoomType returns null via catch → showValidation fires
+    expect(get('#shareYourRoomValidation').text).toBe('Please select a room type.');
+  });
+
   // ── exports ─────────────────────────────────────────────────────────────────
 
   it('exports _VALID_ROOM_TYPES with 5 entries', () => {
     expect(_VALID_ROOM_TYPES).toHaveLength(5);
     expect(_VALID_ROOM_TYPES.map(r => r.value)).toContain('living-room');
     expect(_VALID_ROOM_TYPES.map(r => r.value)).toContain('porch');
+  });
+
+  it('_getUploadedUrl returns the current upload URL', () => {
+    _setUploadedUrl('wix:image://v1/test.jpg');
+    expect(_getUploadedUrl()).toBe('wix:image://v1/test.jpg');
+    _setUploadedUrl(null);
+    expect(_getUploadedUrl()).toBeNull();
+  });
+
+  it('_isModalOpen reflects open/closed state', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    expect(_isModalOpen()).toBe(false);
+    _openModal($w, MEMBER_STATE);
+    expect(_isModalOpen()).toBe(true);
+    _closeModal($w);
+    expect(_isModalOpen()).toBe(false);
   });
 });

--- a/tests/shareYourRoom.test.js
+++ b/tests/shareYourRoom.test.js
@@ -1,0 +1,405 @@
+/**
+ * Tests for ShareYourRoom.js — UGC photo submit CTA on the PDP.
+ *
+ * Covers:
+ * - initShareYourRoomCTA: modal collapsed on init, room type options set
+ * - CTA button click: opens modal, resets form
+ * - Close button / overlay click: collapses modal
+ * - Non-member: login prompt shown, upload disabled
+ * - Upload onChange: triggers startUpload, sets preview, enables submit when room type set
+ * - Upload failure: shows validation message
+ * - Room type change: enables/disables submit based on upload + room type
+ * - Submit: disabled submit button stays disabled while loading
+ * - Submit success: shows success section, hides form
+ * - Submit error (API error): shows validation, re-enables submit
+ * - Submit error (network): shows generic error, re-enables submit
+ * - Submit with no room type: shows validation, does not call backend
+ * - Submit with no upload: shows validation, does not call backend
+ * - _VALID_ROOM_TYPES exported
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockSubmitUGCPhoto = vi.fn();
+vi.mock('backend/ugcService.web', () => ({
+  submitUGCPhoto: (...args) => mockSubmitUGCPhoto(...args),
+}));
+
+vi.mock('public/a11yHelpers', () => ({
+  announce: vi.fn(),
+}));
+
+vi.mock('public/engagementTracker', () => ({
+  trackEvent: vi.fn(),
+}));
+
+// ── $w Mock Factory ──────────────────────────────────────────────────────────
+
+function mockEl(overrides = {}) {
+  return {
+    text: '',
+    src: '',
+    value: undefined,
+    options: [],
+    collapse:     vi.fn(),
+    expand:       vi.fn(),
+    show:         vi.fn(),
+    hide:         vi.fn(),
+    enable:       vi.fn(),
+    disable:      vi.fn(),
+    onClick:      vi.fn(),
+    onChange:     vi.fn(),
+    startUpload:  vi.fn(),
+    fileType:     '',
+    ...overrides,
+  };
+}
+
+function make$w() {
+  const els = {};
+  const get = (sel) => {
+    if (!els[sel]) els[sel] = mockEl();
+    return els[sel];
+  };
+  return { get, els };
+}
+
+// ── Import module under test ─────────────────────────────────────────────────
+
+import {
+  initShareYourRoomCTA,
+  _VALID_ROOM_TYPES,
+  _openModal,
+  _closeModal,
+  _getUploadedUrl,
+  _setUploadedUrl,
+  _isModalOpen,
+} from '../src/public/ShareYourRoom.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const MEMBER_STATE  = { isLoggedIn: true,  product: { _id: 'prod-1', name: 'Eureka Futon' } };
+const GUEST_STATE   = { isLoggedIn: false, product: { _id: 'prod-1', name: 'Eureka Futon' } };
+const EMPTY_PRODUCT = {};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ShareYourRoom', () => {
+  let $w;
+  let get;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubmitUGCPhoto.mockResolvedValue({ success: true, data: { _id: 'ugc-1' } });
+    const w = make$w();
+    get = w.get;
+    $w = (sel) => get(sel);
+    $w.onReady = vi.fn();
+  });
+
+  // ── init ────────────────────────────────────────────────────────────────────
+
+  it('collapses modal and success sections on init', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    expect(get('#shareYourRoomModal').collapse).toHaveBeenCalled();
+    expect(get('#shareYourRoomSuccess').collapse).toHaveBeenCalled();
+  });
+
+  it('disables submit button on init', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    expect(get('#shareYourRoomSubmitBtn').disable).toHaveBeenCalled();
+  });
+
+  it('sets room type dropdown options', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const opts = get('#shareYourRoomRoomType').options;
+    expect(opts).toHaveLength(_VALID_ROOM_TYPES.length);
+    expect(opts[0]).toEqual({ label: 'Living Room', value: 'living-room' });
+  });
+
+  it('registers onClick handler on CTA button', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    expect(get('#shareYourRoomBtn').onClick).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('registers onClick on overlay and close button', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    expect(get('#shareYourRoomOverlay').onClick).toHaveBeenCalled();
+    expect(get('#shareYourRoomClose').onClick).toHaveBeenCalled();
+  });
+
+  it('sets upload fileType to Image', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    expect(get('#shareYourRoomUpload').fileType).toBe('Image');
+  });
+
+  // ── open modal ──────────────────────────────────────────────────────────────
+
+  it('expands modal when CTA button clicked', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
+    handler();
+    expect(get('#shareYourRoomModal').expand).toHaveBeenCalled();
+  });
+
+  it('collapses login prompt for logged-in member', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
+    handler();
+    expect(get('#shareYourRoomLoginPrompt').collapse).toHaveBeenCalled();
+  });
+
+  it('expands login prompt for non-member (guest)', () => {
+    initShareYourRoomCTA($w, GUEST_STATE);
+    const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
+    handler();
+    expect(get('#shareYourRoomLoginPrompt').expand).toHaveBeenCalled();
+  });
+
+  it('disables upload for non-member', () => {
+    initShareYourRoomCTA($w, GUEST_STATE);
+    const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
+    handler();
+    expect(get('#shareYourRoomUpload').disable).toHaveBeenCalled();
+  });
+
+  it('resets caption and room type when modal opens', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    get('#shareYourRoomCaption').value = 'old caption';
+    const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
+    handler();
+    expect(get('#shareYourRoomCaption').value).toBe('');
+  });
+
+  // ── close modal ─────────────────────────────────────────────────────────────
+
+  it('collapses modal when close button clicked', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const closeHandler = get('#shareYourRoomClose').onClick.mock.calls[0][0];
+    closeHandler();
+    expect(get('#shareYourRoomModal').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses modal when overlay clicked', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const overlayHandler = get('#shareYourRoomOverlay').onClick.mock.calls[0][0];
+    overlayHandler();
+    expect(get('#shareYourRoomModal').collapse).toHaveBeenCalled();
+  });
+
+  // ── upload ──────────────────────────────────────────────────────────────────
+
+  it('calls startUpload and sets preview on successful upload', async () => {
+    const previewEl = mockEl();
+    const uploadEl = mockEl({
+      value: [{ name: 'photo.jpg' }],
+      startUpload: vi.fn().mockResolvedValue({ url: 'wix:image://v1/abc.jpg' }),
+    });
+    const localGet = (sel) => {
+      if (sel === '#shareYourRoomUpload') return uploadEl;
+      if (sel === '#shareYourRoomPreview') return previewEl;
+      return get(sel);
+    };
+    const local$w = (sel) => localGet(sel);
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+
+    const changeHandler = uploadEl.onChange.mock.calls[0][0];
+    await changeHandler();
+
+    expect(uploadEl.startUpload).toHaveBeenCalled();
+    expect(previewEl.src).toBe('wix:image://v1/abc.jpg');
+    expect(previewEl.expand).toHaveBeenCalled();
+  });
+
+  it('shows validation message on upload failure', async () => {
+    const uploadEl = mockEl({
+      value: [{ name: 'photo.jpg' }],
+      startUpload: vi.fn().mockRejectedValue(new Error('network error')),
+    });
+    const localGet = (sel) => sel === '#shareYourRoomUpload' ? uploadEl : get(sel);
+    const local$w = (sel) => localGet(sel);
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+
+    const changeHandler = uploadEl.onChange.mock.calls[0][0];
+    await changeHandler();
+
+    expect(get('#shareYourRoomValidation').expand).toHaveBeenCalled();
+    expect(get('#shareYourRoomValidation').text).toBe('Upload failed. Please try again.');
+  });
+
+  it('enables submit only when both upload url and room type are set', async () => {
+    const uploadEl = mockEl({
+      value: [{ name: 'photo.jpg' }],
+      startUpload: vi.fn().mockResolvedValue({ url: 'wix:image://v1/abc.jpg' }),
+    });
+    const roomTypeEl = mockEl({ value: 'bedroom' });
+    const submitEl = mockEl();
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomUpload') return uploadEl;
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      if (sel === '#shareYourRoomSubmitBtn') return submitEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+
+    const changeHandler = uploadEl.onChange.mock.calls[0][0];
+    await changeHandler();
+
+    expect(submitEl.enable).toHaveBeenCalled();
+  });
+
+  it('keeps submit disabled when upload succeeds but room type missing', async () => {
+    const uploadEl = mockEl({
+      value: [{ name: 'photo.jpg' }],
+      startUpload: vi.fn().mockResolvedValue({ url: 'wix:image://v1/abc.jpg' }),
+    });
+    const roomTypeEl = mockEl({ value: undefined });
+    const submitEl = mockEl();
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomUpload') return uploadEl;
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      if (sel === '#shareYourRoomSubmitBtn') return submitEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+
+    const changeHandler = uploadEl.onChange.mock.calls[0][0];
+    await changeHandler();
+
+    expect(submitEl.enable).not.toHaveBeenCalled();
+  });
+
+  // ── submit ──────────────────────────────────────────────────────────────────
+
+  it('calls submitUGCPhoto with correct payload on success', async () => {
+    const roomTypeEl = mockEl({ value: 'living-room' });
+    const captionEl = mockEl({ value: 'My cozy setup' });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      if (sel === '#shareYourRoomCaption') return captionEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/test.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(mockSubmitUGCPhoto).toHaveBeenCalledWith({
+      photoUrl:    'wix:image://v1/test.jpg',
+      roomType:    'living-room',
+      caption:     'My cozy setup',
+      productId:   'prod-1',
+      productName: 'Eureka Futon',
+    });
+  });
+
+  it('shows success section and hides form on successful submit', async () => {
+    const roomTypeEl = mockEl({ value: 'bedroom' });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/test.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(get('#shareYourRoomSuccess').expand).toHaveBeenCalled();
+    expect(get('#shareYourRoomForm').collapse).toHaveBeenCalled();
+  });
+
+  it('shows API error and re-enables submit on failure', async () => {
+    mockSubmitUGCPhoto.mockResolvedValue({ success: false, error: 'Auth required.' });
+    const roomTypeEl = mockEl({ value: 'office' });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/test.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(get('#shareYourRoomValidation').text).toBe('Auth required.');
+    expect(get('#shareYourRoomValidation').expand).toHaveBeenCalled();
+    expect(get('#shareYourRoomSubmitBtn').enable).toHaveBeenCalled();
+  });
+
+  it('shows generic error and re-enables submit on network exception', async () => {
+    mockSubmitUGCPhoto.mockRejectedValue(new Error('fetch failed'));
+    const roomTypeEl = mockEl({ value: 'dorm' });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/test.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(get('#shareYourRoomValidation').text).toBe('An error occurred. Please try again.');
+    expect(get('#shareYourRoomSubmitBtn').enable).toHaveBeenCalled();
+  });
+
+  it('does not call backend if room type missing', async () => {
+    const roomTypeEl = mockEl({ value: undefined });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl('wix:image://v1/test.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(mockSubmitUGCPhoto).not.toHaveBeenCalled();
+    expect(get('#shareYourRoomValidation').text).toBe('Please select a room type.');
+  });
+
+  it('does not call backend if upload url missing', async () => {
+    const roomTypeEl = mockEl({ value: 'porch' });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, MEMBER_STATE);
+    _setUploadedUrl(null);
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(mockSubmitUGCPhoto).not.toHaveBeenCalled();
+    expect(get('#shareYourRoomValidation').text).toBe('Please upload a photo first.');
+  });
+
+  it('submits with null productId when product missing from state', async () => {
+    const roomTypeEl = mockEl({ value: 'bedroom' });
+    const local$w = (sel) => {
+      if (sel === '#shareYourRoomRoomType') return roomTypeEl;
+      return get(sel);
+    };
+    initShareYourRoomCTA(local$w, { isLoggedIn: true, product: EMPTY_PRODUCT });
+    _setUploadedUrl('wix:image://v1/test.jpg');
+
+    const submitHandler = get('#shareYourRoomSubmitBtn').onClick.mock.calls[0][0];
+    await submitHandler();
+
+    expect(mockSubmitUGCPhoto).toHaveBeenCalledWith(
+      expect.objectContaining({ productId: null, productName: null })
+    );
+  });
+
+  // ── exports ─────────────────────────────────────────────────────────────────
+
+  it('exports _VALID_ROOM_TYPES with 5 entries', () => {
+    expect(_VALID_ROOM_TYPES).toHaveLength(5);
+    expect(_VALID_ROOM_TYPES.map(r => r.value)).toContain('living-room');
+    expect(_VALID_ROOM_TYPES.map(r => r.value)).toContain('porch');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `initShareYourRoomCTA($w, state)` in `src/public/ShareYourRoom.js` — wires a "Share your room" CTA button on the PDP that expands an inline photo-submission modal
- Modal flow: upload photo → select room type → optional caption → submit → pending moderation queue via `submitUGCPhoto()`
- Non-members see a sign-in prompt; upload is disabled until signed in
- Submit button stays disabled until both upload URL and room type are present
- Success section replaces form on successful submit; errors shown inline
- Registered as a deferred section in `Product Page.js` (no impact on LCP)
- Editor hookup guide updated with full layout diagram + 13 element IDs (`#shareYourRoom*` prefix)

## Test plan
- [x] `tests/shareYourRoom.test.js` — 25 tests, all passing
- [ ] Stilgar adds elements in Wix Studio Editor per `EDITOR_HOOKUP_GUIDE.html` → "Share Your Room CTA" section
- [ ] Manual: member flow (upload → roomType → submit → success)
- [ ] Manual: guest flow (login prompt visible, upload disabled)
- [ ] Manual: validation path (submit without upload, submit without room type)

## Element IDs (Wix Studio Editor)
`#shareYourRoomBtn` · `#shareYourRoomModal` · `#shareYourRoomOverlay` · `#shareYourRoomClose` · `#shareYourRoomLoginPrompt` · `#shareYourRoomForm` · `#shareYourRoomUpload` · `#shareYourRoomPreview` · `#shareYourRoomRoomType` · `#shareYourRoomCaption` · `#shareYourRoomValidation` · `#shareYourRoomSubmitBtn` · `#shareYourRoomSuccess`

🤖 Generated with [Claude Code](https://claude.com/claude-code)