### PR TITLE
fix(GH-990): IDOR scanner — catch plain exported functions

### DIFF
--- a/scripts/check-member-ownership.mjs
+++ b/scripts/check-member-ownership.mjs
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 /**
- * IDOR guard: scan all SiteMember webMethods for ownership check pattern.
+ * IDOR guard: scan SiteMember webMethods AND plain exported functions in .web.js
+ * files for ownership check patterns.
  *
- * Flags any SiteMember webMethod that:
+ * Flags any function that:
  *   1. Accepts a memberId-like parameter (memberId, userId, contactId, etc.), AND
  *   2. Uses it in a wixData query (.eq(field, param)), AND
  *   3. Does NOT call currentMember.getMember() or getMember() in scope
  *
+ * Two extraction modes:
+ *   - webMethod(Permissions.SiteMember, ...) — original scanner (CF-2za7)
+ *   - export [async] function name(params) in .web.js — plain exports (GH-990 gap)
+ *
  * Exits with code 1 if violations found (for use in CI / pre-commit hook).
  * Run: node scripts/check-member-ownership.mjs
  *
- * CF-2za7: CI lint rule for SiteMember IDOR prevention
+ * CF-2za7, GH-990
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -57,21 +62,50 @@ export function extractSiteMemberMethods(source) {
 }
 
 /**
- * Check a single SiteMember method for IDOR risk.
+ * Extract plain exported functions from a .web.js file's source text.
+ * Matches: export [async] function name(params) { ... }
+ * These are callable from the frontend without a webMethod wrapper.
+ * Returns array of {name, params, body, lineNumber, kind: 'plain'}.
+ */
+export function extractPlainExportedFunctions(source) {
+  const functions = [];
+  const fnRe = /export\s+(async\s+)?function\s+(\w+)\s*\(([^)]*)\)\s*\{/g;
+  let match;
+  while ((match = fnRe.exec(source)) !== null) {
+    const name = match[2];
+    const params = match[3];
+    const startIdx = match.index + match[0].length - 1; // position of opening '{'
+    let depth = 1;
+    let i = startIdx + 1;
+    while (i < source.length && depth > 0) {
+      if (source[i] === '{') depth++;
+      else if (source[i] === '}') depth--;
+      i++;
+    }
+    const body = source.slice(startIdx, i);
+    const lineNumber = source.slice(0, match.index).split('\n').length;
+    functions.push({ name, params, body, lineNumber, kind: 'plain' });
+  }
+  return functions;
+}
+
+/**
+ * Check a single method for IDOR risk.
+ * Works for both webMethod-wrapped and plain exported functions.
  * Returns { violation: boolean, reason?: string }
  */
 export function checkMethodForIDOR(method) {
-  const { name, params, body } = method;
+  const { name, params, body, kind } = method;
   // Only flag if parameter looks like a memberId
   if (!MEMBER_ID_PARAMS.test(params)) return { violation: false };
   // Only flag if the body queries with that param
   if (!QUERY_PATTERN.test(body)) return { violation: false };
   // Check if ownership is verified
   if (OWNERSHIP_CHECK.test(body)) return { violation: false };
-  return {
-    violation: true,
-    reason: `SiteMember webMethod '${name}' accepts memberId-like param and queries data without getMember() ownership check`,
-  };
+  const label = kind === 'plain'
+    ? `Plain export '${name}' accepts memberId-like param and queries data without getMember() ownership check`
+    : `SiteMember webMethod '${name}' accepts memberId-like param and queries data without getMember() ownership check`;
+  return { violation: true, reason: label };
 }
 
 /**
@@ -86,12 +120,22 @@ export function scanBackendFiles(backendDir = BACKEND_DIR) {
   for (const file of files) {
     const filePath = join(backendDir, file);
     const source = readFileSync(filePath, 'utf8');
-    const methods = extractSiteMemberMethods(source);
 
-    for (const method of methods) {
+    // Scan webMethod-wrapped SiteMember functions
+    const webMethods = extractSiteMemberMethods(source);
+    for (const method of webMethods) {
       const result = checkMethodForIDOR(method);
       if (result.violation) {
         violations.push({ file, name: method.name, line: method.lineNumber, reason: result.reason });
+      }
+    }
+
+    // Scan plain exported functions (GH-990 gap)
+    const plainFns = extractPlainExportedFunctions(source);
+    for (const fn of plainFns) {
+      const result = checkMethodForIDOR(fn);
+      if (result.violation) {
+        violations.push({ file, name: fn.name, line: fn.lineNumber, reason: result.reason });
       }
     }
   }
@@ -103,7 +147,7 @@ export function scanBackendFiles(backendDir = BACKEND_DIR) {
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const violations = scanBackendFiles();
   if (violations.length === 0) {
-    console.log('✓ No IDOR violations found in SiteMember webMethods');
+    console.log('✓ No IDOR violations found in SiteMember webMethods or plain exports');
     process.exit(0);
   }
 

--- a/tests/memberOwnershipGuard.test.js
+++ b/tests/memberOwnershipGuard.test.js
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   extractSiteMemberMethods,
+  extractPlainExportedFunctions,
   checkMethodForIDOR,
   scanBackendFiles,
 } from '../scripts/check-member-ownership.mjs';
@@ -84,6 +85,81 @@ export const getItem = webMethod(Permissions.SiteMember, async (memberId) => {
   it('returns empty array for source with no webMethods', () => {
     const methods = extractSiteMemberMethods('const x = 1;');
     expect(methods).toHaveLength(0);
+  });
+});
+
+// ── extractPlainExportedFunctions ────────────────────────────────
+
+describe('extractPlainExportedFunctions', () => {
+  it('finds a plain async exported function', () => {
+    const source = `
+export async function getTrailProgress(memberId) {
+  return await wixData.query('Trails').eq('memberId', memberId).find();
+}`;
+    const fns = extractPlainExportedFunctions(source);
+    expect(fns).toHaveLength(1);
+    expect(fns[0].name).toBe('getTrailProgress');
+    expect(fns[0].params).toBe('memberId');
+    expect(fns[0].kind).toBe('plain');
+  });
+
+  it('finds a plain sync exported function', () => {
+    const source = `
+export function buildQuery(userId) {
+  return wixData.query('Data').eq('userId', userId);
+}`;
+    const fns = extractPlainExportedFunctions(source);
+    expect(fns).toHaveLength(1);
+    expect(fns[0].name).toBe('buildQuery');
+    expect(fns[0].params).toBe('userId');
+  });
+
+  it('extracts body correctly', () => {
+    const source = `
+export async function doStuff(memberId) {
+  const r = await wixData.query('X').eq('memberId', memberId).find();
+  return r;
+}`;
+    const fns = extractPlainExportedFunctions(source);
+    expect(fns[0].body).toContain('wixData.query');
+  });
+
+  it('ignores non-exported functions', () => {
+    const source = `
+async function helperFunc(memberId) {
+  return wixData.query('X').eq('memberId', memberId).find();
+}`;
+    const fns = extractPlainExportedFunctions(source);
+    expect(fns).toHaveLength(0);
+  });
+
+  it('finds multiple exported functions', () => {
+    const source = `
+export async function getA(memberId) {
+  return wixData.query('A').eq('memberId', memberId).find();
+}
+export function getB(userId) {
+  return wixData.query('B').eq('userId', userId).find();
+}`;
+    const fns = extractPlainExportedFunctions(source);
+    expect(fns).toHaveLength(2);
+    expect(fns.map(f => f.name)).toEqual(['getA', 'getB']);
+  });
+
+  it('returns lineNumber for each function', () => {
+    const source = `
+// line 2
+
+export async function getItem(memberId) {
+  return wixData.get('Items', memberId);
+}`;
+    const fns = extractPlainExportedFunctions(source);
+    expect(fns[0].lineNumber).toBeGreaterThan(1);
+  });
+
+  it('returns empty array for source with no exports', () => {
+    const fns = extractPlainExportedFunctions('const x = 1;');
+    expect(fns).toHaveLength(0);
   });
 });
 
@@ -190,6 +266,35 @@ describe('checkMethodForIDOR', () => {
     const result = checkMethodForIDOR(method);
     expect(result.reason).toContain('myDangerousMethod');
   });
+
+  it('labels plain export violations differently from webMethod violations', () => {
+    const plain = {
+      name: 'getTrailProgress',
+      params: 'memberId',
+      body: `{ return await wixData.query('Trails').eq('memberId', memberId).find(); }`,
+      kind: 'plain',
+    };
+    const webMethod = {
+      name: 'getCredits',
+      params: 'memberId',
+      body: `{ return await wixData.query('Credits').eq('memberId', memberId).find(); }`,
+    };
+    expect(checkMethodForIDOR(plain).reason).toContain('Plain export');
+    expect(checkMethodForIDOR(webMethod).reason).toContain('SiteMember webMethod');
+  });
+
+  it('does not flag plain export with getMember() ownership check', () => {
+    const method = {
+      name: 'getTrailProgress',
+      params: 'memberId',
+      body: `{
+        const member = await currentMember.getMember();
+        return await wixData.query('Trails').eq('memberId', memberId).find();
+      }`,
+      kind: 'plain',
+    };
+    expect(checkMethodForIDOR(method).violation).toBe(false);
+  });
 });
 
 // ── scanBackendFiles (integration) ───────────────────────────────
@@ -220,10 +325,26 @@ describe('scanBackendFiles', () => {
     expect(storeCredit).toHaveLength(0);
   });
 
-  it('produces zero violations in current codebase (all ownership checks present)', () => {
+  it('catches plain exported functions with IDOR risk (GH-990 gap)', () => {
     const violations = scanBackendFiles(BACKEND_DIR);
-    // Document violations if any exist — this test acts as a ratchet:
-    // if violations are 0 now, any new IDOR will fail CI
-    expect(violations).toHaveLength(0);
+    const plainViolations = violations.filter(v => v.reason.includes('Plain export'));
+    expect(plainViolations.length).toBeGreaterThan(0);
+  });
+
+  it('flags challengeService.web.js getTrailProgress as plain export violation', () => {
+    const violations = scanBackendFiles(BACKEND_DIR);
+    const match = violations.find(
+      v => v.file.includes('challengeService') && v.name === 'getTrailProgress'
+    );
+    expect(match).toBeDefined();
+    expect(match.reason).toContain('Plain export');
+  });
+
+  it('ratchet: known violation count (15 plain-export violations pending remediation)', () => {
+    const violations = scanBackendFiles(BACKEND_DIR);
+    // GH-990: 15 plain-export violations found after extending scanner.
+    // This ratchet prevents new violations from sneaking in.
+    // As each is fixed with getMember() ownership checks, lower this number.
+    expect(violations).toHaveLength(15);
   });
 });


### PR DESCRIPTION
## Summary
- Extends `scripts/check-member-ownership.mjs` to scan plain `export [async] function` in `.web.js` files — these are callable from frontend without `webMethod()` auth wrapping
- Adds `extractPlainExportedFunctions()` extractor, kind-aware violation labels ("Plain export" vs "SiteMember webMethod"), and dual-scan in `scanBackendFiles`
- 12 new tests (33 total, all green). Ratchet set at 15 known plain-export violations pending remediation

## Test plan
- [x] 33/33 vitest tests pass
- [x] Scanner detects `challengeService.web.js` `getTrailProgress` as plain export violation
- [x] Existing webMethod detection unchanged (21 original tests still pass)
- [x] Ratchet test locks violation count at 15 — any new unguarded export fails CI

Closes GH-990

🤖 Generated with [Claude Code](https://claude.com/claude-code)