### PR TITLE
fix: add suppressAuth:true to all surveyService queries

### DIFF
--- a/src/backend/surveyService.web.js
+++ b/src/backend/surveyService.web.js
@@ -168,7 +168,7 @@ export const submitSurveyResponse = webMethod(
       const result = await wixData.query(SURVEY_COLLECTION)
         .eq('memberId', memberId)
         .eq('orderId', orderId)
-        .find();
+        .find({ suppressAuth: true });
 
       if (result.items.length === 0) {
         return { success: false, error: 'No survey found for this order' };
@@ -224,7 +224,7 @@ export const getSurveyForOrder = webMethod(
       const result = await wixData.query(SURVEY_COLLECTION)
         .eq('memberId', memberId)
         .eq('orderId', cleanId)
-        .find();
+        .find({ suppressAuth: true });
 
       if (result.items.length === 0) return { success: true, survey: null };
 
@@ -278,11 +278,11 @@ export const getSurveyResponseAggregation = webMethod(
           .ge('sentAt', since)
           .isNotEmpty('completedAt')
           .limit(1000)
-          .find(),
+          .find({ suppressAuth: true }),
         wixData.query(SURVEY_COLLECTION)
           .ge('sentAt', since)
           .limit(1000)
-          .find(),
+          .find({ suppressAuth: true }),
       ]);
 
       const completed = completedResult.items;
@@ -354,7 +354,7 @@ export const getNpsStats = webMethod(
         .ge('completedAt', since)
         .isNotEmpty('completedAt')
         .limit(1000)
-        .find();
+        .find({ suppressAuth: true });
 
       const responses = result.items;
       if (responses.length === 0) {

--- a/tests/cf-1mlj-survey-aggregation.test.js
+++ b/tests/cf-1mlj-survey-aggregation.test.js
@@ -17,7 +17,7 @@
  *  - returns error on DB failure
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { __seed, __reset, __setQueryError } from './__mocks__/wix-data.js';
+import { __seed, __reset, __setQueryError, __getLastFindOptions } from './__mocks__/wix-data.js';
 import { getSurveyResponseAggregation } from '../src/backend/surveyService.web.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -243,5 +243,16 @@ describe('getSurveyResponseAggregation — error handling', () => {
     const result = await getSurveyResponseAggregation();
     expect(result.success).toBe(false);
     expect(result.error).toBeTruthy();
+  });
+});
+
+// ── suppressAuth ────────────────────────────────────────────────────────────
+
+describe('getSurveyResponseAggregation — suppressAuth', () => {
+  it('queries SurveyResponses with suppressAuth: true', async () => {
+    __seed('SurveyResponses', [makeCompleted(9, 'great')]);
+    await getSurveyResponseAggregation();
+    const opts = __getLastFindOptions('SurveyResponses');
+    expect(opts).toEqual({ suppressAuth: true });
   });
 });

--- a/tests/surveyService.test.js
+++ b/tests/surveyService.test.js
@@ -338,3 +338,32 @@ describe('getNpsStats', () => {
     expect(result.error).toBeDefined();
   });
 });
+
+// ── suppressAuth on all queries ─────────────────────────────────────────────
+
+describe('suppressAuth — all queries use { suppressAuth: true }', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupQueryMocks();
+    mockGetMember.mockResolvedValue({ _id: MEMBER_ID });
+    mockFind.mockResolvedValue({ items: [makeSurveyRecord()] });
+    mockUpdate.mockResolvedValue({});
+  });
+
+  it('submitSurveyResponse passes suppressAuth to find()', async () => {
+    await submitSurveyResponse({ orderId: ORDER_ID, npsScore: 8 });
+    expect(mockFind).toHaveBeenCalledWith({ suppressAuth: true });
+  });
+
+  it('getSurveyForOrder passes suppressAuth to find()', async () => {
+    mockFind.mockResolvedValue({ items: [] });
+    await getSurveyForOrder(ORDER_ID);
+    expect(mockFind).toHaveBeenCalledWith({ suppressAuth: true });
+  });
+
+  it('getNpsStats passes suppressAuth to find()', async () => {
+    mockFind.mockResolvedValue({ items: [] });
+    await getNpsStats();
+    expect(mockFind).toHaveBeenCalledWith({ suppressAuth: true });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `{ suppressAuth: true }` to all 5 `wixData.query().find()` calls in `surveyService.web.js`
- Affected methods: `submitSurveyResponse`, `getSurveyForOrder`, `getSurveyResponseAggregation` (2 queries), `getNpsStats`
- Without this, queries fail silently when CMS collection has admin-only read permissions

## Test plan

- [x] 4 new TDD tests assert `find()` receives `{ suppressAuth: true }` for each query path
- [x] All 90 survey-related tests pass
- [x] No functional changes — only auth bypass for backend queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)