### PR TITLE
fix(CF-8gzd): unique per-repeater link nicknames & native SocialBar

### DIFF
--- a/src/public/FooterSection.js
+++ b/src/public/FooterSection.js
@@ -120,10 +120,10 @@ export function initFooterColumns($w) {
         const links = getFooterShopLinks();
         shopRepeater.data = links.map((l, i) => ({ ...l, _id: `shop-${i}` }));
         shopRepeater.onItemReady(($item, itemData) => {
-          try { $item('#footerLink').text = itemData.label; } catch (e) {}
-          try { $item('#footerLink').accessibility.ariaLabel = `Shop ${itemData.label}`; } catch (e) {}
+          try { $item('#shopLink').text = itemData.label; } catch (e) {}
+          try { $item('#shopLink').accessibility.ariaLabel = `Shop ${itemData.label}`; } catch (e) {}
           try {
-            $item('#footerLink').onClick(() => {
+            $item('#shopLink').onClick(() => {
               import('wix-location-frontend').then(({ to }) => to(itemData.path));
             });
           } catch (e) {}
@@ -138,10 +138,10 @@ export function initFooterColumns($w) {
         const links = getFooterServiceLinks();
         serviceRepeater.data = links.map((l, i) => ({ ...l, _id: `svc-${i}` }));
         serviceRepeater.onItemReady(($item, itemData) => {
-          try { $item('#footerLink').text = itemData.label; } catch (e) {}
-          try { $item('#footerLink').accessibility.ariaLabel = itemData.label; } catch (e) {}
+          try { $item('#serviceLink').text = itemData.label; } catch (e) {}
+          try { $item('#serviceLink').accessibility.ariaLabel = itemData.label; } catch (e) {}
           try {
-            $item('#footerLink').onClick(() => {
+            $item('#serviceLink').onClick(() => {
               import('wix-location-frontend').then(({ to }) => to(itemData.path));
             });
           } catch (e) {}
@@ -156,10 +156,10 @@ export function initFooterColumns($w) {
         const links = getFooterAboutLinks();
         aboutRepeater.data = links.map((l, i) => ({ ...l, _id: `about-${i}` }));
         aboutRepeater.onItemReady(($item, itemData) => {
-          try { $item('#footerLink').text = itemData.label; } catch (e) {}
-          try { $item('#footerLink').accessibility.ariaLabel = itemData.label; } catch (e) {}
+          try { $item('#aboutLink').text = itemData.label; } catch (e) {}
+          try { $item('#aboutLink').accessibility.ariaLabel = itemData.label; } catch (e) {}
           try {
-            $item('#footerLink').onClick(() => {
+            $item('#aboutLink').onClick(() => {
               import('wix-location-frontend').then(({ to }) => to(itemData.path));
             });
           } catch (e) {}
@@ -244,44 +244,7 @@ export function initFooterSocial($w) {
   try {
     const links = getFooterSocialLinks();
 
-    // Repeater-based social icons (legacy pattern)
-    try {
-      const socialRepeater = $w('#footerSocialRepeater');
-      if (socialRepeater) {
-        socialRepeater.data = links.map((l, i) => ({ ...l, _id: `social-${i}` }));
-        socialRepeater.onItemReady(($item, itemData) => {
-          try { $item('#socialIcon').text = itemData.platform; } catch (e) {}
-          try { $item('#socialIcon').accessibility.ariaLabel = itemData.ariaLabel; } catch (e) {}
-          try {
-            $item('#socialIcon').onClick(() => {
-              if (typeof window !== 'undefined') window.open(itemData.url, '_blank');
-            });
-          } catch (e) {}
-        });
-      }
-    } catch (e) {}
-
-    // Individual BUILD-SPEC social button elements
-    const socialMap = {
-      '#socialFacebook': links.find(l => l.platform === 'facebook'),
-      '#socialInstagram': links.find(l => l.platform === 'instagram'),
-      '#socialPinterest': links.find(l => l.platform === 'pinterest'),
-    };
-
-    Object.entries(socialMap).forEach(([selector, linkData]) => {
-      if (!linkData) return;
-      try {
-        const el = $w(selector);
-        if (!el) return;
-        try { el.accessibility.ariaLabel = linkData.ariaLabel; } catch (e) {}
-        el.onClick(() => {
-          if (typeof window !== 'undefined') window.open(linkData.url, '_blank');
-        });
-      } catch (e) {}
-    });
-
-    // Fallback: fix template social bar links (http → https, missing Pinterest).
-    // The Tera template social bar uses http:// and omits Pinterest.
+    // Fix native SocialBar links (http → https, set canonical URLs).
     fixTemplateSocialBar($w, links);
   } catch (e) {}
 }
@@ -437,37 +400,28 @@ export function applyFooterStyles($w) {
     try { $w('#footerEmailSubmit').style.color = colors.espresso; } catch (e) {}
 
     // Link repeaters: mountainBlue default, coral on hover
-    const linkRepeaters = ['#footerShopRepeater', '#footerServiceRepeater', '#footerAboutRepeater'];
-    linkRepeaters.forEach((sel) => {
+    const linkRepeaters = [
+      { repeater: '#footerShopRepeater', link: '#shopLink' },
+      { repeater: '#footerServiceRepeater', link: '#serviceLink' },
+      { repeater: '#footerAboutRepeater', link: '#aboutLink' },
+    ];
+    linkRepeaters.forEach(({ repeater, link }) => {
       try {
-        $w(sel).onItemReady(($item) => {
+        $w(repeater).onItemReady(($item) => {
           try {
-            $item('#footerLink').style.color = colors.mountainBlue;
-            $item('#footerLink').onMouseIn(() => {
-              try { $item('#footerLink').style.color = colors.sunsetCoral; } catch (e) {}
+            $item(link).style.color = colors.mountainBlue;
+            $item(link).onMouseIn(() => {
+              try { $item(link).style.color = colors.sunsetCoral; } catch (e) {}
             });
-            $item('#footerLink').onMouseOut(() => {
-              try { $item('#footerLink').style.color = colors.mountainBlue; } catch (e) {}
+            $item(link).onMouseOut(() => {
+              try { $item(link).style.color = colors.mountainBlue; } catch (e) {}
             });
           } catch (e) {}
         });
       } catch (e) {}
     });
 
-    // Social icons: sandLight default, coral on hover
-    try {
-      $w('#footerSocialRepeater').onItemReady(($item) => {
-        try {
-          $item('#socialIcon').style.color = colors.sandLight;
-          $item('#socialIcon').onMouseIn(() => {
-            try { $item('#socialIcon').style.color = colors.sunsetCoral; } catch (e) {}
-          });
-          $item('#socialIcon').onMouseOut(() => {
-            try { $item('#socialIcon').style.color = colors.sandLight; } catch (e) {}
-          });
-        } catch (e) {}
-      });
-    } catch (e) {}
+    // Social bar styling is handled by the native Wix SocialBar widget
   } catch (e) {}
 }
 

--- a/tests/footerSection.test.js
+++ b/tests/footerSection.test.js
@@ -309,48 +309,11 @@ describe('initFooterNewsletter', () => {
 // ── initFooterSocial ────────────────────────────────────────────────
 
 describe('initFooterSocial', () => {
-  it('populates social repeater with platform data', () => {
-    initFooterSocial($w);
-    const repeater = $w('#footerSocialRepeater');
-    expect(repeater.data.length).toBeGreaterThan(0);
-    expect(repeater.data[0]).toHaveProperty('platform');
-    expect(repeater.data[0]).toHaveProperty('url');
-  });
-
-  it('registers onItemReady for social repeater', () => {
-    initFooterSocial($w);
-    expect($w('#footerSocialRepeater').onItemReady).toHaveBeenCalledTimes(1);
-  });
-
-  it('onItemReady sets icon text and ARIA label', () => {
-    initFooterSocial($w);
-    const cb = $w('#footerSocialRepeater').onItemReady.mock.calls[0][0];
-    const mockItem = createMockElement();
-    const $item = () => mockItem;
-    cb($item, {
-      platform: 'facebook',
-      url: 'https://www.facebook.com/carolinafutons',
-      ariaLabel: 'Visit Carolina Futons on Facebook',
-    });
-    expect(mockItem.text).toBe('facebook');
-    expect(mockItem.accessibility.ariaLabel).toContain('Facebook');
-  });
-
-  it('onItemReady registers onClick that opens link', () => {
-    initFooterSocial($w);
-    const cb = $w('#footerSocialRepeater').onItemReady.mock.calls[0][0];
-    const mockItem = createMockElement();
-    const $item = () => mockItem;
-    cb($item, {
-      platform: 'instagram',
-      url: 'https://www.instagram.com/carolinafutons',
-      ariaLabel: 'Follow on Instagram',
-    });
-    expect(mockItem.onClick).toHaveBeenCalled();
-  });
-
-  it('survives when social repeater is missing', () => {
-    const broken$w = () => null;
+  it('survives when social bar is missing', () => {
+    const broken$w = (sel) => {
+      if (sel === 'SocialBar') return { length: 0 };
+      return null;
+    };
     expect(() => initFooterSocial(broken$w)).not.toThrow();
   });
 });
@@ -507,99 +470,7 @@ describe('initFooterColumns — BUILD-SPEC contact IDs', () => {
   });
 });
 
-// ── Individual social buttons (cf-0z2w) ──────────────────────────────
-
-describe('initFooterSocial — individual social buttons', () => {
-  it('wires onClick on #socialFacebook', () => {
-    initFooterSocial($w);
-    expect($w('#socialFacebook').onClick).toHaveBeenCalled();
-  });
-
-  it('sets ariaLabel on #socialFacebook', () => {
-    initFooterSocial($w);
-    expect($w('#socialFacebook').accessibility.ariaLabel).toContain('Facebook');
-  });
-
-  it('wires onClick on #socialInstagram', () => {
-    initFooterSocial($w);
-    expect($w('#socialInstagram').onClick).toHaveBeenCalled();
-  });
-
-  it('sets ariaLabel on #socialInstagram', () => {
-    initFooterSocial($w);
-    expect($w('#socialInstagram').accessibility.ariaLabel).toContain('Instagram');
-  });
-
-  it('wires onClick on #socialPinterest', () => {
-    initFooterSocial($w);
-    expect($w('#socialPinterest').onClick).toHaveBeenCalled();
-  });
-
-  it('sets ariaLabel on #socialPinterest', () => {
-    initFooterSocial($w);
-    expect($w('#socialPinterest').accessibility.ariaLabel).toContain('Pinterest');
-  });
-});
-
-// ── initFooterSocial — invoke onClick handlers ───────────────────────
-
-describe('initFooterSocial — onClick handler invocation', () => {
-  it('onClick handler on #socialFacebook opens Facebook URL', () => {
-    const open = vi.fn();
-    global.window = { open };
-    initFooterSocial($w);
-    const handler = $w('#socialFacebook').onClick.mock.calls[0][0];
-    handler();
-    expect(open).toHaveBeenCalledWith('https://www.facebook.com/carolinafutons', '_blank');
-    delete global.window;
-  });
-
-  it('onClick handler on #socialInstagram opens Instagram URL', () => {
-    const open = vi.fn();
-    global.window = { open };
-    initFooterSocial($w);
-    const handler = $w('#socialInstagram').onClick.mock.calls[0][0];
-    handler();
-    expect(open).toHaveBeenCalledWith('https://www.instagram.com/carolinafutons', '_blank');
-    delete global.window;
-  });
-
-  it('onClick handler on #socialPinterest opens Pinterest URL', () => {
-    const open = vi.fn();
-    global.window = { open };
-    initFooterSocial($w);
-    const handler = $w('#socialPinterest').onClick.mock.calls[0][0];
-    handler();
-    expect(open).toHaveBeenCalledWith('https://www.pinterest.com/carolinafutons', '_blank');
-    delete global.window;
-  });
-
-  it('social repeater onItemReady callback sets icon text and aria', () => {
-    initFooterSocial($w);
-    const repeater = $w('#footerSocialRepeater');
-    const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
-    const mockIcon = createMockElement();
-    const $item = () => mockIcon;
-    onItemReadyCb($item, { platform: 'facebook', ariaLabel: 'Visit on Facebook', url: 'https://www.facebook.com/carolinafutons' });
-    expect(mockIcon.text).toBe('facebook');
-    expect(mockIcon.accessibility.ariaLabel).toBe('Visit on Facebook');
-  });
-
-  it('social repeater onItemReady onClick handler opens URL', () => {
-    const open = vi.fn();
-    global.window = { open };
-    initFooterSocial($w);
-    const repeater = $w('#footerSocialRepeater');
-    const onItemReadyCb = repeater.onItemReady.mock.calls[0][0];
-    const mockIcon = createMockElement();
-    const $item = () => mockIcon;
-    onItemReadyCb($item, { platform: 'instagram', ariaLabel: 'Follow on Instagram', url: 'https://www.instagram.com/carolinafutons' });
-    const iconClickHandler = mockIcon.onClick.mock.calls[0][0];
-    iconClickHandler();
-    expect(open).toHaveBeenCalledWith('https://www.instagram.com/carolinafutons', '_blank');
-    delete global.window;
-  });
-});
+// ── Social bar handled by fixTemplateSocialBar (native Wix SocialBar) ──
 
 // ── initFooterColumns — onItemReady branch coverage ─────────────────
 
@@ -1187,25 +1058,7 @@ describe('applyFooterStyles', () => {
     expect(mockLink.style.color).toBe(baseColor);
   });
 
-  it('registers onItemReady with hover on social repeater', () => {
-    applyFooterStyles($w);
-    expect($w('#footerSocialRepeater').onItemReady).toHaveBeenCalled();
-  });
-
-  it('social icon mouseIn/mouseOut toggles color', () => {
-    applyFooterStyles($w);
-    const cb = $w('#footerSocialRepeater').onItemReady.mock.calls[0][0];
-    const mockIcon = createMockElement();
-    const $item = () => mockIcon;
-    cb($item);
-    const baseColor = mockIcon.style.color;
-    const mouseInHandler = mockIcon.onMouseIn.mock.calls[0][0];
-    mouseInHandler();
-    expect(mockIcon.style.color).not.toBe(baseColor);
-    const mouseOutHandler = mockIcon.onMouseOut.mock.calls[0][0];
-    mouseOutHandler();
-    expect(mockIcon.style.color).toBe(baseColor);
-  });
+  // Social bar styling handled by native Wix SocialBar widget
 
   it('survives when all elements throw', () => {
     const broken$w = () => { throw new Error('nope'); };


### PR DESCRIPTION
## Summary
- **Unique repeater link nicknames**: Renamed shared `#footerLink` to `#shopLink`, `#serviceLink`, `#aboutLink` — Wix requires unique nicknames across all repeaters on a page
- **Native SocialBar**: Removed legacy `#footerSocialRepeater` and individual social button wiring (`#socialFacebook`, `#socialInstagram`, `#socialPinterest`); now delegates to `fixTemplateSocialBar()` which patches the native Wix SocialBar widget
- **Test cleanup**: Removed 17 obsolete tests for deleted social repeater/button code; 195 tests pass, 0 failures

## Test plan
- [x] `vitest` — 195 pass, 0 fail
- [ ] Verify in Wix editor that `#shopLink`, `#serviceLink`, `#aboutLink` resolve correctly inside their respective repeaters
- [ ] Verify SocialBar links render with correct URLs (Facebook, Instagram, Pinterest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)