### PR TITLE
feat(CF-e50): YouMightAlsoLike — 4-item similar-products grid on PDP

### DIFF
--- a/src/public/YouMightAlsoLike.js
+++ b/src/public/YouMightAlsoLike.js
@@ -1,0 +1,63 @@
+/**
+ * @module YouMightAlsoLike
+ * @description "You might also like" 4-item product grid for the Product Detail Page.
+ * Queries similar products by category/material and renders a repeater grid.
+ * Collapses the section for guests, errors, or empty results.
+ *
+ * Elements:
+ *   #youMightAlsoLikeSection — Box/Strip wrapper; collapsed when no products
+ *   #youMightAlsoLikeGrid    — Repeater; receives up to 4 product items
+ *   #ymItem_image            — Image; product main media
+ *   #ymItem_name             — Text; product name
+ *   #ymItem_price            — Text; formatted price or "Call for Price"
+ *
+ * CF-e50
+ */
+import { getSimilarProducts as _defaultGetSimilarProducts } from 'backend/productRecommendations.web';
+import { isCallForPrice, CALL_FOR_PRICE_TEXT } from 'public/productPageUtils.js';
+
+/**
+ * Initialise the "You might also like" grid on the Product Detail Page.
+ *
+ * @param {Function} $w    - Wix element selector
+ * @param {Object}   state - Page state; must contain state.product._id
+ * @param {Object}  [opts] - Injectable overrides for testing
+ * @param {Function} [opts.getSimilarProducts] - Backend getSimilarProducts(productId, options)
+ * @returns {Promise<void>}
+ */
+export async function initYouMightAlsoLike($w, state, opts = {}) {
+  const getSimilarProducts = opts.getSimilarProducts ?? _defaultGetSimilarProducts;
+
+  const productId = state?.product?._id;
+  if (!productId) {
+    $w('#youMightAlsoLikeSection').collapse();
+    return;
+  }
+
+  let products;
+  try {
+    const result = await getSimilarProducts(productId, { limit: 4 });
+    if (!result?.success || !result.products?.length) {
+      $w('#youMightAlsoLikeSection').collapse();
+      return;
+    }
+    products = result.products.slice(0, 4);
+  } catch (_) {
+    $w('#youMightAlsoLikeSection').collapse();
+    return;
+  }
+
+  // Register onItemReady BEFORE setting data (Wix repeater requirement).
+  $w('#youMightAlsoLikeGrid').onItemReady(($item, itemData) => {
+    $item('#ymItem_name').text = itemData.name;
+    $item('#ymItem_price').text = isCallForPrice(itemData)
+      ? CALL_FOR_PRICE_TEXT
+      : itemData.formattedPrice;
+    if (itemData.mainMedia) {
+      $item('#ymItem_image').src = itemData.mainMedia;
+    }
+  });
+
+  $w('#youMightAlsoLikeGrid').data = products;
+  $w('#youMightAlsoLikeSection').expand();
+}

--- a/src/public/YouMightAlsoLike.js
+++ b/src/public/YouMightAlsoLike.js
@@ -1,63 +1,95 @@
 /**
  * @module YouMightAlsoLike
  * @description "You might also like" 4-item product grid for the Product Detail Page.
- * Queries similar products by category/material and renders a repeater grid.
- * Collapses the section for guests, errors, or empty results.
+ * Renders a repeater grid of similar products. Delegates similarity lookup to
+ * `backend/productRecommendations.web`. Collapses the section for missing state,
+ * errors, or empty results so there is no blank space on the PDP.
  *
  * Elements:
  *   #youMightAlsoLikeSection — Box/Strip wrapper; collapsed when no products
  *   #youMightAlsoLikeGrid    — Repeater; receives up to 4 product items
- *   #ymItem_image            — Image; product main media
+ *   #ymItem_image            — Image; product main media (only set when mainMedia is present)
  *   #ymItem_name             — Text; product name
  *   #ymItem_price            — Text; formatted price or "Call for Price"
  *
  * CF-e50
  */
 import { getSimilarProducts as _defaultGetSimilarProducts } from 'backend/productRecommendations.web';
+import { to as wixLocationTo } from 'wix-location-frontend';
 import { isCallForPrice, CALL_FOR_PRICE_TEXT } from 'public/productPageUtils.js';
 
 /**
  * Initialise the "You might also like" grid on the Product Detail Page.
+ * Call once per page load from $w.onReady.
  *
  * @param {Function} $w    - Wix element selector
- * @param {Object}   state - Page state; must contain state.product._id
+ * @param {Object}   state - Page state. If state.product._id is absent the section
+ *                           collapses gracefully and no grid is rendered.
  * @param {Object}  [opts] - Injectable overrides for testing
- * @param {Function} [opts.getSimilarProducts] - Backend getSimilarProducts(productId, options)
+ * @param {Function} [opts.getSimilarProducts] - Overrides the backend call.
+ *   Must return `Promise<{ success: boolean, products: Array }>`.
  * @returns {Promise<void>}
  */
 export async function initYouMightAlsoLike($w, state, opts = {}) {
   const getSimilarProducts = opts.getSimilarProducts ?? _defaultGetSimilarProducts;
 
+  const section = $w('#youMightAlsoLikeSection');
   const productId = state?.product?._id;
   if (!productId) {
-    $w('#youMightAlsoLikeSection').collapse();
+    section.collapse();
     return;
   }
 
   let products;
   try {
     const result = await getSimilarProducts(productId, { limit: 4 });
-    if (!result?.success || !result.products?.length) {
-      $w('#youMightAlsoLikeSection').collapse();
+    if (!result?.success) {
+      console.warn('[YouMightAlsoLike] getSimilarProducts returned success:false for productId:', productId);
+      section.collapse();
       return;
     }
-    products = result.products.slice(0, 4);
-  } catch (_) {
-    $w('#youMightAlsoLikeSection').collapse();
+    if (!result.products?.length) {
+      section.collapse();
+      return;
+    }
+    products = result.products.slice(0, 4); // defensive cap — backend may ignore limit
+  } catch (err) {
+    console.warn('[YouMightAlsoLike] getSimilarProducts failed:', err?.message ?? err);
+    section.collapse();
     return;
   }
 
-  // Register onItemReady BEFORE setting data (Wix repeater requirement).
-  $w('#youMightAlsoLikeGrid').onItemReady(($item, itemData) => {
-    $item('#ymItem_name').text = itemData.name;
-    $item('#ymItem_price').text = isCallForPrice(itemData)
-      ? CALL_FOR_PRICE_TEXT
-      : itemData.formattedPrice;
-    if (itemData.mainMedia) {
-      $item('#ymItem_image').src = itemData.mainMedia;
+  const grid = $w('#youMightAlsoLikeGrid');
+
+  // Must register onItemReady BEFORE setting .data — Wix fires the callback per-item
+  // on assignment; registering after means items render without fields populated.
+  grid.onItemReady(($item, itemData) => {
+    try {
+      $item('#ymItem_name').text = itemData.name;
+    } catch (err) {
+      console.warn('[YouMightAlsoLike] ymItem_name set failed:', err?.message ?? err);
+    }
+    try {
+      $item('#ymItem_price').text = isCallForPrice(itemData)
+        ? CALL_FOR_PRICE_TEXT
+        : itemData.formattedPrice;
+    } catch (err) {
+      console.warn('[YouMightAlsoLike] ymItem_price set failed:', err?.message ?? err);
+    }
+    try {
+      if (itemData.mainMedia) {
+        $item('#ymItem_image').src = itemData.mainMedia;
+      }
+      $item('#ymItem_image').onClick(() => {
+        wixLocationTo(`/${itemData.slug}`).catch(e =>
+          console.warn('[YouMightAlsoLike] navigation failed:', e?.message ?? e)
+        );
+      });
+    } catch (err) {
+      console.warn('[YouMightAlsoLike] ymItem_image wiring failed:', err?.message ?? err);
     }
   });
 
-  $w('#youMightAlsoLikeGrid').data = products;
-  $w('#youMightAlsoLikeSection').expand();
+  grid.data = products;
+  section.expand();
 }

--- a/tests/youMightAlsoLike.test.js
+++ b/tests/youMightAlsoLike.test.js
@@ -1,0 +1,230 @@
+/**
+ * Tests for src/public/YouMightAlsoLike.js — CF-e50.
+ * "You might also like" 4-item grid on PDP.
+ * Covers: collapse on missing state, empty results, error fallback,
+ * happy-path grid population, call-for-price formatting, image/name/price,
+ * and view-button navigation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('wix-web-module', () => ({
+  Permissions: { Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+vi.mock('public/productPageUtils.js', () => ({
+  isCallForPrice: vi.fn((p) => p.price <= 1),
+  CALL_FOR_PRICE_TEXT: 'Call for Price',
+}));
+
+vi.mock('wix-location-frontend', () => ({
+  default: { to: vi.fn() },
+  to: vi.fn(),
+}));
+
+const { initYouMightAlsoLike } = await import('../src/public/YouMightAlsoLike.js');
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeProduct(overrides = {}) {
+  const id = overrides._id ?? `prod-${Math.random().toString(36).slice(2, 7)}`;
+  return {
+    _id: id,
+    name: 'Test Futon Frame',
+    slug: 'test-futon-frame',
+    price: 499,
+    formattedPrice: '$499.00',
+    mainMedia: 'https://example.com/frame.jpg',
+    collections: ['futon-frames'],
+    material: 'hardwood',
+    ...overrides,
+  };
+}
+
+function makeEl() {
+  return {
+    text: '',
+    src: '',
+    html: '',
+    _data: null,
+    _visible: true,
+    _onItemReady: null,
+    show: vi.fn().mockImplementation(function () { this._visible = true; }),
+    hide: vi.fn().mockImplementation(function () { this._visible = false; }),
+    collapse: vi.fn(),
+    expand: vi.fn(),
+    onClick: vi.fn(),
+    get data() { return this._data; },
+    set data(v) { this._data = v; },
+    onItemReady: vi.fn().mockImplementation(function (cb) { this._onItemReady = cb; }),
+  };
+}
+
+function make$w() {
+  const els = {};
+  const $w = vi.fn((id) => {
+    if (!els[id]) els[id] = makeEl();
+    return els[id];
+  });
+  $w._els = els;
+  return $w;
+}
+
+function makeState(overrides = {}) {
+  return {
+    product: {
+      _id: 'prod-frame-001',
+      collections: ['futon-frames'],
+      material: 'hardwood',
+      price: 499,
+      ...overrides,
+    },
+  };
+}
+
+// ── Collapse paths ────────────────────────────────────────────────────────────
+
+describe('initYouMightAlsoLike — collapse paths', () => {
+  let $w;
+
+  beforeEach(() => { $w = make$w(); });
+
+  it('collapses section when state is null', async () => {
+    await initYouMightAlsoLike($w, null);
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses section when product is missing', async () => {
+    await initYouMightAlsoLike($w, {});
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses section when product has no _id', async () => {
+    await initYouMightAlsoLike($w, { product: { collections: ['futon-frames'] } });
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses section when getSimilarProducts returns success:false', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: false, products: [] });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses section when products array is empty', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products: [] });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses section when getSimilarProducts throws', async () => {
+    const getSimilarProducts = vi.fn().mockRejectedValue(new Error('backend down'));
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+});
+
+// ── Happy path ────────────────────────────────────────────────────────────────
+
+describe('initYouMightAlsoLike — happy path', () => {
+  let $w;
+  const products = [
+    makeProduct({ _id: 'p1', name: 'Frame A', formattedPrice: '$399.00', price: 399 }),
+    makeProduct({ _id: 'p2', name: 'Frame B', formattedPrice: '$499.00', price: 499 }),
+    makeProduct({ _id: 'p3', name: 'Mattress C', formattedPrice: '$199.00', price: 199 }),
+    makeProduct({ _id: 'p4', name: 'Frame D', formattedPrice: '$599.00', price: 599 }),
+  ];
+
+  beforeEach(() => { $w = make$w(); });
+
+  it('expands section when products are available', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeSection').expand).toHaveBeenCalled();
+  });
+
+  it('sets repeater data with up to 4 products', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    const data = $w('#youMightAlsoLikeGrid').data;
+    expect(data).toHaveLength(4);
+  });
+
+  it('caps grid at 4 items even when more products returned', async () => {
+    const moreProducts = Array.from({ length: 8 }, (_, i) =>
+      makeProduct({ _id: `p${i}`, name: `Product ${i}`, price: 300 + i * 50 })
+    );
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products: moreProducts });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeGrid').data).toHaveLength(4);
+  });
+
+  it('passes productId to getSimilarProducts', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products });
+    await initYouMightAlsoLike($w, makeState({ _id: 'prod-abc' }), { getSimilarProducts });
+    expect(getSimilarProducts).toHaveBeenCalledWith('prod-abc', expect.objectContaining({ limit: 4 }));
+  });
+
+  it('registers onItemReady before setting data (Wix requirement)', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products });
+    const callOrder = [];
+    const grid = make$w()('#youMightAlsoLikeGrid');
+    grid.onItemReady = vi.fn().mockImplementation(() => { callOrder.push('onItemReady'); });
+    Object.defineProperty(grid, 'data', {
+      set: () => callOrder.push('data'),
+      get: () => null,
+    });
+    const $w2 = vi.fn((id) => id === '#youMightAlsoLikeGrid' ? grid : make$w()(id));
+    await initYouMightAlsoLike($w2, makeState(), { getSimilarProducts });
+    expect(callOrder.indexOf('onItemReady')).toBeLessThan(callOrder.indexOf('data'));
+  });
+});
+
+// ── onItemReady rendering ─────────────────────────────────────────────────────
+
+describe('initYouMightAlsoLike — onItemReady', () => {
+  let $w;
+
+  beforeEach(() => { $w = make$w(); });
+
+  async function runAndGetHandler(productOverrides = {}) {
+    const product = makeProduct({ _id: 'p1', ...productOverrides });
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true, products: [product] });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    return $w('#youMightAlsoLikeGrid')._onItemReady;
+  }
+
+  it('sets product name in onItemReady', async () => {
+    const handler = await runAndGetHandler({ name: 'Comfy Frame' });
+    const $item = make$w();
+    handler($item, { _id: 'p1', name: 'Comfy Frame', formattedPrice: '$399.00', price: 399, mainMedia: null, slug: 'comfy-frame' });
+    expect($item('#ymItem_name').text).toBe('Comfy Frame');
+  });
+
+  it('sets formatted price in onItemReady', async () => {
+    const handler = await runAndGetHandler({ price: 599 });
+    const $item = make$w();
+    handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$599.00', price: 599, mainMedia: null, slug: 'frame' });
+    expect($item('#ymItem_price').text).toBe('$599.00');
+  });
+
+  it('shows Call for Price for call-for-price products', async () => {
+    const handler = await runAndGetHandler({ price: 0 });
+    const $item = make$w();
+    handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$0.00', price: 0, mainMedia: null, slug: 'frame' });
+    expect($item('#ymItem_price').text).toBe('Call for Price');
+  });
+
+  it('sets image src when mainMedia present', async () => {
+    const handler = await runAndGetHandler({ mainMedia: 'https://cdn.example.com/frame.jpg' });
+    const $item = make$w();
+    handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$499.00', price: 499, mainMedia: 'https://cdn.example.com/frame.jpg', slug: 'frame' });
+    expect($item('#ymItem_image').src).toBe('https://cdn.example.com/frame.jpg');
+  });
+
+  it('does not set image src when mainMedia is null', async () => {
+    const handler = await runAndGetHandler({ mainMedia: null });
+    const $item = make$w();
+    handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$499.00', price: 499, mainMedia: null, slug: 'frame' });
+    expect($item('#ymItem_image').src).toBe(''); // unchanged
+  });
+});

--- a/tests/youMightAlsoLike.test.js
+++ b/tests/youMightAlsoLike.test.js
@@ -14,7 +14,7 @@ vi.mock('wix-web-module', () => ({
 
 vi.mock('public/productPageUtils.js', () => ({
   isCallForPrice: vi.fn((p) => p.price <= 1),
-  CALL_FOR_PRICE_TEXT: 'Call for Price',
+  CALL_FOR_PRICE_TEXT: 'Call for Pricing \u2014 (828) 252-9449',
 }));
 
 vi.mock('wix-location-frontend', () => ({
@@ -121,6 +121,18 @@ describe('initYouMightAlsoLike — collapse paths', () => {
     await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
     expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
   });
+
+  it('collapses section when getSimilarProducts returns null', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue(null);
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
+
+  it('collapses section when result has success:true but no products key', async () => {
+    const getSimilarProducts = vi.fn().mockResolvedValue({ success: true });
+    await initYouMightAlsoLike($w, makeState(), { getSimilarProducts });
+    expect($w('#youMightAlsoLikeSection').collapse).toHaveBeenCalled();
+  });
 });
 
 // ── Happy path ────────────────────────────────────────────────────────────────
@@ -211,7 +223,7 @@ describe('initYouMightAlsoLike — onItemReady', () => {
     const handler = await runAndGetHandler({ price: 0 });
     const $item = make$w();
     handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$0.00', price: 0, mainMedia: null, slug: 'frame' });
-    expect($item('#ymItem_price').text).toBe('Call for Price');
+    expect($item('#ymItem_price').text).toBe('Call for Pricing \u2014 (828) 252-9449');
   });
 
   it('sets image src when mainMedia present', async () => {
@@ -226,5 +238,18 @@ describe('initYouMightAlsoLike — onItemReady', () => {
     const $item = make$w();
     handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$499.00', price: 499, mainMedia: null, slug: 'frame' });
     expect($item('#ymItem_image').src).toBe(''); // unchanged
+  });
+
+  it('wires onClick on image to navigate to product slug', async () => {
+    const { to: mockTo } = await import('wix-location-frontend');
+    mockTo.mockResolvedValue(undefined);
+    const handler = await runAndGetHandler({ slug: 'comfy-futon', mainMedia: null });
+    const $item = make$w();
+    handler($item, { _id: 'p1', name: 'Frame', formattedPrice: '$499.00', price: 499, mainMedia: null, slug: 'comfy-futon' });
+    // Simulate click
+    const clickHandler = $item('#ymItem_image').onClick.mock.calls[0]?.[0];
+    expect(typeof clickHandler).toBe('function');
+    await clickHandler();
+    expect(mockTo).toHaveBeenCalledWith('/comfy-futon');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `YouMightAlsoLike.js` (`initYouMightAlsoLike`) — compact "You might also like" 4-item repeater grid for the Product Detail Page
- Queries `getSimilarProducts(productId, { limit: 4 })` from `backend/productRecommendations.web`
- Collapses `#youMightAlsoLikeSection` on null state, missing `_id`, `success:false`, empty results, or backend error
- Registers `onItemReady` before setting `.data` (Wix repeater requirement), caps grid at 4 items
- Item rendering: name, formatted price (call-for-price aware), image src (skipped when `mainMedia` is null)

## Test plan
- [x] 6 collapse-path tests (null state, no product, no `_id`, success:false, empty array, throws)
- [x] 5 happy-path tests (expand, 4-item data, cap at 4, productId forwarding with `{limit:4}`, onItemReady ordering)
- [x] 5 onItemReady rendering tests (name, price, call-for-price, image src set, null mainMedia no-op)
- [ ] CI green before merge

Closes CF-e50

🤖 Generated with [Claude Code](https://claude.com/claude-code)