### PR TITLE
test(cf-n16): queryAll multi-page pagination — hasNext/next cursor coverage

### DIFF
--- a/tests/gamificationNotifs.test.js
+++ b/tests/gamificationNotifs.test.js
@@ -309,7 +309,20 @@ describe('notifyChallengePublished', () => {
     expect(result).toEqual({ success: false, queued: 0 });
   });
 
-  it('queryAll multi-page: collects all members when count exceeds 1 000-item page limit', async () => {
+  it('queryAll exact-boundary: 1 000 members fit in one page with no cursor follow', async () => {
+    // Exactly at the limit — hasNext() returns false, no cursor traversal occurs.
+    const memberIds = Array.from({ length: 1000 }, (_, i) => `mem-exact-${i}`);
+    seedOptedIn(memberIds);
+
+    const result = await notifyChallengePublished(makeChallenge());
+
+    expect(result.success).toBe(true);
+    expect(result.queued).toBe(1000);
+    expect(__getInserted('EmailQueue')).toHaveLength(1000);
+    expect(__getInserted('SMSQueue')).toHaveLength(1000);
+  });
+
+  it('queryAll multi-page (2 pages): collects all members when count exceeds 1 000-item page limit', async () => {
     // queryAll() calls .limit(1000).find() — seed OVER_PAGE_LIMIT opted-in
     // members so page 1 returns 1 000 items with hasNext()=true and page 2
     // delivers the final member.  All rows must appear in EmailQueue + SMSQueue.
@@ -323,6 +336,21 @@ describe('notifyChallengePublished', () => {
     expect(result.queued).toBe(OVER_PAGE_LIMIT);
     expect(__getInserted('EmailQueue')).toHaveLength(OVER_PAGE_LIMIT);
     expect(__getInserted('SMSQueue')).toHaveLength(OVER_PAGE_LIMIT);
+  });
+
+  it('queryAll multi-page (3 pages): while loop continues past the second page', async () => {
+    // 2 001 items require 3 cursor fetches.  A queryAll() using `if` instead of
+    // `while` would stop after page 2 and return only 2 000 — this test catches that.
+    const THREE_PAGES = 2001;
+    const memberIds = Array.from({ length: THREE_PAGES }, (_, i) => `mem-3pg-${i}`);
+    seedOptedIn(memberIds);
+
+    const result = await notifyChallengePublished(makeChallenge());
+
+    expect(result.success).toBe(true);
+    expect(result.queued).toBe(THREE_PAGES);
+    expect(__getInserted('EmailQueue')).toHaveLength(THREE_PAGES);
+    expect(__getInserted('SMSQueue')).toHaveLength(THREE_PAGES);
   });
 });
 
@@ -440,10 +468,21 @@ describe('checkStreakMilestoneNotifications', () => {
     expect(result).toEqual({ queued: 0, skipped: 0, errors: 0 });
   });
 
-  it('queryAll multi-page: queues all members when streak count exceeds 1 000-item page limit', async () => {
+  it('queryAll exact-boundary: 1 000 streak members fit in one page with no cursor follow', async () => {
+    const memberIds = Array.from({ length: 1000 }, (_, i) => `mem-sbound-${i}`);
+    seedStreakMembers(memberIds);
+
+    const result = await checkStreakMilestoneNotifications();
+
+    expect(result.queued).toBe(1000);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(__getInserted('EmailQueue')).toHaveLength(1000);
+  });
+
+  it('queryAll multi-page (2 pages): queues all members when streak count exceeds 1 000-item page limit', async () => {
     // queryAll() calls .limit(1000).find() — seed OVER_PAGE_LIMIT day-7 members
     // so page 1 has hasNext()=true and page 2 delivers the final member.
-    // All rows must appear in EmailQueue and StreakMilestoneNotifications.
     const OVER_PAGE_LIMIT = 1001;
     const memberIds = Array.from({ length: OVER_PAGE_LIMIT }, (_, i) => `mem-streak-${i}`);
     seedStreakMembers(memberIds);
@@ -455,6 +494,21 @@ describe('checkStreakMilestoneNotifications', () => {
     expect(result.errors).toBe(0);
     expect(__getInserted('EmailQueue')).toHaveLength(OVER_PAGE_LIMIT);
     expect(__getInserted(STREAK_NOTIFS_COLLECTION)).toHaveLength(OVER_PAGE_LIMIT);
+  });
+
+  it('queryAll multi-page (3 pages): while loop continues past the second page', async () => {
+    // 2 001 streak members require 3 cursor fetches — verifies `while` not `if`.
+    const THREE_PAGES = 2001;
+    const memberIds = Array.from({ length: THREE_PAGES }, (_, i) => `mem-s3pg-${i}`);
+    seedStreakMembers(memberIds);
+
+    const result = await checkStreakMilestoneNotifications();
+
+    expect(result.queued).toBe(THREE_PAGES);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(__getInserted('EmailQueue')).toHaveLength(THREE_PAGES);
+    expect(__getInserted(STREAK_NOTIFS_COLLECTION)).toHaveLength(THREE_PAGES);
   });
 });
 

--- a/tests/gamificationNotifs.test.js
+++ b/tests/gamificationNotifs.test.js
@@ -310,18 +310,19 @@ describe('notifyChallengePublished', () => {
   });
 
   it('queryAll multi-page: collects all members when count exceeds 1 000-item page limit', async () => {
-    // queryAll() calls .limit(1000).find() — seed 1 001 opted-in members so
-    // page 1 returns 1 000 items with hasNext()=true, page 2 returns the
-    // remaining 1 item.  All 1 001 EmailQueue + SMSQueue rows must be inserted.
-    const memberIds = Array.from({ length: 1001 }, (_, i) => `mem-page-${i}`);
+    // queryAll() calls .limit(1000).find() — seed OVER_PAGE_LIMIT opted-in
+    // members so page 1 returns 1 000 items with hasNext()=true and page 2
+    // delivers the final member.  All rows must appear in EmailQueue + SMSQueue.
+    const OVER_PAGE_LIMIT = 1001;
+    const memberIds = Array.from({ length: OVER_PAGE_LIMIT }, (_, i) => `mem-page-${i}`);
     seedOptedIn(memberIds);
 
     const result = await notifyChallengePublished(makeChallenge());
 
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(1001);
-    expect(__getInserted('EmailQueue')).toHaveLength(1001);
-    expect(__getInserted('SMSQueue')).toHaveLength(1001);
+    expect(result.queued).toBe(OVER_PAGE_LIMIT);
+    expect(__getInserted('EmailQueue')).toHaveLength(OVER_PAGE_LIMIT);
+    expect(__getInserted('SMSQueue')).toHaveLength(OVER_PAGE_LIMIT);
   });
 });
 
@@ -440,23 +441,20 @@ describe('checkStreakMilestoneNotifications', () => {
   });
 
   it('queryAll multi-page: queues all members when streak count exceeds 1 000-item page limit', async () => {
-    // queryAll() calls .limit(1000).find() — seed 1 001 members at day-7 so
-    // page 1 has hasNext()=true and page 2 delivers the 1 001st member.
-    // All 1 001 EmailQueue rows must be inserted.
-    const memberIds = Array.from({ length: 1001 }, (_, i) => `mem-streak-${i}`);
-    __seed('MemberPoints', memberIds.map(id => ({
-      _id: `mp-${id}`,
-      memberId: id,
-      currentStreakDays: 7,
-    })));
+    // queryAll() calls .limit(1000).find() — seed OVER_PAGE_LIMIT day-7 members
+    // so page 1 has hasNext()=true and page 2 delivers the final member.
+    // All rows must appear in EmailQueue and StreakMilestoneNotifications.
+    const OVER_PAGE_LIMIT = 1001;
+    const memberIds = Array.from({ length: OVER_PAGE_LIMIT }, (_, i) => `mem-streak-${i}`);
+    seedStreakMembers(memberIds);
 
     const result = await checkStreakMilestoneNotifications();
 
-    expect(result.queued).toBe(1001);
+    expect(result.queued).toBe(OVER_PAGE_LIMIT);
     expect(result.skipped).toBe(0);
     expect(result.errors).toBe(0);
-    expect(__getInserted('EmailQueue')).toHaveLength(1001);
-    expect(__getInserted(STREAK_NOTIFS_COLLECTION)).toHaveLength(1001);
+    expect(__getInserted('EmailQueue')).toHaveLength(OVER_PAGE_LIMIT);
+    expect(__getInserted(STREAK_NOTIFS_COLLECTION)).toHaveLength(OVER_PAGE_LIMIT);
   });
 });
 

--- a/tests/gamificationNotifs.test.js
+++ b/tests/gamificationNotifs.test.js
@@ -308,6 +308,21 @@ describe('notifyChallengePublished', () => {
     const result = await notifyChallengePublished(makeChallenge());
     expect(result).toEqual({ success: false, queued: 0 });
   });
+
+  it('queryAll multi-page: collects all members when count exceeds 1 000-item page limit', async () => {
+    // queryAll() calls .limit(1000).find() — seed 1 001 opted-in members so
+    // page 1 returns 1 000 items with hasNext()=true, page 2 returns the
+    // remaining 1 item.  All 1 001 EmailQueue + SMSQueue rows must be inserted.
+    const memberIds = Array.from({ length: 1001 }, (_, i) => `mem-page-${i}`);
+    seedOptedIn(memberIds);
+
+    const result = await notifyChallengePublished(makeChallenge());
+
+    expect(result.success).toBe(true);
+    expect(result.queued).toBe(1001);
+    expect(__getInserted('EmailQueue')).toHaveLength(1001);
+    expect(__getInserted('SMSQueue')).toHaveLength(1001);
+  });
 });
 
 // ── checkStreakMilestoneNotifications (GH#991: queue + pagination) ────────────
@@ -422,6 +437,26 @@ describe('checkStreakMilestoneNotifications', () => {
     __setQueryError('MemberPoints', new Error('DB down'));
     const result = await checkStreakMilestoneNotifications();
     expect(result).toEqual({ queued: 0, skipped: 0, errors: 0 });
+  });
+
+  it('queryAll multi-page: queues all members when streak count exceeds 1 000-item page limit', async () => {
+    // queryAll() calls .limit(1000).find() — seed 1 001 members at day-7 so
+    // page 1 has hasNext()=true and page 2 delivers the 1 001st member.
+    // All 1 001 EmailQueue rows must be inserted.
+    const memberIds = Array.from({ length: 1001 }, (_, i) => `mem-streak-${i}`);
+    __seed('MemberPoints', memberIds.map(id => ({
+      _id: `mp-${id}`,
+      memberId: id,
+      currentStreakDays: 7,
+    })));
+
+    const result = await checkStreakMilestoneNotifications();
+
+    expect(result.queued).toBe(1001);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(__getInserted('EmailQueue')).toHaveLength(1001);
+    expect(__getInserted(STREAK_NOTIFS_COLLECTION)).toHaveLength(1001);
   });
 });
 


### PR DESCRIPTION
## Summary

- Seeds 1 001 opted-in members in `notifyChallengePublished` and `checkStreakMilestoneNotifications` tests to trigger the `hasNext→next` cursor path in `queryAll()` (limit=1 000 per page)
- Verifies that all items across both pages are collected and the correct number of `EmailQueue` / `SMSQueue` / `StreakMilestoneNotifications` rows are inserted
- 2 new tests, 39 total in `gamificationNotifs.test.js` — all passing

## Test plan

- [x] `notifyChallengePublished — queryAll multi-page` seeds 1 001 prefs, asserts `queued: 1001`, `EmailQueue.length === 1001`, `SMSQueue.length === 1001`
- [x] `checkStreakMilestoneNotifications — queryAll multi-page` seeds 1 001 streak members, asserts `queued: 1001`, `EmailQueue.length === 1001`, `StreakMilestoneNotifications.length === 1001`
- [x] No regression on existing 37 tests (39 total pass)

Closes bead: cf-n16

🤖 Generated with [Claude Code](https://claude.com/claude-code)