### PR TITLE
feat(cf-pyw): gamification chip on Collection/Category product cards

### DIFF
--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -541,6 +541,16 @@ async function preloadLoyaltyAccount() {
     ]);
     _renderCardChipFn = chipMod.renderCardGamificationChip;
     _loyaltyAccount = await loyaltyMod.getMyLoyaltyAccount();
+    // Refresh already-rendered cards — onItemReady fires before this resolves
+    // for items visible at page load, so chips would be blank without this. (CF-pyw)
+    try {
+      const repeater = $w('#productGridRepeater');
+      if (repeater && _renderCardChipFn) {
+        repeater.forEachItem(($item) => {
+          _renderCardChipFn($item, _loyaltyAccount);
+        });
+      }
+    } catch (e) {}
   } catch (e) {
     _loyaltyAccount = null;
   }

--- a/src/pages/Category Page.js
+++ b/src/pages/Category Page.js
@@ -40,6 +40,8 @@ let _debounceTimer = null;
 let _basicFilterTimer = null;
 let _filterSessionState = {}; // persists across category nav within session
 let _wishlistSet = new Set(); // cached wishlist status for product cards
+let _loyaltyAccount = null; // cached loyalty account for per-card gamification chip (CF-pyw)
+let _renderCardChipFn = null; // lazy-loaded render helper (dynamic import keeps page import budget)
 
 // sanitizeInput aliased from shared module
 const sanitizeInput = sanitizeFilterInput;
@@ -109,6 +111,7 @@ $w.onReady(async function () {
     { name: 'filterControls', init: () => initFilterControls(), critical: false },
     { name: 'advancedFilters', init: () => initAdvancedFilters(currentPath), critical: false },
     { name: 'wishlistStatus', init: () => preloadWishlistStatus(), critical: false },
+    { name: 'loyaltyAccount', init: () => preloadLoyaltyAccount(), critical: false },
     { name: 'recentlyViewed', init: () => initRecentlyViewed(), critical: false },
     { name: 'quickView', init: () => initQuickViewHandlers(), critical: false },
     { name: 'categoryMeta', init: () => injectCategoryMeta(currentPath), critical: false },
@@ -525,6 +528,24 @@ async function preloadWishlistStatus() {
   } catch (e) {}
 }
 
+// ── Loyalty Account Preload ─────────────────────────────────────────
+// Fetch the member's loyalty account once per page so product cards can
+// show a gamification chip (tier + points) in browse context.
+// Silently no-ops for unauthenticated visitors. CF-pyw
+
+async function preloadLoyaltyAccount() {
+  try {
+    const [loyaltyMod, chipMod] = await Promise.all([
+      import('backend/loyaltyService.web'),
+      import('public/GamificationProductChip.js'),
+    ]);
+    _renderCardChipFn = chipMod.renderCardGamificationChip;
+    _loyaltyAccount = await loyaltyMod.getMyLoyaltyAccount();
+  } catch (e) {
+    _loyaltyAccount = null;
+  }
+}
+
 // ── Product Grid ────────────────────────────────────────────────────
 // Enhanced product cards with hover effects, quick-view, and badges
 
@@ -569,6 +590,9 @@ function initProductGrid() {
       // Card container structure: white bg, 12px radius, shadow, hover
       try { styleCardContainer($item('#gridCard')); } catch (e) {}
       try { initCardHover($item('#gridCard')); } catch (e) {}
+
+      // Gamification chip: member's tier + points in browse context (CF-pyw)
+      if (_renderCardChipFn) _renderCardChipFn($item, _loyaltyAccount);
 
       // Product image with placeholder fallback + SEO alt text
       const category = wixLocationFrontend.path?.[0] || '';

--- a/src/public/GamificationProductChip.js
+++ b/src/public/GamificationProductChip.js
@@ -82,6 +82,52 @@ export function renderTierChip($wFn, account) {
 }
 
 /**
+ * Format the compact card chip label used on collection/category product
+ * grids. Combines tier and points so a member sees their standing while
+ * browsing. Exported for unit testing.
+ *
+ * CF-pyw
+ *
+ * @param {Object|null} account - Loyalty account from getMyLoyaltyAccount
+ * @returns {string} e.g. "🔵 Trail Blazer · 200 pts", or tier-only, or points-only, or ''
+ */
+export function formatCardChipLabel(account) {
+  const tierLabel   = formatTierChipLabel(account);
+  const pointsLabel = formatPointsChipLabel(account);
+  if (tierLabel && pointsLabel) return `${tierLabel} · ${pointsLabel}`;
+  return tierLabel || pointsLabel || '';
+}
+
+/**
+ * Render the gamification chip on a single product card within a
+ * collection/category repeater. Called from the repeater's onItemReady
+ * with the per-item selector ($item). No-ops gracefully if the chip
+ * element is absent (template without the chip) or if $item throws
+ * (item not mounted). Hides the chip for unauthenticated visitors.
+ *
+ * CF-pyw
+ *
+ * @param {Function} $item - Repeater item selector
+ * @param {Object|null} account - Loyalty account from getMyLoyaltyAccount
+ */
+export function renderCardGamificationChip($item, account) {
+  try {
+    const chip = $item('#gridGamificationChip');
+    if (!chip) return;
+    const label = formatCardChipLabel(account);
+    if (label) {
+      chip.text = label;
+      if (account?.tier) chip.style.color = getTierColor(account.tier);
+      chip.show();
+    } else {
+      chip.hide();
+    }
+  } catch (err) {
+    console.warn('[GamificationProductChip] renderCardGamificationChip failed:', err?.message ?? err);
+  }
+}
+
+/**
  * Initialise the member tier chip on any page.
  * Fetches the loyalty account and renders the chip elements.
  * Silently no-ops for unauthenticated visitors (null account).

--- a/tests/gamificationProductChip.test.js
+++ b/tests/gamificationProductChip.test.js
@@ -9,6 +9,8 @@ import {
   formatPointsChipLabel,
   renderTierChip,
   initMemberTierChip,
+  formatCardChipLabel,
+  renderCardGamificationChip,
 } from '../src/public/GamificationProductChip.js';
 
 // ── formatTierChipLabel ───────────────────────────────────────────────
@@ -170,5 +172,113 @@ describe('initMemberTierChip', () => {
       getMyLoyaltyAccount: async () => { throw new Error('x'); },
     });
     expect(result).toBeNull();
+  });
+});
+
+// ── formatCardChipLabel ───────────────────────────────────────────────
+// CF-pyw: per-card chip shown on collection/category product grids.
+
+describe('formatCardChipLabel', () => {
+  it('returns empty string for null account', () => {
+    expect(formatCardChipLabel(null)).toBe('');
+  });
+
+  it('returns empty string when account has neither tier nor points', () => {
+    expect(formatCardChipLabel({})).toBe('');
+  });
+
+  it('returns tier-only label when points are absent', () => {
+    const label = formatCardChipLabel({ tier: 'Trail Blazer' });
+    expect(label).toContain('Trail Blazer');
+    expect(label).not.toContain('pts');
+  });
+
+  it('returns points-only label when tier is absent', () => {
+    const label = formatCardChipLabel({ points: { balance: 120 } });
+    expect(label).toBe('120 pts');
+  });
+
+  it('combines tier and points with a separator', () => {
+    const label = formatCardChipLabel({ tier: 'Trail Blazer', points: { balance: 200 } });
+    expect(label).toContain('Trail Blazer');
+    expect(label).toContain('200 pts');
+    expect(label).toMatch(/[·•|·\-]/); // some separator between
+  });
+
+  it('handles zero balance alongside tier', () => {
+    const label = formatCardChipLabel({ tier: 'Bronze', points: { balance: 0 } });
+    expect(label).toContain('Bronze');
+    expect(label).toContain('0 pts');
+  });
+});
+
+// ── renderCardGamificationChip ────────────────────────────────────────
+
+describe('renderCardGamificationChip', () => {
+  function makeEl() {
+    return {
+      text:  null,
+      style: { color: null },
+      show:  vi.fn(),
+      hide:  vi.fn(),
+    };
+  }
+
+  function make$item(chip) {
+    return (id) => (id === '#gridGamificationChip' ? chip : null);
+  }
+
+  it('shows the card chip with tier + points when account is present', () => {
+    const chip = makeEl();
+    renderCardGamificationChip(make$item(chip), {
+      tier: 'Trail Blazer',
+      points: { balance: 200 },
+    });
+    expect(chip.text).toContain('Trail Blazer');
+    expect(chip.text).toContain('200 pts');
+    expect(chip.show).toHaveBeenCalledOnce();
+    expect(chip.hide).not.toHaveBeenCalled();
+  });
+
+  it('applies tier color when account has a known tier', () => {
+    const chip = makeEl();
+    renderCardGamificationChip(make$item(chip), { tier: 'Mountain Guide' });
+    expect(chip.style.color).toBeTruthy();
+  });
+
+  it('hides the card chip when account is null', () => {
+    const chip = makeEl();
+    renderCardGamificationChip(make$item(chip), null);
+    expect(chip.hide).toHaveBeenCalledOnce();
+    expect(chip.show).not.toHaveBeenCalled();
+  });
+
+  it('hides the card chip when account has neither tier nor points', () => {
+    const chip = makeEl();
+    renderCardGamificationChip(make$item(chip), {});
+    expect(chip.hide).toHaveBeenCalledOnce();
+  });
+
+  it('shows points-only label without setting tier color', () => {
+    const chip = makeEl();
+    renderCardGamificationChip(make$item(chip), { points: { balance: 50 } });
+    expect(chip.text).toBe('50 pts');
+    expect(chip.show).toHaveBeenCalledOnce();
+    expect(chip.style.color).toBeNull();
+  });
+
+  it('logs a non-Error thrown value without crashing', () => {
+    const $item = () => { throw 'string-error'; };
+    expect(() => renderCardGamificationChip($item, { tier: 'Bronze' })).not.toThrow();
+  });
+
+  it('no-ops when #gridGamificationChip element is absent', () => {
+    const $item = () => null;
+    expect(() => renderCardGamificationChip($item, { tier: 'Bronze' })).not.toThrow();
+  });
+
+  it('no-ops gracefully when $item throws', () => {
+    const $item = () => { throw new Error('not mounted'); };
+    expect(() => renderCardGamificationChip($item, { tier: 'Bronze' })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `renderCardGamificationChip` + `formatCardChipLabel` helpers in `GamificationProductChip.js`.
- Wires the chip into Category Page's `#productGridRepeater` onItemReady so members see their tier + points on each product card in browse context.
- Preloads the loyalty account once per page via a new deferred section; chip/service modules are dynamic-imported to preserve the page import budget (cap 27).
- Unauthenticated visitors and templates without `#gridGamificationChip` are silent no-ops.

## Test plan
- [x] `npx vitest run tests/gamificationProductChip.test.js` — 34 pass
- [x] `npx vitest run tests/importBudget.test.js` — passes (Category Page still at 27)
- [x] Coverage for `src/public/GamificationProductChip.js`: 100% stmts/funcs/lines, 87.23% branches
- [ ] Browser verify once Wix Studio template exposes `#gridGamificationChip` on product cards

Bead: cf-pyw