### PR TITLE
fix: homeHandlers section count 17→18 after cf-nqq ChallengeOfTheWeek

### DIFF
--- a/tests/homeHandlers.test.js
+++ b/tests/homeHandlers.test.js
@@ -265,13 +265,13 @@ describe('Home page onReady', () => {
     expect(seo.critical).toBe(false);
   });
 
-  it('has exactly 3 critical and 17 deferred sections', async () => {
+  it('has exactly 3 critical and 18 deferred sections', async () => {
     await onReadyHandler();
     const sections = prioritizeSections.mock.calls[0][0];
     const critical = sections.filter(s => s.critical);
     const deferred = sections.filter(s => !s.critical);
     expect(critical).toHaveLength(3);
-    expect(deferred).toHaveLength(17);
+    expect(deferred).toHaveLength(18);
   });
 
   it('every section has a name and init function', async () => {


### PR DESCRIPTION
## Summary
cf-nqq (PR #1023) added ChallengeOfTheWeek as the 18th deferred section in Home.js.
The homeHandlers.test.js count test was hardcoded at 17 — causes CI failure on all branches based on current main.

One-line fix: 17 → 18.

## Test plan
- [x] \`npx vitest run tests/homeHandlers.test.js\` — 19/19 PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)