### PR TITLE
feat(cf-z51): cross-rig sync service — mobile points log + badge→push dispatch

### DIFF
--- a/src/backend/crossRigSyncService.web.js
+++ b/src/backend/crossRigSyncService.web.js
@@ -1,0 +1,68 @@
+/**
+ * crossRigSyncService — bidirectional web↔mobile gamification sync.
+ *
+ * syncMobilePoints: logs points earned on CFM devices into CrossRigSyncLog.
+ * syncBadgeEarnedToPush: fires push notification to member devices on badge earn.
+ *
+ * CF-z51
+ */
+import wixData from 'wix-data';
+import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web.js';
+
+export const SYNC_LOG_COLLECTION = 'CrossRigSyncLog';
+const ALLOWED_SOURCE_RIGS = ['cfutons_mobile'];
+
+/**
+ * Log a mobile-side points award into the cross-rig sync log.
+ * Called by crossRigEventReceiver on quiz_completed, ar_discovery_completed,
+ * social_share_completed events.
+ *
+ * @param {string} memberId
+ * @param {number} points    - Must be >= 0
+ * @param {string} eventType - e.g. 'quiz_completed'
+ * @param {string} sourceRig - Must be 'cfutons_mobile'
+ * @returns {Promise<{ success: boolean, points?: number, error?: string }>}
+ */
+export async function syncMobilePoints(memberId, points, eventType, sourceRig) {
+  if (!ALLOWED_SOURCE_RIGS.includes(sourceRig)) {
+    return { success: false, error: `unknown source rig: ${sourceRig}` };
+  }
+  if (typeof points !== 'number' || points < 0) {
+    return { success: false, error: 'points must be a non-negative number' };
+  }
+  try {
+    await wixData.insert(
+      SYNC_LOG_COLLECTION,
+      {
+        memberId,
+        points,
+        eventType,
+        sourceRig,
+        syncedAt: new Date(),
+        direction: 'mobile_to_web',
+      },
+      { suppressAuth: true }
+    );
+    return { success: true, points };
+  } catch (err) {
+    console.error('[crossRigSyncService] syncMobilePoints error:', err);
+    return { success: false, error: err.message };
+  }
+}
+
+/**
+ * Send a push notification to all member devices when a badge is earned.
+ *
+ * @param {string} memberId
+ * @param {string} badgeId
+ * @returns {Promise<{ success: boolean, pushSent?: number, error?: string }>}
+ */
+export async function syncBadgeEarnedToPush(memberId, badgeId) {
+  try {
+    const { sent } = await sendPushToMember(memberId, PUSH_EVENTS.BADGE_EARNED, { badgeId });
+    return { success: true, pushSent: sent };
+  } catch (err) {
+    console.error('[crossRigSyncService] syncBadgeEarnedToPush error:', err);
+    return { success: false, error: err.message };
+  }
+}

--- a/src/backend/crossRigSyncService.web.js
+++ b/src/backend/crossRigSyncService.web.js
@@ -7,7 +7,7 @@
  * CF-z51
  */
 import wixData from 'wix-data';
-import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web.js';
+import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web';
 
 export const SYNC_LOG_COLLECTION = 'CrossRigSyncLog';
 const ALLOWED_SOURCE_RIGS = ['cfutons_mobile'];
@@ -24,6 +24,9 @@ const ALLOWED_SOURCE_RIGS = ['cfutons_mobile'];
  * @returns {Promise<{ success: boolean, points?: number, error?: string }>}
  */
 export async function syncMobilePoints(memberId, points, eventType, sourceRig) {
+  if (!memberId) {
+    return { success: false, error: 'memberId is required' };
+  }
   if (!ALLOWED_SOURCE_RIGS.includes(sourceRig)) {
     return { success: false, error: `unknown source rig: ${sourceRig}` };
   }

--- a/tests/crossRigSyncService.test.js
+++ b/tests/crossRigSyncService.test.js
@@ -10,7 +10,7 @@ import {
 const MEMBER_ID = 'member-sync-1';
 function setMember() { __setMember({ _id: MEMBER_ID }); }
 
-vi.mock('backend/pushNotificationService.web.js', () => ({
+vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: vi.fn(async () => ({ sent: 1, failed: 0 })),
   PUSH_EVENTS: {
     BADGE_EARNED: 'badge_earned',
@@ -34,6 +34,17 @@ describe('syncMobilePoints', () => {
     const result = await syncMobilePoints(MEMBER_ID, 150, 'quiz_completed', 'cfutons_mobile');
     expect(result.success).toBe(true);
     expect(result.points).toBe(150);
+  });
+
+  it('rejects empty memberId', async () => {
+    const result = await syncMobilePoints('', 100, 'quiz_completed', 'cfutons_mobile');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/memberId/i);
+  });
+
+  it('rejects null memberId', async () => {
+    const result = await syncMobilePoints(null, 100, 'quiz_completed', 'cfutons_mobile');
+    expect(result.success).toBe(false);
   });
 
   it('rejects unknown source rig', async () => {
@@ -95,7 +106,7 @@ describe('syncBadgeEarnedToPush', () => {
 
   it('calls sendPushToMember with correct args', async () => {
     setMember();
-    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web.js');
+    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
     await syncBadgeEarnedToPush(MEMBER_ID, 'first_purchase');
     expect(sendPushToMember).toHaveBeenCalledWith(
       MEMBER_ID,
@@ -106,7 +117,7 @@ describe('syncBadgeEarnedToPush', () => {
 
   it('returns success: false on push service error', async () => {
     setMember();
-    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    const { sendPushToMember } = await import('backend/pushNotificationService.web');
     sendPushToMember.mockRejectedValueOnce(new Error('push service down'));
     const result = await syncBadgeEarnedToPush(MEMBER_ID, 'badge-x');
     expect(result.success).toBe(false);
@@ -115,7 +126,7 @@ describe('syncBadgeEarnedToPush', () => {
 
   it('returns pushSent 0 when member has no tokens', async () => {
     setMember();
-    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    const { sendPushToMember } = await import('backend/pushNotificationService.web');
     sendPushToMember.mockResolvedValueOnce({ sent: 0, failed: 0 });
     const result = await syncBadgeEarnedToPush(MEMBER_ID, 'new_badge');
     expect(result.success).toBe(true);

--- a/tests/crossRigSyncService.test.js
+++ b/tests/crossRigSyncService.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { __seed, __reset } from './__mocks__/wix-data.js';
+import { __setMember, __reset as resetMember } from './__mocks__/wix-members-backend.js';
+import {
+  syncMobilePoints,
+  syncBadgeEarnedToPush,
+  SYNC_LOG_COLLECTION,
+} from '../src/backend/crossRigSyncService.web.js';
+
+const MEMBER_ID = 'member-sync-1';
+function setMember() { __setMember({ _id: MEMBER_ID }); }
+
+vi.mock('backend/pushNotificationService.web.js', () => ({
+  sendPushToMember: vi.fn(async () => ({ sent: 1, failed: 0 })),
+  PUSH_EVENTS: {
+    BADGE_EARNED: 'badge_earned',
+    TIER_CHANGED: 'tier_changed',
+  },
+}));
+
+beforeEach(() => { __reset(); resetMember(); vi.clearAllMocks(); });
+
+describe('SYNC_LOG_COLLECTION', () => {
+  it('is a non-empty string', () => {
+    expect(typeof SYNC_LOG_COLLECTION).toBe('string');
+    expect(SYNC_LOG_COLLECTION.length).toBeGreaterThan(0);
+  });
+});
+
+describe('syncMobilePoints', () => {
+  it('returns success: true and logs the sync event', async () => {
+    setMember();
+    __seed(SYNC_LOG_COLLECTION, []);
+    const result = await syncMobilePoints(MEMBER_ID, 150, 'quiz_completed', 'cfutons_mobile');
+    expect(result.success).toBe(true);
+    expect(result.points).toBe(150);
+  });
+
+  it('rejects unknown source rig', async () => {
+    setMember();
+    const result = await syncMobilePoints(MEMBER_ID, 100, 'quiz_completed', 'unknown_rig');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/source/i);
+  });
+
+  it('rejects negative point values', async () => {
+    setMember();
+    const result = await syncMobilePoints(MEMBER_ID, -50, 'quiz_completed', 'cfutons_mobile');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-numeric points', async () => {
+    setMember();
+    const result = await syncMobilePoints(MEMBER_ID, 'hundred', 'quiz_completed', 'cfutons_mobile');
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts zero points', async () => {
+    setMember();
+    __seed(SYNC_LOG_COLLECTION, []);
+    const result = await syncMobilePoints(MEMBER_ID, 0, 'quiz_completed', 'cfutons_mobile');
+    expect(result.success).toBe(true);
+  });
+
+  it('logs direction as mobile_to_web', async () => {
+    setMember();
+    const { __getSpy } = await import('./__mocks__/wix-data.js');
+    let inserted;
+    const wixData = (await import('wix-data')).default;
+    const spy = vi.spyOn(wixData, 'insert').mockImplementationOnce(async (col, item) => {
+      inserted = item;
+      return { ...item, _id: 'log-1' };
+    });
+    await syncMobilePoints(MEMBER_ID, 100, 'ar_discovery_completed', 'cfutons_mobile');
+    if (inserted) {
+      expect(inserted.direction).toBe('mobile_to_web');
+      expect(inserted.sourceRig).toBe('cfutons_mobile');
+    }
+    spy.mockRestore();
+  });
+});
+
+describe('syncBadgeEarnedToPush', () => {
+  it('returns success: true when push sends successfully', async () => {
+    setMember();
+    const result = await syncBadgeEarnedToPush(MEMBER_ID, 'first_purchase');
+    expect(result.success).toBe(true);
+  });
+
+  it('returns pushSent count from sendPushToMember', async () => {
+    setMember();
+    const result = await syncBadgeEarnedToPush(MEMBER_ID, 'streak_7');
+    expect(typeof result.pushSent).toBe('number');
+  });
+
+  it('calls sendPushToMember with correct args', async () => {
+    setMember();
+    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web.js');
+    await syncBadgeEarnedToPush(MEMBER_ID, 'first_purchase');
+    expect(sendPushToMember).toHaveBeenCalledWith(
+      MEMBER_ID,
+      PUSH_EVENTS.BADGE_EARNED,
+      { badgeId: 'first_purchase' }
+    );
+  });
+
+  it('returns success: false on push service error', async () => {
+    setMember();
+    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    sendPushToMember.mockRejectedValueOnce(new Error('push service down'));
+    const result = await syncBadgeEarnedToPush(MEMBER_ID, 'badge-x');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/push service down/i);
+  });
+
+  it('returns pushSent 0 when member has no tokens', async () => {
+    setMember();
+    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    sendPushToMember.mockResolvedValueOnce({ sent: 0, failed: 0 });
+    const result = await syncBadgeEarnedToPush(MEMBER_ID, 'new_badge');
+    expect(result.success).toBe(true);
+    expect(result.pushSent).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- crossRigSyncService.web.js: syncMobilePoints logs CFM events to CrossRigSyncLog, syncBadgeEarnedToPush fires FCM push on badge earn
- Validates sourceRig in cfutons_mobile, rejects negative/non-numeric points
- 12 tests covering success paths, validation, push error propagation

## Test plan
- [ ] npx vitest run tests/crossRigSyncService.test.js — 12/12 PASS
- [ ] Full suite green, no regressions

Note: Hold merge until cf-axn (pushNotificationService) lands on main.

Generated with Claude Code