### PR TITLE
feat(cf-bdl): wire badge_earned + tier_changed push dispatch into crossRigEventReceiver

### DIFF
--- a/src/backend/crossRigEventReceiver.web.js
+++ b/src/backend/crossRigEventReceiver.web.js
@@ -19,6 +19,8 @@ import { Permissions, webMethod } from 'wix-web-module';
 import { currentMember } from 'wix-members-backend';
 import { insertAnalyticsEvent } from 'backend/utils/analyticsEvents';
 import { logError } from 'backend/utils/errorHandler';
+import { syncBadgeEarnedToPush } from 'backend/crossRigSyncService.web.js';
+import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web.js';
 
 const SUPPORTED_EVENTS = new Set([
   'streak_extended',
@@ -133,6 +135,24 @@ export const crossRigEvent = webMethod(
     } catch (err) {
       logError('crossRigEvent — insertAnalyticsEvent failed', err);
       return { success: false, error: 'analytics write failed' };
+    }
+
+    // ── Post-analytics push side effects ──────────────────────────────────
+    if (body.event === 'badge_earned' && body.badgeId) {
+      try {
+        await syncBadgeEarnedToPush(memberId, body.badgeId);
+      } catch (err) {
+        logError('crossRigEvent — syncBadgeEarnedToPush failed', err);
+        // Non-fatal: analytics logged, push failure does not fail the event
+      }
+    }
+    if (body.event === 'tier_changed' && body.newTier) {
+      try {
+        await sendPushToMember(memberId, PUSH_EVENTS.TIER_CHANGED, { tier: body.newTier });
+      } catch (err) {
+        logError('crossRigEvent — tier_changed push failed', err);
+        // Non-fatal
+      }
     }
 
     return { success: true };

--- a/src/backend/crossRigEventReceiver.web.js
+++ b/src/backend/crossRigEventReceiver.web.js
@@ -19,8 +19,8 @@ import { Permissions, webMethod } from 'wix-web-module';
 import { currentMember } from 'wix-members-backend';
 import { insertAnalyticsEvent } from 'backend/utils/analyticsEvents';
 import { logError } from 'backend/utils/errorHandler';
-import { syncBadgeEarnedToPush } from 'backend/crossRigSyncService.web.js';
-import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web.js';
+import { syncBadgeEarnedToPush } from 'backend/crossRigSyncService.web';
+import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web';
 
 const SUPPORTED_EVENTS = new Set([
   'streak_extended',

--- a/src/backend/crossRigEventReceiver.web.js
+++ b/src/backend/crossRigEventReceiver.web.js
@@ -138,6 +138,8 @@ export const crossRigEvent = webMethod(
     }
 
     // ── Post-analytics push side effects ──────────────────────────────────
+    // badge_earned routes through syncBadgeEarnedToPush so the dispatch is
+    // also recorded in CrossRigSyncLog (cross-rig audit trail).
     if (body.event === 'badge_earned' && body.badgeId) {
       try {
         await syncBadgeEarnedToPush(memberId, body.badgeId);
@@ -146,6 +148,7 @@ export const crossRigEvent = webMethod(
         // Non-fatal: analytics logged, push failure does not fail the event
       }
     }
+    // tier_changed fires directly — web-side trigger, no cross-rig sync log needed.
     if (body.event === 'tier_changed' && body.newTier) {
       try {
         await sendPushToMember(memberId, PUSH_EVENTS.TIER_CHANGED, { tier: body.newTier });

--- a/tests/crossRigEventReceiver.test.js
+++ b/tests/crossRigEventReceiver.test.js
@@ -24,6 +24,18 @@ import {
 import { crossRigEvent } from '../src/backend/crossRigEventReceiver.web.js';
 import { ANALYTICS_EVENTS_COLLECTION } from '../src/backend/utils/analyticsEvents.js';
 
+vi.mock('backend/crossRigSyncService.web.js', () => ({
+  syncBadgeEarnedToPush: vi.fn(async () => ({ success: true, pushSent: 1 })),
+}));
+
+vi.mock('backend/pushNotificationService.web.js', () => ({
+  sendPushToMember: vi.fn(async () => ({ sent: 1, failed: 0 })),
+  PUSH_EVENTS: {
+    BADGE_EARNED: 'badge_earned',
+    TIER_CHANGED: 'tier_changed',
+  },
+}));
+
 beforeEach(() => {
   __reset();
   __resetMembers();
@@ -501,5 +513,81 @@ describe('crossRigEvent — new mobile events (cf-l8xt)', () => {
     });
     expect(result.success).toBe(false);
     expect(result.status).toBe(400);
+  });
+});
+
+// ── cf-bdl: badge_earned + tier_changed fire push notifications ───────────
+
+describe('crossRigEvent — badge_earned push dispatch (cf-bdl)', () => {
+  beforeEach(() => { __setMember({ _id: 'mem-push-1' }); vi.clearAllMocks(); });
+
+  it('calls syncBadgeEarnedToPush with memberId and badgeId', async () => {
+    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web.js');
+    await crossRigEvent({
+      schemaVersion: '1.0',
+      event: 'badge_earned',
+      badgeId: 'first_purchase',
+    });
+    expect(syncBadgeEarnedToPush).toHaveBeenCalledWith('mem-push-1', 'first_purchase');
+  });
+
+  it('still returns success even if push dispatch throws', async () => {
+    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web.js');
+    syncBadgeEarnedToPush.mockRejectedValueOnce(new Error('push service down'));
+    const result = await crossRigEvent({
+      schemaVersion: '1.0',
+      event: 'badge_earned',
+      badgeId: 'streak_7',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('does not call syncBadgeEarnedToPush when badgeId is missing', async () => {
+    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web.js');
+    await crossRigEvent({
+      schemaVersion: '1.0',
+      event: 'badge_earned',
+    });
+    expect(syncBadgeEarnedToPush).not.toHaveBeenCalled();
+  });
+});
+
+describe('crossRigEvent — tier_changed push dispatch (cf-bdl)', () => {
+  beforeEach(() => { __setMember({ _id: 'mem-push-2' }); vi.clearAllMocks(); });
+
+  it('calls sendPushToMember with TIER_CHANGED and newTier', async () => {
+    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web.js');
+    await crossRigEvent({
+      schemaVersion: '1.0',
+      event: 'tier_changed',
+      newTier: 'gold',
+      prevTier: 'silver',
+    });
+    expect(sendPushToMember).toHaveBeenCalledWith(
+      'mem-push-2',
+      PUSH_EVENTS.TIER_CHANGED,
+      { tier: 'gold' }
+    );
+  });
+
+  it('still returns success even if tier push throws', async () => {
+    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    sendPushToMember.mockRejectedValueOnce(new Error('FCM down'));
+    const result = await crossRigEvent({
+      schemaVersion: '1.0',
+      event: 'tier_changed',
+      newTier: 'silver',
+      prevTier: 'bronze',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('does not call sendPushToMember when newTier is missing', async () => {
+    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    await crossRigEvent({
+      schemaVersion: '1.0',
+      event: 'tier_changed',
+    });
+    expect(sendPushToMember).not.toHaveBeenCalled();
   });
 });

--- a/tests/crossRigEventReceiver.test.js
+++ b/tests/crossRigEventReceiver.test.js
@@ -24,11 +24,11 @@ import {
 import { crossRigEvent } from '../src/backend/crossRigEventReceiver.web.js';
 import { ANALYTICS_EVENTS_COLLECTION } from '../src/backend/utils/analyticsEvents.js';
 
-vi.mock('backend/crossRigSyncService.web.js', () => ({
+vi.mock('backend/crossRigSyncService.web', () => ({
   syncBadgeEarnedToPush: vi.fn(async () => ({ success: true, pushSent: 1 })),
 }));
 
-vi.mock('backend/pushNotificationService.web.js', () => ({
+vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: vi.fn(async () => ({ sent: 1, failed: 0 })),
   PUSH_EVENTS: {
     BADGE_EARNED: 'badge_earned',
@@ -522,7 +522,7 @@ describe('crossRigEvent — badge_earned push dispatch (cf-bdl)', () => {
   beforeEach(() => { __setMember({ _id: 'mem-push-1' }); vi.clearAllMocks(); });
 
   it('calls syncBadgeEarnedToPush with memberId and badgeId', async () => {
-    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web.js');
+    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web');
     await crossRigEvent({
       schemaVersion: '1.0',
       event: 'badge_earned',
@@ -532,7 +532,7 @@ describe('crossRigEvent — badge_earned push dispatch (cf-bdl)', () => {
   });
 
   it('still returns success even if push dispatch throws', async () => {
-    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web.js');
+    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web');
     syncBadgeEarnedToPush.mockRejectedValueOnce(new Error('push service down'));
     const result = await crossRigEvent({
       schemaVersion: '1.0',
@@ -543,7 +543,7 @@ describe('crossRigEvent — badge_earned push dispatch (cf-bdl)', () => {
   });
 
   it('does not call syncBadgeEarnedToPush when badgeId is missing', async () => {
-    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web.js');
+    const { syncBadgeEarnedToPush } = await import('backend/crossRigSyncService.web');
     await crossRigEvent({
       schemaVersion: '1.0',
       event: 'badge_earned',
@@ -556,7 +556,7 @@ describe('crossRigEvent — tier_changed push dispatch (cf-bdl)', () => {
   beforeEach(() => { __setMember({ _id: 'mem-push-2' }); vi.clearAllMocks(); });
 
   it('calls sendPushToMember with TIER_CHANGED and newTier', async () => {
-    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web.js');
+    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
     await crossRigEvent({
       schemaVersion: '1.0',
       event: 'tier_changed',
@@ -571,7 +571,7 @@ describe('crossRigEvent — tier_changed push dispatch (cf-bdl)', () => {
   });
 
   it('still returns success even if tier push throws', async () => {
-    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    const { sendPushToMember } = await import('backend/pushNotificationService.web');
     sendPushToMember.mockRejectedValueOnce(new Error('FCM down'));
     const result = await crossRigEvent({
       schemaVersion: '1.0',
@@ -583,7 +583,7 @@ describe('crossRigEvent — tier_changed push dispatch (cf-bdl)', () => {
   });
 
   it('does not call sendPushToMember when newTier is missing', async () => {
-    const { sendPushToMember } = await import('backend/pushNotificationService.web.js');
+    const { sendPushToMember } = await import('backend/pushNotificationService.web');
     await crossRigEvent({
       schemaVersion: '1.0',
       event: 'tier_changed',


### PR DESCRIPTION
## Summary
badge_earned fires syncBadgeEarnedToPush post-analytics. tier_changed fires sendPushToMember with TIER_CHANGED. Both non-fatal: push error logged but success:true returned. Missing field guards prevent spurious push calls.

## Test plan
- [ ] npx vitest run tests/crossRigEventReceiver.test.js — 43/43 PASS (37 existing + 6 new)
- [ ] badge_earned calls syncBadgeEarnedToPush with correct memberId + badgeId
- [ ] tier_changed calls sendPushToMember with TIER_CHANGED + tier payload
- [ ] Push failure does not fail the event (success:true returned)

Note: Depends on cf-axn + cf-z51. Hold merge until both land on main.

Generated with Claude Code