### PR TITLE
feat(cf-axn): FCM push notification service — dispatch to member devices, stale token cleanup

### DIFF
--- a/src/backend/pushNotificationService.web.js
+++ b/src/backend/pushNotificationService.web.js
@@ -1,0 +1,91 @@
+/**
+ * pushNotificationService — FCM HTTP v1 push dispatch.
+ *
+ * Sends push notifications to all active device tokens for a member.
+ * Handles per-token FCM failures; deactivates stale tokens (NOT_FOUND/UNREGISTERED).
+ *
+ * CF-axn
+ */
+import { getActiveTokensForMember, deactivateToken } from 'backend/pushTokenRegistry.web';
+
+export const PUSH_EVENTS = {
+  BADGE_EARNED:       'badge_earned',
+  TIER_CHANGED:       'tier_changed',
+  CHALLENGE_COMPLETE: 'challenge_complete',
+  STREAK_MILESTONE:   'streak_milestone',
+  PRICE_DROP:         'price_drop',
+};
+
+const FCM_STALE_STATUSES = ['NOT_FOUND', 'UNREGISTERED'];
+
+function _buildMessage(event, payload) {
+  switch (event) {
+    case PUSH_EVENTS.BADGE_EARNED:
+      return { title: 'Badge Earned!', body: `You earned the ${payload.badgeId} badge.` };
+    case PUSH_EVENTS.TIER_CHANGED:
+      return { title: 'Tier Upgrade!', body: `You reached ${payload.tier} tier.` };
+    case PUSH_EVENTS.CHALLENGE_COMPLETE:
+      return { title: 'Challenge Complete!', body: payload.challengeName || 'You finished a challenge.' };
+    case PUSH_EVENTS.STREAK_MILESTONE:
+      return { title: 'Streak Milestone!', body: `${payload.days}-day streak achieved.` };
+    case PUSH_EVENTS.PRICE_DROP:
+      return { title: 'Price Drop Alert', body: payload.productName ? `${payload.productName} is on sale!` : 'A wishlisted item dropped in price.' };
+    default:
+      return { title: 'Carolina Futons', body: 'You have a new notification.' };
+  }
+}
+
+async function _sendFcm(token, title, body, data) {
+  const projectId = process.env.FCM_PROJECT_ID || 'carolina-futons';
+  const serverKey  = process.env.FCM_SERVER_KEY || '';
+  const url = `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
+  const payload = { message: { token, notification: { title, body }, data: data || {} } };
+  const res = await fetch(url, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${serverKey}` },
+    body:    JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    return { ok: false, status: res.status, fcmStatus: err?.error?.status };
+  }
+  return { ok: true };
+}
+
+/**
+ * Send a push notification to all active device tokens for a member.
+ *
+ * @param {string} memberId
+ * @param {string} event    - One of PUSH_EVENTS values
+ * @param {object} [payload] - Event-specific data (badgeId, tier, etc.)
+ * @returns {Promise<{ sent: number, failed: number }>}
+ */
+export async function sendPushToMember(memberId, event, payload = {}) {
+  const tokens = await getActiveTokensForMember(memberId);
+  if (!tokens.length) return { sent: 0, failed: 0 };
+
+  const { title, body } = _buildMessage(event, payload);
+  let sent = 0;
+  let failed = 0;
+
+  await Promise.allSettled(
+    tokens.map(async (tokenRecord) => {
+      try {
+        const result = await _sendFcm(tokenRecord.token, title, body, payload);
+        if (result.ok) {
+          sent++;
+        } else {
+          failed++;
+          if (FCM_STALE_STATUSES.includes(result.fcmStatus)) {
+            await deactivateToken(memberId, tokenRecord.token);
+          }
+        }
+      } catch (err) {
+        console.error('[pushNotificationService] FCM error:', err);
+        failed++;
+      }
+    })
+  );
+
+  return { sent, failed };
+}

--- a/tests/pushNotificationService.test.js
+++ b/tests/pushNotificationService.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { __seed, __reset } from './__mocks__/wix-data.js';
+import { __setMember, __reset as resetMember } from './__mocks__/wix-members-backend.js';
+import { sendPushToMember, PUSH_EVENTS } from '../src/backend/pushNotificationService.web.js';
+import { PUSH_TOKENS_COLLECTION } from '../src/backend/pushTokenRegistry.web.js';
+
+const MEMBER_ID = 'member-push-2';
+function setMember() { __setMember({ _id: MEMBER_ID }); }
+
+beforeEach(() => { __reset(); resetMember(); vi.restoreAllMocks(); });
+
+describe('PUSH_EVENTS', () => {
+  it('defines BADGE_EARNED and TIER_CHANGED', () => {
+    expect(typeof PUSH_EVENTS.BADGE_EARNED).toBe('string');
+    expect(typeof PUSH_EVENTS.TIER_CHANGED).toBe('string');
+  });
+
+  it('defines all 5 event types', () => {
+    expect(typeof PUSH_EVENTS.CHALLENGE_COMPLETE).toBe('string');
+    expect(typeof PUSH_EVENTS.STREAK_MILESTONE).toBe('string');
+    expect(typeof PUSH_EVENTS.PRICE_DROP).toBe('string');
+  });
+});
+
+describe('sendPushToMember — no tokens', () => {
+  it('returns sent: 0 when member has no push tokens', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, []);
+    const result = await sendPushToMember(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED, { badgeId: 'first_purchase' });
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+});
+
+describe('sendPushToMember — with tokens', () => {
+  it('returns sent count equal to active token count on FCM success', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 't1', memberId: MEMBER_ID, token: 'tok-ios', platform: 'ios', active: true },
+      { _id: 't2', memberId: MEMBER_ID, token: 'tok-android', platform: 'android', active: true },
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'projects/x/messages/1' }),
+    }));
+    const result = await sendPushToMember(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED, { badgeId: 'streak_7' });
+    expect(result.sent).toBe(2);
+    expect(result.failed).toBe(0);
+  });
+
+  it('counts FCM failures without throwing', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 't1', memberId: MEMBER_ID, token: 'tok-bad', platform: 'ios', active: true },
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: { status: 'NOT_FOUND' } }),
+    }));
+    const result = await sendPushToMember(MEMBER_ID, PUSH_EVENTS.TIER_CHANGED, { tier: 'silver' });
+    expect(result.failed).toBe(1);
+    expect(result.sent).toBe(0);
+  });
+
+  it('deactivates stale tokens on FCM NOT_FOUND response', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 't1', memberId: MEMBER_ID, token: 'stale-tok', platform: 'android', active: true },
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: { status: 'NOT_FOUND' } }),
+    }));
+    await sendPushToMember(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED, { badgeId: 'x' });
+    // After deactivation, getActiveTokensForMember should return empty
+    const { getActiveTokensForMember } = await import('../src/backend/pushTokenRegistry.web.js');
+    const tokens = await getActiveTokensForMember(MEMBER_ID);
+    expect(tokens).toHaveLength(0);
+  });
+
+  it('deactivates stale tokens on UNREGISTERED response', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 't2', memberId: MEMBER_ID, token: 'unreg-tok', platform: 'ios', active: true },
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 410,
+      json: async () => ({ error: { status: 'UNREGISTERED' } }),
+    }));
+    await sendPushToMember(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED, { badgeId: 'y' });
+    const { getActiveTokensForMember } = await import('../src/backend/pushTokenRegistry.web.js');
+    const tokens = await getActiveTokensForMember(MEMBER_ID);
+    expect(tokens).toHaveLength(0);
+  });
+
+  it('does NOT deactivate on non-stale FCM errors', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 't3', memberId: MEMBER_ID, token: 'rate-tok', platform: 'ios', active: true },
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: { status: 'QUOTA_EXCEEDED' } }),
+    }));
+    await sendPushToMember(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED, { badgeId: 'z' });
+    const { getActiveTokensForMember } = await import('../src/backend/pushTokenRegistry.web.js');
+    const tokens = await getActiveTokensForMember(MEMBER_ID);
+    expect(tokens).toHaveLength(1); // token still active
+  });
+
+  it('handles fetch exception without throwing', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 't4', memberId: MEMBER_ID, token: 'err-tok', platform: 'ios', active: true },
+    ]);
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+    const result = await sendPushToMember(MEMBER_ID, PUSH_EVENTS.PRICE_DROP, { productName: 'Oak Futon' });
+    expect(result.failed).toBe(1);
+    expect(result.sent).toBe(0);
+  });
+});
+
+describe('sendPushToMember — message building', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'msg/1' }),
+    }));
+  });
+
+  it.each([
+    [PUSH_EVENTS.BADGE_EARNED, { badgeId: 'first_purchase' }],
+    [PUSH_EVENTS.TIER_CHANGED, { tier: 'gold' }],
+    [PUSH_EVENTS.CHALLENGE_COMPLETE, { challengeName: 'Spring Challenge' }],
+    [PUSH_EVENTS.STREAK_MILESTONE, { days: 30 }],
+    [PUSH_EVENTS.PRICE_DROP, { productName: 'Futon Frame' }],
+  ])('sends without error for event type %s', async (event, payload) => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 'tx', memberId: MEMBER_ID, token: 'tok-x', platform: 'ios', active: true },
+    ]);
+    const result = await sendPushToMember(MEMBER_ID, event, payload);
+    expect(result.sent).toBe(1);
+  });
+
+  it('uses default message for unknown event type', async () => {
+    setMember();
+    __seed(PUSH_TOKENS_COLLECTION, [
+      { _id: 'ty', memberId: MEMBER_ID, token: 'tok-y', platform: 'ios', active: true },
+    ]);
+    const result = await sendPushToMember(MEMBER_ID, 'unknown_event', {});
+    expect(result.sent).toBe(1); // default message used
+  });
+});


### PR DESCRIPTION
## Summary
- sendPushToMember dispatches to all active tokens via FCM HTTP v1 fetch
- Deactivates stale tokens on NOT_FOUND/UNREGISTERED FCM response
- Non-stale failures (rate limit, etc.) counted but token preserved
- PUSH_EVENTS: BADGE_EARNED, TIER_CHANGED, CHALLENGE_COMPLETE, STREAK_MILESTONE, PRICE_DROP
- Default message for unknown event types

## Test plan
- [ ] npx vitest run tests/pushNotificationService.test.js — 15/15 PASS
- [ ] No-tokens early return: sent:0, failed:0
- [ ] Success count matches active token count
- [ ] Stale token deactivation on NOT_FOUND / UNREGISTERED
- [ ] Non-stale errors (QUOTA_EXCEEDED) preserve token
- [ ] Fetch exceptions: counted as failed, no throw
- [ ] All 5 event types + unknown default

Generated with Claude Code