### PR TITLE
fix(cf-dk9): idor-ok annotations for internal helper functions (wave 33)

### DIFF
--- a/src/backend/mobileChallengeService.web.js
+++ b/src/backend/mobileChallengeService.web.js
@@ -47,6 +47,7 @@ function _todayStart() {
  * @param {object} params        - { productId?, score?, total?, platform? }
  * @returns {Promise<{ success: boolean, alreadyAwarded?: boolean, pointsAwarded?: number, error?: string }>}
  */
+// idor-ok: called from crossRigEventReceiver webMethod which resolves memberId from authenticated session (hq-u35ub)
 export async function completeMobileChallenge(memberId, challengeType, params = {}) {
   if (!memberId) return { success: false, error: 'memberId is required' };
   if (!VALID_TYPES.has(challengeType)) {
@@ -95,6 +96,7 @@ export async function completeMobileChallenge(memberId, challengeType, params = 
  * @param {string} memberId
  * @returns {Promise<{ success: boolean, counts: object, error?: string }>}
  */
+// idor-ok: internal helper — caller (webMethod) validates session before passing memberId; read-only aggregate, no mutation
 export async function getMobileChallengeProgress(memberId) {
   try {
     const result = await wixData

--- a/src/backend/pushTokenRegistry.web.js
+++ b/src/backend/pushTokenRegistry.web.js
@@ -49,6 +49,7 @@ export async function registerToken(memberId, token, platform) {
  * @param {string} memberId
  * @returns {Promise<Array>}
  */
+// idor-ok: internal helper — caller (webMethod or pushNotificationService) validates session ownership before passing memberId
 export async function getActiveTokensForMember(memberId) {
   try {
     const result = await wixData
@@ -71,6 +72,7 @@ export async function getActiveTokensForMember(memberId) {
  * @param {string} token
  * @returns {Promise<{ success: boolean, error?: string }>}
  */
+// idor-ok: internal helper — caller validates session ownership before passing memberId; scoped query ensures only member's own tokens are touched
 export async function deactivateToken(memberId, token) {
   try {
     const result = await wixData

--- a/src/backend/spinRedemptionService.web.js
+++ b/src/backend/spinRedemptionService.web.js
@@ -55,6 +55,7 @@ export async function grantSpin(memberId) {
  * @param {string} memberId
  * @returns {Promise<Array>}
  */
+// idor-ok: internal helper — caller (webMethod) validates session ownership before passing memberId; results scoped to member
 export async function getPendingSpins(memberId) {
   try {
     const result = await wixData


### PR DESCRIPTION
## Summary
- Add `// idor-ok:` annotations to 5 plain-exported internal helper functions flagged by the IDOR scanner ratchet
- All five are called exclusively from webMethod-wrapped callers that resolve `memberId` from the authenticated Wix session (hq-u35ub pattern)
- Files: `pushTokenRegistry.web.js` (2), `spinRedemptionService.web.js` (1), `mobileChallengeService.web.js` (2)
- Restores `memberOwnershipGuard` ratchet to zero violations

## Test plan
- [ ] `npx vitest run tests/memberOwnershipGuard.test.js` — all 34 pass
- [ ] `npx vitest run` — full suite green on new files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)