### PR TITLE
fix(cf-4r4): IDOR guard on getMyRank + suppressAuth on _getTrailProgressForMember

### DIFF
--- a/src/backend/challengeService.web.js
+++ b/src/backend/challengeService.web.js
@@ -91,7 +91,7 @@ export async function _getTrailProgressForMember(memberId) {
       .query(TRAIL_PROGRESS_COLLECTION)
       .eq('memberId', memberId)
       .limit(100)
-      .find();
+      .find({ suppressAuth: true });
 
     // Index saved progress by trailId for O(1) lookup
     const progressByTrailId = {};

--- a/src/backend/leaderboardService.web.js
+++ b/src/backend/leaderboardService.web.js
@@ -24,6 +24,7 @@
  * @requires wix-data
  */
 import { webMethod, Permissions } from 'wix-web-module';
+import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
 import { logError } from 'backend/utils/errorHandler';
 import { MEMBER_POINTS_LEDGER_COLLECTION } from 'backend/utils/memberPointsLedger';
@@ -286,16 +287,23 @@ export const getLeaderboardByPeriod = webMethod(
 );
 
 /**
- * Returns the rank, points, and tier for a single member.
+ * Returns the rank, points, and tier for the currently authenticated member.
  * Rank is the count of opted-in members with strictly more points, plus 1.
- * Returns null if the member has no MemberPoints record or has not opted in.
+ * Returns null if unauthenticated or if the member has no MemberPoints record.
+ * memberId is resolved from the Wix session — never accepted from the caller (IDOR guard).
  *
- * @param {string} memberId
  * @returns {Promise<{rank: number, points: number, tier: string|null} | null>}
  */
 export const getMyRank = webMethod(
   Permissions.SiteMember,
-  async (memberId) => {
+  async () => {
+    let memberId;
+    try {
+      const member = await currentMember.getMember();
+      memberId = member?._id ?? null;
+    } catch (err) {
+      logError('leaderboardService.getMyRank — getMember failed', err);
+    }
     if (!memberId) return null;
 
     try {

--- a/src/backend/leaderboardService.web.js
+++ b/src/backend/leaderboardService.web.js
@@ -12,7 +12,7 @@
  * webMethod getLeaderboardByPeriod(period, limit) — ranked top-N with period support.
  *   period: 'allTime' | 'weekly' (default 'allTime'), limit: 1–50 (default 20).
  *   Returns {rank, memberId, displayName, points, tier}[].
- * webMethod getMyRank(memberId) — personal rank lookup for a single member.
+ * webMethod getMyRank() — personal rank lookup; memberId resolved from session (IDOR guard).
  *
  * CMS collections:
  *   MemberPoints (read)          — memberId, displayName, totalPoints, tier, lastActivityAt

--- a/tests/leaderboardByPeriod.test.js
+++ b/tests/leaderboardByPeriod.test.js
@@ -22,6 +22,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { __reset, __seed, __setQueryError } from 'wix-data';
+import { __setMember, __reset as resetMember } from 'wix-members-backend';
 import { getLeaderboardByPeriod, getMyRank } from '../src/backend/leaderboardService.web.js';
 
 const NOW = new Date('2026-04-13T12:00:00.000Z');
@@ -45,6 +46,7 @@ function makeLedgerEntry(memberId, delta, timestamp) {
 
 beforeEach(() => {
   __reset();
+  resetMember();
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
 });
@@ -173,45 +175,52 @@ describe('getLeaderboardByPeriod — invalid period', () => {
 // ── getMyRank ─────────────────────────────────────────────────────────────────
 
 describe('getMyRank', () => {
-  it('returns null for falsy memberId', async () => {
-    expect(await getMyRank(null)).toBeNull();
-    expect(await getMyRank('')).toBeNull();
+  it('returns null when unauthenticated (no session)', async () => {
+    // No __setMember call — getMember throws → returns null
+    __seed('MemberPoints', [makeMember({ memberId: 'mem-top', totalPoints: 1000, leaderboardOptIn: true })]);
+    const result = await getMyRank();
+    expect(result).toBeNull();
   });
 
   it('returns null when member has no MemberPoints record', async () => {
+    __setMember({ _id: 'mem-unknown' });
     __seed('MemberPoints', []);
-    const result = await getMyRank('mem-unknown');
+    const result = await getMyRank();
     expect(result).toBeNull();
   });
 
   it('returns rank 1 when member has the most points', async () => {
+    __setMember({ _id: 'mem-top' });
     __seed('MemberPoints', [
       makeMember({ memberId: 'mem-top', totalPoints: 1000, leaderboardOptIn: true }),
       makeMember({ memberId: 'mem-low', totalPoints: 100,  leaderboardOptIn: true }),
     ]);
-    const result = await getMyRank('mem-top');
+    const result = await getMyRank();
     expect(result).toMatchObject({ rank: 1, points: 1000 });
   });
 
   it('returns correct rank when others have more points', async () => {
+    __setMember({ _id: 'mem-me' });
     __seed('MemberPoints', [
       makeMember({ memberId: 'mem-1', totalPoints: 900, leaderboardOptIn: true }),
       makeMember({ memberId: 'mem-2', totalPoints: 700, leaderboardOptIn: true }),
       makeMember({ memberId: 'mem-me', totalPoints: 300, leaderboardOptIn: true }),
     ]);
-    const result = await getMyRank('mem-me');
+    const result = await getMyRank();
     expect(result).toMatchObject({ rank: 3, points: 300 });
   });
 
   it('includes tier in the result', async () => {
+    __setMember({ _id: 'mem-a' });
     __seed('MemberPoints', [makeMember({ memberId: 'mem-a', tier: 'Mountain Guide', totalPoints: 500, leaderboardOptIn: true })]);
-    const result = await getMyRank('mem-a');
+    const result = await getMyRank();
     expect(result.tier).toBe('Mountain Guide');
   });
 
   it('returns null on query error', async () => {
+    __setMember({ _id: 'mem-a' });
     __setQueryError('MemberPoints', new Error('DB down'));
-    const result = await getMyRank('mem-a');
+    const result = await getMyRank();
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase 6 code-audit findings from post-merge review of cf-73p + cf-rsr. Cherry-picks the fix commit from `polecat/guzzle/cf-2yd@mnx8war0` onto a clean branch against `main`.

- `leaderboardService.web.js`: `getMyRank` now resolves `memberId` from `currentMember.getMember()` instead of accepting a caller-supplied value — closes IDOR (caller previously could query any member's rank).
- `challengeService.web.js`: `_getTrailProgressForMember` adds `suppressAuth: true` on `find()` — prevents silent empty results when invoked from cron/event contexts without a user session.

## Test plan

- [x] `tests/leaderboardByPeriod.test.js` — 17/17 pass (updated to match session-derived memberId)
- [ ] CI green
- [ ] IDOR ratchet unchanged

Closes bead: cf-4r4