### PR TITLE
feat(cf-ndx): customerRoomPhotos — getApprovedPhotos + submission-flow ack

### DIFF
--- a/src/backend/customerRoomPhotos.web.js
+++ b/src/backend/customerRoomPhotos.web.js
@@ -215,6 +215,38 @@ export const likeRoomPhoto = webMethod(
   }
 );
 
+/**
+ * Paginated approved-photo feed (CF-ndx). Thin positional-args wrapper around
+ * the approved-status query — simpler surface for clients that only need
+ * "give me the next N approved photos". The CustomerRoomPhotos collection
+ * itself serves as the moderation queue via its `status` field.
+ *
+ * @param {number} [limit=20]  max photos to return (clamped 1..GALLERY_MAX_LIMIT)
+ * @param {number} [offset=0]  pagination offset (>=0)
+ * @returns {Promise<{success:boolean, photos:Array, total:number}>}
+ * @permission Anyone
+ */
+export const getApprovedPhotos = webMethod(
+  Permissions.Anyone,
+  async (limit = 20, offset = 0) => {
+    try {
+      const safeLimit  = Math.min(Math.max(1, Number(limit)  || 1), GALLERY_MAX_LIMIT);
+      const safeOffset = Math.max(0, Number(offset) || 0);
+
+      const result = await wixData.query(COLLECTION)
+        .hasSome('status', APPROVED_STATUSES)
+        .descending('submittedAt')
+        .limit(safeLimit).skip(safeOffset)
+        .find({ suppressAuth: true });
+
+      return { success: true, photos: result.items.map(toPublicPhoto), total: result.totalCount };
+    } catch (err) {
+      logError('customerRoomPhotos.getApprovedPhotos', err);
+      return { success: false, photos: [], total: 0 };
+    }
+  }
+);
+
 export const moderateRoomPhoto = webMethod(
   Permissions.Admin,
   async (photoId, action, notes = '') => {

--- a/tests/customerRoomPhotos.test.js
+++ b/tests/customerRoomPhotos.test.js
@@ -23,6 +23,7 @@ import {
   submitRoomPhoto,
   getProductRoomPhotos,
   getAllRoomPhotos,
+  getApprovedPhotos,
   likeRoomPhoto,
   moderateRoomPhoto,
   _COLLECTION,
@@ -466,6 +467,86 @@ describe('getAllRoomPhotos', () => {
     ]);
     const result = await getAllRoomPhotos();
     expect(result.total).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ── getApprovedPhotos (CF-ndx) ────────────────────────────────────────────────
+
+describe('getApprovedPhotos', () => {
+  it('returns approved + featured photos only', async () => {
+    __seed(_COLLECTION, [
+      makePhoto({ _id: 'p1', status: 'approved' }),
+      makePhoto({ _id: 'p2', status: 'pending' }),
+      makePhoto({ _id: 'p3', status: 'featured' }),
+      makePhoto({ _id: 'p4', status: 'rejected' }),
+    ]);
+    const result = await getApprovedPhotos();
+    expect(result.success).toBe(true);
+    expect(result.photos).toHaveLength(2);
+    expect(result.photos.every(p => p.status === 'approved' || p.status === 'featured')).toBe(true);
+  });
+
+  it('uses positional limit + offset args', async () => {
+    const photos = Array.from({ length: 5 }, (_, i) =>
+      makePhoto({ _id: `p${i}`, status: 'approved', submittedAt: new Date(2026, 0, i + 1) })
+    );
+    __seed(_COLLECTION, photos);
+    const result = await getApprovedPhotos(2, 1);
+    expect(result.success).toBe(true);
+    expect(result.photos.length).toBeLessThanOrEqual(2);
+    expect(result.total).toBeGreaterThanOrEqual(5);
+  });
+
+  it('defaults to limit=20 offset=0 when no args', async () => {
+    __seed(_COLLECTION, [makePhoto({ status: 'approved' })]);
+    const result = await getApprovedPhotos();
+    expect(result.success).toBe(true);
+    expect(result.photos).toHaveLength(1);
+  });
+
+  it('clamps limit to GALLERY_MAX_LIMIT (50)', async () => {
+    const photos = Array.from({ length: 60 }, (_, i) =>
+      makePhoto({ _id: `p${i}`, status: 'approved' })
+    );
+    __seed(_COLLECTION, photos);
+    const result = await getApprovedPhotos(999, 0);
+    expect(result.photos.length).toBeLessThanOrEqual(50);
+  });
+
+  it('clamps negative limit/offset to safe minimums', async () => {
+    __seed(_COLLECTION, [makePhoto({ status: 'approved' })]);
+    const result = await getApprovedPhotos(-5, -10);
+    expect(result.success).toBe(true);
+    expect(result.photos).toHaveLength(1);
+  });
+
+  it('coerces non-numeric args to defaults', async () => {
+    __seed(_COLLECTION, [makePhoto({ status: 'approved' })]);
+    const result = await getApprovedPhotos('abc', 'xyz');
+    expect(result.success).toBe(true);
+  });
+
+  it('does not expose memberEmail/memberId', async () => {
+    __seed(_COLLECTION, [makePhoto({ status: 'approved' })]);
+    const result = await getApprovedPhotos();
+    expect(result.photos[0]).not.toHaveProperty('memberEmail');
+    expect(result.photos[0]).not.toHaveProperty('memberId');
+  });
+
+  it('returns success:false on query error', async () => {
+    const { __setQueryError } = await import('./__mocks__/wix-data.js');
+    __setQueryError(_COLLECTION, new Error('db down'));
+    const result = await getApprovedPhotos();
+    expect(result.success).toBe(false);
+    expect(result.photos).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('returns empty array when no approved photos exist', async () => {
+    __seed(_COLLECTION, [makePhoto({ status: 'pending' })]);
+    const result = await getApprovedPhotos();
+    expect(result.success).toBe(true);
+    expect(result.photos).toHaveLength(0);
   });
 });
 

--- a/tests/customerRoomPhotos.test.js
+++ b/tests/customerRoomPhotos.test.js
@@ -526,11 +526,12 @@ describe('getApprovedPhotos', () => {
     expect(result.success).toBe(true);
   });
 
-  it('does not expose memberEmail/memberId', async () => {
-    __seed(_COLLECTION, [makePhoto({ status: 'approved' })]);
+  it('does not expose memberEmail/memberId/moderatorNotes', async () => {
+    __seed(_COLLECTION, [makePhoto({ status: 'approved', moderatorNotes: 'INTERNAL: spam suspicion' })]);
     const result = await getApprovedPhotos();
     expect(result.photos[0]).not.toHaveProperty('memberEmail');
     expect(result.photos[0]).not.toHaveProperty('memberId');
+    expect(result.photos[0]).not.toHaveProperty('moderatorNotes');
   });
 
   it('returns success:false on query error', async () => {


### PR DESCRIPTION
## Summary
Closes CF-ndx. The bead asked for three things:
1. **isWixMediaUrl validation** — already present in `submitRoomPhoto`; rejects non-Wix URLs.
2. **Pending-status insert with memberId from session** — already present; identity resolved via `currentMember.getMember()`.
3. **`getApprovedPhotos(limit, offset)`** — **NEW**. Thin positional-args wrapper around the approved-status query.

The existing `CustomerRoomPhotos` collection acts as the moderation queue via its `status` field — pending/approved/rejected/featured state machine is already implemented in `moderateRoomPhoto`.

## Coverage
- `customerRoomPhotos.web.js`: 93% lines, 100% functions, 89% branches
- 70 tests passing (9 new for `getApprovedPhotos`)

## Test plan
- [x] `npx vitest run tests/customerRoomPhotos.test.js` — 70/70 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)