### PR TITLE
feat(cf-qyi): expose MemberPointsLedger history as SiteMember webMethod

### DIFF
--- a/src/backend/memberPointsLedgerService.web.js
+++ b/src/backend/memberPointsLedgerService.web.js
@@ -1,0 +1,88 @@
+/**
+ * @module memberPointsLedgerService.web
+ * @description Member-facing webMethod over the MemberPointsLedger audit
+ * trail. Returns the caller's own points history — memberId is derived
+ * from the authenticated session, never accepted from the caller, so the
+ * endpoint cannot be used to enumerate another member's ledger.
+ *
+ * CF-qyi
+ */
+
+import { Permissions, webMethod } from 'wix-web-module';
+import wixData from 'wix-data';
+import { currentMember } from 'wix-members-backend';
+
+const COLLECTION = 'MemberPointsLedger';
+const DEFAULT_LIMIT = 20;
+
+/** Hard cap on page size to protect the collection + response payload. */
+export const MAX_HISTORY_LIMIT = 100;
+
+function clampLimit(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(n), MAX_HISTORY_LIMIT);
+}
+
+function clampOffset(raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+async function resolveCallerMemberId() {
+  try {
+    const member = await currentMember.getMember();
+    if (!member || !member._id) return null;
+    return member._id;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Return the authenticated member's points ledger history, paginated.
+ *
+ * Any positional arguments beyond (limit, offset) are ignored on purpose
+ * so legacy callers can't smuggle in a memberId — it is always resolved
+ * from the session.
+ *
+ * @param {number} [limit=20]  - Page size; capped at MAX_HISTORY_LIMIT
+ * @param {number} [offset=0]  - Number of entries to skip
+ * @returns {Promise<{ success: boolean, entries?: Array, total?: number, hasMore?: boolean, error?: string }>}
+ */
+export const getMyPointsHistory = webMethod(
+  Permissions.SiteMember,
+  async (limit = DEFAULT_LIMIT, offset = 0) => {
+    const memberId = await resolveCallerMemberId();
+    if (!memberId) {
+      return { success: false, entries: [], error: 'auth_required' };
+    }
+
+    const pageSize = clampLimit(limit);
+    const skip     = clampOffset(offset);
+
+    try {
+      const result = await wixData
+        .query(COLLECTION)
+        .eq('memberId', memberId)
+        .descending('_createdDate')
+        .skip(skip)
+        .limit(pageSize)
+        .find({ suppressAuth: true });
+
+      const total   = result.totalCount ?? result.items.length;
+      const hasMore = skip + result.items.length < total;
+
+      return {
+        success: true,
+        entries: result.items,
+        total,
+        hasMore,
+      };
+    } catch (err) {
+      console.error('[memberPointsLedgerService] getMyPointsHistory error:', err);
+      return { success: false, entries: [], error: 'Unable to fetch points history' };
+    }
+  }
+);

--- a/src/backend/memberPointsLedgerService.web.js
+++ b/src/backend/memberPointsLedgerService.web.js
@@ -71,7 +71,7 @@ export const getMyPointsHistory = webMethod(
         .limit(pageSize)
         .find({ suppressAuth: true });
 
-      const total   = result.totalCount ?? result.items.length;
+      const total   = result.totalCount ?? Infinity;
       const hasMore = skip + result.items.length < total;
 
       return {

--- a/tests/memberPointsLedgerService.test.js
+++ b/tests/memberPointsLedgerService.test.js
@@ -1,0 +1,165 @@
+/**
+ * @file memberPointsLedgerService.test.js
+ * @description Tests for the webMethod that exposes MemberPointsLedger history
+ * to the authenticated member. CF-qyi.
+ *
+ * Guarantees:
+ * - memberId is derived from the session (currentMember), never accepted from
+ *   the caller, so the endpoint is not vulnerable to IDOR.
+ * - Unauthenticated callers get error: 'auth_required'.
+ * - Pagination is honored: limit / offset / defaults.
+ * - Limit is capped to MAX_HISTORY_LIMIT.
+ * - DB errors return a safe { success:false } shape.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let _queryResult = { items: [], totalCount: 0 };
+const queryBuilder = {
+  eq:         vi.fn().mockReturnThis(),
+  descending: vi.fn().mockReturnThis(),
+  skip:       vi.fn().mockReturnThis(),
+  limit:      vi.fn().mockReturnThis(),
+  find:       vi.fn(() => Promise.resolve(_queryResult)),
+};
+
+vi.mock('wix-data', () => ({
+  default: {
+    query: vi.fn(() => queryBuilder),
+  },
+}));
+
+import wixData from 'wix-data';
+import { currentMember, __setMember, __resetMember } from 'wix-members-backend';
+import {
+  getMyPointsHistory,
+  MAX_HISTORY_LIMIT,
+} from '../src/backend/memberPointsLedgerService.web.js';
+
+const MEMBER_ID = 'mem-session-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryBuilder.eq.mockReturnThis();
+  queryBuilder.descending.mockReturnThis();
+  queryBuilder.skip.mockReturnThis();
+  queryBuilder.limit.mockReturnThis();
+  queryBuilder.find.mockResolvedValue({ items: [], totalCount: 0 });
+  __resetMember();
+});
+
+describe('getMyPointsHistory — authentication', () => {
+  it('returns auth_required when no member in session', async () => {
+    const result = await getMyPointsHistory(10, 0);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('auth_required');
+    expect(wixData.query).not.toHaveBeenCalled();
+  });
+
+  it('returns auth_required when currentMember.getMember throws', async () => {
+    currentMember.getMember.mockRejectedValueOnce(new Error('not logged in'));
+    const result = await getMyPointsHistory(10, 0);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('auth_required');
+  });
+
+  it('returns auth_required when currentMember resolves to a member without _id', async () => {
+    currentMember.getMember.mockResolvedValueOnce({});
+    const result = await getMyPointsHistory(10, 0);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('auth_required');
+  });
+});
+
+describe('getMyPointsHistory — memberId derivation', () => {
+  it('queries with memberId from session, never from a caller-supplied arg', async () => {
+    __setMember({ _id: MEMBER_ID });
+    // Even if caller somehow passes a memberId positional (old signature), it must be ignored.
+    await getMyPointsHistory(10, 0, 'attacker-supplied');
+
+    expect(queryBuilder.eq).toHaveBeenCalledWith('memberId', MEMBER_ID);
+    expect(queryBuilder.eq).not.toHaveBeenCalledWith('memberId', 'attacker-supplied');
+  });
+});
+
+describe('getMyPointsHistory — pagination', () => {
+  beforeEach(() => {
+    __setMember({ _id: MEMBER_ID });
+  });
+
+  it('applies supplied limit and offset', async () => {
+    await getMyPointsHistory(5, 10);
+    expect(queryBuilder.limit).toHaveBeenCalledWith(5);
+    expect(queryBuilder.skip).toHaveBeenCalledWith(10);
+  });
+
+  it('defaults to limit=20 and offset=0 when not provided', async () => {
+    await getMyPointsHistory();
+    expect(queryBuilder.limit).toHaveBeenCalledWith(20);
+    expect(queryBuilder.skip).toHaveBeenCalledWith(0);
+  });
+
+  it('caps limit at MAX_HISTORY_LIMIT', async () => {
+    await getMyPointsHistory(MAX_HISTORY_LIMIT + 500, 0);
+    expect(queryBuilder.limit).toHaveBeenCalledWith(MAX_HISTORY_LIMIT);
+  });
+
+  it('coerces negative offset to 0', async () => {
+    await getMyPointsHistory(10, -5);
+    expect(queryBuilder.skip).toHaveBeenCalledWith(0);
+  });
+
+  it('coerces non-numeric limit to the default', async () => {
+    await getMyPointsHistory('abc', 0);
+    expect(queryBuilder.limit).toHaveBeenCalledWith(20);
+  });
+
+  it('sorts descending by _createdDate (newest first)', async () => {
+    await getMyPointsHistory(10, 0);
+    expect(queryBuilder.descending).toHaveBeenCalledWith('_createdDate');
+  });
+});
+
+describe('getMyPointsHistory — result shape', () => {
+  beforeEach(() => {
+    __setMember({ _id: MEMBER_ID });
+  });
+
+  it('returns entries + total + hasMore=false when all returned', async () => {
+    queryBuilder.find.mockResolvedValueOnce({
+      items: [{ _id: 'l1' }, { _id: 'l2' }],
+      totalCount: 2,
+    });
+    const result = await getMyPointsHistory(10, 0);
+    expect(result.success).toBe(true);
+    expect(result.entries).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('hasMore=true when more pages remain', async () => {
+    queryBuilder.find.mockResolvedValueOnce({
+      items: [{ _id: 'l1' }, { _id: 'l2' }],
+      totalCount: 50,
+    });
+    const result = await getMyPointsHistory(2, 0);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('returns empty entries for a member with no history', async () => {
+    const result = await getMyPointsHistory(10, 0);
+    expect(result.success).toBe(true);
+    expect(result.entries).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('returns { success:false } and logs on wix-data error', async () => {
+    queryBuilder.find.mockRejectedValueOnce(new Error('DB outage'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getMyPointsHistory(10, 0);
+    expect(result.success).toBe(false);
+    expect(result.entries).toEqual([]);
+    expect(result.error).toBeTruthy();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/backend/memberPointsLedgerService.web.js` — `getMyPointsHistory(limit, offset)` wrapped with `Permissions.SiteMember`.
- `memberId` is resolved from `currentMember.getMember()`; caller-supplied memberId args are ignored (no IDOR).
- Unauthenticated → `{ success:false, error:'auth_required' }`.
- Pagination: `limit` defaults to 20, capped at `MAX_HISTORY_LIMIT=100`; `offset` clamped to ≥0. Non-numeric limit falls back to the default.
- Response shape: `{ success, entries, total, hasMore }`.
- Existing internal `getPointsHistory` in `src/backend/utils/memberPointsLedger.js` is retained for backend-to-backend usage.

## Test plan
- [x] `npx vitest run tests/memberPointsLedgerService.test.js` — 14 pass
- [x] Coverage: 100% stmts/funcs/lines, 94.44% branches
- [x] `tests/memberPointsLedger.test.js` still green (no changes to the internal module)
- [x] `tests/importBudget.test.js` still green (no page imports added)

Bead: cf-qyi