### PR TITLE
fix(cf-bgh): prevent announcement bar setInterval leaks across tests

### DIFF
--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -966,12 +966,28 @@ describe('Navigation Helpers', () => {
 // ── masterPage.js integration tests ─────────────────────────────────
 
 describe('masterPage.js', () => {
+  // Track real-timer setInterval handles so tests can't leak the 5s announcement
+  // bar rotation into later tests and race with their assertions (cf-bgh).
+  const _trackedIntervals = new Set();
+  let _origSetInterval;
+
   beforeAll(async () => {
+    _origSetInterval = globalThis.setInterval;
+    globalThis.setInterval = (fn, ms, ...args) => {
+      const id = _origSetInterval.call(globalThis, fn, ms, ...args);
+      _trackedIntervals.add(id);
+      return id;
+    };
     await import('../src/pages/masterPage.js');
   });
 
   beforeEach(() => {
     elements.clear();
+  });
+
+  afterEach(() => {
+    _trackedIntervals.forEach(id => clearInterval(id));
+    _trackedIntervals.clear();
   });
 
   describe('$w.onReady', () => {


### PR DESCRIPTION
## Summary
- Fixes flake in tests/masterPage.test.js CMS integration discovered during cf-sxu full-suite run
- Track real-timer setInterval handles within the masterPage describe; clear in afterEach so announcement bar rotation can't overwrite element text across test boundaries
- bd: cf-bgh

## Root cause
Earlier tests call onReadyHandler() which starts the 5s announcement bar rotation (real timers, no cleanup). Leaked setInterval fires during the CMS test's vi.waitFor window, overwriting element.text (set synchronously to 'Spring Sale...' by the helper) with a static-message index — vi.waitFor then times out observing the wrong text.

## Test plan
- [x] tests/masterPage.test.js isolated: 204/204 pass
- [x] Full vitest suite: 1082 files / 39513 pass / 0 fail (was 1/39503 failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)