### PR TITLE
fix(cf-ddd): alias dailyContentRotation export so Wix cron resolves

### DIFF
--- a/src/backend/socialStoryScheduler.web.js
+++ b/src/backend/socialStoryScheduler.web.js
@@ -979,8 +979,9 @@ export const runDailyContentRotation = webMethod(
   }
 );
 
-// Cron job alias — jobs.config key must match exported function name
+// Cron job aliases — jobs.config key must match exported function name
 export { runDailySocialStories as dailySocialStories };
+export { runDailyContentRotation as dailyContentRotation };
 
 // Export internals for testing
 export const _DEDUP_WINDOW_MS = DEDUP_WINDOW_MS;

--- a/tests/socialStoryCron.test.js
+++ b/tests/socialStoryCron.test.js
@@ -327,4 +327,29 @@ describe('jobs.config cron registration', () => {
     expect(result).toHaveProperty('priceDrops');
     expect(result).toHaveProperty('errors');
   });
+
+  // ── cf-ddd: dailyContentRotation parity ─────────────────────────────
+  // The Wix Jobs Scheduler invokes the function whose *export name* matches
+  // the jobs.config key. dailyContentRotation is registered in jobs.config
+  // but the scheduler file exports it as runDailyContentRotation internally,
+  // so a matching alias export must exist or the cron silently fails.
+
+  it('jobs.config includes dailyContentRotation cron entry', async () => {
+    const { config } = await import('../src/backend/jobs.config');
+    const jobs = config();
+    expect(jobs).toHaveProperty('dailyContentRotation');
+    expect(jobs.dailyContentRotation.functionLocation).toBe('/socialStoryScheduler.web.js');
+    expect(jobs.dailyContentRotation.executionConfig.cronExpression).toMatch(/\d+ \d+ \* \* \*/);
+  });
+
+  it('dailyContentRotation alias export resolves to a callable function', async () => {
+    const mod = await import('../src/backend/socialStoryScheduler.web.js');
+    expect(mod).toHaveProperty('dailyContentRotation');
+    expect(typeof mod.dailyContentRotation).toBe('function');
+  });
+
+  it('dailyContentRotation and runDailyContentRotation refer to the same implementation', async () => {
+    const { dailyContentRotation, runDailyContentRotation } = await import('../src/backend/socialStoryScheduler.web.js');
+    expect(dailyContentRotation).toBe(runDailyContentRotation);
+  });
 });


### PR DESCRIPTION
## Summary — verify(SEO): socialStoryScheduler live

**Finding.** `jobs.config` registers two socialStoryScheduler crons:
- `dailySocialStories` (17:00 UTC) → handler export also named `dailySocialStories` ✓ (alias was already in place)
- `dailyContentRotation` (17:05 UTC) → handler exported as **`runDailyContentRotation`**, no alias ✗

Wix Jobs Scheduler invokes the function whose *export name* matches the jobs.config key. Without the alias, `dailyContentRotation` would silently fail to resolve in production — the cron fires, Wix looks for `dailyContentRotation` on the module, and finds nothing.

**Fix.** Add `export { runDailyContentRotation as dailyContentRotation };` next to the pre-existing `dailySocialStories` alias.

## Other verification points (all green)
- `src/backend/socialStoryScheduler.web.js` present; both handlers are `webMethod(Permissions.Admin, …)` with try/catch + structured logging.
- `jobs.config` entries both point to `/socialStoryScheduler.web.js` with sane daily cron expressions.
- Full `tests/socialStory*` suite: 352 pass (baseline was 341; +3 new in this PR for the alias parity, rest were from unrelated recent commits).

## Test plan
- [x] `npx vitest run tests/socialStoryCron.test.js` — 22 pass (3 new)
- [x] `npx vitest run tests/socialStory tests/importBudget.test.js` — 352 pass
- [ ] Wix Automation panel confirmation of both cron entries (live env check — requires dashboard access)

Bead: cf-ddd