### PR TITLE
fix(cf-awz): correct LocalBusiness phone + hours in /near/[city] schema

### DIFF
--- a/src/backend/utils/localSeoData.js
+++ b/src/backend/utils/localSeoData.js
@@ -10,7 +10,7 @@
 export const SITE_URL = 'https://www.carolinafutons.com';
 export const STORE_CITY = 'hendersonville-nc';
 
-export const STORE_PHONE = '+1-828-693-1935';
+export const STORE_PHONE = '+1-828-252-9449';
 export const STORE_ADDRESS = {
   streetAddress: '824 Locust St',
   addressLocality: 'Hendersonville',
@@ -19,7 +19,7 @@ export const STORE_ADDRESS = {
   addressCountry: 'US',
 };
 export const STORE_GEO = { latitude: 35.3162, longitude: -82.4609 };
-export const STORE_HOURS = ['Mo-Fr 10:00-18:00', 'Sa 10:00-17:00'];
+export const STORE_HOURS = ['We-Sa 10:00-17:00'];
 
 /**
  * Approximate city-center geo coordinates for each /near/[city] page.

--- a/tests/localSeoS3.test.js
+++ b/tests/localSeoS3.test.js
@@ -161,9 +161,26 @@ describe('generateLocalBusinessSchema — FurnitureStore schema', () => {
     expect(schema.telephone).toContain('+1');
   });
 
+  it('telephone is the correct store number (+1-828-252-9449)', () => {
+    const schema = generateLocalBusinessSchema(ASHEVILLE);
+    // Strip formatting to normalize and compare digits only
+    const digits = schema.telephone.replace(/\D/g, '');
+    expect(digits).toBe('18282529449');
+  });
+
   it('includes openingHours from SCHEMA_OPENING_HOURS', () => {
     const schema = generateLocalBusinessSchema(ASHEVILLE);
     expect(schema.openingHours).toEqual(SCHEMA_OPENING_HOURS);
+  });
+
+  it('openingHours reflects Wed-Sat 10am-5pm schedule', () => {
+    const schema = generateLocalBusinessSchema(ASHEVILLE);
+    expect(schema.openingHours).toEqual(['We-Sa 10:00-17:00']);
+  });
+
+  it('address street is 824 Locust St (matches physical storefront)', () => {
+    const schema = generateLocalBusinessSchema(ASHEVILLE);
+    expect(schema.address.streetAddress).toBe('824 Locust St');
   });
 
   it('includes areaServed with city and state', () => {


### PR DESCRIPTION
## Summary
- Fix wrong `STORE_PHONE` (`+1-828-693-1935` → `+1-828-252-9449`) in `src/backend/utils/localSeoData.js`. This is rendered into every `/near/[city]` page's LocalBusiness JSON-LD via `generateLocalBusinessSchema` — Google and other crawlers have been indexing the wrong telephone.
- Fix wrong `STORE_HOURS` (`Mo-Fr 10-18, Sa 10-17` → `We-Sa 10:00-17:00`). `STORE_HOURS` itself is not currently rendered into schema (`SCHEMA_OPENING_HOURS` is the active constant, which was already correct), but the export is available to future callers — fixed to prevent drift.
- Add 3 new tests in `tests/localSeoS3.test.js` locking the correct values: telephone digits must equal `18282529449`, `openingHours` must equal `['We-Sa 10:00-17:00']`, and `address.streetAddress` must equal `'824 Locust St'`.

## Scope verification
- Home + Contact pages already inject LocalBusiness JSON-LD via `masterPage.js → getBusinessSchema` (sourced from `seoHelpers.web.js`, which had the correct phone `+18282529449` and hours already). Contact page additionally posts its own copy to `#contactSchemaHtml`.
- Wiring for /near/[city] pages comes from `generateLocalBusinessSchema` in `localSeo.web.js`, which pulls from `localSeoData.js` — that was the only data source holding stale values.
- Bead spec: name=Carolina Futons ✓, address=824 Locust St Hendersonville NC 28792 ✓, phone=(828) 252-9449 ✓ (fixed), hours=Wed-Sat 10-5 ✓.

## Test plan
- [x] `npx vitest run tests/localSeo` — 9 files, 357 passed
- [x] `npx vitest run tests/seoHelpersDeep.test.js tests/contactPageIntegration.test.js tests/masterPageHandlers.test.js` — 584 passed
- [x] Full suite: 1083 test files passed, 1 unrelated pre-existing flake (`wishlistCardButtonHardening.test.js`)

Closes cf-awz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)