### PR TITLE
feat(cf-2tm): wire TikTok pixel events on PDP/cart/wishlist/purchase

### DIFF
--- a/src/public/WishlistCardButton.js
+++ b/src/public/WishlistCardButton.js
@@ -10,6 +10,7 @@
  * @module WishlistCardButton
  */
 import { trackEvent } from 'public/engagementTracker';
+import { fireAddToWishlist } from 'public/ga4Tracking';
 import { colors } from 'public/designTokens.js';
 
 // SVG heart icons — same visual language as socialWishlist.js
@@ -104,6 +105,7 @@ export function initCardWishlistButton($item, product, isWishlisted) {
           wishlisted = true;
           setHeartState($item, true, product.name);
           trackEvent('wishlist_add', { productId: product._id, source: 'product_card' });
+          fireAddToWishlist(product);
         }
       } catch (e) {
         console.error('[WishlistCardButton] toggle failed for product:', product._id, e);

--- a/src/public/ga4Tracking.js
+++ b/src/public/ga4Tracking.js
@@ -16,6 +16,14 @@ import {
   buildViewCartEvent,
 } from 'backend/analyticsHelpers.web';
 import wixPrivacy from 'wix-privacy-frontend';
+import { fireTrackedTikTokEvent } from 'public/pixelConsentService';
+
+// Fire a TikTok pixel event alongside a GA4 event. Consent gating
+// (analytics + advertising) is enforced inside fireTrackedTikTokEvent;
+// swallow errors so TikTok failures never break GA4 or the caller.
+function _fireTikTok(eventName, params) {
+  try { fireTrackedTikTokEvent(eventName, params); } catch (e) {}
+}
 
 let _wixWindow = null;
 
@@ -55,6 +63,12 @@ export async function fireViewContent(product) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('ViewContent', payload);
     }
+    _fireTikTok('ViewContent', {
+      content_id: product?._id,
+      content_name: product?.name,
+      value: product?.price,
+      currency: 'USD',
+    });
   } catch (e) {
     // GA4 tracking is non-critical
   }
@@ -74,6 +88,12 @@ export async function fireAddToCart(product, quantity = 1) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('AddToCart', payload);
     }
+    _fireTikTok('AddToCart', {
+      content_id: product?._id,
+      quantity,
+      value: (product?.price || 0) * quantity,
+      currency: 'USD',
+    });
   } catch (e) {}
 }
 
@@ -107,6 +127,11 @@ export async function firePurchase(order) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('Purchase', payload);
     }
+    _fireTikTok('Purchase', {
+      order_id: order?._id,
+      value: order?.totals?.total,
+      currency: 'USD',
+    });
   } catch (e) {}
 }
 
@@ -123,6 +148,11 @@ export async function fireAddToWishlist(product) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('AddToWishlist', payload);
     }
+    _fireTikTok('AddToWishlist', {
+      content_id: product?._id,
+      value: product?.price,
+      currency: 'USD',
+    });
   } catch (e) {}
 }
 

--- a/src/public/tikTokPixel.js
+++ b/src/public/tikTokPixel.js
@@ -6,7 +6,9 @@
 // Setup: Set your TikTok Pixel ID in the PIXEL_ID constant below, or
 // configure it via Wix Dashboard > Marketing Integrations.
 
-let PIXEL_ID = ''; // Set TikTok Pixel ID here when obtained
+// Placeholder — real ID pending from Stilgar / Wix Dashboard > Marketing Integrations.
+// initTikTokPixel() short-circuits on the placeholder value so no broken script loads.
+let PIXEL_ID = 'TIKTOK_PIXEL_ID';
 
 /**
  * Set the TikTok Pixel ID at runtime (useful for tests and dynamic config).
@@ -27,7 +29,7 @@ export function initTikTokPixel() {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
     if (window.ttq) return; // Already initialized
 
-    if (!PIXEL_ID) return; // No pixel ID configured
+    if (!PIXEL_ID || PIXEL_ID === 'TIKTOK_PIXEL_ID') return; // No real pixel ID configured yet
 
     /* eslint-disable */
     !function (w, d, t) {

--- a/tests/ga4TikTokBridge.test.js
+++ b/tests/ga4TikTokBridge.test.js
@@ -1,0 +1,78 @@
+/**
+ * @file ga4TikTokBridge.test.js
+ * @description Verifies ga4Tracking fire* functions also dispatch TikTok pixel
+ * events through pixelConsentService (cf-2tm Phase 7 pixel wiring).
+ *
+ * Each existing GA4 entry point (ViewContent, AddToCart, Purchase, AddToWishlist)
+ * must fan out to fireTrackedTikTokEvent with the matching event name and a
+ * TikTok-shaped payload (content_id / order_id + value + currency).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { fireTrackedTikTokEvent } = vi.hoisted(() => ({ fireTrackedTikTokEvent: vi.fn() }));
+
+vi.mock('public/pixelConsentService', () => ({
+  fireTrackedTikTokEvent,
+  initConsentGate: vi.fn(),
+}));
+
+vi.mock('backend/analyticsHelpers.web', () => ({
+  buildViewContentEvent: vi.fn(async () => ({})),
+  buildAddToCartEvent:   vi.fn(async () => ({})),
+  buildCheckoutEvent:    vi.fn(async () => ({})),
+  buildPurchaseEvent:    vi.fn(async () => ({})),
+  buildWishlistEvent:    vi.fn(async () => ({})),
+  buildViewItemListEvent:vi.fn(async () => ({})),
+  buildSearchEvent:      vi.fn(async () => ({})),
+  buildViewCartEvent:    vi.fn(async () => ({})),
+}));
+
+import {
+  fireViewContent,
+  fireAddToCart,
+  firePurchase,
+  fireAddToWishlist,
+} from '../src/public/ga4Tracking.js';
+
+beforeEach(() => {
+  fireTrackedTikTokEvent.mockClear();
+});
+
+describe('ga4 → TikTok bridge', () => {
+  it('fireViewContent fans out to TikTok ViewContent with content_id/value/currency', async () => {
+    await fireViewContent({ _id: 'p1', name: 'Kodiak', price: 899 });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'ViewContent',
+      expect.objectContaining({ content_id: 'p1', content_name: 'Kodiak', value: 899, currency: 'USD' }),
+    );
+  });
+
+  it('fireAddToCart fans out to TikTok AddToCart with quantity-scaled value', async () => {
+    await fireAddToCart({ _id: 'p2', price: 100 }, 3);
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'AddToCart',
+      expect.objectContaining({ content_id: 'p2', quantity: 3, value: 300, currency: 'USD' }),
+    );
+  });
+
+  it('firePurchase fans out to TikTok Purchase with order_id + total', async () => {
+    await firePurchase({ _id: 'ord-42', totals: { total: 1299 }, lineItems: [] });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'Purchase',
+      expect.objectContaining({ order_id: 'ord-42', value: 1299, currency: 'USD' }),
+    );
+  });
+
+  it('fireAddToWishlist fans out to TikTok AddToWishlist with content_id + value', async () => {
+    await fireAddToWishlist({ _id: 'p3', price: 499 });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'AddToWishlist',
+      expect.objectContaining({ content_id: 'p3', value: 499, currency: 'USD' }),
+    );
+  });
+
+  it('TikTok fan-out failures do not propagate to the caller', async () => {
+    fireTrackedTikTokEvent.mockImplementationOnce(() => { throw new Error('consent service offline'); });
+    await expect(fireViewContent({ _id: 'p4', price: 10 })).resolves.not.toThrow();
+  });
+});

--- a/tests/wishlistCardButton.test.js
+++ b/tests/wishlistCardButton.test.js
@@ -53,6 +53,10 @@ vi.mock('public/engagementTracker', () => ({
   trackEvent: vi.fn(),
 }));
 
+vi.mock('public/ga4Tracking', () => ({
+  fireAddToWishlist: vi.fn(),
+}));
+
 import { trackEvent } from 'public/engagementTracker';
 
 // ── Mock helpers ────────────────────────────────────────────────────

--- a/tests/wishlistCardButtonHardening.test.js
+++ b/tests/wishlistCardButtonHardening.test.js
@@ -40,6 +40,10 @@ vi.mock('public/engagementTracker', () => ({
   trackEvent: vi.fn(),
 }));
 
+vi.mock('public/ga4Tracking', () => ({
+  fireAddToWishlist: vi.fn(),
+}));
+
 import { trackEvent } from 'public/engagementTracker';
 
 // ── Helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fan out TikTok pixel fires from the four existing GA4 entry points in `ga4Tracking.js` — so ViewContent (PDP), AddToCart (PDP+sticky+bundle), Purchase (Thank You), and AddToWishlist (PDP+category card) all reach TikTok through `pixelConsentService.fireTrackedTikTokEvent` (advertising-consent gated, Purchase dedup handled).
- New call from `WishlistCardButton.js` card heart adds GA4+TikTok for category-grid saves (previously only `trackEvent`).
- Seed `tikTokPixel.PIXEL_ID` with the placeholder `'TIKTOK_PIXEL_ID'` literal and short-circuit `initTikTokPixel()` on that value so no broken SDK script loads until Stilgar/Wix Dashboard supplies the real ID.

Closes cf-2tm. Follow-on to the cf-31l verification audit.

## Test plan
- [x] `npx vitest run tests/ga4TikTokBridge.test.js tests/ga4Tracking.test.js tests/ga4TrackingDeep.test.js tests/tikTokPixel.test.js tests/pixelConsentService.test.js tests/wishlistCardButton.test.js tests/wishlistCardButtonHardening.test.js tests/addToCart.test.js tests/funnelTracker.test.js tests/masterPage.test.js` — 553 passed
- [x] New `tests/ga4TikTokBridge.test.js` asserts each GA4 fire fans out to `fireTrackedTikTokEvent` with the correct event name + TikTok payload (content_id/order_id, value, currency) and that TikTok failures don't propagate to callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)