### PR TITLE
feat(cf-bjv): Blog Post → Topic Cluster backlink + isPartOf schema

### DIFF
--- a/src/backend/topicClusters.web.js
+++ b/src/backend/topicClusters.web.js
@@ -242,6 +242,62 @@ export const generateInternalLinks = webMethod(
   }
 );
 
+// ── getClusterForPost ─────────────────────────────────────────────────
+
+/**
+ * Reverse lookup: given a spoke (blog post) slug, return its parent
+ * topic cluster + sibling spokes. Used by Blog Post pages to render
+ * "Part of: {pillar}" backlink nav and isPartOf JSON-LD. (CF-bjv)
+ *
+ * @param {string} postSlug — spoke page slug (e.g. "wood-vs-metal-frames")
+ * @returns {Promise<{success:boolean, cluster:Object|null}>}
+ */
+export const getClusterForPost = webMethod(
+  Permissions.Anyone,
+  async (postSlug) => {
+    try {
+      const slug = validateSlug(postSlug) || sanitize(postSlug, 100);
+      if (!slug) return { success: false, error: 'Post slug is required.', cluster: null };
+
+      for (const [pillarSlug, cluster] of Object.entries(CLUSTERS)) {
+        const spoke = cluster.spokePages.find(sp => sp.slug === slug);
+        if (!spoke) continue;
+
+        const siblings = cluster.spokePages
+          .filter(sp => sp.slug !== slug)
+          .map(sp => ({
+            slug: sp.slug,
+            title: sp.title,
+            type: sp.type,
+            url: `${SITE_URL}/buying-guides/${sp.slug}`,
+          }));
+
+        return {
+          success: true,
+          cluster: {
+            pillarSlug,
+            pillarTitle: cluster.pillarTitle,
+            pillarUrl: `${GUIDES_URL}/${pillarSlug}`,
+            topic: cluster.topic,
+            currentSpoke: {
+              slug: spoke.slug,
+              title: spoke.title,
+              type: spoke.type,
+              url: `${SITE_URL}/buying-guides/${spoke.slug}`,
+            },
+            siblingSpokes: siblings,
+          },
+        };
+      }
+
+      return { success: true, cluster: null };
+    } catch (err) {
+      console.error('[topicClusters] Error resolving cluster for post:', err);
+      return { success: false, error: 'Failed to resolve cluster.', cluster: null };
+    }
+  }
+);
+
 // ── getSchemaMarkup ───────────────────────────────────────────────────
 
 /**

--- a/src/pages/Blog Post.js
+++ b/src/pages/Blog Post.js
@@ -2,6 +2,8 @@
 // Wix Blog app renders the post content — this code adds SEO schema,
 // reading time, social share buttons, author bio, and related posts
 import { getBlogArticleSchema, getBlogFaqSchema, getPageTitle, getCanonicalUrl, getPageMetaDescription } from 'backend/seoHelpers.web';
+import { getClusterForPost } from 'backend/topicClusters.web';
+import { buildBlogPostClusterNav, buildIsPartOfSchema } from 'public/topicClusterHelpers';
 import { getGuidePinData } from 'backend/pinterestRichPins.web';
 // eslint-disable-next-line @wix/cli/no-invalid-backend-import
 import { getBlogPost, getAllBlogPosts } from 'backend/blogContent';
@@ -51,11 +53,17 @@ $w.onReady(async function () {
     // ── Related Posts ─────────────────────────────────────────────────
     initRelatedPosts(post);
 
+    // ── Topic Cluster Backlink (CF-bjv) ───────────────────────────────
+    const clusterResult = await getClusterForPost(slug).catch(() => null);
+    const cluster = clusterResult && clusterResult.success ? clusterResult.cluster : null;
+    initClusterBacklink(cluster);
+
     // ── SEO Schema Injection ──────────────────────────────────────────
     const schemas = [];
     const articleSchema = await getBlogArticleSchema(post);
     if (articleSchema) {
-      schemas.push(`<script type="application/ld+json">${articleSchema}</script>`);
+      const withIsPartOf = injectIsPartOf(articleSchema, cluster);
+      schemas.push(`<script type="application/ld+json">${withIsPartOf}</script>`);
     }
     const faqSchema = await getBlogFaqSchema(slug);
     if (faqSchema) {
@@ -89,6 +97,49 @@ $w.onReady(async function () {
     console.error('Blog post page init error:', err);
   }
 });
+
+// ── Topic Cluster Backlink ────────────────────────────────────────────
+// If the post is a spoke in a topic cluster, render "Part of: {pillar}"
+// nav + sibling-post links. CF-bjv.
+
+function initClusterBacklink(cluster) {
+  const nav = buildBlogPostClusterNav(cluster);
+  if (!nav) {
+    try { $w('#clusterBacklinkContainer').collapse(); } catch (e) {}
+    return;
+  }
+  try { $w('#clusterBacklinkContainer').expand(); } catch (e) {}
+  try { $w('#clusterBacklinkLabel').text = nav.label; } catch (e) {}
+  try {
+    const link = $w('#clusterBacklinkPillar');
+    link.label = 'View pillar guide';
+    link.link = nav.pillarUrl;
+  } catch (e) {}
+  try {
+    const repeater = $w('#clusterSiblingRepeater');
+    repeater.data = nav.siblings.map((s, i) => ({ _id: `sib-${i}`, ...s }));
+    repeater.onItemReady(($item, itemData) => {
+      try { $item('#siblingTitle').text = itemData.title; } catch (e) {}
+      try {
+        const sl = $item('#siblingLink');
+        sl.label = itemData.title;
+        sl.link = itemData.url;
+      } catch (e) {}
+    });
+  } catch (e) {}
+}
+
+function injectIsPartOf(articleSchemaJson, cluster) {
+  const isPartOf = buildIsPartOfSchema(cluster);
+  if (!isPartOf) return articleSchemaJson;
+  try {
+    const parsed = JSON.parse(articleSchemaJson);
+    parsed.isPartOf = isPartOf;
+    return JSON.stringify(parsed);
+  } catch (e) {
+    return articleSchemaJson;
+  }
+}
 
 // ── Post Header ───────────────────────────────────────────────────────
 // Sets the post title, excerpt body, author byline, and date near the top of the page

--- a/src/public/topicClusterHelpers.js
+++ b/src/public/topicClusterHelpers.js
@@ -99,3 +99,38 @@ export function buildRelatedClusterNav(currentSlug, allClusters) {
       url: `${GUIDES_URL}/${slug}`,
     }));
 }
+
+/**
+ * Build "Part of: {pillar}" backlink + sibling-spoke nav for Blog Post pages.
+ * (CF-bjv) Takes the cluster shape returned by getClusterForPost().
+ *
+ * @param {{ pillarTitle: string, pillarUrl: string, siblingSpokes: Array }} cluster
+ * @returns {{ label: string, pillarUrl: string, siblings: Array }|null}
+ */
+export function buildBlogPostClusterNav(cluster) {
+  if (!cluster || typeof cluster !== 'object' || !cluster.pillarTitle) return null;
+  return {
+    label: `Part of: ${cluster.pillarTitle}`,
+    pillarUrl: cluster.pillarUrl,
+    siblings: Array.isArray(cluster.siblingSpokes)
+      ? cluster.siblingSpokes.map(s => ({ title: s.title, url: s.url }))
+      : [],
+  };
+}
+
+/**
+ * Build schema.org isPartOf linkage for a spoke (blog post) that belongs
+ * to a topic cluster. Returns a plain object (callers JSON-stringify into
+ * JSON-LD alongside BlogPosting). (CF-bjv)
+ *
+ * @param {{ pillarTitle: string, pillarUrl: string }} cluster
+ * @returns {{ '@type': 'WebPage', name: string, url: string }|null}
+ */
+export function buildIsPartOfSchema(cluster) {
+  if (!cluster || !cluster.pillarUrl) return null;
+  return {
+    '@type': 'WebPage',
+    name: cluster.pillarTitle || '',
+    url: cluster.pillarUrl,
+  };
+}

--- a/tests/topicClusterForPost.test.js
+++ b/tests/topicClusterForPost.test.js
@@ -1,0 +1,130 @@
+/**
+ * CF-bjv: getClusterForPost reverse lookup + public nav/schema helpers.
+ */
+import { describe, it, expect } from 'vitest';
+import { getClusterForPost } from '../src/backend/topicClusters.web.js';
+import { buildBlogPostClusterNav, buildIsPartOfSchema } from '../src/public/topicClusterHelpers.js';
+
+describe('getClusterForPost', () => {
+  it('finds parent cluster for a known spoke slug', async () => {
+    const res = await getClusterForPost('wood-vs-metal-frames');
+    expect(res.success).toBe(true);
+    expect(res.cluster).not.toBeNull();
+    expect(res.cluster.pillarSlug).toBe('futon-frames');
+    expect(res.cluster.pillarTitle).toBeTruthy();
+    expect(res.cluster.pillarUrl).toContain('/guides/futon-frames');
+    expect(res.cluster.currentSpoke.slug).toBe('wood-vs-metal-frames');
+    expect(res.cluster.currentSpoke.url).toContain('/buying-guides/wood-vs-metal-frames');
+  });
+
+  it('returns sibling spokes (excluding current)', async () => {
+    const res = await getClusterForPost('wood-vs-metal-frames');
+    expect(res.cluster.siblingSpokes.length).toBeGreaterThan(0);
+    const siblingSlugs = res.cluster.siblingSpokes.map(s => s.slug);
+    expect(siblingSlugs).not.toContain('wood-vs-metal-frames');
+    expect(siblingSlugs).toContain('wall-hugger-guide');
+  });
+
+  it('resolves mattresses-cluster spoke', async () => {
+    const res = await getClusterForPost('mattress-fill-types');
+    expect(res.success).toBe(true);
+    expect(res.cluster.pillarSlug).toBe('mattresses');
+  });
+
+  it('resolves covers-cluster spoke', async () => {
+    const res = await getClusterForPost('cover-fabric-comparison');
+    expect(res.success).toBe(true);
+    expect(res.cluster.pillarSlug).toBe('covers');
+  });
+
+  it('returns cluster:null for unknown slug', async () => {
+    const res = await getClusterForPost('not-a-real-post');
+    expect(res.success).toBe(true);
+    expect(res.cluster).toBeNull();
+  });
+
+  it('returns success:false for empty slug', async () => {
+    const res = await getClusterForPost('');
+    expect(res.success).toBe(false);
+    expect(res.cluster).toBeNull();
+  });
+
+  it('returns success:false for non-string slug', async () => {
+    const res = await getClusterForPost(null);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects slug with invalid characters', async () => {
+    const res = await getClusterForPost('bad slug!!');
+    // sanitize + validateSlug fallback should still return success with cluster:null
+    // (nothing matches) or success:false if slug became empty — both acceptable.
+    if (res.success) expect(res.cluster).toBeNull();
+    else expect(res.cluster).toBeNull();
+  });
+
+  it('sibling URLs point at /buying-guides/{slug}', async () => {
+    const res = await getClusterForPost('wood-vs-metal-frames');
+    res.cluster.siblingSpokes.forEach(s => {
+      expect(s.url).toMatch(/\/buying-guides\/[a-z0-9-]+$/);
+    });
+  });
+});
+
+describe('buildBlogPostClusterNav', () => {
+  it('builds nav with label + pillarUrl + sibling list', () => {
+    const nav = buildBlogPostClusterNav({
+      pillarTitle: 'Futon Frame Guide',
+      pillarUrl: 'https://www.carolinafutons.com/guides/futon-frames',
+      siblingSpokes: [
+        { title: 'Wall Hugger Guide', url: 'https://x/wall-hugger-guide' },
+        { title: 'Size Guide', url: 'https://x/size-guide' },
+      ],
+    });
+    expect(nav.label).toBe('Part of: Futon Frame Guide');
+    expect(nav.pillarUrl).toContain('/guides/futon-frames');
+    expect(nav.siblings).toHaveLength(2);
+    expect(nav.siblings[0].title).toBe('Wall Hugger Guide');
+  });
+
+  it('returns null when cluster is null/undefined', () => {
+    expect(buildBlogPostClusterNav(null)).toBeNull();
+    expect(buildBlogPostClusterNav(undefined)).toBeNull();
+  });
+
+  it('returns null when pillarTitle missing', () => {
+    expect(buildBlogPostClusterNav({ pillarUrl: 'x' })).toBeNull();
+  });
+
+  it('tolerates missing siblingSpokes array', () => {
+    const nav = buildBlogPostClusterNav({ pillarTitle: 'T', pillarUrl: 'u' });
+    expect(nav.siblings).toEqual([]);
+  });
+});
+
+describe('buildIsPartOfSchema', () => {
+  it('builds schema.org WebPage node for cluster', () => {
+    const schema = buildIsPartOfSchema({
+      pillarTitle: 'Futon Frame Guide',
+      pillarUrl: 'https://www.carolinafutons.com/guides/futon-frames',
+    });
+    expect(schema).toEqual({
+      '@type': 'WebPage',
+      name: 'Futon Frame Guide',
+      url: 'https://www.carolinafutons.com/guides/futon-frames',
+    });
+  });
+
+  it('returns null for null cluster', () => {
+    expect(buildIsPartOfSchema(null)).toBeNull();
+  });
+
+  it('returns null when pillarUrl missing', () => {
+    expect(buildIsPartOfSchema({ pillarTitle: 'T' })).toBeNull();
+  });
+
+  it('uses empty string when pillarTitle missing but pillarUrl present', () => {
+    const schema = buildIsPartOfSchema({ pillarUrl: 'https://x/guides/y' });
+    expect(schema.name).toBe('');
+    expect(schema.url).toBe('https://x/guides/y');
+  });
+});


### PR DESCRIPTION
## Summary
Closes cf-bjv (follow-up from cf-9vk audit). Blog posts that are spokes in a topic cluster now:
1. Render a "Part of: {pillar}" backlink + sibling-spoke nav.
2. Emit schema.org \`isPartOf\` linkage in the JSON-LD BlogPosting.

## Changes
- **backend/topicClusters.web.js** — new \`getClusterForPost(slug)\` webMethod (Permissions.Anyone). Reverse lookup over CLUSTERS.spokePages; returns pillar slug/title/URL, the current spoke, and siblings.
- **public/topicClusterHelpers.js** — \`buildBlogPostClusterNav(cluster)\` + \`buildIsPartOfSchema(cluster)\`.
- **pages/Blog Post.js** — fetches cluster on load, wires \`#clusterBacklinkContainer\` / \`#clusterBacklinkLabel\` / \`#clusterBacklinkPillar\` / \`#clusterSiblingRepeater\` elements, and merges \`isPartOf\` into the Article JSON-LD.

## Tests
- 17 new tests in \`tests/topicClusterForPost.test.js\`
- Full topic-cluster + blog-post suite: **393/393 passing**

## Test plan
- [x] \`npx vitest run tests/topicClusterForPost.test.js tests/topicCluster*.test.js tests/topicClusters*.test.js tests/blogPost*.test.js\`
- [ ] Designer to add the four elements referenced above to the Blog Post page layout (IDs: \`#clusterBacklinkContainer\`, \`#clusterBacklinkLabel\`, \`#clusterBacklinkPillar\`, \`#clusterSiblingRepeater\` with inner \`#siblingTitle\` + \`#siblingLink\`). Missing elements silently collapse — safe to merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)