### PR TITLE
test(cf-gjc): lock Pinterest feed CDN image normalization

### DIFF
--- a/tests/httpFunctions.test.js
+++ b/tests/httpFunctions.test.js
@@ -328,6 +328,36 @@ describe('get_pinterestProductFeed', () => {
     await get_pinterestProductFeed();
     expect(__getLastFindOptions('Stores/Products')).toEqual({ suppressAuth: true });
   });
+
+  it('normalizes wix:image:// URIs in image_link to static.wixstatic.com CDN URLs', async () => {
+    __seed('Stores/Products', [{
+      _id: 'prod-wix',
+      name: 'Wix Image Product',
+      slug: 'wix-image-product',
+      price: 499,
+      discountedPrice: null,
+      mainMedia: 'wix:image://v1/abc123.jpg/photo.jpg#originWidth=1200',
+      description: 'Test product.',
+      inStock: true,
+      collections: ['futon-frames'],
+      _updatedDate: new Date('2026-01-15'),
+      mediaItems: [
+        { src: 'wix:image://v1/main_abc123.jpg/photo.jpg' }, // index 0 — skipped
+        { src: 'wix:image://v1/side_def456.jpg/side.jpg#w=800' },
+        { src: 'wix:image://v1/back_ghi789.jpg/back.jpg#w=800' },
+      ],
+    }]);
+
+    const result = await get_pinterestProductFeed();
+    expect(result.status).toBe(200);
+    // image_link for mainMedia must be a CDN URL, not the raw wix:image:// URI
+    expect(result.body).toContain('https://static.wixstatic.com/media/abc123.jpg');
+    // additional_image_link must also be normalized (mediaItems index 1+)
+    expect(result.body).toContain('https://static.wixstatic.com/media/side_def456.jpg');
+    expect(result.body).toContain('https://static.wixstatic.com/media/back_ghi789.jpg');
+    // No raw wix:image:// URIs should leak into the feed — Pinterest would reject them
+    expect(result.body).not.toContain('wix:image://');
+  });
 });
 
 // ── Cron Endpoint Auth Tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- cf-gjc verification: Pinterest catalog feed at `GET /_functions/pinterestProductFeed` is live, wired to `fetchAllProducts()` (no filter — emits the full `Stores/Products` collection), and already uses `getImageUrl()` to normalize `wix:image://` URIs into `https://static.wixstatic.com/media/...` CDN URLs for both `image_link` and `additional_image_link`.
- Adds a regression test to `tests/httpFunctions.test.js` that seeds a product whose `mainMedia` and `mediaItems[].src` are all raw `wix:image://v1/…` URIs, then asserts the TSV feed output contains normalized CDN URLs and **no** raw `wix:image://` URIs. This locks the feed against the same bug pattern fixed in PR #1045 for OG tags.

## Verification findings
- **Endpoint**: `src/backend/http-functions.js:429` → `get_pinterestProductFeed`
- **Data source**: `fetchAllProducts()` pages `Stores/Products` with `suppressAuth: true` and no filter — all live products are emitted. Local mocks can't count production rows; the feed will cover all 88 (or current count).
- **Fields emitted per row**: `id, title, description, link, image_link, price, availability, brand, google_product_category, condition, sale_price, product_type, additional_image_link` ✓
- **Image normalization**: `getImageUrl(p.mainMedia)` and `getImageUrl(m.src || m)` for each `mediaItems[1..5]` entry. `getImageUrl` itself is also covered by PR #1045's recursion fix for `{ url: '…' }` objects.
- **Rate limits**: Feed `Cache-Control: public, max-age=3600` — 1h TTL aligns with Pinterest's 6-refreshes-per-day limit (every 4h).

## Test plan
- [x] `npx vitest run tests/httpFunctions.test.js tests/pinterest` — 8 files, 406 passed (was 405)
- [x] No src/ changes — pure test lock, zero production risk.

Closes cf-gjc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)