### PR TITLE
fix(cf-5rt): decouple TikTok fan-out from GA4 analytics consent guard

### DIFF
--- a/src/public/ga4Tracking.js
+++ b/src/public/ga4Tracking.js
@@ -56,6 +56,15 @@ export function _hasAnalyticsConsent() {
  */
 export async function fireViewContent(product) {
   try {
+    // TikTok fan-out runs before the analytics-only guard: pixelConsentService
+    // enforces its own (analytics + advertising + queueing) consent contract,
+    // so advertising-only users still reach TikTok. (cf-5rt)
+    _fireTikTok('ViewContent', {
+      content_id: product?._id,
+      content_name: product?.name,
+      value: product?.price,
+      currency: 'USD',
+    });
     if (!_hasAnalyticsConsent()) return;
     const ww = await getWixWindow();
     if (!ww?.trackEvent) return;
@@ -63,12 +72,6 @@ export async function fireViewContent(product) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('ViewContent', payload);
     }
-    _fireTikTok('ViewContent', {
-      content_id: product?._id,
-      content_name: product?.name,
-      value: product?.price,
-      currency: 'USD',
-    });
   } catch (e) {
     // GA4 tracking is non-critical
   }
@@ -81,6 +84,12 @@ export async function fireViewContent(product) {
  */
 export async function fireAddToCart(product, quantity = 1) {
   try {
+    _fireTikTok('AddToCart', {
+      content_id: product?._id,
+      quantity,
+      value: (product?.price || 0) * quantity,
+      currency: 'USD',
+    });
     if (!_hasAnalyticsConsent()) return;
     const ww = await getWixWindow();
     if (!ww?.trackEvent) return;
@@ -88,12 +97,6 @@ export async function fireAddToCart(product, quantity = 1) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('AddToCart', payload);
     }
-    _fireTikTok('AddToCart', {
-      content_id: product?._id,
-      quantity,
-      value: (product?.price || 0) * quantity,
-      currency: 'USD',
-    });
   } catch (e) {}
 }
 
@@ -120,6 +123,11 @@ export async function fireInitiateCheckout(cartItems, cartTotal) {
  */
 export async function firePurchase(order) {
   try {
+    _fireTikTok('Purchase', {
+      order_id: order?._id,
+      value: order?.totals?.total,
+      currency: 'USD',
+    });
     if (!_hasAnalyticsConsent()) return;
     const ww = await getWixWindow();
     if (!ww?.trackEvent) return;
@@ -127,11 +135,6 @@ export async function firePurchase(order) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('Purchase', payload);
     }
-    _fireTikTok('Purchase', {
-      order_id: order?._id,
-      value: order?.totals?.total,
-      currency: 'USD',
-    });
   } catch (e) {}
 }
 
@@ -141,6 +144,11 @@ export async function firePurchase(order) {
  */
 export async function fireAddToWishlist(product) {
   try {
+    _fireTikTok('AddToWishlist', {
+      content_id: product?._id,
+      value: product?.price,
+      currency: 'USD',
+    });
     if (!_hasAnalyticsConsent()) return;
     const ww = await getWixWindow();
     if (!ww?.trackEvent) return;
@@ -148,11 +156,6 @@ export async function fireAddToWishlist(product) {
     if (payload && Object.keys(payload).length > 0) {
       ww.trackEvent('AddToWishlist', payload);
     }
-    _fireTikTok('AddToWishlist', {
-      content_id: product?._id,
-      value: product?.price,
-      currency: 'USD',
-    });
   } catch (e) {}
 }
 

--- a/tests/ga4TikTokBridge.test.js
+++ b/tests/ga4TikTokBridge.test.js
@@ -9,11 +9,19 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { fireTrackedTikTokEvent } = vi.hoisted(() => ({ fireTrackedTikTokEvent: vi.fn() }));
+const { fireTrackedTikTokEvent, getCurrentConsentPolicy } = vi.hoisted(() => ({
+  fireTrackedTikTokEvent: vi.fn(),
+  getCurrentConsentPolicy: vi.fn(() => ({ policy: { analytics: true, advertising: true } })),
+}));
 
 vi.mock('public/pixelConsentService', () => ({
   fireTrackedTikTokEvent,
   initConsentGate: vi.fn(),
+}));
+
+vi.mock('wix-privacy-frontend', () => ({
+  default: { getCurrentConsentPolicy },
+  getCurrentConsentPolicy,
 }));
 
 vi.mock('backend/analyticsHelpers.web', () => ({
@@ -36,6 +44,7 @@ import {
 
 beforeEach(() => {
   fireTrackedTikTokEvent.mockClear();
+  getCurrentConsentPolicy.mockReturnValue({ policy: { analytics: true, advertising: true } });
 });
 
 describe('ga4 → TikTok bridge', () => {
@@ -74,5 +83,49 @@ describe('ga4 → TikTok bridge', () => {
   it('TikTok fan-out failures do not propagate to the caller', async () => {
     fireTrackedTikTokEvent.mockImplementationOnce(() => { throw new Error('consent service offline'); });
     await expect(fireViewContent({ _id: 'p4', price: 10 })).resolves.not.toThrow();
+  });
+});
+
+// ── cf-5rt: TikTok fires must be decoupled from GA4 analytics consent ──
+// pixelConsentService is the sole arbiter of TikTok consent (analytics +
+// advertising + queueing). Advertising-only users must still reach TikTok
+// even though their analytics grant is absent; conversely denying both at
+// wix-privacy is handled downstream in fireTrackedTikTokEvent.
+
+describe('ga4 → TikTok bridge — consent decoupling', () => {
+  it('fires TikTok even when analytics consent is denied (advertising-only user)', async () => {
+    getCurrentConsentPolicy.mockReturnValue({ policy: { analytics: false, advertising: true } });
+    await fireViewContent({ _id: 'p1', price: 100 });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'ViewContent',
+      expect.objectContaining({ content_id: 'p1' }),
+    );
+  });
+
+  it('fireAddToCart still dispatches TikTok when analytics consent is denied', async () => {
+    getCurrentConsentPolicy.mockReturnValue({ policy: { analytics: false, advertising: true } });
+    await fireAddToCart({ _id: 'p2', price: 50 }, 2);
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'AddToCart',
+      expect.objectContaining({ content_id: 'p2', quantity: 2, value: 100 }),
+    );
+  });
+
+  it('firePurchase still dispatches TikTok when analytics consent is denied', async () => {
+    getCurrentConsentPolicy.mockReturnValue({ policy: { analytics: false, advertising: true } });
+    await firePurchase({ _id: 'ord-7', totals: { total: 499 } });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'Purchase',
+      expect.objectContaining({ order_id: 'ord-7', value: 499 }),
+    );
+  });
+
+  it('fireAddToWishlist still dispatches TikTok when analytics consent is denied', async () => {
+    getCurrentConsentPolicy.mockReturnValue({ policy: { analytics: false, advertising: true } });
+    await fireAddToWishlist({ _id: 'p3', price: 299 });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledWith(
+      'AddToWishlist',
+      expect.objectContaining({ content_id: 'p3', value: 299 }),
+    );
   });
 });

--- a/tests/ga4TikTokBridge.test.js
+++ b/tests/ga4TikTokBridge.test.js
@@ -128,4 +128,19 @@ describe('ga4 → TikTok bridge — consent decoupling', () => {
       expect.objectContaining({ content_id: 'p3', value: 299 }),
     );
   });
+
+  // Guard regression: even with BOTH analytics and advertising denied, the GA4
+  // layer must still dispatch to pixelConsentService so the event can be queued
+  // for later consent grants. pixelConsentService — not ga4Tracking — is the
+  // sole arbiter of whether the pixel actually fires / queues / drops.
+  it('fires TikTok unconditionally when analytics AND advertising are both denied (pixelConsentService queues)', async () => {
+    getCurrentConsentPolicy.mockReturnValue({ policy: { analytics: false, advertising: false } });
+    await fireViewContent({ _id: 'p-both-deny', price: 10 });
+    await fireAddToCart({ _id: 'p-both-deny', price: 10 }, 1);
+    await firePurchase({ _id: 'ord-both-deny', totals: { total: 10 } });
+    await fireAddToWishlist({ _id: 'p-both-deny', price: 10 });
+    expect(fireTrackedTikTokEvent).toHaveBeenCalledTimes(4);
+    const events = fireTrackedTikTokEvent.mock.calls.map(c => c[0]);
+    expect(events).toEqual(['ViewContent', 'AddToCart', 'Purchase', 'AddToWishlist']);
+  });
 });


### PR DESCRIPTION
## Summary
- Addresses cf-2tm PR #1047 review (confidence 87): `_fireTikTok` calls sat inside each GA4 analytics-consent early-return, so an advertising-only user (analytics denied, advertising granted) never reached the `pixelConsentService` queue.
- Moves `_fireTikTok` above the analytics guard in `fireViewContent` / `fireAddToCart` / `firePurchase` / `fireAddToWishlist`. `pixelConsentService.fireTrackedTikTokEvent` is now the sole arbiter of TikTok consent (it already enforces both analytics + advertising and queues until consent resolves).

## Test plan
- [x] TDD: new "consent decoupling" describe block in `tests/ga4TikTokBridge.test.js` mocks `wix-privacy-frontend` to `{ analytics: false, advertising: true }` and asserts each of the four entry points still dispatches to `fireTrackedTikTokEvent` — red pre-fix, green after moving the call
- [x] `npx vitest run tests/ga4TikTokBridge.test.js tests/ga4Tracking.test.js tests/ga4TrackingDeep.test.js tests/tikTokPixel.test.js tests/pixelConsentService.test.js` — 163/163 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)