### PR TITLE
feat(cf-bpt): extend re-engagement to non-purchasers + multi-step win-back

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -83,8 +83,11 @@ const SEQUENCES = {
     ],
   },
   reengagement: {
+    // cf-bpt: multi-step win-back — day 0 miss-you, day 7 deal, day 21 last call
     steps: [
-      { step: 1, templateId: 'reengagement_1', delayHours: 0, description: 'We miss you + exclusive offer' },
+      { step: 1, templateId: 'reengagement_1', delayHours: 0,   description: 'Day 0 — we miss you + exclusive offer (cf-bpt)' },
+      { step: 2, templateId: 'reengagement_2', delayHours: 168, description: 'Day 7 — here\'s a deal (cf-bpt)' },
+      { step: 3, templateId: 'reengagement_3', delayHours: 504, description: 'Day 21 — last chance (cf-bpt)' },
     ],
   },
   restock: {
@@ -1024,7 +1027,17 @@ export const triggerAbandonedCartRecovery = webMethod(
 );
 
 /**
- * Find dormant contacts (no activity in 90+ days) and queue re-engagement.
+ * Find dormant members (no gamification activity in 90+ days) and queue the
+ * multi-step win-back sequence.
+ *
+ * cf-bvn: Dormancy signal is MemberPoints.lastActivityAt — updated by
+ * gamificationCore on every points-earning event (purchase, review, quiz,
+ * wishlist add, streak check-in, etc.). This reaches browse-only members who
+ * never purchased, which the previous post-purchase-email-sentAt proxy missed.
+ *
+ * cf-bpt: All 3 steps of SEQUENCES.reengagement are queued up-front with
+ * staggered scheduledFor offsets (day 0 / day 7 / day 21), mirroring the
+ * welcome/cart_recovery multi-step pattern.
  *
  * @function triggerReengagement
  * @returns {Promise<{success: boolean, contacted: number}>}
@@ -1036,13 +1049,14 @@ export const triggerReengagement = webMethod(
     try {
       const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
 
-      // Find contacts who placed orders but not recently
-      const result = await wixData.query('EmailQueue')
-        .eq('sequenceType', 'post_purchase')
-        .eq('sequenceStep', 1)
-        .eq('status', 'sent')
-        .le('sentAt', ninetyDaysAgo)
-        .find();
+      // Dormant = MemberPoints.lastActivityAt older than 90 days.
+      // (Members with no lastActivityAt yet — pre-cf-bvn records — are skipped
+      // to avoid spraying the entire back catalog the first time this runs.
+      // Their next activity will stamp lastActivityAt and bring them into scope.)
+      const dormant = await wixData.query('MemberPoints')
+        .le('lastActivityAt', ninetyDaysAgo)
+        .limit(1000)
+        .find({ suppressAuth: true });
 
       let contacted = 0;
       let discountCode = '';
@@ -1054,32 +1068,59 @@ export const triggerReengagement = webMethod(
         console.warn('[emailAutomation] Reengagement discount unavailable, emails will omit discount:', e.message);
       }
 
-      for (const item of result.items) {
-        if (!item.recipientEmail) continue;
-        if (await isUnsubscribed(item.recipientEmail, 'reengagement')) continue;
+      for (const mp of dormant.items) {
+        if (!mp.memberId) continue;
 
-        // Skip if already sent reengagement recently
+        // Resolve memberId → email + firstName via PrivateMembersData.
+        let email = '';
+        let contactId = '';
+        let firstName = '';
+        try {
+          const memberRow = await wixData.query('Members/PrivateMembersData')
+            .eq('_id', mp.memberId)
+            .find({ suppressAuth: true });
+          const m = memberRow.items?.[0];
+          email = m?.loginEmail || '';
+          contactId = m?.contactId || '';
+          firstName = m?.firstName || m?.nickname || '';
+        } catch (e) {
+          console.warn('[emailAutomation] Reengagement member lookup failed:', mp.memberId, e.message);
+          continue;
+        }
+
+        if (!email) continue;
+        if (await isUnsubscribed(email, 'reengagement')) continue;
+
+        // Dedup: skip members we've already queued/sent reengagement to.
         const alreadySent = await wixData.query('EmailQueue')
-          .eq('recipientEmail', item.recipientEmail)
+          .eq('recipientEmail', email)
           .eq('sequenceType', 'reengagement')
           .find();
 
         if (alreadySent.items.length > 0) continue;
 
-        await queueEmail({
-          templateId: SEQUENCES.reengagement.steps[0].templateId,
-          recipientEmail: item.recipientEmail,
-          recipientContactId: item.recipientContactId || '',
-          variables: {
-            firstName: item.variables?.firstName || '',
-            discountCode,
-            discountAvailable,
-            email: item.recipientEmail,
-          },
-          sequenceType: 'reengagement',
-          sequenceStep: 1,
-          scheduledFor: new Date(),
-        });
+        // cf-bpt: queue all 3 win-back steps up-front with staggered
+        // scheduledFor offsets (day 0 / day 7 / day 21). processEmailQueue
+        // releases each when its scheduledFor arrives, mirroring welcome/
+        // cart_recovery multi-step cadence.
+        const queueStart = new Date();
+        for (const step of SEQUENCES.reengagement.steps) {
+          const scheduledFor = new Date(queueStart.getTime() + step.delayHours * 60 * 60 * 1000);
+          await queueEmail({
+            templateId: step.templateId,
+            recipientEmail: email,
+            recipientContactId: contactId,
+            variables: {
+              firstName,
+              discountCode,
+              discountAvailable,
+              email,
+            },
+            sequenceType: 'reengagement',
+            sequenceStep: step.step,
+            scheduledFor,
+          });
+        }
 
         contacted++;
       }

--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -1039,6 +1039,12 @@ export const triggerAbandonedCartRecovery = webMethod(
  * staggered scheduledFor offsets (day 0 / day 7 / day 21), mirroring the
  * welcome/cart_recovery multi-step pattern.
  *
+ * @note Single-page cap: the dormant query is capped at 1 000 records per
+ *   invocation (Wix CMS page-size ceiling). If the dormant cohort exceeds
+ *   1 000 in one cron tick, overflow members slip to the next run — they
+ *   remain dormant and are picked up then. Queue a queryAll-style pagination
+ *   follow-up if the dormant backlog regularly exceeds this ceiling.
+ *
  * @function triggerReengagement
  * @returns {Promise<{success: boolean, contacted: number}>}
  * @permission Admin
@@ -1089,6 +1095,10 @@ export const triggerReengagement = webMethod(
         }
 
         if (!email) continue;
+        // Refuse to queue without a contactId: downstream Wix triggeredEmails
+        // dispatch resolves the recipient via contactId — an empty value would
+        // either drop the send silently or target the wrong member.
+        if (!contactId) continue;
         if (await isUnsubscribed(email, 'reengagement')) continue;
 
         // Dedup: skip members we've already queued/sent reengagement to.

--- a/tests/emailAutomation.integration.test.js
+++ b/tests/emailAutomation.integration.test.js
@@ -513,15 +513,16 @@ describe('re-engagement filtering', () => {
 
   it('contacts dormant contacts (> 90 days)', async () => {
     const hundredDaysAgo = new Date(Date.now() - 100 * 24 * 3600000);
-    __seed('EmailQueue', [{
-      _id: 'eq-dormant',
-      recipientEmail: 'dormant@test.com',
-      recipientContactId: 'contact-dormant',
-      sequenceType: 'post_purchase',
-      sequenceStep: 1,
-      status: 'sent',
-      sentAt: hundredDaysAgo,
-      variables: { firstName: 'Dormant' },
+    __seed('MemberPoints', [{
+      _id: 'mp-dormant',
+      memberId: 'mem-dormant',
+      lastActivityAt: hundredDaysAgo,
+    }]);
+    __seed('Members/PrivateMembersData', [{
+      _id: 'mem-dormant',
+      loginEmail: 'dormant@test.com',
+      contactId: 'contact-dormant',
+      firstName: 'Dormant',
     }]);
 
     let insertedItems = [];
@@ -538,17 +539,18 @@ describe('re-engagement filtering', () => {
 
   it('does not send reengagement twice to same contact', async () => {
     const hundredDaysAgo = new Date(Date.now() - 100 * 24 * 3600000);
+    __seed('MemberPoints', [{
+      _id: 'mp-double',
+      memberId: 'mem-double',
+      lastActivityAt: hundredDaysAgo,
+    }]);
+    __seed('Members/PrivateMembersData', [{
+      _id: 'mem-double',
+      loginEmail: 'double@test.com',
+      contactId: 'contact-double',
+      firstName: 'Double',
+    }]);
     __seed('EmailQueue', [
-      {
-        _id: 'eq-pp-old',
-        recipientEmail: 'double@test.com',
-        recipientContactId: 'contact-double',
-        sequenceType: 'post_purchase',
-        sequenceStep: 1,
-        status: 'sent',
-        sentAt: hundredDaysAgo,
-        variables: { firstName: 'Double' },
-      },
       {
         _id: 'eq-re-existing',
         recipientEmail: 'double@test.com',

--- a/tests/emailAutomation.test.js
+++ b/tests/emailAutomation.test.js
@@ -58,8 +58,9 @@ describe('sequence definitions', () => {
     expect(_SEQUENCES.post_purchase.steps[2].description).toMatch(/cross.sell|complete.*room/i);
   });
 
-  it('has reengagement sequence with 1 step', () => {
-    expect(_SEQUENCES.reengagement.steps).toHaveLength(1);
+  it('has reengagement sequence with 3 steps (day 0/7/21 win-back — cf-bpt)', () => {
+    expect(_SEQUENCES.reengagement.steps).toHaveLength(3);
+    expect(_SEQUENCES.reengagement.steps.map(s => s.delayHours)).toEqual([0, 168, 504]);
   });
 
   it('has A/B variants for welcome step 1', () => {
@@ -527,18 +528,22 @@ describe('triggerAbandonedCartRecovery', () => {
 // ── triggerReengagement ────────────────────────────────────────────
 
 describe('triggerReengagement', () => {
-  it('queues reengagement for dormant contacts', async () => {
-    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000);
-    __seed('EmailQueue', [{
-      _id: 'eq-pp-1',
-      recipientEmail: 'dormant@test.com',
-      recipientContactId: 'contact-d1',
-      sequenceType: 'post_purchase',
-      sequenceStep: 1,
-      status: 'sent',
-      sentAt: ninetyOneDaysAgo,
-      variables: { firstName: 'Dormant' },
-    }]);
+  // cf-bpt: seeding moved from EmailQueue(post_purchase sentAt) → MemberPoints.lastActivityAt
+  // so browse-only members (no purchase) are now reachable. Extensive coverage of the new
+  // seeding path + multi-step sequence lives in tests/reEngagementWinBack.test.js.
+  const ninetyOneDaysAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000);
+
+  function seedDormant(memberId, email, firstName = '') {
+    __seed('MemberPoints', [
+      { _id: `mp-${memberId}`, memberId, lastActivityAt: ninetyOneDaysAgo },
+    ]);
+    __seed('Members/PrivateMembersData', [
+      { _id: memberId, loginEmail: email, contactId: `c-${memberId}`, firstName },
+    ]);
+  }
+
+  it('queues reengagement for dormant members', async () => {
+    seedDormant('mem-d1', 'dormant@test.com', 'Dormant');
 
     const result = await triggerReengagement();
     expect(result.success).toBe(true);
@@ -546,18 +551,7 @@ describe('triggerReengagement', () => {
   });
 
   it('includes discount code in reengagement', async () => {
-    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000);
-    __seed('EmailQueue', [{
-      _id: 'eq-pp-1',
-      recipientEmail: 'dormant@test.com',
-      recipientContactId: 'contact-d1',
-      sequenceType: 'post_purchase',
-      sequenceStep: 1,
-      status: 'sent',
-      sentAt: ninetyOneDaysAgo,
-      variables: { firstName: 'Dormant' },
-    }]);
-
+    seedDormant('mem-d1', 'dormant@test.com', 'Dormant');
     let insertedItems = [];
     __onInsert((collection, item) => { insertedItems.push(item); });
 
@@ -571,18 +565,7 @@ describe('triggerReengagement', () => {
 
   it('sets discountAvailable false when reengagement secret missing', async () => {
     __resetSecrets();
-    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000);
-    __seed('EmailQueue', [{
-      _id: 'eq-pp-1',
-      recipientEmail: 'dormant@test.com',
-      recipientContactId: 'contact-d1',
-      sequenceType: 'post_purchase',
-      sequenceStep: 1,
-      status: 'sent',
-      sentAt: ninetyOneDaysAgo,
-      variables: { firstName: 'Dormant' },
-    }]);
-
+    seedDormant('mem-d1', 'dormant@test.com', 'Dormant');
     let insertedItems = [];
     __onInsert((collection, item) => { insertedItems.push(item); });
 
@@ -594,44 +577,22 @@ describe('triggerReengagement', () => {
     expect(reengagement.variables.discountAvailable).toBe(false);
   });
 
-  it('skips contacts with recent reengagement', async () => {
-    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000);
-    __seed('EmailQueue', [
-      {
-        _id: 'eq-pp-1',
-        recipientEmail: 'dormant@test.com',
-        recipientContactId: 'contact-d1',
-        sequenceType: 'post_purchase',
-        sequenceStep: 1,
-        status: 'sent',
-        sentAt: ninetyOneDaysAgo,
-        variables: { firstName: 'Dormant' },
-      },
-      {
-        _id: 'eq-re-1',
-        recipientEmail: 'dormant@test.com',
-        sequenceType: 'reengagement',
-        sequenceStep: 1,
-        status: 'sent',
-      },
-    ]);
+  it('skips members with an existing queued reengagement (any step)', async () => {
+    seedDormant('mem-d1', 'dormant@test.com', 'Dormant');
+    __seed('EmailQueue', [{
+      _id: 'eq-re-1',
+      recipientEmail: 'dormant@test.com',
+      sequenceType: 'reengagement',
+      sequenceStep: 1,
+      status: 'sent',
+    }]);
 
     const result = await triggerReengagement();
     expect(result.contacted).toBe(0);
   });
 
-  it('skips unsubscribed contacts', async () => {
-    const ninetyOneDaysAgo = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000);
-    __seed('EmailQueue', [{
-      _id: 'eq-pp-1',
-      recipientEmail: 'unsub@test.com',
-      recipientContactId: 'contact-u1',
-      sequenceType: 'post_purchase',
-      sequenceStep: 1,
-      status: 'sent',
-      sentAt: ninetyOneDaysAgo,
-      variables: { firstName: 'Unsub' },
-    }]);
+  it('skips unsubscribed members', async () => {
+    seedDormant('mem-u1', 'unsub@test.com', 'Unsub');
     __seed('Unsubscribes', [{
       email: 'unsub@test.com',
       sequenceType: 'reengagement',
@@ -642,7 +603,7 @@ describe('triggerReengagement', () => {
     expect(result.contacted).toBe(0);
   });
 
-  it('returns zero when no dormant contacts', async () => {
+  it('returns zero when no dormant members', async () => {
     const result = await triggerReengagement();
     expect(result.success).toBe(true);
     expect(result.contacted).toBe(0);

--- a/tests/emailAutomationDeepen.test.js
+++ b/tests/emailAutomationDeepen.test.js
@@ -258,12 +258,13 @@ describe('triggerReengagement skips', () => {
   const longAgo = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
 
   it('skips contacts already sent reengagement', async () => {
+    __seed('MemberPoints', [{
+      _id: 'mp-old', memberId: 'mem-old', lastActivityAt: longAgo,
+    }]);
+    __seed('Members/PrivateMembersData', [{
+      _id: 'mem-old', loginEmail: 'old@buyer.com', contactId: 'c10', firstName: 'Old',
+    }]);
     __seed('EmailQueue', [
-      {
-        _id: 'pp1', recipientEmail: 'old@buyer.com', recipientContactId: 'c10',
-        sequenceType: 'post_purchase', sequenceStep: 1, status: 'sent',
-        sentAt: longAgo, variables: { firstName: 'Old' },
-      },
       {
         _id: 're1', recipientEmail: 'old@buyer.com',
         sequenceType: 'reengagement', sequenceStep: 1, status: 'sent',
@@ -275,10 +276,11 @@ describe('triggerReengagement skips', () => {
   });
 
   it('skips unsubscribed contacts', async () => {
-    __seed('EmailQueue', [{
-      _id: 'pp2', recipientEmail: 'unsub@buyer.com', recipientContactId: 'c11',
-      sequenceType: 'post_purchase', sequenceStep: 1, status: 'sent',
-      sentAt: longAgo, variables: { firstName: 'Unsub' },
+    __seed('MemberPoints', [{
+      _id: 'mp-unsub', memberId: 'mem-unsub', lastActivityAt: longAgo,
+    }]);
+    __seed('Members/PrivateMembersData', [{
+      _id: 'mem-unsub', loginEmail: 'unsub@buyer.com', contactId: 'c11', firstName: 'Unsub',
     }]);
     __seed('Unsubscribes', [{
       _id: 'u1', email: 'unsub@buyer.com', sequenceType: 'reengagement',
@@ -289,10 +291,11 @@ describe('triggerReengagement skips', () => {
   });
 
   it('queues reengagement for eligible dormant contact', async () => {
-    __seed('EmailQueue', [{
-      _id: 'pp3', recipientEmail: 'eligible@buyer.com', recipientContactId: 'c12',
-      sequenceType: 'post_purchase', sequenceStep: 1, status: 'sent',
-      sentAt: longAgo, variables: { firstName: 'Eli' },
+    __seed('MemberPoints', [{
+      _id: 'mp-eli', memberId: 'mem-eli', lastActivityAt: longAgo,
+    }]);
+    __seed('Members/PrivateMembersData', [{
+      _id: 'mem-eli', loginEmail: 'eligible@buyer.com', contactId: 'c12', firstName: 'Eli',
     }]);
 
     const inserts = [];

--- a/tests/reEngagementWinBack.test.js
+++ b/tests/reEngagementWinBack.test.js
@@ -1,0 +1,219 @@
+/**
+ * reEngagementWinBack.test.js
+ * cf-bpt — Multi-step win-back + non-purchaser re-engagement.
+ *
+ * Gap 1: triggerReengagement previously seeded only from EmailQueue
+ * (post_purchase step 1 sentAt <= 90d ago). Browse-only members who never
+ * purchased — quiz takers, wishlist adders, streak earners — were invisible.
+ * Fix: seed from MemberPoints.lastActivityAt (cf-bvn).
+ *
+ * Gap 2: SEQUENCES.reengagement was 1 step. Win-back is now 3 steps —
+ * day 0 "we miss you", day 7 "here's a deal", day 21 "last chance".
+ * All 3 steps queue on the same invocation with appropriate scheduledFor
+ * offsets, mirroring the welcome/cart_recovery multi-step pattern.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __seed, __onInsert, __reset as __resetData } from './__mocks__/wix-data.js';
+import { __setSecrets, __reset as __resetSecrets } from './__mocks__/wix-secrets-backend.js';
+import {
+  triggerReengagement,
+  _SEQUENCES,
+} from '../src/backend/emailAutomation.web.js';
+
+const NOW = Date.now();
+const HUNDRED_DAYS_AGO = new Date(NOW - 100 * 24 * 60 * 60 * 1000);
+const NINETY_ONE_DAYS_AGO = new Date(NOW - 91 * 24 * 60 * 60 * 1000);
+const THIRTY_DAYS_AGO = new Date(NOW - 30 * 24 * 60 * 60 * 1000);
+
+function seedMember(memberId, email, firstName = '') {
+  __seed('Members/PrivateMembersData', [
+    { _id: memberId, loginEmail: email, contactId: `contact-${memberId}`, firstName },
+  ]);
+}
+
+beforeEach(() => {
+  __resetData();
+  __setSecrets({ RECOVERY_DISCOUNT_CODE: 'COMEBACK15' });
+});
+
+describe('SEQUENCES.reengagement — multi-step win-back definition', () => {
+  it('has 3 steps: day 0, day 7, day 21', () => {
+    expect(_SEQUENCES.reengagement.steps).toHaveLength(3);
+    expect(_SEQUENCES.reengagement.steps[0].delayHours).toBe(0);
+    expect(_SEQUENCES.reengagement.steps[1].delayHours).toBe(168);
+    expect(_SEQUENCES.reengagement.steps[2].delayHours).toBe(504);
+  });
+
+  it('has step numbering 1/2/3 with distinct template ids', () => {
+    const steps = _SEQUENCES.reengagement.steps;
+    expect(steps.map(s => s.step)).toEqual([1, 2, 3]);
+    expect(steps.map(s => s.templateId)).toEqual(['reengagement_1', 'reengagement_2', 'reengagement_3']);
+  });
+});
+
+describe('triggerReengagement — non-purchaser seeding from MemberPoints', () => {
+  it('reaches a browse-only member (wishlist/quiz, no purchase) with dormant lastActivityAt', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-browse', lastActivityAt: HUNDRED_DAYS_AGO, totalPoints: 25 },
+    ]);
+    seedMember('mem-browse', 'browse@test.com', 'Browser');
+
+    const result = await triggerReengagement();
+
+    expect(result.success).toBe(true);
+    expect(result.contacted).toBe(1);
+  });
+
+  it('does NOT reach a member active within the 90-day window', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-active', lastActivityAt: THIRTY_DAYS_AGO, totalPoints: 100 },
+    ]);
+    seedMember('mem-active', 'active@test.com', 'Active');
+
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(0);
+  });
+
+  it('skips MemberPoints records with no lastActivityAt (pre-cf-bvn rows)', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-legacy', totalPoints: 10 },
+    ]);
+    seedMember('mem-legacy', 'legacy@test.com');
+
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(0);
+  });
+
+  it('skips members whose PrivateMembersData lookup yields no email', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-noemail', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(0);
+  });
+});
+
+describe('triggerReengagement — queues all 3 steps with correct delays', () => {
+  function captureInserts() {
+    const inserted = [];
+    __onInsert((_collection, item) => {
+      if (item.sequenceType === 'reengagement') inserted.push(item);
+    });
+    return inserted;
+  }
+
+  it('queues all 3 win-back steps for a dormant member in one pass', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    seedMember('mem-1', 'm1@test.com', 'Alice');
+    const inserts = captureInserts();
+
+    const result = await triggerReengagement();
+
+    expect(result.contacted).toBe(1);
+    expect(inserts).toHaveLength(3);
+    expect(inserts.map(i => i.sequenceStep).sort()).toEqual([1, 2, 3]);
+  });
+
+  it('each queued step has the correct scheduledFor offset (0h, 168h, 504h)', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    seedMember('mem-1', 'm1@test.com');
+    const inserts = captureInserts();
+    const before = Date.now();
+
+    await triggerReengagement();
+
+    const after = Date.now();
+    const byStep = Object.fromEntries(inserts.map(i => [i.sequenceStep, i]));
+    const step1Time = new Date(byStep[1].scheduledFor).getTime();
+    const step2Time = new Date(byStep[2].scheduledFor).getTime();
+    const step3Time = new Date(byStep[3].scheduledFor).getTime();
+
+    expect(step1Time).toBeGreaterThanOrEqual(before);
+    expect(step1Time).toBeLessThanOrEqual(after);
+    const HOUR = 60 * 60 * 1000;
+    expect(step2Time - step1Time).toBeCloseTo(168 * HOUR, -3);
+    expect(step3Time - step1Time).toBeCloseTo(504 * HOUR, -3);
+  });
+
+  it('each queued step carries the distinct templateId from SEQUENCES', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    seedMember('mem-1', 'm1@test.com');
+    const inserts = captureInserts();
+
+    await triggerReengagement();
+
+    const byStep = Object.fromEntries(inserts.map(i => [i.sequenceStep, i]));
+    expect(byStep[1].templateId).toBe('reengagement_1');
+    expect(byStep[2].templateId).toBe('reengagement_2');
+    expect(byStep[3].templateId).toBe('reengagement_3');
+  });
+
+  it('propagates discount code to every step', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    seedMember('mem-1', 'm1@test.com', 'Alice');
+    const inserts = captureInserts();
+
+    await triggerReengagement();
+
+    for (const item of inserts) {
+      expect(item.variables.discountCode).toBe('COMEBACK15');
+      expect(item.variables.discountAvailable).toBe(true);
+      expect(item.variables.firstName).toBe('Alice');
+    }
+  });
+});
+
+describe('triggerReengagement — dedup across multi-step runs', () => {
+  it('skips a member who already has a queued reengagement step (any step)', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    seedMember('mem-1', 'm1@test.com');
+    __seed('EmailQueue', [
+      { _id: 'eq-dup', recipientEmail: 'm1@test.com', sequenceType: 'reengagement', sequenceStep: 1, status: 'sent' },
+    ]);
+
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(0);
+  });
+
+  it('skips unsubscribed members even when lastActivityAt is dormant', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    seedMember('mem-1', 'unsub@test.com');
+    __seed('Unsubscribes', [
+      { email: 'unsub@test.com', sequenceType: 'reengagement', unsubscribedAt: new Date() },
+    ]);
+
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(0);
+  });
+
+  it('queues all 3 steps for each of multiple dormant members', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', lastActivityAt: HUNDRED_DAYS_AGO },
+      { _id: 'mp-2', memberId: 'mem-2', lastActivityAt: NINETY_ONE_DAYS_AGO },
+    ]);
+    __seed('Members/PrivateMembersData', [
+      { _id: 'mem-1', loginEmail: 'm1@test.com', contactId: 'c1' },
+      { _id: 'mem-2', loginEmail: 'm2@test.com', contactId: 'c2' },
+    ]);
+
+    const inserts = [];
+    __onInsert((_c, item) => { if (item.sequenceType === 'reengagement') inserts.push(item); });
+
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(2);
+    expect(inserts).toHaveLength(6); // 3 steps × 2 members
+  });
+});

--- a/tests/reEngagementWinBack.test.js
+++ b/tests/reEngagementWinBack.test.js
@@ -92,6 +92,24 @@ describe('triggerReengagement — non-purchaser seeding from MemberPoints', () =
     const result = await triggerReengagement();
     expect(result.contacted).toBe(0);
   });
+
+  it('skips members whose PrivateMembersData row has an email but no contactId', async () => {
+    // Without contactId, triggeredEmails can't resolve the recipient — queuing
+    // anyway would silently drop the send or mis-target.
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-nocid', lastActivityAt: HUNDRED_DAYS_AGO },
+    ]);
+    __seed('Members/PrivateMembersData', [
+      { _id: 'mem-nocid', loginEmail: 'noc@test.com', contactId: '', firstName: 'NoCid' },
+    ]);
+
+    const inserted = [];
+    __onInsert((_c, item) => { if (item.sequenceType === 'reengagement') inserted.push(item); });
+
+    const result = await triggerReengagement();
+    expect(result.contacted).toBe(0);
+    expect(inserted).toHaveLength(0);
+  });
 });
 
 describe('triggerReengagement — queues all 3 steps with correct delays', () => {


### PR DESCRIPTION
## Summary
Closes both gaps from the cf-4hs notification audit.

**Gap 1 — non-purchasers**: \`triggerReengagement\` previously seeded from \`EmailQueue(post_purchase, sentAt <= 90d)\`, so browse-only members (quiz/wishlist/streak, no purchase) were invisible. Now seeds from \`MemberPoints.lastActivityAt\` — catches all registered members. Members with no \`lastActivityAt\` yet are skipped (avoids spraying the back catalogue on first run).

**Gap 2 — single-step win-back**: \`SEQUENCES.reengagement\` was 1 email. Now 3 steps — day 0 \"we miss you\", day 7 \"here's a deal\", day 21 \"last chance\" — queued up-front with staggered \`scheduledFor\` offsets (0h / 168h / 504h), mirroring the welcome/cart_recovery multi-step pattern. Existing dedup (any queued reengagement row) still prevents re-entry.

## Dependency on cf-bvn
\`lastActivityAt\` is populated by \`gamificationCore\` (cf-bvn, in flight in a sibling PR). Without it, \`triggerReengagement\` gracefully no-ops (skips members without the field). Once cf-bvn lands, the full non-purchaser reach kicks in automatically — no code change required here.

## Test plan
- [x] 14 new tests in \`tests/reEngagementWinBack.test.js\`: sequence shape, non-purchaser seeding, pre-cf-bvn fallthrough, multi-step queuing with correct offsets, distinct templateIds per step, discount propagation, dedup across steps, unsubscribe skip, multi-member fan-out (6 inserts for 2 members).
- [x] Updated 4 pre-existing \`triggerReengagement\` tests in \`tests/emailAutomation.test.js\` for MemberPoints-based seeding + 3-step expectation.
- [x] \`npx vitest run tests/reEngagementWinBack tests/emailAutomation.test.js\` → 103/103 pass.

## Schema note
No new collections. Uses existing \`MemberPoints.lastActivityAt\` (added by cf-bvn) and \`EmailQueue\` / \`Members/PrivateMembersData\` / \`Unsubscribes\`.

Email templates \`reengagement_2\` and \`reengagement_3\` need to be created in Wix triggered emails (Dallas / content team) before this reaches production — queued rows for missing templates will fail to dispatch, but the queue itself is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)