### PR TITLE
fix(cf-bvn): stamp MemberPoints.lastActivityAt on every gamification event

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -187,6 +187,10 @@ export const receiveGamificationEvent = webMethod(
         lastActivityDate: streakState.lastActivityDate,
         streakMultiplier: streakState.streakMultiplier,
         graceTokenUsedDate: streakState.graceTokenUsedDate ?? null,
+        // cf-bvn: authoritative "last activity" timestamp used by re-engagement
+        // dormancy detection. Written on every gamification event so browse-only
+        // members (quiz/login/wishlist with no purchase) are still reachable.
+        lastActivityAt: new Date(),
       };
 
       if (record) {
@@ -418,6 +422,7 @@ export async function seedWelcomePoints(memberId, welcomePoints = 50) {
       graceApplied: false,
       tier: getTierForPoints(welcomePoints),
       bonusSpinsAvailable: 0,
+      lastActivityAt: new Date(), // cf-bvn: seed dormancy timestamp on signup
     }, { suppressAuth: true });
 
     try {
@@ -888,6 +893,7 @@ export const recordChallengeProgress = webMethod(
           await wixData.update(MEMBER_POINTS_COLLECTION, {
             ...mp,
             totalPoints: mp.totalPoints + pointsAwarded,
+            lastActivityAt: new Date(), // cf-bvn
           }, { suppressAuth: true });
         } else {
           await wixData.insert(MEMBER_POINTS_COLLECTION, {
@@ -902,6 +908,7 @@ export const recordChallengeProgress = webMethod(
             graceApplied: false,
             tier: getTierForPoints(pointsAwarded),
             bonusSpinsAvailable: 0,
+            lastActivityAt: new Date(), // cf-bvn
           }, { suppressAuth: true });
         }
       }
@@ -988,6 +995,7 @@ export const recoverStreak = webMethod(
         currentStreakDays: 1,
         streakStartDate: todayET,    // reset so derived streak length stays accurate
         lastStreakRecoveryDate: todayET,
+        lastActivityAt: new Date(),  // cf-bvn: user-initiated action
       };
       // NOTE: When CF-ledger lands this will become two sequential wixData writes
       // with no rollback. If the ledger insert fails after the points deduction,

--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -37,6 +37,16 @@ import { insertAnalyticsEvent } from 'backend/utils/analyticsEvents';
 import { dispatchBusEvent } from 'backend/utils/eventBusDispatcher';
 
 export const MEMBER_POINTS_COLLECTION = 'MemberPoints';
+// ── MemberPoints: two activity fields, do not conflate ──────────────────────
+// lastActivityDate — ET *date string* ("2026-04-13"). Day-granularity,
+//   timezone-bound. Read by streak engine, pointsExpiryService,
+//   gamificationNotifs (streak danger), loyaltyService. NEVER compare to
+//   lastActivityAt — different type AND different granularity.
+// lastActivityAt   — UTC *Date*. Millisecond-granularity timestamp stamped
+//   on every user-initiated MemberPoints write (cf-bvn). Read by
+//   leaderboardService (tie-breaker) and re-engagement dormancy (cf-bpt).
+//   Consumers must query with a Date value, never with an ET string.
+// ──────────────────────────────────────────────────────────────────────────
 export const MEMBER_BADGES_COLLECTION = 'MemberBadges';
 const BONUS_SPIN_GRANTS_COLLECTION = 'BonusSpinGrants';
 export const CHALLENGE_PROGRESS_COLLECTION = 'MemberChallengeProgress';

--- a/tests/gamificationEventReceiver.test.js
+++ b/tests/gamificationEventReceiver.test.js
@@ -27,7 +27,7 @@ import {
   __onUpdate,
   __onInsert,
 } from './__mocks__/wix-data.js';
-import { receiveGamificationEvent, updateStreakState, updateChallengeProgress, checkWishlistMonthlyCap, recordWishlistAdd, getActiveChallenges, _resetActiveChallengesRateLimit, recordChallengeProgress, _resetRecordChallengeProgressRateLimit, recoverStreak, getRecentAchievements } from '../src/backend/gamificationEventReceiver.web.js';
+import { receiveGamificationEvent, updateStreakState, updateChallengeProgress, checkWishlistMonthlyCap, recordWishlistAdd, getActiveChallenges, _resetActiveChallengesRateLimit, recordChallengeProgress, _resetRecordChallengeProgressRateLimit, recoverStreak, getRecentAchievements, seedWelcomePoints } from '../src/backend/gamificationEventReceiver.web.js';
 import { POINT_VALUES, STREAK_RECOVERY_COST } from '../src/public/gamificationTokens.js';
 import { getTodayET, getYesterdayOf } from '../src/backend/utils/dateUtils.js';
 import { ANALYTICS_EVENTS_COLLECTION } from '../src/backend/utils/analyticsEvents.js';
@@ -2358,5 +2358,103 @@ describe('getRecentAchievements', () => {
     expect(results).toHaveLength(2);
     expect(results[0].memberNickname).toBe('Tay');
     expect(results[1].memberNickname).toBe('Tay');
+  });
+});
+
+// ── cf-bvn: lastActivityAt stamped on every MemberPoints write path ──────────
+// Dormancy detection (re-engagement win-back) reads MemberPoints.lastActivityAt.
+// If any producer path forgets to stamp it, browse-only members silently fall
+// out of the dormant cohort. These tests lock every write path.
+
+describe('cf-bvn: lastActivityAt is stamped on every MemberPoints write path', () => {
+  it('receiveGamificationEvent stamps lastActivityAt on wixData.update for existing record', async () => {
+    __seed('MemberPoints', [{ _id: 'mp-1', memberId: 'mem-1', totalPoints: 50, tier: 'Trail Blazer' }]);
+    const updated = [];
+    __onUpdate((col, item) => { if (col === 'MemberPoints') updated.push(item); });
+
+    await receiveGamificationEvent('gamification_add_to_cart', {}, 'mem-1');
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0].lastActivityAt).toBeInstanceOf(Date);
+    expect(Math.abs(updated[0].lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
+  });
+
+  it('receiveGamificationEvent stamps lastActivityAt on wixData.insert for new member', async () => {
+    const inserted = [];
+    __onInsert((col, item) => { if (col === 'MemberPoints') inserted.push(item); });
+
+    await receiveGamificationEvent('gamification_add_to_cart', {}, 'mem-new');
+
+    const mp = inserted.find(i => i.memberId === 'mem-new');
+    expect(mp).toBeDefined();
+    expect(mp.lastActivityAt).toBeInstanceOf(Date);
+    expect(Math.abs(mp.lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
+  });
+
+  it('seedWelcomePoints stamps lastActivityAt on initial insert', async () => {
+    const inserted = [];
+    __onInsert((col, item) => { if (col === 'MemberPoints') inserted.push(item); });
+
+    await seedWelcomePoints('mem-welcome', 50);
+
+    const mp = inserted.find(i => i.memberId === 'mem-welcome');
+    expect(mp).toBeDefined();
+    expect(mp.lastActivityAt).toBeInstanceOf(Date);
+    expect(Math.abs(mp.lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
+  });
+
+  it('recordChallengeProgress stamps lastActivityAt on update (existing MemberPoints, challenge completes)', async () => {
+    const CHALLENGES_COLLECTION = 'Challenges';
+    const CHALLENGE_PROGRESS_COLLECTION = 'MemberChallengeProgress';
+    const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    __seed(CHALLENGES_COLLECTION, [
+      { _id: 'ch-1', challengeId: 'ch-1', name: 'X', type: 'daily', targetCount: 1, rewardPoints: 50, expiresAt: FUTURE, active: true },
+    ]);
+    __seed(CHALLENGE_PROGRESS_COLLECTION, []);
+    __seed('MemberPoints', [{ _id: 'mp-1', memberId: 'mem-1', totalPoints: 100, tier: 'Trail Blazer' }]);
+    const updated = [];
+    __onUpdate((col, item) => { if (col === 'MemberPoints') updated.push(item); });
+
+    await recordChallengeProgress({ memberId: 'mem-1', challengeId: 'ch-1' });
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0].lastActivityAt).toBeInstanceOf(Date);
+    expect(Math.abs(updated[0].lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
+  });
+
+  it('recordChallengeProgress stamps lastActivityAt on insert (new MemberPoints, challenge completes)', async () => {
+    const CHALLENGES_COLLECTION = 'Challenges';
+    const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    __seed(CHALLENGES_COLLECTION, [
+      { _id: 'ch-1', challengeId: 'ch-1', name: 'X', type: 'daily', targetCount: 1, rewardPoints: 50, expiresAt: FUTURE, active: true },
+    ]);
+    const inserted = [];
+    __onInsert((col, item) => { if (col === 'MemberPoints') inserted.push(item); });
+
+    await recordChallengeProgress({ memberId: 'mem-new', challengeId: 'ch-1' });
+
+    const mp = inserted.find(i => i.memberId === 'mem-new');
+    expect(mp).toBeDefined();
+    expect(mp.lastActivityAt).toBeInstanceOf(Date);
+    expect(Math.abs(mp.lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
+  });
+
+  it('recoverStreak stamps lastActivityAt on updatedRecord', async () => {
+    __seed('MemberPoints', [{
+      _id: 'mp-1', memberId: 'mem-1',
+      totalPoints: 500,
+      tier: 'Mountain Guide',
+      currentStreakDays: 0,
+      lastStreakRecoveryDate: null,
+    }]);
+    const updated = [];
+    __onUpdate((col, item) => { if (col === 'MemberPoints') updated.push(item); });
+
+    const result = await recoverStreak('mem-1');
+
+    expect(result.success).toBe(true);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].lastActivityAt).toBeInstanceOf(Date);
+    expect(Math.abs(updated[0].lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
   });
 });


### PR DESCRIPTION
## Summary

Dormancy fix: `MemberPoints.lastActivityAt` was read by `leaderboardService` as a tie-breaker but never written by any code path. Downstream triggers that key off "last activity" have nothing to query.

This PR stamps `lastActivityAt: new Date()` on every `MemberPoints` write that reflects user-initiated activity:

- `receiveGamificationEvent` — main earn path (purchase, review, quiz, wishlist, streak check-in, etc.)
- `seedWelcomePoints` — first-touch signup
- `recordChallengeProgress` — challenge completion award
- `recoverStreak` — user-initiated streak recovery

## Why now

cf-4hs audit flagged that `triggerReengagement` was proxying dormancy off `EmailQueue(post_purchase sentAt)` — a signal that excludes browse-only members entirely. Fixing the consumer (cf-bpt, blaidd's branch) requires the producer side first — this PR.

## Non-goals

- The `triggerReengagement` query rewrite and multi-step win-back sequence (cf-bpt) depend on this PR and will land separately.
- `pointsExpiryService` / `rewardsStore` writes — skipped here because expiry is cron-driven (not activity) and rewardsStore burns are already a user action that also routes through `receiveGamificationEvent` upstream. Revisit if any user-facing path bypasses gamificationCore.

## Test plan

- [x] Full vitest suite: 1086 files / 39601 tests pass.
- [x] `tests/gamification*` (18 files, 630 tests) pass with the new field write.
- [ ] Post-deploy: spot-check a fresh signup has `lastActivityAt` set; confirm an existing active member's `lastActivityAt` updates after a gamification event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)