### PR TITLE
docs(cf-pfw): sync EDITOR guides to Phase 7+8 features shipped 2026-04-13

### DIFF
--- a/EDITOR-HOOKUP-GUIDE.md
+++ b/EDITOR-HOOKUP-GUIDE.md
@@ -2893,3 +2893,23 @@ Backend: `gamificationChipsService.web.js` — `getGamificationChipsForProducts(
 | `gamificationChip` | Box | Hidden by default; shown when member earned relevant badge |
 | `chipBadgeIcon` | Image | Badge icon, 24×24px |
 | `chipLabel` | Text | e.g. "You've earned a badge here!" |
+
+---
+
+## Feature Log
+
+### Phase 7 Shipped (2026-04-13)
+
+- **GA4 consent gate** (`ga4Tracking.js`): all `fire*` analytics events are now gated behind `wixPrivacy.getCurrentConsentPolicy().analytics === true`. `fireGA4Event` added with event-name sanitization matching `fireCustomEvent`. Raw callers auto-gated — no call-site migration needed.
+- **TikTok consent decoupling** (PR #1050): TikTok fires via the `pixelConsentService` queue regardless of analytics consent; retargeting requires `analytics && advertising`.
+- **Local SEO data fix** (PR #1046): phone `+1-828-252-9449`, hours Wed–Sat 10–17.
+- **Blog post topic cluster backlink** (PR #1048): `Blog Post.js` injects `isPartOf` schema + cluster nav.
+- **OG image CDN normalize** (PR #1045): `wix:image://` URIs resolved to CDN URLs.
+
+### Phase 8 Shipped (2026-04-13)
+
+- **Tier upgrade email + push** (PR #1051): `gamificationNotifs.web.js::notifyTierUpgrade()`.
+- **Phase 8 trigger verification** complete (audit cf-4hs / cf-538): welcome (`wixMembers_onMemberCreated`), cart-abandon (hourly cron `triggerAbandonedCartRecovery`), post-purchase (`wixEcom_onOrderDelivered`) all wired.
+- **Merchant Center + sitemap verification** (cf-xe8): feed service live with all GMC required fields; 249 tests green.
+
+> No editor hookup action required for this phase. Element nicknames and hookup status are unchanged — this log is informational only.

--- a/EDITOR_HOOKUP_GUIDE.html
+++ b/EDITOR_HOOKUP_GUIDE.html
@@ -6547,5 +6547,28 @@ document.getElementById('priorityFilter').addEventListener('change', render);
 // Initial render
 render();
 </script>
+
+<section style="max-width:1200px;margin:32px auto;padding:24px;background:var(--off-white);border:1px solid var(--espresso-light);border-radius:var(--radius-lg);font-family:var(--font-body);color:var(--espresso);">
+  <h2 style="font-family:var(--font-heading);margin-top:0;">Feature Log</h2>
+
+  <h3 id="phase-7-shipped-2026-04-13">Phase 7 Shipped (2026-04-13)</h3>
+  <ul>
+    <li><strong>GA4 consent gate</strong> (<code>ga4Tracking.js</code>): all fire* analytics events are now gated behind <code>wixPrivacy.getCurrentConsentPolicy().analytics === true</code>. <code>fireGA4Event</code> added with event-name sanitization matching <code>fireCustomEvent</code>. Raw callers auto-gated — no call-site migration needed.</li>
+    <li><strong>TikTok consent decoupling</strong> (PR #1050): TikTok fires via the pixelConsentService queue regardless of analytics consent; retargeting gated on <code>analytics &amp;&amp; advertising</code>.</li>
+    <li><strong>Local SEO data fix</strong> (PR #1046): phone <code>+1-828-252-9449</code>, hours Wed–Sat 10–17.</li>
+    <li><strong>Blog post topic cluster backlink</strong> (PR #1048): <code>Blog Post.js</code> injects <code>isPartOf</code> schema + cluster nav.</li>
+    <li><strong>OG image CDN normalize</strong> (PR #1045): <code>wix:image://</code> URIs resolved to CDN URLs.</li>
+  </ul>
+
+  <h3 id="phase-8-shipped-2026-04-13">Phase 8 Shipped (2026-04-13)</h3>
+  <ul>
+    <li><strong>Tier upgrade email + push</strong> (PR #1051): <code>gamificationNotifs.web.js::notifyTierUpgrade()</code>.</li>
+    <li><strong>Phase 8 trigger verification</strong> complete (audit cf-4hs / cf-538): welcome (<code>wixMembers_onMemberCreated</code>), cart-abandon (hourly cron), post-purchase (<code>wixEcom_onOrderDelivered</code>) all wired.</li>
+    <li><strong>Merchant Center + sitemap verification</strong> (cf-xe8): feed service live with all GMC required fields; 249 tests green.</li>
+  </ul>
+
+  <p style="font-size:13px;color:var(--espresso-light);margin-bottom:0;"><em>No editor hookup action required for this phase. Element nicknames and hookup status are unchanged — this log is informational only.</em></p>
+</section>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

Per standing order, append a Feature Log to both EDITOR_HOOKUP_GUIDE.html and EDITOR-HOOKUP-GUIDE.md summarizing Phase 7 (SEO/analytics) and Phase 8 (triggered emails) work shipped 2026-04-13.

**Phase 7:**
- GA4 consent gate (raw `fire*` functions now gated on `wixPrivacy.analytics`, `fireGA4Event` added with name sanitization)
- TikTok consent decoupling (PR #1050)
- Local SEO data fix (PR #1046)
- Blog post topic cluster backlink (PR #1048)
- OG image CDN normalize (PR #1045)

**Phase 8:**
- Tier upgrade email + push (PR #1051)
- Trigger verification cf-538: welcome/cart-abandon/post-purchase all wired
- Merchant Center + sitemap verification cf-xe8 (249 tests green)

Element nicknames and hookup status are unchanged — informational log only.

## Test plan

- [x] `git diff --stat` shows only the two guide files changed
- [x] HTML section renders below dynamic `#mainContent` area, uses existing CSS tokens
- [x] Markdown section appended at end, preserves prior structure

Closes cf-pfw

🤖 Generated with [Claude Code](https://claude.com/claude-code)