### PR TITLE
fix(cf-f2h): ShareYourRoom announce() missing $w arg — a11y dead code

### DIFF
--- a/src/public/ShareYourRoom.js
+++ b/src/public/ShareYourRoom.js
@@ -141,7 +141,7 @@ function openModal($w, state) {
   try { $w('#shareYourRoomModal').expand(); } catch (e) {}
   try { $w('#shareYourRoomOverlay').expand(); } catch (e) {}
 
-  announce('Share your room photo dialog opened');
+  announce($w, 'Share your room photo dialog opened');
   trackEvent('ugc_modal_open', {
     productId: state && state.product && state.product._id,
   });
@@ -151,7 +151,7 @@ function closeModal($w) {
   _isOpen = false;
   try { $w('#shareYourRoomModal').collapse(); } catch (e) {}
   try { $w('#shareYourRoomOverlay').collapse(); } catch (e) {}
-  announce('Share your room dialog closed');
+  announce($w, 'Share your room dialog closed');
 }
 
 async function handleUploadChange($w) {
@@ -232,7 +232,7 @@ async function handleSubmit($w, product) {
     if (result && result.success) {
       try { $w('#shareYourRoomForm').collapse(); } catch (e) {}
       try { $w('#shareYourRoomSuccess').expand(); } catch (e) {}
-      announce('Photo submitted! It will appear in the gallery after review.');
+      announce($w, 'Photo submitted! It will appear in the gallery after review.');
       trackEvent('ugc_photo_submitted', {
         roomType,
         productId: product._id,

--- a/tests/shareYourRoom.test.js
+++ b/tests/shareYourRoom.test.js
@@ -26,12 +26,14 @@ vi.mock('backend/ugcService.web', () => ({
   submitUGCPhoto: (...args) => mockSubmitUGCPhoto(...args),
 }));
 
+const mockAnnounce = vi.fn();
 vi.mock('public/a11yHelpers', () => ({
-  announce: vi.fn(),
+  announce: (...args) => mockAnnounce(...args),
 }));
 
+const mockTrackEvent = vi.fn();
 vi.mock('public/engagementTracker', () => ({
-  trackEvent: vi.fn(),
+  trackEvent: (...args) => mockTrackEvent(...args),
 }));
 
 // ── $w Mock Factory ──────────────────────────────────────────────────────────
@@ -143,6 +145,13 @@ describe('ShareYourRoom', () => {
     expect(get('#shareYourRoomModal').expand).toHaveBeenCalled();
   });
 
+  it('announces modal open to screen readers with $w', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
+    handler();
+    expect(mockAnnounce).toHaveBeenCalledWith($w, expect.stringContaining('opened'));
+  });
+
   it('collapses login prompt for logged-in member', () => {
     initShareYourRoomCTA($w, MEMBER_STATE);
     const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
@@ -179,6 +188,13 @@ describe('ShareYourRoom', () => {
     const closeHandler = get('#shareYourRoomClose').onClick.mock.calls[0][0];
     closeHandler();
     expect(get('#shareYourRoomModal').collapse).toHaveBeenCalled();
+  });
+
+  it('announces modal close to screen readers with $w', () => {
+    initShareYourRoomCTA($w, MEMBER_STATE);
+    const closeHandler = get('#shareYourRoomClose').onClick.mock.calls[0][0];
+    closeHandler();
+    expect(mockAnnounce).toHaveBeenCalledWith($w, expect.stringContaining('closed'));
   });
 
   it('collapses modal when overlay clicked', () => {
@@ -309,6 +325,11 @@ describe('ShareYourRoom', () => {
 
     expect(get('#shareYourRoomSuccess').expand).toHaveBeenCalled();
     expect(get('#shareYourRoomForm').collapse).toHaveBeenCalled();
+    expect(mockAnnounce).toHaveBeenCalledWith(local$w, expect.stringContaining('submitted'));
+    expect(mockTrackEvent).toHaveBeenCalledWith('ugc_photo_submitted', expect.objectContaining({
+      roomType: 'bedroom',
+      productId: 'prod-1',
+    }));
   });
 
   it('shows API error and re-enables submit on failure', async () => {


### PR DESCRIPTION
## Summary
- `announce()` signature is `($w, message, priority)`. All 3 calls in `src/public/ShareYourRoom.js` passed only a string, so `$w` received the string, `message` was `undefined`, and `announce()` returned on the `!message` guard.
- Result: modal-open, modal-close, and submit-success screen reader announcements were silently dead in production.
- Fix: pass `$w` as first arg to all three calls.
- Tests: assert `announce` was called with `$w` on modal open/close; assert `trackEvent('ugc_photo_submitted', ...)` was called on submit success.

Closes cf-f2h.

## Test plan
- [x] `npx vitest run tests/shareYourRoom.test.js` — 31/31 pass
- [x] All 3 announce calls pass `$w` as first argument
- [x] Open / close / submit-success assertions added