### PR TITLE
fix(cf-gyi): wire processChallengeNotifSMSQueue into jobs.config cron

### DIFF
--- a/src/backend/jobs.config
+++ b/src/backend/jobs.config
@@ -19,6 +19,15 @@ export function config() {
       },
     },
 
+    // Drain ChallengeNotifSMSQueue — send pending challenge alert SMS via Twilio (CF-qhdo)
+    processChallengeNotifSMSQueue: {
+      functionLocation: '/gamificationNotifs.web.js',
+      description: 'Drain ChallengeNotifSMSQueue — send pending SMS challenge alerts',
+      executionConfig: {
+        cronExpression: '*/15 * * * *',
+      },
+    },
+
     // Check for abandoned carts and queue recovery emails every hour
     triggerAbandonedCartRecovery: {
       functionLocation: '/emailAutomation.web.js',

--- a/tests/challengeNotificationPipeline.test.js
+++ b/tests/challengeNotificationPipeline.test.js
@@ -230,3 +230,18 @@ describe('processChallengeNotifSMSQueue — in-flight lock', () => {
     expect(r2.skipped).toBeUndefined();
   });
 });
+
+describe('jobs.config — processChallengeNotifSMSQueue entry', () => {
+  it('registers processChallengeNotifSMSQueue pointing to gamificationNotifs.web.js', async () => {
+    const { config } = await import('../src/backend/jobs.config');
+    const jobs = config();
+    expect(jobs.processChallengeNotifSMSQueue).toBeDefined();
+    expect(jobs.processChallengeNotifSMSQueue.functionLocation).toBe('/gamificationNotifs.web.js');
+  });
+
+  it('schedules processChallengeNotifSMSQueue every 15 minutes to match processEmailQueue cadence', async () => {
+    const { config } = await import('../src/backend/jobs.config');
+    const jobs = config();
+    expect(jobs.processChallengeNotifSMSQueue.executionConfig.cronExpression).toBe('*/15 * * * *');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up from cf-9r9 audit. `processChallengeNotifSMSQueue` existed in `gamificationNotifs.web.js` with an in-flight lock and per-item error handling, but no cron entry pointed at it — `ChallengeNotifSMSQueue` would have filled without ever draining once Twilio secrets are populated.

- `src/backend/jobs.config`: add `processChallengeNotifSMSQueue` entry → `/gamificationNotifs.web.js`, cron `*/15 * * * *` (matches `processEmailQueue` cadence).
- `tests/challengeNotificationPipeline.test.js`: new `describe` block asserts registration + cadence.

## Test plan

- [x] `challengeNotificationPipeline` + `gamificationNotifs` + `lifecycleCron` + `socialStoryCron` → 137/137 pass locally
- [x] `jobs.config` parses clean (ESM import returns 23 jobs incl. new entry)
- [ ] CI green

Closes bead: cf-gyi