### PR TITLE
feat(cf-fsm): wire review_request sequence via daily cron + HTTP endpoint

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -9,7 +9,7 @@ import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
 import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence, getCampaignAnalytics } from 'backend/emailAutomation.web';
-import { scanAndTriggerWinback } from 'backend/marketingSequences.web';
+import { scanAndTriggerWinback, runReviewRequestEmails } from 'backend/marketingSequences.web';
 import { processContentSchedule } from 'backend/contentScheduler.web';
 import { sendWeeklyBlogDigest } from 'backend/blogDigestService.web';
 import { getAssemblyFollowUpData } from 'backend/postPurchaseCare.web';
@@ -843,6 +843,50 @@ export async function get_scanAndTriggerWinbackCron(request) {
     });
   } catch (err) {
     console.error('HTTP function error (scanAndTriggerWinbackCron):', err);
+    return serverError({
+      body: JSON.stringify({ error: 'Internal server error' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// ── Review Request Cron (cf-fsm) ──────────────────────────────────────
+// URL: GET https://www.carolinafutons.com/_functions/runReviewRequestEmailsCron
+// Fires review_request email sequence for orders placed 7 days ago (±1 day).
+// Pass X-Cron-Secret header for auth (ALERT_CRON_KEY in Secrets Manager).
+// Primary schedule is jobs.config `runReviewRequestEmails` (daily 10 AM EST).
+// This HTTP endpoint is a manual/external trigger for the same logic.
+export async function get_runReviewRequestEmailsCron(request) {
+  try {
+    const { getSecret } = await import('wix-secrets-backend');
+    const cronKey = await getSecret('ALERT_CRON_KEY');
+    const requestKey = request.headers?.['x-cron-secret'];
+
+    if (!cronKey || !requestKey || !timingSafeEqual(requestKey, cronKey)) {
+      return forbidden({
+        body: JSON.stringify({ error: 'Unauthorized' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const result = await runReviewRequestEmails();
+
+    return ok({
+      body: JSON.stringify({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+        ordersScanned: result.ordersScanned || 0,
+        triggered: result.triggered || 0,
+        skipped: result.skipped || 0,
+        failed: result.failed || 0,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (err) {
+    console.error('HTTP function error (runReviewRequestEmailsCron):', err);
     return serverError({
       body: JSON.stringify({ error: 'Internal server error' }),
       headers: { 'Content-Type': 'application/json' },

--- a/src/backend/jobs.config
+++ b/src/backend/jobs.config
@@ -226,6 +226,17 @@ export function config() {
       },
     },
 
+    // cf-fsm: Daily review-request emails at 10 AM EST — fires review_request
+    // sequence for orders placed 7 days ago (±1 day tolerance window).
+    // Idempotent via enqueueEmail dedup on (email, sequenceType, step).
+    runReviewRequestEmails: {
+      functionLocation: '/marketingSequences.web.js',
+      description: 'Scan Stores/Orders placed 6–8 days ago and enqueue review-request email sequence',
+      executionConfig: {
+        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+      },
+    },
+
     // cf-2yd: Daily streak-at-risk push notifications at 9 AM EST.
     // Finds members whose streak is intact but who haven't acted today
     // (lastActivityDate = yesterday ET) and sends a push reminder.

--- a/src/backend/marketingSequences.web.js
+++ b/src/backend/marketingSequences.web.js
@@ -209,6 +209,77 @@ export const triggerReviewRequestSequence = webMethod(Permissions.Admin, async (
   }
 });
 
+// ── runReviewRequestEmails (cf-fsm) ───────────────────────────────────────────
+
+const ORDERS_COLLECTION = 'Stores/Orders';
+const REVIEW_WINDOW = { minDays: 6, maxDays: 8 };
+const REVIEW_LOOKBACK_DAYS = REVIEW_WINDOW.maxDays + 1;
+const ORDERS_PAGE_SIZE = 100;
+
+async function fetchOrdersInReviewWindow() {
+  const cutoff = new Date(Date.now() - REVIEW_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+  const results = [];
+  let offset = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch = await wixData
+      .query(ORDERS_COLLECTION)
+      .ge('_createdDate', cutoff)
+      .limit(ORDERS_PAGE_SIZE)
+      .skip(offset)
+      .find({ suppressAuth: true });
+    results.push(...batch.items);
+    if (batch.items.length < ORDERS_PAGE_SIZE) break;
+    offset += ORDERS_PAGE_SIZE;
+  }
+  return results;
+}
+
+/**
+ * Daily cron entrypoint: finds orders placed 6–8 days ago and enqueues the
+ * review-request sequence for each buyer. Idempotent via enqueueEmail's
+ * (email, sequenceType, step) dedup — repeat fires within the window are no-ops.
+ *
+ * @returns {Promise<{ success: boolean, ordersScanned: number, triggered: number, skipped: number, failed: number }>}
+ */
+export const runReviewRequestEmails = webMethod(Permissions.Admin, async () => {
+  try {
+    const orders = await fetchOrdersInReviewWindow();
+    const now = Date.now();
+    let triggered = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const order of orders) {
+      const orderDate = order._createdDate;
+      if (!orderDate) { skipped++; continue; }
+
+      const daysSince = Math.floor((now - new Date(orderDate).getTime()) / (24 * 60 * 60 * 1000));
+      if (daysSince < REVIEW_WINDOW.minDays || daysSince > REVIEW_WINDOW.maxDays) continue;
+
+      const email = order.buyerInfo?.email || '';
+      const contactId = order.buyerInfo?.contactId || order.buyerInfo?.memberId || '';
+      if (!email || !contactId) { skipped++; continue; }
+
+      const firstName = order.billingInfo?.firstName || order.buyerInfo?.firstName || '';
+      const result = await triggerReviewRequestSequence({
+        email,
+        contactId,
+        firstName,
+        orderId: order._id,
+      });
+
+      if (result?.success) triggered++;
+      else failed++;
+    }
+
+    return { success: true, ordersScanned: orders.length, triggered, skipped, failed };
+  } catch (err) {
+    logError('runReviewRequestEmails failed', err);
+    return { success: false, ordersScanned: 0, triggered: 0, skipped: 0, failed: 0 };
+  }
+});
+
 // ── triggerWinbackSequence ────────────────────────────────────────────────────
 
 /**
@@ -243,7 +314,6 @@ export const triggerWinbackSequence = webMethod(Permissions.Admin, async (params
 
 // ── scanAndTriggerWinback ─────────────────────────────────────────────────────
 
-const ORDERS_COLLECTION = 'Stores/Orders';
 // Weekly Monday cron. Window must cover at least one week so a customer who
 // hit day 30 the day after last Monday's run isn't silently skipped. 30–37
 // days picks up every lapsed buyer exactly once without backfilling history.

--- a/tests/runReviewRequestEmails.test.js
+++ b/tests/runReviewRequestEmails.test.js
@@ -1,0 +1,130 @@
+/**
+ * cf-fsm — runReviewRequestEmails daily cron.
+ * Scans Stores/Orders placed 6–8 days ago (±1 day tolerance around day 7) and
+ * invokes triggerReviewRequestSequence for each order with a valid email+contactId.
+ * Dedup is delegated to enqueueEmail (via EmailQueue), so repeat firings for the
+ * same order within its window are safe and return skipped.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  __seed,
+  __reset as resetData,
+  __getInserted,
+} from './__mocks__/wix-data.js';
+import { __reset as resetCRM } from './__mocks__/wix-crm-backend.js';
+
+import {
+  runReviewRequestEmails,
+  EMAIL_SEQUENCES_COLLECTION,
+} from '../src/backend/marketingSequences.web.js';
+import { EMAIL_QUEUE_COLLECTION } from '../src/backend/emailQueueService.web.js';
+
+const ORDERS_COLLECTION = 'Stores/Orders';
+
+function daysAgo(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+function makeOrder(overrides = {}) {
+  return {
+    _id: `order-${Math.random().toString(36).slice(2, 8)}`,
+    _createdDate: daysAgo(7),
+    buyerInfo: {
+      email: 'buyer@example.com',
+      contactId: 'contact-1',
+      memberId: 'mem-1',
+      firstName: 'Buyer',
+    },
+    ...overrides,
+  };
+}
+
+function seedReviewRequestStep() {
+  __seed(EMAIL_SEQUENCES_COLLECTION, [{
+    _id: 'seq-rr-1',
+    sequenceType: 'review_request',
+    step: 1,
+    templateId: 'tpl-review-1',
+    delayHours: 168,
+    subject: 'How are you liking it?',
+    active: true,
+  }]);
+}
+
+beforeEach(() => {
+  resetData();
+  resetCRM();
+});
+
+describe('runReviewRequestEmails — daily cron (cf-fsm)', () => {
+  it('triggers review request for orders placed 7 days ago', async () => {
+    seedReviewRequestStep();
+    __seed(ORDERS_COLLECTION, [makeOrder({ _id: 'order-a', _createdDate: daysAgo(7) })]);
+
+    const result = await runReviewRequestEmails();
+
+    expect(result.success).toBe(true);
+    expect(result.ordersScanned).toBe(1);
+    expect(result.triggered).toBe(1);
+
+    const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
+    expect(queued).toHaveLength(1);
+    expect(queued[0].sequenceType).toBe('review_request');
+    expect(queued[0].recipientEmail).toBe('buyer@example.com');
+  });
+
+  it('fires within ±1 day window (6 and 8 days)', async () => {
+    seedReviewRequestStep();
+    __seed(ORDERS_COLLECTION, [
+      makeOrder({ _id: 'order-6d', _createdDate: daysAgo(6), buyerInfo: { email: 'a@x.com', contactId: 'c-a' } }),
+      makeOrder({ _id: 'order-8d', _createdDate: daysAgo(8), buyerInfo: { email: 'b@x.com', contactId: 'c-b' } }),
+    ]);
+
+    const result = await runReviewRequestEmails();
+    expect(result.triggered).toBe(2);
+  });
+
+  it('skips orders outside the window (5 and 9 days)', async () => {
+    seedReviewRequestStep();
+    __seed(ORDERS_COLLECTION, [
+      makeOrder({ _id: 'order-5d', _createdDate: daysAgo(5), buyerInfo: { email: 'a@x.com', contactId: 'c-a' } }),
+      makeOrder({ _id: 'order-9d', _createdDate: daysAgo(9), buyerInfo: { email: 'b@x.com', contactId: 'c-b' } }),
+    ]);
+
+    const result = await runReviewRequestEmails();
+    expect(result.triggered).toBe(0);
+    expect(__getInserted(EMAIL_QUEUE_COLLECTION)).toHaveLength(0);
+  });
+
+  it('skips orders missing email or contactId', async () => {
+    seedReviewRequestStep();
+    __seed(ORDERS_COLLECTION, [
+      makeOrder({ _id: 'order-noemail', buyerInfo: { contactId: 'c-x' } }),
+      makeOrder({ _id: 'order-nocontact', buyerInfo: { email: 'a@x.com' } }),
+      makeOrder({ _id: 'order-ok', buyerInfo: { email: 'ok@x.com', contactId: 'c-ok' } }),
+    ]);
+
+    const result = await runReviewRequestEmails();
+    expect(result.triggered).toBe(1);
+    expect(result.skipped).toBe(2);
+  });
+
+  it('is idempotent — second run within the same window is a no-op (dedup in enqueueEmail)', async () => {
+    seedReviewRequestStep();
+    __seed(ORDERS_COLLECTION, [makeOrder({ _id: 'order-dup', buyerInfo: { email: 'dup@x.com', contactId: 'c-dup' } })]);
+
+    await runReviewRequestEmails();
+    await runReviewRequestEmails();
+
+    const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
+    expect(queued).toHaveLength(1);
+  });
+
+  it('returns success:false on unexpected failure', async () => {
+    const { __setQueryError } = await import('./__mocks__/wix-data.js');
+    __setQueryError(ORDERS_COLLECTION, new Error('boom'));
+
+    const result = await runReviewRequestEmails();
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `runReviewRequestEmails` (marketingSequences.web.js) — scans Stores/Orders placed 6–8 days ago and enqueues the `review_request` sequence for each buyer with a valid email+contactId.
- Wires it into jobs.config as a daily cron at 10 AM EST (`0 15 * * *`).
- Adds `get_runReviewRequestEmailsCron` HTTP function (auth via `X-Cron-Secret`) for manual/external triggering.
- Closes the cf-pmu audit gap: `triggerReviewRequestSequence` was orphaned — exported but never called. Now it fires daily.

## Design notes
- **Window**: 6–8 days (±1 day around day 7), matching the `DAY7_WINDOW` convention in lifecycleCron.
- **Dedup**: delegated to `enqueueEmail`, which dedups on `(recipientEmail, sequenceType, sequenceStep)`. Repeat firings within the window are safe no-ops.
- **Query shape**: uses `.ge('_createdDate', cutoff)` + paginated `skip/limit` to avoid O(N²) scans — same pattern as `fetchAllOrders` in lifecycleCron.

## Test plan
- [x] New `tests/runReviewRequestEmails.test.js` — 6 tests covering: 7-day fire, ±1 day window, outside-window skip, missing email/contactId skip, idempotency (dedup), and graceful failure.
- [x] Existing `tests/marketingSequences.test.js` — 38 tests still green (44/44 total for marketingSequences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)