### PR TITLE
feat(cf-amx): wire triggerWinbackSequence into weekly cron + HTTP endpoint

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -9,6 +9,7 @@ import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
 import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence, getCampaignAnalytics } from 'backend/emailAutomation.web';
+import { scanAndTriggerWinback } from 'backend/marketingSequences.web';
 import { processContentSchedule } from 'backend/contentScheduler.web';
 import { sendWeeklyBlogDigest } from 'backend/blogDigestService.web';
 import { getAssemblyFollowUpData } from 'backend/postPurchaseCare.web';
@@ -802,6 +803,46 @@ export async function get_triggerReengagementCron(request) {
     });
   } catch (err) {
     console.error('HTTP function error (triggerReengagementCron):', err);
+    return serverError({
+      body: JSON.stringify({ error: 'Internal server error' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// ── cf-amx: Winback Scanner Cron ───────────────────────────────────────
+// URL: GET https://www.carolinafutons.com/_functions/scanAndTriggerWinbackCron
+// Weekly Monday 10 AM EST via jobs.config. Also callable by external cron.
+// Pass X-Cron-Secret header for auth (ALERT_CRON_KEY in Secrets Manager).
+export async function get_scanAndTriggerWinbackCron(request) {
+  try {
+    const { getSecret } = await import('wix-secrets-backend');
+    const cronKey = await getSecret('ALERT_CRON_KEY');
+    const requestKey = request.headers?.['x-cron-secret'];
+
+    if (!cronKey || !requestKey || !timingSafeEqual(requestKey, cronKey)) {
+      return forbidden({
+        body: JSON.stringify({ error: 'Unauthorized' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const result = await scanAndTriggerWinback();
+
+    return ok({
+      body: JSON.stringify({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+        scanned: result.scanned || 0,
+        triggered: result.triggered || 0,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (err) {
+    console.error('HTTP function error (scanAndTriggerWinbackCron):', err);
     return serverError({
       body: JSON.stringify({ error: 'Internal server error' }),
       headers: { 'Content-Type': 'application/json' },

--- a/src/backend/jobs.config
+++ b/src/backend/jobs.config
@@ -214,6 +214,18 @@ export function config() {
       },
     },
 
+    // cf-amx: Weekly winback scanner — finds buyers whose most recent order was
+    // 30-37 days ago and triggers the winback email sequence via
+    // marketingSequences.triggerWinbackSequence. EmailQueue-level dedup keeps
+    // re-runs idempotent.
+    scanAndTriggerWinback: {
+      functionLocation: '/marketingSequences.web.js',
+      description: 'Scan Stores/Orders for buyers 30-37 days post-purchase and trigger the winback email sequence',
+      executionConfig: {
+        cronExpression: '0 15 * * 1', // 15:00 UTC Monday = 10 AM EST / 11 AM EDT
+      },
+    },
+
     // cf-2yd: Daily streak-at-risk push notifications at 9 AM EST.
     // Finds members whose streak is intact but who haven't acted today
     // (lastActivityDate = yesterday ET) and sends a push reminder.

--- a/src/backend/marketingSequences.web.js
+++ b/src/backend/marketingSequences.web.js
@@ -240,3 +240,59 @@ export const triggerWinbackSequence = webMethod(Permissions.Admin, async (params
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
+
+// ── scanAndTriggerWinback ─────────────────────────────────────────────────────
+
+const ORDERS_COLLECTION = 'Stores/Orders';
+// Weekly Monday cron. Window must cover at least one week so a customer who
+// hit day 30 the day after last Monday's run isn't silently skipped. 30–37
+// days picks up every lapsed buyer exactly once without backfilling history.
+const WINBACK_WINDOW_MIN_DAYS = 30;
+const WINBACK_WINDOW_MAX_DAYS = 37;
+
+/**
+ * Cron orchestrator: scans Stores/Orders for buyers whose most recent order
+ * landed in the winback window (30–37 days ago) and fires triggerWinbackSequence
+ * per unique buyer. enqueueEmail-level dedup in EmailQueue prevents double-sends
+ * across runs; an in-run Set prevents double-triggering for buyers with multiple
+ * orders in the same window.
+ *
+ * @function scanAndTriggerWinback
+ * @returns {Promise<{success: boolean, scanned: number, triggered: number, error?: string}>}
+ * @permission Admin
+ */
+export const scanAndTriggerWinback = webMethod(Permissions.Admin, async () => {
+  try {
+    const now = Date.now();
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const minDate = new Date(now - WINBACK_WINDOW_MAX_DAYS * DAY_MS);
+    const maxDate = new Date(now - WINBACK_WINDOW_MIN_DAYS * DAY_MS);
+
+    const orders = await wixData.query(ORDERS_COLLECTION)
+      .ge('_createdDate', minDate)
+      .le('_createdDate', maxDate)
+      .limit(1000)
+      .find({ suppressAuth: true });
+
+    const scanned = orders.items.length;
+    const seenEmails = new Set();
+    let triggered = 0;
+
+    for (const order of orders.items) {
+      const email = order?.buyerInfo?.email || '';
+      const contactId = order?.buyerInfo?.contactId || '';
+      const firstName = order?.buyerInfo?.firstName || '';
+      if (!email || !contactId) continue;
+      if (seenEmails.has(email)) continue;
+      seenEmails.add(email);
+
+      const result = await triggerWinbackSequence({ email, contactId, firstName });
+      if (result?.success && result?.enqueued > 0) triggered++;
+    }
+
+    return { success: true, scanned, triggered };
+  } catch (err) {
+    logError('scanAndTriggerWinback failed', err);
+    return { success: false, scanned: 0, triggered: 0, error: err?.message ?? 'unknown error' };
+  }
+});

--- a/tests/marketingSequences.test.js
+++ b/tests/marketingSequences.test.js
@@ -26,6 +26,7 @@ import {
   triggerPostPurchaseSequence,
   triggerReviewRequestSequence,
   triggerWinbackSequence,
+  scanAndTriggerWinback,
   EMAIL_SEQUENCES_COLLECTION,
 } from '../src/backend/marketingSequences.web.js';
 
@@ -652,5 +653,136 @@ describe('triggerWinbackSequence — null params', () => {
     const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
     const vars = JSON.parse(queued[0].variables);
     expect(vars.firstName).toBe('');
+  });
+});
+
+// ── scanAndTriggerWinback — cf-amx cron scanner ───────────────────────────────
+
+describe('scanAndTriggerWinback — cf-amx', () => {
+  const ORDERS = 'Stores/Orders';
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  function makeOrder(overrides = {}) {
+    return {
+      _id: overrides._id ?? `order-${Math.random().toString(36).slice(2, 8)}`,
+      _createdDate: overrides._createdDate ?? new Date(Date.now() - 30 * DAY_MS),
+      buyerInfo: overrides.buyerInfo ?? {
+        email: 'buyer@example.com',
+        contactId: 'contact-1',
+        firstName: 'Alice',
+      },
+    };
+  }
+
+  it('triggers winback for an order placed ~30 days ago', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(EMAIL_QUEUE_COLLECTION, []);
+    __seed(ORDERS, [makeOrder({ _createdDate: new Date(Date.now() - 30 * DAY_MS) })]);
+
+    const result = await scanAndTriggerWinback();
+
+    expect(result.success).toBe(true);
+    expect(result.triggered).toBe(1);
+    const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
+    expect(queued).toHaveLength(1);
+    expect(queued[0].sequenceType).toBe('winback');
+  });
+
+  it('skips orders outside the 30–37 day lookback window', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(EMAIL_QUEUE_COLLECTION, []);
+    __seed(ORDERS, [
+      makeOrder({ _id: 'too-recent', _createdDate: new Date(Date.now() - 20 * DAY_MS) }),
+      makeOrder({ _id: 'too-old',    _createdDate: new Date(Date.now() - 60 * DAY_MS) }),
+    ]);
+
+    const result = await scanAndTriggerWinback();
+    expect(result.triggered).toBe(0);
+    expect(__getInserted(EMAIL_QUEUE_COLLECTION)).toHaveLength(0);
+  });
+
+  it('dedups multiple orders from the same buyer to a single winback trigger', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(EMAIL_QUEUE_COLLECTION, []);
+    const buyer = { email: 'repeat@example.com', contactId: 'c-repeat', firstName: 'Repeat' };
+    __seed(ORDERS, [
+      makeOrder({ _id: 'o1', _createdDate: new Date(Date.now() - 30 * DAY_MS), buyerInfo: buyer }),
+      makeOrder({ _id: 'o2', _createdDate: new Date(Date.now() - 32 * DAY_MS), buyerInfo: buyer }),
+    ]);
+
+    const result = await scanAndTriggerWinback();
+    expect(result.triggered).toBe(1);
+    expect(__getInserted(EMAIL_QUEUE_COLLECTION)).toHaveLength(1);
+  });
+
+  it('skips buyers whose winback is already in EmailQueue (idempotent re-run)', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(ORDERS, [makeOrder({ _createdDate: new Date(Date.now() - 30 * DAY_MS) })]);
+    __seed(EMAIL_QUEUE_COLLECTION, [{
+      _id: 'dup-wb',
+      recipientEmail: 'buyer@example.com',
+      sequenceType: 'winback',
+      sequenceStep: 1,
+      status: 'pending',
+    }]);
+
+    await scanAndTriggerWinback();
+    // enqueueEmail dedup prevents a second queue row — only the pre-seeded row
+    // should remain.
+    const winbackRows = __getInserted(EMAIL_QUEUE_COLLECTION)
+      .filter(r => r.sequenceType === 'winback');
+    expect(winbackRows).toHaveLength(1);
+    expect(winbackRows[0]._id).toBe('dup-wb');
+  });
+
+  it('skips orders missing buyerInfo.email', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(EMAIL_QUEUE_COLLECTION, []);
+    __seed(ORDERS, [makeOrder({
+      _createdDate: new Date(Date.now() - 30 * DAY_MS),
+      buyerInfo: { email: '', contactId: 'c-1', firstName: '' },
+    })]);
+
+    const result = await scanAndTriggerWinback();
+    expect(result.triggered).toBe(0);
+  });
+
+  it('skips orders missing buyerInfo.contactId', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(EMAIL_QUEUE_COLLECTION, []);
+    __seed(ORDERS, [makeOrder({
+      _createdDate: new Date(Date.now() - 30 * DAY_MS),
+      buyerInfo: { email: 'no-cid@example.com', contactId: '', firstName: '' },
+    })]);
+
+    const result = await scanAndTriggerWinback();
+    expect(result.triggered).toBe(0);
+  });
+
+  it('returns { success: false } on query error', async () => {
+    __setQueryError(ORDERS, new Error('query boom'));
+    const result = await scanAndTriggerWinback();
+    expect(result.success).toBe(false);
+    expect(result.triggered).toBe(0);
+  });
+
+  it('reports scanned and triggered counts', async () => {
+    seedSequence('winback', [{ delayHours: 720, templateId: 'tpl-wb' }]);
+    __seed(EMAIL_QUEUE_COLLECTION, []);
+    __seed(ORDERS, [
+      makeOrder({ _id: 'o1', _createdDate: new Date(Date.now() - 30 * DAY_MS),
+        buyerInfo: { email: 'a@x.com', contactId: 'c-a', firstName: 'A' } }),
+      makeOrder({ _id: 'o2', _createdDate: new Date(Date.now() - 31 * DAY_MS),
+        buyerInfo: { email: 'b@x.com', contactId: 'c-b', firstName: 'B' } }),
+      makeOrder({ _id: 'o3', _createdDate: new Date(Date.now() - 10 * DAY_MS), // out of window
+        buyerInfo: { email: 'c@x.com', contactId: 'c-c', firstName: 'C' } }),
+    ]);
+
+    const result = await scanAndTriggerWinback();
+    expect(result.success).toBe(true);
+    // scanned counts orders returned by the range query (window filter),
+    // so the out-of-window order is excluded.
+    expect(result.scanned).toBe(2);
+    expect(result.triggered).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- `triggerWinbackSequence` (marketingSequences.web.js) was orphaned — no scheduler was calling it, so the day-30 winback email sequence never fired.
- Add `scanAndTriggerWinback` batch orchestrator that queries `Stores/Orders` in a 30–37 day lookback window, dedups buyers within the run, and fans out to `triggerWinbackSequence` per unique buyer. EmailQueue-level dedup keeps re-runs idempotent.
- Wire into `jobs.config` as a weekly Mondays 10 AM EST cron (`0 15 * * 1`).
- Add `get_scanAndTriggerWinbackCron` HTTP endpoint gated by `ALERT_CRON_KEY`, mirroring `triggerReengagementCron`.

**Window sizing.** Cron runs weekly on Mondays; the 30–37 day window guarantees every lapsed buyer is picked up exactly once regardless of which weekday their order landed on.

**TDD.** 8 tests authored first (red), implementation landed green. Covers: window hit, out-of-window exclusion, multi-order per-buyer dedup, EmailQueue idempotency across runs, missing email/contactId skips, query error path, scanned/triggered counters.

## Test plan
- [x] `npx vitest run tests/marketingSequences.test.js` — 46/46 green
- [ ] Post-deploy: verify `scanAndTriggerWinback` shows up in Wix Jobs scheduler UI with the Monday 10 AM ET cadence
- [ ] Post-deploy: hit `/_functions/scanAndTriggerWinbackCron` with `X-Cron-Secret: $ALERT_CRON_KEY` → 200 with `scanned`/`triggered` counts
- [ ] Post-deploy: hit the endpoint without the header → 403
- [ ] Post-deploy: confirm `EmailSequences` has a `sequenceType='winback'` row with `active=true` and `delayHours=720` (else scanner returns `triggered=0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)