### PR TITLE
feat(cf-20c): extend SEQUENCES.welcome from 3 to 5 emails (Day 14 + Day 21)

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -54,6 +54,8 @@ const SEQUENCES = {
       { step: 1, templateId: 'welcome_series_1', delayHours: 0, description: 'Brand story + 10% discount' },
       { step: 2, templateId: 'welcome_series_2', delayHours: 48, description: 'Best sellers showcase (Day 2 — CF-o63p)' },
       { step: 3, templateId: 'welcome_series_3', delayHours: 120, description: 'Buying guide + purchase nudge (Day 5 — CF-o63p)' },
+      { step: 4, templateId: 'welcome_series_4', delayHours: 336, description: 'Day 14 engagement check — browse reminder + activity-based nudge (cf-20c)' },
+      { step: 5, templateId: 'welcome_series_5', delayHours: 504, description: 'Day 21 final value email — social proof + last nudge before series ends (cf-20c)' },
     ],
     abTestStep: 1,
     abVariants: {

--- a/tests/campaignAnalytics.test.js
+++ b/tests/campaignAnalytics.test.js
@@ -119,11 +119,15 @@ describe('getCampaignAnalytics', () => {
 
   it('calculates sequence completion rates', async () => {
     const emailItems = [
+      // a@t.com completes all 5 steps (welcome now extends to step 5 per cf-20c)
       { _id: 'w1', sequenceType: 'welcome', sequenceStep: 1, status: 'sent', recipientEmail: 'a@t.com' },
       { _id: 'w2', sequenceType: 'welcome', sequenceStep: 2, status: 'sent', recipientEmail: 'a@t.com' },
       { _id: 'w3', sequenceType: 'welcome', sequenceStep: 3, status: 'sent', recipientEmail: 'a@t.com' },
-      { _id: 'w4', sequenceType: 'welcome', sequenceStep: 1, status: 'sent', recipientEmail: 'b@t.com' },
-      { _id: 'w5', sequenceType: 'welcome', sequenceStep: 2, status: 'cancelled', recipientEmail: 'b@t.com' },
+      { _id: 'w4', sequenceType: 'welcome', sequenceStep: 4, status: 'sent', recipientEmail: 'a@t.com' },
+      { _id: 'w5', sequenceType: 'welcome', sequenceStep: 5, status: 'sent', recipientEmail: 'a@t.com' },
+      // b@t.com drops off at step 2
+      { _id: 'w6', sequenceType: 'welcome', sequenceStep: 1, status: 'sent', recipientEmail: 'b@t.com' },
+      { _id: 'w7', sequenceType: 'welcome', sequenceStep: 2, status: 'cancelled', recipientEmail: 'b@t.com' },
     ];
 
     mockQuery.mockImplementation((collection) =>

--- a/tests/cf-o63p-welcome-series.test.js
+++ b/tests/cf-o63p-welcome-series.test.js
@@ -54,6 +54,22 @@ describe('welcome sequence step spec (CF-o63p)', () => {
     expect(step3.delayHours).toBe(120);
     expect(step3.description).toMatch(/buying guide/i);
   });
+
+  it('step 4 is Day 14 (336h) with engagement check description (cf-20c)', () => {
+    const step4 = _SEQUENCES.welcome.steps.find(s => s.step === 4);
+    expect(step4).toBeDefined();
+    expect(step4.delayHours).toBe(336);
+    expect(step4.templateId).toBe('welcome_series_4');
+    expect(step4.description).toMatch(/engagement/i);
+  });
+
+  it('step 5 is Day 21 (504h) with final value email description (cf-20c)', () => {
+    const step5 = _SEQUENCES.welcome.steps.find(s => s.step === 5);
+    expect(step5).toBeDefined();
+    expect(step5.delayHours).toBe(504);
+    expect(step5.templateId).toBe('welcome_series_5');
+    expect(step5.description).toMatch(/final value|value/i);
+  });
 });
 
 // ── Step 1: welcome + 10% coupon ──────────────────────────────────────
@@ -232,7 +248,7 @@ describe('wixMembers_onMemberCreated triggers welcome series', () => {
     await new Promise(r => setTimeout(r, 100));
 
     const welcomeSteps = items.filter(i => i.sequenceType === 'welcome');
-    expect(welcomeSteps).toHaveLength(3);
+    expect(welcomeSteps).toHaveLength(5);
   });
 
   it('step 2 in event-triggered sequence has bestSellersUrl', async () => {

--- a/tests/emailAutomation.integration.test.js
+++ b/tests/emailAutomation.integration.test.js
@@ -42,11 +42,11 @@ beforeEach(() => {
 // ── Full Welcome Lifecycle ─────────────────────────────────────────
 
 describe('welcome sequence lifecycle', () => {
-  it('member created → 3 emails queued → step 1 sent immediately → steps 2-3 stay pending', async () => {
+  it('member created → 5 emails queued → step 1 sent immediately → steps 2-5 stay pending', async () => {
     // Step 1: Trigger welcome sequence
     const queued = await triggerWelcomeSequence('contact-lc1', 'lifecycle@test.com', 'Lori');
     expect(queued.success).toBe(true);
-    expect(queued.queued).toBe(3);
+    expect(queued.queued).toBe(5);
 
     // Collect what was inserted into EmailQueue
     let queueItems = [];
@@ -149,7 +149,7 @@ describe('welcome sequence lifecycle', () => {
 
     // Welcome emails were queued
     const welcomeEmails = insertedItems.filter(i => i.sequenceType === 'welcome');
-    expect(welcomeEmails).toHaveLength(3);
+    expect(welcomeEmails).toHaveLength(5);
 
     // Seed them for processing with step 1 due now
     __seed('EmailQueue', welcomeEmails.map((item, i) => ({
@@ -618,7 +618,7 @@ describe('multiple sequences for same contact', () => {
   it('welcome and post-purchase can coexist for same email', async () => {
     // Welcome queued
     const welcome = await triggerWelcomeSequence('contact-multi', 'multi@test.com', 'Multi');
-    expect(welcome.queued).toBe(3);
+    expect(welcome.queued).toBe(5);
 
     // Post-purchase also queued (different sequence type)
     const pp = await triggerPostPurchaseSequence('contact-multi', 'multi@test.com', 'Multi', 'ORD-M1', 899, []);

--- a/tests/emailAutomation.test.js
+++ b/tests/emailAutomation.test.js
@@ -30,11 +30,13 @@ beforeEach(() => {
 // ── Sequence Definitions ────────────────────────────────────────────
 
 describe('sequence definitions', () => {
-  it('has welcome sequence with 3 steps at Day 0/2/5 timing (CF-o63p)', () => {
-    expect(_SEQUENCES.welcome.steps).toHaveLength(3);
+  it('has welcome sequence with 5 steps at Day 0/2/5/14/21 timing (CF-o63p + cf-20c)', () => {
+    expect(_SEQUENCES.welcome.steps).toHaveLength(5);
     expect(_SEQUENCES.welcome.steps[0].delayHours).toBe(0);
     expect(_SEQUENCES.welcome.steps[1].delayHours).toBe(48);   // Day 2
     expect(_SEQUENCES.welcome.steps[2].delayHours).toBe(120);  // Day 5
+    expect(_SEQUENCES.welcome.steps[3].delayHours).toBe(336);  // Day 14 — engagement check (cf-20c)
+    expect(_SEQUENCES.welcome.steps[4].delayHours).toBe(504);  // Day 21 — final value email (cf-20c)
   });
 
   it('has cart_recovery sequence with 1h/24h/72h triggers', () => {
@@ -77,10 +79,10 @@ describe('sequence definitions', () => {
 // ── triggerWelcomeSequence ──────────────────────────────────────────
 
 describe('triggerWelcomeSequence', () => {
-  it('queues 3 welcome emails for a new member', async () => {
+  it('queues 5 welcome emails for a new member', async () => {
     const result = await triggerWelcomeSequence('contact-1', 'alice@test.com', 'Alice');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 
   it('includes discount code in variables', async () => {
@@ -89,7 +91,7 @@ describe('triggerWelcomeSequence', () => {
 
     await triggerWelcomeSequence('contact-1', 'alice@test.com', 'Alice');
 
-    expect(insertedItems.length).toBe(3);
+    expect(insertedItems.length).toBe(5);
     expect(insertedItems[0].variables.discountCode).toBe('WELCOME10');
     expect(insertedItems[0].variables.discountAvailable).toBe(true);
   });
@@ -214,7 +216,7 @@ describe('triggerWelcomeSequence', () => {
 
     const result = await triggerWelcomeSequence('contact-1', 'alice@test.com', 'Alice');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 });
 
@@ -948,7 +950,7 @@ describe('wixMembers_onMemberCreated', () => {
     await new Promise(r => setTimeout(r, 100));
 
     const welcomeEmails = insertedItems.filter(i => i.sequenceType === 'welcome');
-    expect(welcomeEmails).toHaveLength(3);
+    expect(welcomeEmails).toHaveLength(5);
   });
 
   it('extracts email from contactDetails when loginEmail missing', async () => {
@@ -965,7 +967,7 @@ describe('wixMembers_onMemberCreated', () => {
     await new Promise(r => setTimeout(r, 100));
 
     const welcomeEmails = insertedItems.filter(i => i.sequenceType === 'welcome');
-    expect(welcomeEmails).toHaveLength(3);
+    expect(welcomeEmails).toHaveLength(5);
     expect(welcomeEmails[0].recipientEmail).toBe('fallback@test.com');
   });
 

--- a/tests/emailAutomationDeep.test.js
+++ b/tests/emailAutomationDeep.test.js
@@ -62,7 +62,7 @@ describe('triggerWelcomeSequence — edge-case inputs', () => {
 
     const result = await triggerWelcomeSequence('a0b1c2d3-e4f5-6789-abcd-ef0123456789', 'test@example.com', '');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
     expect(insertedItems[0].variables.firstName).toBe('');
   });
 
@@ -80,7 +80,7 @@ describe('triggerWelcomeSequence — edge-case inputs', () => {
   it('handles empty contactId without error', async () => {
     const result = await triggerWelcomeSequence('', 'test@example.com', 'Alice');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 
   it('replaces {firstName} in A/B variant B subject line', async () => {
@@ -885,7 +885,7 @@ describe('wixMembers_onMemberCreated — event shape edge cases', () => {
     });
 
     const welcomeEmails = insertedItems.filter(i => i.sequenceType === 'welcome');
-    expect(welcomeEmails.length).toBe(3);
+    expect(welcomeEmails.length).toBe(5);
     expect(welcomeEmails[0].variables.firstName).toBe('NickName');
   });
 
@@ -900,7 +900,7 @@ describe('wixMembers_onMemberCreated — event shape edge cases', () => {
     });
 
     const welcomeEmails = insertedItems.filter(i => i.sequenceType === 'welcome');
-    expect(welcomeEmails.length).toBe(3);
+    expect(welcomeEmails.length).toBe(5);
   });
 });
 

--- a/tests/emailAutomationDeepen.test.js
+++ b/tests/emailAutomationDeepen.test.js
@@ -701,11 +701,13 @@ describe('A/B variant selection in welcome sequence', () => {
 
     await triggerWelcomeSequence('c1', 'ab@test.com', 'Tester');
 
-    expect(inserts.length).toBe(3);
+    expect(inserts.length).toBe(5);
     expect(inserts[0].abVariant).toBe('A');
     expect(inserts[0].variables.subjectLine).toContain('Welcome to Carolina Futons');
     expect(inserts[1].abVariant).toBeNull();
     expect(inserts[2].abVariant).toBeNull();
+    expect(inserts[3].abVariant).toBeNull();
+    expect(inserts[4].abVariant).toBeNull();
     expect(inserts[1].variables.subjectLine).toBeUndefined();
   });
 

--- a/tests/welcomeEmailSeries.test.js
+++ b/tests/welcomeEmailSeries.test.js
@@ -38,15 +38,15 @@ describe('triggerWelcomeSeries — happy path', () => {
     expect(result.success).toBe(true);
   });
 
-  it('returns queued:3 (all three welcome steps)', async () => {
+  it('returns queued:5 (all five welcome steps — cf-20c)', async () => {
     const result = await triggerWelcomeSeries(EMAIL, FIRST_NAME);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 
-  it('inserts 3 records into EmailQueue', async () => {
+  it('inserts 5 records into EmailQueue', async () => {
     await triggerWelcomeSeries(EMAIL, FIRST_NAME);
     const records = __getInserted('EmailQueue');
-    expect(records).toHaveLength(3);
+    expect(records).toHaveLength(5);
   });
 
   it('queued records have sequenceType:welcome', async () => {
@@ -55,10 +55,10 @@ describe('triggerWelcomeSeries — happy path', () => {
     expect(records.every(r => r.sequenceType === 'welcome')).toBe(true);
   });
 
-  it('queued records have sequenceSteps 1, 2, 3', async () => {
+  it('queued records have sequenceSteps 1, 2, 3, 4, 5', async () => {
     await triggerWelcomeSeries(EMAIL, FIRST_NAME);
     const steps = __getInserted('EmailQueue').map(r => r.sequenceStep).sort();
-    expect(steps).toEqual([1, 2, 3]);
+    expect(steps).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('queued records have correct recipientEmail', async () => {
@@ -161,7 +161,7 @@ describe('triggerWelcomeSeries — dedup guard', () => {
     ]);
     const result = await triggerWelcomeSeries('bob@example.com', 'Bob');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 });
 
@@ -235,7 +235,7 @@ describe('triggerWelcomeSeries — input validation', () => {
   it('accepts valid email and queues successfully', async () => {
     const result = await triggerWelcomeSeries('valid@test.com', 'Test');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 });
 
@@ -255,7 +255,7 @@ describe('triggerWelcomeSeries — discount secret fallback', () => {
     // No secrets set — getSecret will throw
     const result = await triggerWelcomeSeries(EMAIL, FIRST_NAME);
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 
   it('stores empty discountCode when secret is unavailable', async () => {

--- a/tests/welcomeEmailSeriesDeep.test.js
+++ b/tests/welcomeEmailSeriesDeep.test.js
@@ -148,16 +148,16 @@ describe('welcome sequence — each step fires exactly once per member', () => {
 
     const first = await triggerWelcomeSeries('twice@test.com', 'Twice');
     expect(first.success).toBe(true);
-    expect(first.queued).toBe(3);
+    expect(first.queued).toBe(5);
 
     const second = await triggerWelcomeSeries('twice@test.com', 'Twice');
     expect(second.success).toBe(false);
     expect(second.queued).toBe(0);
 
-    // Exactly 3 records in the queue — not 6
+    // Exactly 5 records in the queue — not 10
     const all = __getInserted('EmailQueue');
     const welcome = all.filter(r => r.sequenceType === 'welcome');
-    expect(welcome).toHaveLength(3);
+    expect(welcome).toHaveLength(5);
   });
 });
 
@@ -513,6 +513,6 @@ describe('sequence deduplication — new signup during active sequence', () => {
 
     const result = await triggerWelcomeSeries('different@test.com', 'Diff');
     expect(result.success).toBe(true);
-    expect(result.queued).toBe(3);
+    expect(result.queued).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary

Extends the welcome drip series from 3 to 5 emails:
- **Step 4** `welcome_series_4` at Day 14 (336h) — engagement check, browse reminder + activity-based nudge
- **Step 5** `welcome_series_5` at Day 21 (504h) — final value email, social proof + last nudge before series ends

TDD: tests updated first (step-count + new step specs) → then `SEQUENCES.welcome.steps` extended in `src/backend/emailAutomation.web.js`.

## Changes

- `src/backend/emailAutomation.web.js` — 2 new step entries in `SEQUENCES.welcome.steps`
- `tests/cf-o63p-welcome-series.test.js` — 2 new specs for steps 4 & 5, bump event-handler count to 5
- `tests/emailAutomation.test.js` — bump length + delayHours assertions to 5-step shape
- `tests/welcomeEmailSeries.test.js` — bump queued/length/sequenceSteps assertions
- `tests/welcomeEmailSeriesDeep.test.js` — bump dedup-test expectations
- `tests/emailAutomation.integration.test.js` — bump lifecycle counts
- `tests/emailAutomationDeep.test.js` — edge-case queued counts + event handler counts
- `tests/emailAutomationDeepen.test.js` — A/B variant null-assertions for steps 4, 5
- `tests/campaignAnalytics.test.js` — completion-rate fixture extended (a@t.com completes all 5, b@t.com still drops at step 2)

## Test plan

- [x] 8 changed test files → **305/305 pass**
- [x] Full email suite (13 files) → **426/426 pass**
- [x] Full repo suite: 39637/39640 pass; 2 pre-existing `whiteGloveScheduling` date-rot failures on main (unrelated, `campaignAnalytics` fixture fix is part of this PR)
- [ ] CI green
- [ ] Templates `welcome_series_4` / `welcome_series_5` created in Wix Email Marketing (separate bead — content work, not code)

Closes bead: cf-20c