### PR TITLE
feat(cf-3z1): getChallengeOfTheWeek webMethod

### DIFF
--- a/src/backend/challengeService.web.js
+++ b/src/backend/challengeService.web.js
@@ -250,6 +250,62 @@ export async function _recordTrailChallengeCompletion(memberId, trailId, challen
  * @param {string} challengeId
  * @returns {Promise<{ success: boolean, trailComplete?: boolean, perkDelivered?: boolean, couponCode?: string|null, error?: string }>}
  */
+// ── getChallengeOfTheWeek (cf-3z1) ──────────────────────────────────────────
+
+const CHALLENGE_OF_THE_WEEK_COLLECTION = 'ChallengeOfTheWeek';
+
+/**
+ * Returns the most recent Sunday <= today (start of the current week).
+ */
+function getMostRecentSunday() {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - d.getDay());
+  return d;
+}
+
+/**
+ * WebMethod (public): returns the current week's featured challenge.
+ * Finds the record whose weekStart is the most recent Sunday <= today.
+ * Falls back to the most recent record if no current-week record exists.
+ */
+export const getChallengeOfTheWeek = webMethod(Permissions.Anyone, async () => {
+  try {
+    const sunday = getMostRecentSunday();
+
+    // Try current week first
+    const currentWeek = await wixData
+      .query(CHALLENGE_OF_THE_WEEK_COLLECTION)
+      .le('weekStart', sunday)
+      .descending('weekStart')
+      .limit(1)
+      .find({ suppressAuth: true });
+
+    const challenge = currentWeek.items[0] || null;
+
+    if (!challenge) {
+      return { success: false, error: 'no_challenges' };
+    }
+
+    return {
+      success: true,
+      challenge: {
+        challengeId: challenge.challengeId,
+        title: challenge.title,
+        description: challenge.description,
+        pointValue: challenge.pointValue,
+        imageUrl: challenge.imageUrl,
+        weekStart: challenge.weekStart,
+      },
+    };
+  } catch (err) {
+    console.error('[challengeService] getChallengeOfTheWeek error:', err);
+    return { success: false, error: 'Failed to load challenge of the week.' };
+  }
+});
+
+// ── recordTrailChallengeCompletion ────────────────────────────────────────────
+
 export const recordTrailChallengeCompletion = webMethod(Permissions.SiteMember, async (trailId, challengeId) => {
   let member;
   try { member = await currentMember.getMember(); } catch { member = null; }

--- a/tests/challengeOfWeek.test.js
+++ b/tests/challengeOfWeek.test.js
@@ -1,0 +1,96 @@
+/**
+ * @file challengeOfWeek.test.js
+ * @description Tests for getChallengeOfTheWeek webMethod.
+ *
+ * Covers:
+ *  1. Returns most recent week's challenge when record exists
+ *  2. Falls back to most recent record when no current-week record exists
+ *  3. Returns { success: false } on query error
+ *  4. Returns { success: false, error: 'no_challenges' } when collection empty
+ *
+ * cf-3z1
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __reset, __seed, __setQueryError } from 'wix-data';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Most recent Sunday <= today (2026-04-16 is a Thursday → Sunday = 2026-04-12) */
+function getMostRecentSunday(ref = new Date()) {
+  const d = new Date(ref);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - d.getDay());
+  return d;
+}
+
+function makeChallenge(overrides = {}) {
+  return {
+    _id: 'cotw-1',
+    challengeId: 'cotw-apr-w3',
+    weekStart: getMostRecentSunday(),
+    title: 'Share a Room Photo',
+    description: 'Post your futon setup and earn points!',
+    pointValue: 200,
+    imageUrl: 'https://example.com/challenge.jpg',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  __reset();
+});
+
+// Import AFTER mocks are registered by vitest config
+import { getChallengeOfTheWeek } from '../src/backend/challengeService.web.js';
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('getChallengeOfTheWeek (cf-3z1)', () => {
+  it('returns most recent week\'s challenge when record exists', async () => {
+    const sunday = getMostRecentSunday();
+    __seed('ChallengeOfTheWeek', [makeChallenge({ weekStart: sunday })]);
+
+    const result = await getChallengeOfTheWeek();
+
+    expect(result.success).toBe(true);
+    expect(result.challenge).toBeDefined();
+    expect(result.challenge.challengeId).toBe('cotw-apr-w3');
+    expect(result.challenge.title).toBe('Share a Room Photo');
+    expect(result.challenge.description).toBe('Post your futon setup and earn points!');
+    expect(result.challenge.pointValue).toBe(200);
+    expect(result.challenge.imageUrl).toBe('https://example.com/challenge.jpg');
+    expect(result.challenge.weekStart).toEqual(sunday);
+  });
+
+  it('falls back to most recent record when no current-week record exists', async () => {
+    // Only an old challenge — no record for current week's Sunday
+    const oldSunday = new Date('2026-03-29');
+    __seed('ChallengeOfTheWeek', [
+      makeChallenge({ weekStart: oldSunday, challengeId: 'cotw-mar-w5', title: 'Old Challenge' }),
+    ]);
+
+    const result = await getChallengeOfTheWeek();
+
+    expect(result.success).toBe(true);
+    expect(result.challenge.challengeId).toBe('cotw-mar-w5');
+    expect(result.challenge.title).toBe('Old Challenge');
+  });
+
+  it('returns { success: false } on query error', async () => {
+    __setQueryError('ChallengeOfTheWeek', new Error('DB down'));
+
+    const result = await getChallengeOfTheWeek();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns { success: false, error: "no_challenges" } when collection empty', async () => {
+    __seed('ChallengeOfTheWeek', []);
+
+    const result = await getChallengeOfTheWeek();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('no_challenges');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `getChallengeOfTheWeek` public webMethod to `challengeService.web.js`
- Reads `ChallengeOfTheWeek` CMS collection, returns the record with the most recent `weekStart` Sunday <= today
- Falls back to most recent record when no current-week entry exists
- Returns `{ success: false, error: 'no_challenges' }` for empty collection

## Test plan
- [x] 4 TDD tests in `tests/challengeOfWeek.test.js` — all passing
- [x] Existing `challengeOfTheWeek.test.js` (12 tests) still passing — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)