### PR TITLE
feat(cf-5je): push notification preferences — managePushPreferences webMethod

### DIFF
--- a/src/backend/crossRigEventReceiver.web.js
+++ b/src/backend/crossRigEventReceiver.web.js
@@ -20,7 +20,7 @@ import { currentMember } from 'wix-members-backend';
 import { insertAnalyticsEvent } from 'backend/utils/analyticsEvents';
 import { logError } from 'backend/utils/errorHandler';
 import { syncBadgeEarnedToPush } from 'backend/utils/crossRigSyncUtils';
-import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web';
+import { sendPushToMember, PUSH_EVENTS, skipIfOptedOut } from 'backend/pushNotificationService.web';
 import { completeMobileChallenge, MOBILE_CHALLENGE_TYPES } from 'backend/mobileChallengeService.web';
 
 const SUPPORTED_EVENTS = new Set([
@@ -152,9 +152,13 @@ export const crossRigEvent = webMethod(
       }
     }
     // tier_changed fires directly — web-side trigger, no cross-rig sync log needed.
+    // skipIfOptedOut checks member preferences before dispatching (cf-5je).
     if (body.event === 'tier_changed' && body.newTier) {
       try {
-        await sendPushToMember(memberId, PUSH_EVENTS.TIER_CHANGED, { tier: body.newTier });
+        const skip = await skipIfOptedOut(memberId, PUSH_EVENTS.TIER_CHANGED);
+        if (!skip) {
+          await sendPushToMember(memberId, PUSH_EVENTS.TIER_CHANGED, { tier: body.newTier });
+        }
       } catch (err) {
         logError('crossRigEvent — tier_changed push failed', err);
         // Non-fatal

--- a/src/backend/gamificationNotifs.web.js
+++ b/src/backend/gamificationNotifs.web.js
@@ -418,8 +418,11 @@ export async function checkStreakMilestoneNotifications() {
         // Push notification remains inline — it's best-effort and cheap compared
         // to the email triggeredEmails call that caused the original timeout.
         try {
-          const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
-          await sendPushToMember(memberId, PUSH_EVENTS.STREAK_MILESTONE, { days: String(STREAK_MILESTONE_DAY) });
+          const { sendPushToMember, PUSH_EVENTS, skipIfOptedOut } = await import('backend/pushNotificationService.web');
+          const skip = await skipIfOptedOut(memberId, PUSH_EVENTS.STREAK_MILESTONE);
+          if (!skip) {
+            await sendPushToMember(memberId, PUSH_EVENTS.STREAK_MILESTONE, { days: String(STREAK_MILESTONE_DAY) });
+          }
         } catch (pushErr) {
           logError(`checkStreakMilestoneNotifications — push failed for ${memberId}`, pushErr);
         }
@@ -515,8 +518,11 @@ export async function notifyTierUpgrade(memberId, newTier, previousTier) {
 
     // Push is best-effort — email already sent, so we still record dedup below.
     try {
-      const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
-      await sendPushToMember(memberId, PUSH_EVENTS.TIER_CHANGED, { tier: newTier });
+      const { sendPushToMember, PUSH_EVENTS, skipIfOptedOut } = await import('backend/pushNotificationService.web');
+      const skip = await skipIfOptedOut(memberId, PUSH_EVENTS.TIER_CHANGED);
+      if (!skip) {
+        await sendPushToMember(memberId, PUSH_EVENTS.TIER_CHANGED, { tier: newTier });
+      }
     } catch (pushErr) {
       logError(`notifyTierUpgrade — push failed for ${memberId}`, pushErr);
     }
@@ -600,7 +606,7 @@ export async function runStreakAtRiskPushNotifications() {
       prefsResult.items.map(p => [p.memberId, p])
     );
 
-    const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
+    const { sendPushToMember, PUSH_EVENTS, skipIfOptedOut } = await import('backend/pushNotificationService.web');
 
     for (const record of atRiskMembers) {
       const memberId = record.memberId;
@@ -609,6 +615,13 @@ export async function runStreakAtRiskPushNotifications() {
       // Strict === false: undefined/null/missing prefs = opted IN by default.
       const prefs = prefsMap[memberId];
       if (prefs && prefs.streakReminders === false) {
+        result.skipped++;
+        continue;
+      }
+
+      // cf-5je: category-level opt-out (PushPreferences) is independent of the
+      // legacy per-member streakReminders flag above. Both must pass.
+      if (await skipIfOptedOut(memberId, PUSH_EVENTS.STREAK_MILESTONE)) {
         result.skipped++;
         continue;
       }

--- a/src/backend/lifecycleCron.web.js
+++ b/src/backend/lifecycleCron.web.js
@@ -170,7 +170,7 @@ export const runDailyChallengeReminders = webMethod(
   async () => {
     try {
       const { triggeredEmails } = await import('wix-crm-backend');
-      const { sendPushToMember, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
+      const { sendPushToMember, PUSH_EVENTS, skipIfOptedOut } = await import('backend/pushNotificationService.web');
 
       const sendFn = async (record) => {
         await triggeredEmails.emailMember(
@@ -189,8 +189,13 @@ export const runDailyChallengeReminders = webMethod(
         // Failures are logged but do not affect send/failed counting or the
         // notifiedAt mark (otherwise a flaky FCM response would re-send the
         // entire batch on the next cron tick). cf-h6w
+        // cf-5je: category-level opt-out guard — email still sends (it's the
+        // primary channel), only the supplementary push is gated.
         try {
-          await sendPushToMember(record.memberId, PUSH_EVENTS.CHALLENGE_REMINDER, {});
+          const skip = await skipIfOptedOut(record.memberId, PUSH_EVENTS.CHALLENGE_REMINDER);
+          if (!skip) {
+            await sendPushToMember(record.memberId, PUSH_EVENTS.CHALLENGE_REMINDER, {});
+          }
         } catch (pushErr) {
           console.error(`[lifecycleCron] challenge reminder push failed for ${record.memberId}:`, pushErr?.message);
         }

--- a/src/backend/pushNotificationService.web.js
+++ b/src/backend/pushNotificationService.web.js
@@ -1,11 +1,17 @@
 /**
- * pushNotificationService — FCM HTTP v1 push dispatch.
+ * pushNotificationService — FCM HTTP v1 push dispatch + push preferences.
  *
  * Sends push notifications to all active device tokens for a member.
  * Handles per-token FCM failures; deactivates stale tokens (NOT_FOUND/UNREGISTERED).
  *
- * CF-axn
+ * Push preferences (cf-5je): members can opt in/out of push categories
+ * (challenges, streak, marketing, tier). Stored in PushPreferences collection.
+ *
+ * CF-axn / cf-5je
  */
+import { Permissions, webMethod } from 'wix-web-module';
+import wixData from 'wix-data';
+import { currentMember } from 'wix-members-backend';
 import { getActiveTokensForMember, deactivateToken } from 'backend/pushTokenRegistry.web';
 
 export const PUSH_EVENTS = {
@@ -92,3 +98,130 @@ export async function sendPushToMember(memberId, event, payload = {}) {
 
   return { sent, failed };
 }
+
+// ── Push Preferences (cf-5je) ───────────────────────────────────────────────
+
+export const PUSH_PREFERENCES_COLLECTION = 'PushPreferences';
+
+const VALID_CATEGORIES = ['challenges', 'streak', 'marketing', 'tier'];
+
+const DEFAULT_PREFS = Object.freeze({
+  challenges: true,
+  streak: true,
+  marketing: true,
+  tier: true,
+});
+
+/** Map PUSH_EVENTS values to preference categories. */
+const EVENT_TO_CATEGORY = {
+  [PUSH_EVENTS.CHALLENGE_COMPLETE]: 'challenges',
+  [PUSH_EVENTS.CHALLENGE_REMINDER]: 'challenges',
+  [PUSH_EVENTS.STREAK_MILESTONE]:   'streak',
+  [PUSH_EVENTS.PRICE_DROP]:         'marketing',
+  [PUSH_EVENTS.TIER_CHANGED]:       'tier',
+};
+
+/**
+ * Check whether a push should be skipped based on member preferences.
+ *
+ * @param {string} memberId
+ * @param {string} event - One of PUSH_EVENTS values
+ * @returns {Promise<boolean>} true if the member has opted out of this category
+ */
+export async function skipIfOptedOut(memberId, event) {
+  const category = EVENT_TO_CATEGORY[event];
+  if (!category) return false; // unmapped events always send
+
+  const result = await wixData.query(PUSH_PREFERENCES_COLLECTION)
+    .eq('memberId', memberId)
+    .find({ suppressAuth: true });
+
+  if (!result.items.length) return false; // no record -> default all-in
+
+  const record = result.items[0];
+  const prefs = record.categoryPrefs || {};
+  return prefs[category] === false;
+}
+
+/**
+ * Update push notification preferences for the current member.
+ *
+ * @param {{ challenges?: boolean, streak?: boolean, marketing?: boolean, tier?: boolean }} prefs
+ * @returns {Promise<{ success: boolean, prefs?: object, error?: string }>}
+ */
+export const managePushPreferences = webMethod(
+  Permissions.SiteMember,
+  async (prefs) => {
+    if (!prefs || typeof prefs !== 'object') {
+      return { success: false, error: 'prefs object is required' };
+    }
+
+    for (const key of Object.keys(prefs)) {
+      if (!VALID_CATEGORIES.includes(key)) {
+        return { success: false, error: `unknown category: ${key}` };
+      }
+      if (typeof prefs[key] !== 'boolean') {
+        return { success: false, error: `category ${key} must be boolean` };
+      }
+    }
+
+    // ── Resolve memberId from session (idor-ok) ───────────────────────────
+    let memberId;
+    try {
+      const member = await currentMember.getMember();
+      memberId = member?._id;
+    } catch (_) { /* handled below */ }
+    if (!memberId) return { success: false, error: 'unauthenticated' };
+
+    const existing = await wixData.query(PUSH_PREFERENCES_COLLECTION)
+      .eq('memberId', memberId)
+      .find({ suppressAuth: true });
+
+    let merged;
+    if (existing.items.length) {
+      const record = existing.items[0];
+      merged = { ...DEFAULT_PREFS, ...record.categoryPrefs, ...prefs };
+      await wixData.update(PUSH_PREFERENCES_COLLECTION, {
+        ...record,
+        categoryPrefs: merged,
+        updatedAt: new Date(),
+      }, { suppressAuth: true });
+    } else {
+      merged = { ...DEFAULT_PREFS, ...prefs };
+      await wixData.insert(PUSH_PREFERENCES_COLLECTION, {
+        memberId,
+        categoryPrefs: merged,
+        updatedAt: new Date(),
+      });
+    }
+
+    return { success: true, prefs: merged };
+  },
+);
+
+/**
+ * Read-only companion — returns current push preferences for the caller.
+ *
+ * @returns {Promise<{ success: boolean, prefs?: object, error?: string }>}
+ */
+export const getMyPushPreferences = webMethod(
+  Permissions.SiteMember,
+  async () => {
+    let memberId;
+    try {
+      const member = await currentMember.getMember();
+      memberId = member?._id;
+    } catch (_) { /* handled below */ }
+    if (!memberId) return { success: false, error: 'unauthenticated' };
+
+    const result = await wixData.query(PUSH_PREFERENCES_COLLECTION)
+      .eq('memberId', memberId)
+      .find({ suppressAuth: true });
+
+    if (!result.items.length) {
+      return { success: true, prefs: { ...DEFAULT_PREFS } };
+    }
+
+    return { success: true, prefs: { ...DEFAULT_PREFS, ...result.items[0].categoryPrefs } };
+  },
+);

--- a/src/backend/pushNotificationService.web.js
+++ b/src/backend/pushNotificationService.web.js
@@ -103,13 +103,14 @@ export async function sendPushToMember(memberId, event, payload = {}) {
 
 export const PUSH_PREFERENCES_COLLECTION = 'PushPreferences';
 
-const VALID_CATEGORIES = ['challenges', 'streak', 'marketing', 'tier'];
+const VALID_CATEGORIES = ['challenges', 'streak', 'marketing', 'tier', 'badges'];
 
 const DEFAULT_PREFS = Object.freeze({
   challenges: true,
   streak: true,
   marketing: true,
   tier: true,
+  badges: true,
 });
 
 /** Map PUSH_EVENTS values to preference categories. */
@@ -119,6 +120,7 @@ const EVENT_TO_CATEGORY = {
   [PUSH_EVENTS.STREAK_MILESTONE]:   'streak',
   [PUSH_EVENTS.PRICE_DROP]:         'marketing',
   [PUSH_EVENTS.TIER_CHANGED]:       'tier',
+  [PUSH_EVENTS.BADGE_EARNED]:       'badges',
 };
 
 /**
@@ -192,7 +194,7 @@ export const managePushPreferences = webMethod(
         memberId,
         categoryPrefs: merged,
         updatedAt: new Date(),
-      });
+      }, { suppressAuth: true });
     }
 
     return { success: true, prefs: merged };

--- a/src/backend/utils/crossRigSyncUtils.js
+++ b/src/backend/utils/crossRigSyncUtils.js
@@ -8,7 +8,7 @@
  * CF-z51
  */
 import wixData from 'wix-data';
-import { sendPushToMember, PUSH_EVENTS } from 'backend/pushNotificationService.web';
+import { sendPushToMember, skipIfOptedOut, PUSH_EVENTS } from 'backend/pushNotificationService.web';
 
 export const SYNC_LOG_COLLECTION = 'CrossRigSyncLog';
 const ALLOWED_SOURCE_RIGS = ['cfutons_mobile'];
@@ -63,6 +63,9 @@ export async function syncMobilePoints(memberId, points, eventType, sourceRig) {
  */
 export async function syncBadgeEarnedToPush(memberId, badgeId) {
   try {
+    if (await skipIfOptedOut(memberId, PUSH_EVENTS.BADGE_EARNED)) {
+      return { success: true, pushSent: 0, skipped: true };
+    }
     const { sent } = await sendPushToMember(memberId, PUSH_EVENTS.BADGE_EARNED, { badgeId });
     return { success: true, pushSent: sent };
   } catch (err) {

--- a/tests/crossRigEventReceiver.test.js
+++ b/tests/crossRigEventReceiver.test.js
@@ -30,6 +30,7 @@ vi.mock('backend/utils/crossRigSyncUtils', () => ({
 
 vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: vi.fn(async () => ({ sent: 1, failed: 0 })),
+  skipIfOptedOut: vi.fn(async () => false),
   PUSH_EVENTS: {
     BADGE_EARNED: 'badge_earned',
     TIER_CHANGED: 'tier_changed',

--- a/tests/crossRigSyncService.test.js
+++ b/tests/crossRigSyncService.test.js
@@ -12,6 +12,7 @@ function setMember() { __setMember({ _id: MEMBER_ID }); }
 
 vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: vi.fn(async () => ({ sent: 1, failed: 0 })),
+  skipIfOptedOut: vi.fn(async () => false),
   PUSH_EVENTS: {
     BADGE_EARNED: 'badge_earned',
     TIER_CHANGED: 'tier_changed',
@@ -131,5 +132,15 @@ describe('syncBadgeEarnedToPush', () => {
     const result = await syncBadgeEarnedToPush(MEMBER_ID, 'new_badge');
     expect(result.success).toBe(true);
     expect(result.pushSent).toBe(0);
+  });
+
+  it('skips push when member opted out of badges category', async () => {
+    setMember();
+    const { sendPushToMember, skipIfOptedOut, PUSH_EVENTS } = await import('backend/pushNotificationService.web');
+    skipIfOptedOut.mockResolvedValueOnce(true);
+    const result = await syncBadgeEarnedToPush(MEMBER_ID, 'first_purchase');
+    expect(result).toEqual({ success: true, pushSent: 0, skipped: true });
+    expect(sendPushToMember).not.toHaveBeenCalled();
+    expect(skipIfOptedOut).toHaveBeenCalledWith(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED);
   });
 });

--- a/tests/lifecycleCron.test.js
+++ b/tests/lifecycleCron.test.js
@@ -36,8 +36,10 @@ import {
 
 // cf-h6w: push dispatch mock — runDailyChallengeReminders fires push alongside email
 const mockSendPushToMember = vi.fn(async () => ({ sent: 1, failed: 0 }));
+const mockSkipIfOptedOut = vi.fn(async () => false);
 vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: (...args) => mockSendPushToMember(...args),
+  skipIfOptedOut: (...args) => mockSkipIfOptedOut(...args),
   PUSH_EVENTS: {
     BADGE_EARNED: 'badge_earned',
     TIER_CHANGED: 'tier_changed',
@@ -90,6 +92,8 @@ beforeEach(() => {
   resetCrm();
   mockSendPushToMember.mockClear();
   mockSendPushToMember.mockResolvedValue({ sent: 1, failed: 0 });
+  mockSkipIfOptedOut.mockClear();
+  mockSkipIfOptedOut.mockResolvedValue(false);
   vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.spyOn(console, 'log').mockImplementation(() => {});
 });
@@ -643,6 +647,22 @@ describe('runDailyChallengeReminders — push dispatch (cf-h6w)', () => {
     ]);
     await runDailyChallengeReminders();
     expect(mockSendPushToMember).not.toHaveBeenCalled();
+  });
+
+  // cf-5je: category-level opt-out skips the supplementary push but the
+  // primary email still fires — counted in `sent` and notifiedAt still marked.
+  it('skips push when skipIfOptedOut returns true but still sends email', async () => {
+    __seed('MemberChallengeProgress', [
+      challengeRecord({ _id: 'mcp-a', memberId: 'mem-opted-out' }),
+    ]);
+    mockSkipIfOptedOut.mockResolvedValue(true);
+
+    const result = await runDailyChallengeReminders();
+
+    expect(result).toEqual({ success: true, sent: 1, failed: 0 });
+    expect(__getEmailLog()).toHaveLength(1);
+    expect(mockSendPushToMember).not.toHaveBeenCalled();
+    expect(mockSkipIfOptedOut).toHaveBeenCalledWith('mem-opted-out', 'challenge_reminder');
   });
 });
 

--- a/tests/pushPreferences.test.js
+++ b/tests/pushPreferences.test.js
@@ -29,6 +29,7 @@ describe('managePushPreferences', () => {
       streak: true,
       marketing: false,
       tier: true,
+      badges: true,
     });
   });
 
@@ -56,6 +57,7 @@ describe('managePushPreferences', () => {
       streak: false,
       marketing: false,
       tier: false,
+      badges: false,
     });
     expect(result.success).toBe(true);
     expect(result.prefs).toEqual({
@@ -63,6 +65,7 @@ describe('managePushPreferences', () => {
       streak: false,
       marketing: false,
       tier: false,
+      badges: false,
     });
   });
 
@@ -119,6 +122,7 @@ describe('getMyPushPreferences', () => {
       streak: true,
       marketing: true,
       tier: true,
+      badges: true,
     });
   });
 
@@ -151,7 +155,17 @@ describe('skipIfOptedOut', () => {
     expect(skip).toBe(false);
   });
 
-  it('returns false for unmapped event types (BADGE_EARNED)', async () => {
+  it('maps BADGE_EARNED to badges category', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { badges: false },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED);
+    expect(skip).toBe(true);
+  });
+
+  it('does not skip BADGE_EARNED when no badges pref is set (defaults opt-in)', async () => {
     __seed(PUSH_PREFERENCES_COLLECTION, [{
       _id: 'pref-1',
       memberId: MEMBER_ID,

--- a/tests/pushPreferences.test.js
+++ b/tests/pushPreferences.test.js
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { __seed, __reset, __getInserted } from './__mocks__/wix-data.js';
+import { __setMember, __reset as resetMember } from './__mocks__/wix-members-backend.js';
+import {
+  managePushPreferences,
+  getMyPushPreferences,
+  skipIfOptedOut,
+  PUSH_PREFERENCES_COLLECTION,
+  PUSH_EVENTS,
+} from '../src/backend/pushNotificationService.web.js';
+
+const MEMBER_ID = 'member-prefs-1';
+const OTHER_MEMBER = 'member-prefs-2';
+
+function setMember(id = MEMBER_ID) { __setMember({ _id: id }); }
+
+beforeEach(() => { __reset(); resetMember(); });
+
+// ── managePushPreferences ─────────────────────────────────────────────────
+
+describe('managePushPreferences', () => {
+  it('creates a new record with defaults + overrides on first call', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const result = await managePushPreferences({ marketing: false });
+    expect(result.success).toBe(true);
+    expect(result.prefs).toEqual({
+      challenges: true,
+      streak: true,
+      marketing: false,
+      tier: true,
+    });
+  });
+
+  it('updates a single category without changing others', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { challenges: true, streak: true, marketing: true, tier: true },
+      updatedAt: new Date('2026-01-01'),
+    }]);
+    const result = await managePushPreferences({ streak: false });
+    expect(result.success).toBe(true);
+    expect(result.prefs.streak).toBe(false);
+    expect(result.prefs.challenges).toBe(true);
+    expect(result.prefs.marketing).toBe(true);
+    expect(result.prefs.tier).toBe(true);
+  });
+
+  it('handles bulk update of multiple categories', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const result = await managePushPreferences({
+      challenges: false,
+      streak: false,
+      marketing: false,
+      tier: false,
+    });
+    expect(result.success).toBe(true);
+    expect(result.prefs).toEqual({
+      challenges: false,
+      streak: false,
+      marketing: false,
+      tier: false,
+    });
+  });
+
+  it('rejects unknown category names', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const result = await managePushPreferences({ sms: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('unknown category');
+  });
+
+  it('rejects non-boolean category values', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const result = await managePushPreferences({ marketing: 'yes' });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('must be boolean');
+  });
+
+  it('rejects null/missing prefs argument', async () => {
+    setMember();
+    const result = await managePushPreferences(null);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('prefs object is required');
+  });
+
+  it('returns unauthenticated when no session', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const result = await managePushPreferences({ marketing: false });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('unauthenticated');
+  });
+
+  it('IDOR guard — uses session memberId, not request data', async () => {
+    setMember(MEMBER_ID);
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    await managePushPreferences({ marketing: false });
+    const inserted = __getInserted(PUSH_PREFERENCES_COLLECTION);
+    expect(inserted.length).toBe(1);
+    expect(inserted[0].memberId).toBe(MEMBER_ID);
+  });
+});
+
+// ── getMyPushPreferences ──────────────────────────────────────────────────
+
+describe('getMyPushPreferences', () => {
+  it('returns default all-true when no record exists', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const result = await getMyPushPreferences();
+    expect(result.success).toBe(true);
+    expect(result.prefs).toEqual({
+      challenges: true,
+      streak: true,
+      marketing: true,
+      tier: true,
+    });
+  });
+
+  it('returns stored preferences merged with defaults', async () => {
+    setMember();
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { marketing: false },
+    }]);
+    const result = await getMyPushPreferences();
+    expect(result.success).toBe(true);
+    expect(result.prefs.marketing).toBe(false);
+    expect(result.prefs.challenges).toBe(true);
+  });
+
+  it('returns unauthenticated when no session', async () => {
+    const result = await getMyPushPreferences();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('unauthenticated');
+  });
+});
+
+// ── skipIfOptedOut ────────────────────────────────────────────────────────
+
+describe('skipIfOptedOut', () => {
+  it('returns false (do not skip) when no preferences record exists', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, []);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.TIER_CHANGED);
+    expect(skip).toBe(false);
+  });
+
+  it('returns false for unmapped event types (BADGE_EARNED)', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { challenges: false, streak: false, marketing: false, tier: false },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.BADGE_EARNED);
+    expect(skip).toBe(false);
+  });
+
+  it('returns true when member opted out of the event category', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { challenges: true, streak: true, marketing: false, tier: true },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.PRICE_DROP);
+    expect(skip).toBe(true);
+  });
+
+  it('returns false when member opted in to the event category', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { challenges: true, streak: true, marketing: true, tier: true },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.PRICE_DROP);
+    expect(skip).toBe(false);
+  });
+
+  it('maps CHALLENGE_REMINDER to challenges category', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { challenges: false },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.CHALLENGE_REMINDER);
+    expect(skip).toBe(true);
+  });
+
+  it('maps CHALLENGE_COMPLETE to challenges category', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { challenges: false },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.CHALLENGE_COMPLETE);
+    expect(skip).toBe(true);
+  });
+
+  it('maps STREAK_MILESTONE to streak category', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: MEMBER_ID,
+      categoryPrefs: { streak: false },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.STREAK_MILESTONE);
+    expect(skip).toBe(true);
+  });
+
+  it('does not cross-contaminate between members', async () => {
+    __seed(PUSH_PREFERENCES_COLLECTION, [{
+      _id: 'pref-1',
+      memberId: OTHER_MEMBER,
+      categoryPrefs: { tier: false },
+    }]);
+    const skip = await skipIfOptedOut(MEMBER_ID, PUSH_EVENTS.TIER_CHANGED);
+    expect(skip).toBe(false);
+  });
+});

--- a/tests/streakAtRiskPush.test.js
+++ b/tests/streakAtRiskPush.test.js
@@ -26,8 +26,11 @@ vi.mock('backend/utils/dateUtils', () => ({
   getTodayET: () => TODAY_ET,
 }));
 
+const mockSkipIfOptedOut = vi.fn(async () => false);
+
 vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: (...args) => mockSendPushToMember(...args),
+  skipIfOptedOut: (...args) => mockSkipIfOptedOut(...args),
   PUSH_EVENTS: {
     STREAK_MILESTONE: 'streak_milestone',
   },
@@ -38,6 +41,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Default: sends 1 push per call
   mockSendPushToMember.mockResolvedValue({ sent: 1, failed: 0 });
+  mockSkipIfOptedOut.mockResolvedValue(false);
 });
 
 // ── Core send path ────────────────────────────────────────────────────────────
@@ -252,5 +256,24 @@ describe('runStreakAtRiskPushNotifications — token availability + errors', () 
     const result = await runStreakAtRiskPushNotifications();
 
     expect(result).toEqual({ sent: 0, skipped: 0, errors: 0 });
+  });
+});
+
+// ── cf-5je: category-level opt-out ────────────────────────────────────────────
+
+describe('runStreakAtRiskPushNotifications — cf-5je category opt-out', () => {
+  it('skips push when skipIfOptedOut returns true for the streak category', async () => {
+    __seed('MemberPoints', [
+      { _id: 'mp-1', memberId: 'mem-1', currentStreakDays: 5, lastActivityDate: YESTERDAY_ET },
+    ]);
+    __seed('MemberNotificationPrefs', []);
+    mockSkipIfOptedOut.mockResolvedValue(true);
+
+    const result = await runStreakAtRiskPushNotifications();
+
+    expect(result.sent).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockSendPushToMember).not.toHaveBeenCalled();
+    expect(mockSkipIfOptedOut).toHaveBeenCalledWith('mem-1', 'streak_milestone');
   });
 });

--- a/tests/tierUpgradeNotif.test.js
+++ b/tests/tierUpgradeNotif.test.js
@@ -17,9 +17,11 @@ import {
 } from './__mocks__/wix-crm-backend.js';
 
 const mockSendPushToMember = vi.fn(async () => ({ sent: 1, failed: 0 }));
+const mockSkipIfOptedOut = vi.fn(async () => false);
 
 vi.mock('backend/pushNotificationService.web', () => ({
   sendPushToMember: (...args) => mockSendPushToMember(...args),
+  skipIfOptedOut: (...args) => mockSkipIfOptedOut(...args),
   PUSH_EVENTS: {
     TIER_CHANGED: 'tier_changed',
   },
@@ -35,6 +37,7 @@ beforeEach(() => {
   resetCrm();
   vi.clearAllMocks();
   mockSendPushToMember.mockResolvedValue({ sent: 1, failed: 0 });
+  mockSkipIfOptedOut.mockResolvedValue(false);
 });
 
 describe('notifyTierUpgrade — happy path', () => {
@@ -169,5 +172,20 @@ describe('notifyTierUpgrade — failure modes', () => {
     // Email + push did fire on this branch (race-duplicate by definition), but
     // caller must NOT treat this as a successful fresh send and retry.
     expect(__getEmailLog()).toHaveLength(1);
+  });
+});
+
+// cf-5je: push-level opt-out must NOT block the email (email is the primary
+// artifact for tier upgrades; push is supplementary).
+describe('notifyTierUpgrade — cf-5je push opt-out', () => {
+  it('sends email but skips push when member opted out of tier category', async () => {
+    mockSkipIfOptedOut.mockResolvedValue(true);
+
+    const result = await notifyTierUpgrade('mem-1', 'gold', 'silver');
+
+    expect(result.sent).toBe(true);
+    expect(__getEmailLog()).toHaveLength(1);
+    expect(mockSendPushToMember).not.toHaveBeenCalled();
+    expect(mockSkipIfOptedOut).toHaveBeenCalledWith('mem-1', 'tier_changed');
   });
 });


### PR DESCRIPTION
## Summary
- Add `managePushPreferences` and `getMyPushPreferences` webMethods to `pushNotificationService.web.js` for member opt-in/out of push categories (challenges, streak, marketing, tier)
- Add `skipIfOptedOut` helper that gates push dispatch by checking member preferences; integrated into `crossRigEventReceiver` for `tier_changed` events
- Default all categories opt-in; stored in `PushPreferences` CMS collection with `memberId` + `categoryPrefs` JSON map
- 19 new tests covering single/bulk update, default behavior, IDOR guard, unmapped events, and cross-member isolation

## Test plan
- [x] 19 new tests in `tests/pushPreferences.test.js` — all pass
- [x] 66 existing tests in `pushNotificationService.test.js` + `crossRigEventReceiver.test.js` — 0 regressions
- [x] Pre-commit hooks (eslint + vitest) pass
- [ ] Verify `PushPreferences` CMS collection is provisioned in Wix dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cf-5je