### PR TITLE
fix(cf-f2h): pass $w to announce() in ShareYourRoom

### DIFF
--- a/src/public/ShareYourRoom.js
+++ b/src/public/ShareYourRoom.js
@@ -141,7 +141,7 @@ function openModal($w, state) {
   try { $w('#shareYourRoomModal').expand(); } catch (e) {}
   try { $w('#shareYourRoomOverlay').expand(); } catch (e) {}
 
-  announce('Share your room photo dialog opened');
+  announce($w, 'Share your room photo dialog opened');
   trackEvent('ugc_modal_open', {
     productId: state && state.product && state.product._id,
   });
@@ -151,7 +151,7 @@ function closeModal($w) {
   _isOpen = false;
   try { $w('#shareYourRoomModal').collapse(); } catch (e) {}
   try { $w('#shareYourRoomOverlay').collapse(); } catch (e) {}
-  announce('Share your room dialog closed');
+  announce($w, 'Share your room dialog closed');
 }
 
 async function handleUploadChange($w) {
@@ -232,7 +232,7 @@ async function handleSubmit($w, product) {
     if (result && result.success) {
       try { $w('#shareYourRoomForm').collapse(); } catch (e) {}
       try { $w('#shareYourRoomSuccess').expand(); } catch (e) {}
-      announce('Photo submitted! It will appear in the gallery after review.');
+      announce($w, 'Photo submitted! It will appear in the gallery after review.');
       trackEvent('ugc_photo_submitted', {
         roomType,
         productId: product._id,
@@ -262,7 +262,7 @@ function showValidation($w, message) {
   try {
     $w('#shareYourRoomValidation').text = message;
     $w('#shareYourRoomValidation').expand();
-    announce(message);
+    announce($w, message);
   } catch (e) {}
 }
 

--- a/tests/shareYourRoom.test.js
+++ b/tests/shareYourRoom.test.js
@@ -34,8 +34,7 @@ vi.mock('public/engagementTracker', () => ({
   trackEvent: vi.fn(),
 }));
 
-import { announce }    from 'public/a11yHelpers';
-import { trackEvent }  from 'public/engagementTracker';
+import { announce } from 'public/a11yHelpers';
 
 // ── $w Mock Factory ──────────────────────────────────────────────────────────
 
@@ -315,6 +314,7 @@ describe('ShareYourRoom', () => {
 
     expect(get('#shareYourRoomSuccess').expand).toHaveBeenCalled();
     expect(get('#shareYourRoomForm').collapse).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith(local$w, 'Photo submitted! It will appear in the gallery after review.');
   });
 
   it('shows API error and re-enables submit on failure', async () => {
@@ -333,6 +333,7 @@ describe('ShareYourRoom', () => {
     expect(get('#shareYourRoomValidation').text).toBe('Auth required.');
     expect(get('#shareYourRoomValidation').expand).toHaveBeenCalled();
     expect(get('#shareYourRoomSubmitBtn').enable).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith(local$w, 'Auth required.');
   });
 
   it('shows generic error and re-enables submit on network exception', async () => {

--- a/tests/shareYourRoom.test.js
+++ b/tests/shareYourRoom.test.js
@@ -34,6 +34,9 @@ vi.mock('public/engagementTracker', () => ({
   trackEvent: vi.fn(),
 }));
 
+import { announce }    from 'public/a11yHelpers';
+import { trackEvent }  from 'public/engagementTracker';
+
 // ── $w Mock Factory ──────────────────────────────────────────────────────────
 
 function mockEl(overrides = {}) {
@@ -141,6 +144,7 @@ describe('ShareYourRoom', () => {
     const handler = get('#shareYourRoomBtn').onClick.mock.calls[0][0];
     handler();
     expect(get('#shareYourRoomModal').expand).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith($w, 'Share your room photo dialog opened');
   });
 
   it('collapses login prompt for logged-in member', () => {
@@ -179,6 +183,7 @@ describe('ShareYourRoom', () => {
     const closeHandler = get('#shareYourRoomClose').onClick.mock.calls[0][0];
     closeHandler();
     expect(get('#shareYourRoomModal').collapse).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith($w, 'Share your room dialog closed');
   });
 
   it('collapses modal when overlay clicked', () => {
@@ -186,6 +191,7 @@ describe('ShareYourRoom', () => {
     const overlayHandler = get('#shareYourRoomOverlay').onClick.mock.calls[0][0];
     overlayHandler();
     expect(get('#shareYourRoomModal').collapse).toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith($w, 'Share your room dialog closed');
   });
 
   // ── upload ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `announce()` in `a11yHelpers.js` takes `($w, message, priority)` but 4 call sites in `ShareYourRoom.js` passed only `message`
- Screen readers never got modal open/close/submit/validation announcements because the live region lookup failed silently
- Fixes the 4 call paths: `openModal`, `closeModal`, `handleSubmit` success, `showValidation`

## Test plan
- [x] Added `expect(announce).toHaveBeenCalledWith($w, '...')` assertions for open / close-via-button / close-via-overlay paths
- [x] `npx vitest run tests/shareYourRoom.test.js` — 29/29 pass (pop-os)

🤖 Generated with [Claude Code](https://claude.com/claude-code)