### PR TITLE
docs(cf-3qt.4,5): blaidd prep — blog API, URL→CMS map, contact form spec

### DIFF
--- a/docs/cf-3qt/CMS-COLLECTION-AUDIT.md
+++ b/docs/cf-3qt/CMS-COLLECTION-AUDIT.md
@@ -1,0 +1,186 @@
+# CMS Collection Audit — Phase 4 & 5 Content Gap Analysis
+
+**Owner:** blaidd
+**For:** melania (reply to PR #1078 review)
+**Date:** 2026-04-17
+**Method:** grep of `wixData.(query|insert|update|remove|get)('...')` calls across `src/backend/`, `src/pages/`, `src/public/`.
+
+---
+
+## TL;DR
+
+**Phase 4 (content pages) — all collections exist. No blockers.**
+
+**Phase 5 (marketing + utility) — 4 collections missing. Blaidd owns seeding them.**
+
+Missing:
+1. `PressMentions` — needed for `/press` landing
+2. `PressKitAssets` — press kit downloads
+3. `Landings` — needed for `/spring-sale`, `/winback`, `/press` hero content
+4. `ComparisonFeatures` — needed for `/compare` matrix (Phase 4, not Phase 5 — correction below)
+
+---
+
+## 1. Phase 4 — content pages
+
+| Page | Collection(s) | Exists? | Schema source | Notes |
+|---|---|---|---|---|
+| `/about` | `AboutContent` | ✅ | `src/backend/contentImport.web.js:27-33` | Fields: `sectionKey` (Text, indexed), `title`, `content`, `sortOrder`. Correction: our doc called it `About` — real name is **`AboutContent`**. |
+| `/faq` | `FAQ` | ✅ | `src/backend/contentImport.web.js:16-22` | Fields: `question`, `answer`, `category`, `sortOrder`. |
+| `/contact` | `ContactSubmissions`, `ContactRateLimits` | ✅ | `src/backend/contactSubmissions.web.js` | Write-only from forms. |
+| `/getting-it-home` | (none — pure util) | n/a | `src/public/gettingItHomeHelpers.js` | Zip→zone logic is in code, not CMS. |
+| `/compare` | **`ComparisonFeatures`** | ❌ | — | **GAP.** I'll seed during Phase 4 implementation. |
+| `/videos` | `ProductVideos` | ✅ | `src/backend/productVideos.web.js` | Fields include `slug`, `title`, `videoUrl`, `thumbnailUrl`, `tags`. Also separate legacy `Videos` collection — verify which one carolinafutons.com's videos page reads. |
+| `/blog` | Wix Blog app (`Blog/Posts`, `Blog/Categories`, `Blog/Tags`) | ✅ | `src/backend/blogService.web.js` | Managed by Wix Blog app — don't touch schema. |
+| `/blog/[slug]` | Wix Blog app | ✅ | same | same |
+
+Ancillary used by `/contact` page layout:
+- `Testimonials` — ✅ `src/backend/testimonialService.web.js`
+
+---
+
+## 2. Phase 5 — marketing + utility
+
+| Page | Collection(s) | Exists? | Owner to seed |
+|---|---|---|---|
+| `/spring-sale` | **`Landings`** + `Stores/Products` | ❌ Landings / ✅ Products | blaidd |
+| `/newsletter` | `NewsletterSubscribers`, `NewsletterRateLimit`, `Unsubscribes` | ✅ | — |
+| `/press` | **`PressMentions`**, **`PressKitAssets`**, **`Landings`** | ❌ all | blaidd |
+| `/winback` | **`Landings`** | ❌ | blaidd |
+| `/404` | (static) | n/a | — |
+| `/search` | `Stores/Products`, Wix Blog | ✅ | — |
+| `/sitemap.xml` | `Stores/Products` + Wix Blog + route list | ✅ | — |
+
+---
+
+## 3. Missing collections — proposed schemas
+
+### 3a. `Landings`
+
+Purpose: hero content + CTA blocks for marketing landing routes. Editor-managed (melania).
+
+```
+slug (Text, indexed, unique)           // 'spring-sale' | 'winback' | 'press' | etc.
+title (Text)                            // SEO title
+headline (Text)                         // Hero H1
+subheadline (Text)                      // Hero subhead
+heroImageUrl (URL)                      // Wix media asset
+ctaPrimaryLabel (Text)
+ctaPrimaryHref (Text)
+ctaSecondaryLabel (Text, optional)
+ctaSecondaryHref (Text, optional)
+bodyMdx (Text, 20000)                   // Long copy, rendered as markdown
+utmDefaults (Object JSON)               // { campaign, content } applied to outbound links
+activeFrom (Date, optional)             // Visibility window
+activeUntil (Date, optional)
+seoDescription (Text)
+ogImageUrl (URL)
+```
+
+Permissions: Read = Anyone. Write = Admin.
+
+### 3b. `PressMentions`
+
+Purpose: "As seen in" list for `/press`. Populated by outreach as placements land.
+
+```
+outlet (Text, indexed)                  // 'Hendersonville Times-News'
+outletLogoUrl (URL)                     // grayscale logo asset
+articleTitle (Text)
+articleUrl (URL)
+publishedDate (Date, indexed)
+excerpt (Text, 500)                     // pull quote
+category (Text, indexed)                // 'local-press' | 'national' | 'podcast' | 'blog'
+featured (Boolean)                      // pin to top
+sortOrder (Number)
+```
+
+Permissions: Read = Anyone. Write = Admin.
+
+**Seed data source:** currently zero confirmed placements. `content/press/media-research.json` is outreach research, not placements. Until outreach lands, `/press` should show a roadmap/coming-soon treatment (see Phase 5 implementation note below).
+
+### 3c. `PressKitAssets`
+
+Purpose: downloadable assets (logos, product images, bios) for journalists.
+
+```
+name (Text)                             // 'Primary logo — SVG'
+description (Text)
+fileUrl (URL)                           // Wix media
+fileType (Text)                         // 'svg' | 'png' | 'pdf' | 'zip'
+fileSizeBytes (Number)
+category (Text, indexed)                // 'logo' | 'product-photo' | 'team-photo' | 'bio' | 'fact-sheet'
+sortOrder (Number)
+```
+
+Permissions: Read = Anyone. Write = Admin.
+
+### 3d. `ComparisonFeatures` (Phase 4 correction)
+
+Purpose: feature-matrix rows for `/compare`. Each row is one spec dimension (e.g. "Frame material") with per-product cell values.
+
+```
+featureKey (Text, indexed, unique)      // 'frame-material'
+label (Text)                            // 'Frame material'
+description (Text)                      // hover/help text
+category (Text, indexed)                // 'construction' | 'comfort' | 'price' | 'warranty'
+sortOrder (Number)
+values (Object JSON)                    // { '<productSlug>': '<cell value or icon key>' }
+```
+
+Alternative: normalize into two collections — `ComparisonRows` + `ComparisonCells` — but the denormalized-values map is simpler and `/compare` renders ≤20 rows × ≤5 products, so JSON blob is fine.
+
+Permissions: Read = Anyone. Write = Admin.
+
+---
+
+## 4. Seeding plan
+
+| Collection | Blocker? | Seed approach | When |
+|---|---|---|---|
+| `Landings` (`spring-sale` row) | blocks `/spring-sale` | Pull hero copy + image from current Wix Studio Sale page (radahn has it) → seed script | Phase 5 impl |
+| `Landings` (`winback` row) | blocks `/winback` | Copy from `docs/strategy/klaviyo-migration-spike.md` winback section + UTM defaults | Phase 5 impl |
+| `Landings` (`press` row) | blocks `/press` | Write fresh hero copy — "Carolina Futons in the News" + coming-soon treatment | Phase 5 impl |
+| `PressMentions` | blocks populated `/press` | Empty on launch. Roadmap treatment (see below). | Ongoing — melania's outreach populates |
+| `PressKitAssets` | nice-to-have | godfrey provides logo SVG + product shots. Seed 6-8 assets. | Phase 5 impl (coordinate w/ godfrey) |
+| `ComparisonFeatures` | blocks `/compare` | Port from current Wix Studio Compare page (if live) or from existing product spec data in `Products` | Phase 4 impl |
+
+---
+
+## 5. `/press` launch treatment (since `PressMentions` is empty)
+
+Proposed for Phase 5:
+
+1. Hero from `Landings` row — "Carolina Futons in the News"
+2. `PressMentions` list: if empty, render "Want to feature us? Get in touch." + link to media-contacts form
+3. Press kit downloads from `PressKitAssets` — ships populated (logos, fact sheet)
+4. When first placement lands (outreach from `content/press/media-research.json`), melania adds via Wix Studio CMS UI — page auto-hydrates, no code change.
+
+---
+
+## 6. Environment + OAuth confirmation (Q1 locked-in)
+
+Per melania's decision:
+- **Content reads** (Phase 4 all, Phase 5 all) → anonymous OAuth visitor token (`WIX_CLIENT_ID` only).
+- **Sitemap / seed scripts** (build-time) → admin API key (`WIX_ADMIN_API_KEY`).
+- **Form submits** (contact, newsletter) → anonymous token is enough; webMethods are `Permissions.Anyone` and handle their own rate-limiting.
+
+---
+
+## 7. Action items (tracked)
+
+- [ ] **blaidd:** when Phase 1 ships, include seed script `scripts/seed-cf-3qt-collections.ts` that provisions the 4 missing collections and seeds `Landings` rows.
+- [ ] **blaidd:** file a bead (or sub-task on cf-3qt.5) for `PressMentions` outreach loop — melania owns outreach, this just tracks when the first placement lands so we can flip `/press` from roadmap → populated.
+- [ ] **millicent (per Q5):** Phase 0 infra PR — `/api/revalidate` route handler + Wix onPublish webhook (HMAC-signed). Collections that need tags: `products`, `blog`, `pages`, `landings`.
+- [ ] **godfrey:** press-kit visual assets (logo SVG + product photos + fact-sheet PDF) for `PressKitAssets` seed.
+- [ ] **melania:** confirm `Landings` schema before I code the seed script.
+
+---
+
+## 8. What I checked
+
+```
+grep -rhoE "wixData\.(query|insert|update|remove|get)\(['\"][A-Za-z0-9_/]+['\"]" src/backend src/pages src/public
+```
+
+Full collection list (130 collections currently in use across the codebase) available in the grep output. None of `PressMentions`, `PressKitAssets`, `Landings`, `ComparisonFeatures` appear.

--- a/docs/cf-3qt/CONTACT-FORM-SPEC-NEXT.md
+++ b/docs/cf-3qt/CONTACT-FORM-SPEC-NEXT.md
@@ -2,8 +2,9 @@
 
 **Owner:** blaidd
 **Phase:** cf-3qt.4 (content) — `/contact`
-**Status:** prep (Phase 1 still blocked)
+**Status:** prep (Phase 1 still blocked) · decisions locked by melania 2026-04-17
 **Replaces:** `src/pages/Contact.js` (Velo) → Next.js route + route handler.
+**Appointment booking on this page:** OUT OF SCOPE for Phase 4 (punted post-migration — confirmed).
 
 This spec is the single source of truth for the Next.js contact form. It re-uses the existing Velo backend verbatim — no server-side behavior change. The Next.js layer is a proxy + UI.
 
@@ -172,7 +173,7 @@ submitContactForm(input: {
 }): Promise<{ success: boolean; message?: string }>;
 ```
 
-Auth: **Admin visitor token** (site-owner credentials). Webforms are `Permissions.Anyone`, but routing through an admin client keeps the option open for future Admin-only methods to share one client. Credentials via `WIX_ADMIN_API_KEY` in Vercel env.
+Auth: **anonymous OAuth visitor token** (`WIX_CLIENT_ID`) per melania 2026-04-17. Both target webMethods are `Permissions.Anyone`, so the visitor token is sufficient — no admin credentials in this request path. Admin API key is reserved for build-time sitemap/seed scripts.
 
 ---
 
@@ -216,12 +217,13 @@ These replace the Velo `trackEvent('contact_form_submit')` calls.
 - [ ] Lighthouse a11y ≥ 95
 - [ ] JSON-LD validates (Rich Results test)
 - [ ] No secrets in client bundle (grep the Vercel build output for `WIX_ADMIN_API_KEY`)
+- [ ] `WIX_ADMIN_API_KEY` is NOT read by this route — only `WIX_CLIENT_ID` (visitor token)
 
 ---
 
 ## 9. Out of scope (for Phase 4)
 
-- Appointment booking (Velo sections 7A/7B) — punt to post-migration bead.
+- Appointment booking (Velo sections 7A/7B) — confirmed punt to post-migration (melania 2026-04-17). Revisit only if traffic data justifies.
 - A/B testing submit copy — punt.
 - Inline captcha — rate-limiting + honeypot is sufficient per current posture; revisit if spam metrics regress.
 

--- a/docs/cf-3qt/CONTACT-FORM-SPEC-NEXT.md
+++ b/docs/cf-3qt/CONTACT-FORM-SPEC-NEXT.md
@@ -1,0 +1,235 @@
+# Contact Form Spec — Next.js (cf-3qt Phase 4)
+
+**Owner:** blaidd
+**Phase:** cf-3qt.4 (content) — `/contact`
+**Status:** prep (Phase 1 still blocked)
+**Replaces:** `src/pages/Contact.js` (Velo) → Next.js route + route handler.
+
+This spec is the single source of truth for the Next.js contact form. It re-uses the existing Velo backend verbatim — no server-side behavior change. The Next.js layer is a proxy + UI.
+
+---
+
+## 1. Contract with the existing backend
+
+Two webMethods are already correct; we call both (matching current Velo flow in `src/pages/Contact.js:100-115`).
+
+### 1a. `emailService.sendEmail` (Permissions.Anyone)
+
+Fires the triggered email to the site owner and inserts to `ContactSubmissions` collection.
+
+Input shape:
+```ts
+{
+  name: string;      // required, max 200
+  email: string;     // required, max 254, must match email regex
+  phone?: string;    // max 20
+  subject?: string;  // max 300
+  message: string;   // required, max 2000
+}
+```
+
+Response:
+```ts
+{ success: true }
+| { success: false, message: string }   // validation / rate-limit / invalid email
+```
+
+Server enforces: schema validation, sanitization, email regex, **3 submissions/hour per email** (`EMAIL_RATE_LIMIT_MAX`). Rate-limit message is user-facing.
+
+### 1b. `contactSubmissions.submitContactForm` (Permissions.Anyone)
+
+A secondary lightweight capture with different rate limits (3/hour per email in `ContactRateLimits`) — fires even if `sendEmail` throws, to preserve the lead.
+
+The Velo page calls both in parallel. The Next.js proxy does the same.
+
+---
+
+## 2. Route layout
+
+```
+app/
+  contact/
+    page.tsx                 # Server component — SEO + static copy
+    contact-form.tsx         # Client component — form UI + validation
+  api/
+    contact/
+      route.ts               # POST proxy → sendEmail + submitContactForm
+```
+
+### `app/contact/page.tsx` (server)
+
+- SEO: title, description, canonical via `generateMetadata`. Reuse copy from existing `seoHelpers.getPageTitle('contact')` / `getPageMetaDescription('contact')` by calling them via `/api/seo/page?slug=contact` — keeps the Velo content store authoritative.
+- Layout: two-column on `md+`, stacked on mobile. Form left, business info right.
+- Static blocks below fold: Business Hours (rendered from `lib/business/hours.ts`, ported from `public/aboutContactHelpers.js:formatBusinessHours`), Testimonials (from `@wix/data` `Testimonials` collection, ISR 3600), FAQ link.
+- Appointment booking (Section 7 of Velo spec) is **out of scope for Phase 4** — deferred. Flag this to Melania.
+- JSON-LD: `LocalBusiness` schema block rendered server-side (port `localBusinessSeo.js`).
+
+### `app/contact/contact-form.tsx` (client)
+
+- React Hook Form + Zod for validation (matches Phase 1 design-system convention).
+- Fields, in order: Name, Email, Phone (optional), Subject (optional), Message.
+- Submit button disabled while pending; aria-busy on form during in-flight.
+- Success: swap form for `<SubmittedState />` with thank-you copy + "Send another" link.
+- Error: inline banner at top + field-level errors; keep form values intact.
+- Honeypot: hidden `website` field; non-empty → drop client-side (also server-drops).
+
+---
+
+## 3. Validation (Zod → shared with server)
+
+```ts
+// lib/contact/schema.ts
+import { z } from 'zod';
+
+export const contactSchema = z.object({
+  name: z.string().trim().min(1, 'Please enter your name').max(200),
+  email: z.string().trim().toLowerCase().email('Enter a valid email').max(254),
+  phone: z.string().trim().max(20).optional().default(''),
+  subject: z.string().trim().max(300).optional().default(''),
+  message: z.string().trim().min(1, 'Message is required').max(2000),
+  website: z.string().max(0).optional(), // honeypot — must stay empty
+});
+
+export type ContactInput = z.infer<typeof contactSchema>;
+```
+
+Server re-parses on the route handler (never trust client validation).
+
+Max lengths match the Velo `validateSchema` contract so we never send a payload the backend will reject.
+
+---
+
+## 4. Route handler — `app/api/contact/route.ts`
+
+```ts
+import { NextResponse } from 'next/server';
+import { contactSchema } from '@/lib/contact/schema';
+import { wixServerClient } from '@/lib/wix/server';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  if (!body) return NextResponse.json({ ok: false, error: 'invalid-json' }, { status: 400 });
+
+  const parsed = contactSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'validation', issues: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  if (parsed.data.website) {
+    return NextResponse.json({ ok: true }); // silent honeypot drop
+  }
+
+  const { name, email, phone, subject, message } = parsed.data;
+
+  // Call both webMethods in parallel — same as current Velo page.
+  const [emailRes, submissionRes] = await Promise.allSettled([
+    wixServerClient.sendEmail({ name, email, phone, subject, message }),
+    wixServerClient.submitContactForm({
+      email,
+      name,
+      phone,
+      notes: `${subject ? `Subject: ${subject}\n` : ''}${message}`,
+      source: 'contact-page',
+    }),
+  ]);
+
+  // sendEmail success is the signal users see. submitContactForm failing
+  // only loses the redundant CMS row; log but don't surface.
+  const emailOk = emailRes.status === 'fulfilled' && emailRes.value?.success === true;
+  if (!emailOk) {
+    const msg = emailRes.status === 'fulfilled'
+      ? (emailRes.value?.message ?? 'Send failed')
+      : 'Send failed';
+    return NextResponse.json({ ok: false, error: 'send-failed', message: msg }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+```
+
+### Rate-limit & abuse posture
+
+- Server-side rate limit lives in the Velo backend (3/hour per email). No second limiter in Next.js.
+- Honeypot drops silently ({ ok: true }) — matches existing behavior and avoids telling bots they're caught.
+- Log failures to Sentry with `tag: 'contact-form'`. Do not log PII bodies.
+
+---
+
+## 5. Wix server client (shared with other webMethods)
+
+Phase 1 will ship `lib/wix/server.ts`. Contact only needs:
+
+```ts
+sendEmail(input: ContactInput): Promise<{ success: boolean; message?: string }>;
+submitContactForm(input: {
+  email: string; name?: string; phone?: string;
+  notes?: string; source?: string; productId?: string; productName?: string;
+}): Promise<{ success: boolean; message?: string }>;
+```
+
+Auth: **Admin visitor token** (site-owner credentials). Webforms are `Permissions.Anyone`, but routing through an admin client keeps the option open for future Admin-only methods to share one client. Credentials via `WIX_ADMIN_API_KEY` in Vercel env.
+
+---
+
+## 6. Accessibility requirements (port from Velo spec)
+
+- Every input has a `<label>` or `aria-label`. No placeholder-as-label.
+- Required fields use `aria-required="true"` + visual asterisk in label.
+- Errors announced via `aria-describedby` → `<p id="contactNameError" role="alert">`.
+- Submit button text changes to "Sending…" when pending; loading state readable by screen readers (`aria-live="polite"`).
+- Success region uses `role="status"` + `aria-live="polite"` so the form→thankyou swap is announced.
+- Minimum target size 44×44 on mobile.
+- Tab order: Name → Email → Phone → Subject → Message → honeypot (hidden, `tabindex="-1"`) → Submit.
+
+---
+
+## 7. Analytics
+
+Fire events via `lib/analytics/track.ts`:
+
+| Event | When | Props |
+|---|---|---|
+| `contact_form_view` | page mount | `{}` |
+| `contact_form_submit_attempt` | onSubmit fired | `{ hasPhone, hasSubject }` |
+| `contact_form_submit_success` | API returned ok | `{}` |
+| `contact_form_submit_error` | API returned 4xx/5xx | `{ reason }` |
+| `contact_form_validation_error` | client Zod failure | `{ field }` |
+
+These replace the Velo `trackEvent('contact_form_submit')` calls.
+
+---
+
+## 8. Acceptance checklist
+
+- [ ] `/contact` renders on Vercel preview with Phase 1 design tokens
+- [ ] Form validates client-side; shows field-level errors
+- [ ] Submitting with valid data fires both webMethods; Stilgar's test inbox receives the triggered email
+- [ ] A new row lands in the `ContactSubmissions` CMS collection
+- [ ] Rate-limit path (4th submission within 1h for same email) shows the user-facing rate-limit message
+- [ ] Honeypot submissions return 200 with no email fired, no CMS row
+- [ ] Screen-reader walk-through passes (NVDA or VoiceOver)
+- [ ] Lighthouse a11y ≥ 95
+- [ ] JSON-LD validates (Rich Results test)
+- [ ] No secrets in client bundle (grep the Vercel build output for `WIX_ADMIN_API_KEY`)
+
+---
+
+## 9. Out of scope (for Phase 4)
+
+- Appointment booking (Velo sections 7A/7B) — punt to post-migration bead.
+- A/B testing submit copy — punt.
+- Inline captcha — rate-limiting + honeypot is sufficient per current posture; revisit if spam metrics regress.
+
+---
+
+## 10. References
+
+- Velo page: `src/pages/Contact.js`
+- Backends: `src/backend/emailService.web.js` (`sendEmail` @ line 116), `src/backend/contactSubmissions.web.js` (`submitContactForm` @ line 109)
+- Helpers ported from: `src/public/aboutContactHelpers.js`, `src/public/localBusinessSeo.js`, `src/public/validators.js`
+- Wix Studio spec (decommissioned after cf-3qt.6): `docs/CONTACT-PAGE-BUILD-SPEC.md`

--- a/docs/cf-3qt/URL-CMS-MAP.md
+++ b/docs/cf-3qt/URL-CMS-MAP.md
@@ -1,0 +1,117 @@
+# URL → CMS / Backend Map (cf-3qt Phase 4 + 5)
+
+**Owner:** blaidd
+**Phase:** cf-3qt.4 (content) and cf-3qt.5 (marketing + utility)
+**Status:** prep (Phase 1 still blocked)
+**Scope:** Every production route the migration must keep live. Core commerce routes (Home, Category, Product, Cart, Checkout, Search) are called out for continuity but owned by Phase 2/3.
+
+**Legend:**
+- **Render** = Next.js render strategy: `static`, `ISR(ttl)`, `SSR`, `dynamic`
+- **Source** = where the page's data comes from. `@wix/stores`, `@wix/blog`, `@wix/data` (generic CMS), or a named webMethod we must port.
+- **Owner phase** = which bead owns the migration.
+
+---
+
+## Phase 4 — Content pages (blaidd owns these)
+
+| Route | Page file (Velo) | Render | Source | Notes |
+|---|---|---|---|---|
+| `/about` | `About.js` | `ISR(3600)` | `@wix/data` → `About` collection | Single-doc collection. Flat fields. |
+| `/faq` | `FAQ.js` | `ISR(3600)` | `@wix/data` → `FAQ` collection | Fields: `question`, `answer` (rich), `category`, `order`. Collapsible UI client-side. |
+| `/contact` | `Contact.js` | `static` + client form | `contactSubmissions.submitContactForm` webMethod | See `CONTACT-FORM-SPEC-NEXT.md`. Form POSTs to Next.js route handler → proxies to existing webMethod. |
+| `/getting-it-home` | `Getting It Home.js` | `static` + client calc | `src/public/gettingItHomeHelpers.js` (port to `lib/delivery/zones.ts`) | Pure JS — zip→zone + distance. No Wix call needed; ship as client util. |
+| `/compare` | `Compare Page.js` | `ISR(3600)` | `@wix/stores` products + `@wix/data` → `ComparisonFeatures` | Pulls matrix rows from collection; hydrates product cells from Stores SDK. |
+| `/videos` | `Product Videos.js` | `ISR(3600)` | `@wix/data` → `ProductVideos` collection | Fields: `title`, `description`, `videoUrl` (YouTube), `thumbnailUrl`, `tags`, `order`. |
+| `/blog` | `Blog.js` | `ISR(300)` | `@wix/blog` `posts.listPosts` | Paginated. See `WIX-BLOG-API-RESEARCH.md`. |
+| `/blog/[slug]` | `Blog Post.js` | `ISR(600)` + `generateStaticParams` | `@wix/blog` `posts.getPostBySlug` | 404 on missing slug. Render via `@wix/ricos-viewer`. |
+
+### Phase 4 CMS collections required
+
+| Collection | Read access | Write access | Used by |
+|---|---|---|---|
+| `About` | Anyone | — | `/about` |
+| `FAQ` | Anyone | — | `/faq`, blog FAQ blocks |
+| `ComparisonFeatures` | Anyone | — | `/compare` |
+| `ProductVideos` | Anyone | — | `/videos` |
+| `Blog/Posts` | Anyone (Wix app) | Wix Studio authors | `/blog`, `/blog/[slug]`, RSS |
+| `Blog/Categories`, `Blog/Tags` | Anyone (Wix app) | Wix Studio | future category filters |
+| `ContactSubmissions` | — | webMethod (server-side only) | contact form |
+| `ContactRateLimits` | — | webMethod | contact form spam guard |
+
+---
+
+## Phase 5 — Marketing + utility (blaidd owns these)
+
+| Route | Page file (Velo) | Render | Source | Notes |
+|---|---|---|---|---|
+| `/spring-sale` | `Sale.js` (variant) | `ISR(1800)` | `@wix/data` → `Landings` (filter `slug="spring-sale"`) + `@wix/stores` sale collection | Hero + featured-products block. |
+| `/newsletter` | `Newsletter.js` | `static` + client form | `newsletterService.subscribeToNewsletter` webMethod | Double opt-in already wired server-side. |
+| `/press` | — (new Velo page TBD) | `static` | `@wix/data` → `PressMentions` + `PressKitAssets` | If `PressMentions` not seeded, Phase 5 creates seed script. |
+| `/winback` | — (new) | `ISR(1800)` | `@wix/data` → `Landings` (filter `slug="winback"`); UTM passthrough to `analyticsHelpers.recordUtmTouch` | UTM params → fire `events.js` emit → automation engine picks up. |
+| `/404` | `masterPage.js` error route | `static` | — | Brand shell + search widget. |
+| `/search` | `Search Results.js` | `SSR` (reads `?q=`) | `@wix/stores` product search + `@wix/blog` `queryPosts().contains('title', q)` | Merge results client-side. |
+| `/sitemap.xml` | — (generated) | route handler | Stores products + blog slugs + static routes list | Build at request time; cache 1h. |
+| `/robots.txt` | — | `static` | constant | Allow all + sitemap pointer. |
+
+### Phase 5 CMS collections required
+
+| Collection | Read access | Write access | Used by |
+|---|---|---|---|
+| `Landings` | Anyone | Editors | `/spring-sale`, `/winback`, any future campaign URL |
+| `PressMentions` | Anyone | Editors | `/press` |
+| `PressKitAssets` | Anyone | Editors | `/press` downloads |
+| `Subscribers` | — | webMethod | newsletter |
+| `Unsubscribes` | — | webMethod | newsletter + blog digest |
+
+---
+
+## Commerce + account routes (NOT our phase — for completeness)
+
+These are Phase 2/3 territory. Listed so the sitemap generator has the full route table.
+
+| Route | Source | Phase |
+|---|---|---|
+| `/` | `@wix/stores` featured + `@wix/data` `HomepageBlocks` | 2 |
+| `/product/[slug]` | `@wix/stores` `getProductBySlug` | 2 |
+| `/category/[slug]` | `@wix/stores` `queryProducts` + `Categories` | 2 |
+| `/cart`, `/checkout` | `@wix/stores` / `@wix/ecom` | 2 |
+| `/account/*` | `@wix/members` | 3 |
+| `/loyalty`, `/referral`, `/rewards` | `@wix/loyalty` + `loyaltyService` webMethods | 3 |
+| `/style-quiz`, `/style-quiz/result` | `styleQuizService` webMethods | 3 |
+| `/swatch-kit`, `/fabric-swatches` | `emailService.submitSwatchRequest` | 3 |
+| `/virtual-consultation` | `consultationService` webMethods | 3 |
+| `/wishlist`, `/wishlist-share/[id]` | `wishlistService` webMethods | 3 |
+| `/gift-cards`, `/gift-registry` | `@wix/gift-cards` | 3 |
+| `/store-locator`, `/local-seo/[city]` | `storeLocatorService`, `localSeoService` | 3 |
+| `/admin/*` | membership-gated, backend-heavy | post-migration (keeps Wix Studio until cf-3qt.6 passes) |
+
+---
+
+## webMethod → Next.js route handler mapping
+
+Every webMethod we call from the Next.js client goes through a thin `app/api/*` proxy (to keep secrets + OAuth server-side). Phase 4/5 needs:
+
+| Next.js route handler | Proxies to webMethod | Method |
+|---|---|---|
+| `POST /api/contact` | `contactSubmissions.submitContactForm` | POST |
+| `POST /api/newsletter/subscribe` | `newsletterService.subscribeToNewsletter` | POST |
+| `POST /api/newsletter/unsubscribe` | `newsletterService.unsubscribeFromESP` | POST |
+| `GET  /api/delivery-zone?zip=` | `storeLocatorService` distance calc (or inline `lib/delivery/zones.ts`) | GET |
+| `GET  /api/search?q=` | fan-out to stores + blog | GET |
+
+---
+
+## Open questions for Phase 1 / Melania
+
+1. **Route casing** — keep `/getting-it-home` (current) or switch to `/delivery`? Current Velo URL is live; SEO says keep.
+2. **Winback landing** — is the `Landings` collection already seeded with a `winback` row, or does Phase 5 own the seed?
+3. **Press page** — if `PressMentions` is empty, do we soft-launch with a "coming soon" stub or block the route?
+4. **Sitemap cache** — 1h ok, or do we need revalidate-on-publish? (Webhook from Wix → `revalidateTag('sitemap')`.)
+
+---
+
+## Source of truth
+
+- Velo pages: `src/pages/*.js`
+- webMethods: `src/backend/*.web.js`
+- Route casing comes from Wix Studio page settings — before Phase 6 parity audit, grab the live-site URL list and diff.

--- a/docs/cf-3qt/URL-CMS-MAP.md
+++ b/docs/cf-3qt/URL-CMS-MAP.md
@@ -2,8 +2,9 @@
 
 **Owner:** blaidd
 **Phase:** cf-3qt.4 (content) and cf-3qt.5 (marketing + utility)
-**Status:** prep (Phase 1 still blocked)
+**Status:** prep (Phase 1 still blocked) · decisions locked by melania 2026-04-17
 **Scope:** Every production route the migration must keep live. Core commerce routes (Home, Category, Product, Cart, Checkout, Search) are called out for continuity but owned by Phase 2/3.
+**Companion:** `CMS-COLLECTION-AUDIT.md` — what exists vs. what needs seeding.
 
 **Legend:**
 - **Render** = Next.js render strategy: `static`, `ISR(ttl)`, `SSR`, `dynamic`
@@ -16,23 +17,23 @@
 
 | Route | Page file (Velo) | Render | Source | Notes |
 |---|---|---|---|---|
-| `/about` | `About.js` | `ISR(3600)` | `@wix/data` → `About` collection | Single-doc collection. Flat fields. |
-| `/faq` | `FAQ.js` | `ISR(3600)` | `@wix/data` → `FAQ` collection | Fields: `question`, `answer` (rich), `category`, `order`. Collapsible UI client-side. |
-| `/contact` | `Contact.js` | `static` + client form | `contactSubmissions.submitContactForm` webMethod | See `CONTACT-FORM-SPEC-NEXT.md`. Form POSTs to Next.js route handler → proxies to existing webMethod. |
-| `/getting-it-home` | `Getting It Home.js` | `static` + client calc | `src/public/gettingItHomeHelpers.js` (port to `lib/delivery/zones.ts`) | Pure JS — zip→zone + distance. No Wix call needed; ship as client util. |
-| `/compare` | `Compare Page.js` | `ISR(3600)` | `@wix/stores` products + `@wix/data` → `ComparisonFeatures` | Pulls matrix rows from collection; hydrates product cells from Stores SDK. |
-| `/videos` | `Product Videos.js` | `ISR(3600)` | `@wix/data` → `ProductVideos` collection | Fields: `title`, `description`, `videoUrl` (YouTube), `thumbnailUrl`, `tags`, `order`. |
-| `/blog` | `Blog.js` | `ISR(300)` | `@wix/blog` `posts.listPosts` | Paginated. See `WIX-BLOG-API-RESEARCH.md`. |
-| `/blog/[slug]` | `Blog Post.js` | `ISR(600)` + `generateStaticParams` | `@wix/blog` `posts.getPostBySlug` | 404 on missing slug. Render via `@wix/ricos-viewer`. |
+| `/about` | `About.js` | `ISR(900)` tag=`pages` | `@wix/data` → **`AboutContent`** | Collection name corrected (was `About`). Fields: `sectionKey`, `title`, `content`, `sortOrder`. |
+| `/faq` | `FAQ.js` | `ISR(900)` tag=`pages` | `@wix/data` → `FAQ` | Fields: `question`, `answer`, `category`, `sortOrder`. Collapsible UI client-side. |
+| `/contact` | `Contact.js` | `static` + client form | `contactSubmissions.submitContactForm` + `emailService.sendEmail` webMethods | See `CONTACT-FORM-SPEC-NEXT.md`. |
+| `/getting-it-home` | `Getting It Home.js` | `static` + client calc | `src/public/gettingItHomeHelpers.js` → `lib/delivery/zones.ts` | Keep `/getting-it-home` (SEO/inbound links/GSC). Add `/delivery` 301 if marketing needs a shorter URL. |
+| `/compare` | `Compare Page.js` | `ISR(3600)` tag=`pages` | `@wix/stores` products + `@wix/data` → **`ComparisonFeatures`** (new) | Collection doesn't exist yet — blaidd seeds in Phase 4 impl. |
+| `/videos` | `Product Videos.js` | `ISR(3600)` tag=`pages` | `@wix/data` → `ProductVideos` | Verify which of `ProductVideos` vs. legacy `Videos` collection the live site reads before seeding. |
+| `/blog` | `Blog.js` | `ISR(300)` tag=`blog` | `@wix/blog` `posts.listPosts` | Paginated. See `WIX-BLOG-API-RESEARCH.md`. |
+| `/blog/[slug]` | `Blog Post.js` | `ISR(600)` tag=`blog` + `generateStaticParams` | `@wix/blog` `posts.getPostBySlug` | 404 on missing slug. Render via `@wix/ricos-viewer`. |
 
 ### Phase 4 CMS collections required
 
 | Collection | Read access | Write access | Used by |
 |---|---|---|---|
-| `About` | Anyone | — | `/about` |
-| `FAQ` | Anyone | — | `/faq`, blog FAQ blocks |
-| `ComparisonFeatures` | Anyone | — | `/compare` |
-| `ProductVideos` | Anyone | — | `/videos` |
+| `AboutContent` | Anyone | Admin | `/about` — exists ✓ |
+| `FAQ` | Anyone | Admin | `/faq`, blog FAQ blocks — exists ✓ |
+| `ComparisonFeatures` | Anyone | Admin | `/compare` — **missing, blaidd seeds** |
+| `ProductVideos` | Anyone | Admin | `/videos` — exists ✓ |
 | `Blog/Posts` | Anyone (Wix app) | Wix Studio authors | `/blog`, `/blog/[slug]`, RSS |
 | `Blog/Categories`, `Blog/Tags` | Anyone (Wix app) | Wix Studio | future category filters |
 | `ContactSubmissions` | — | webMethod (server-side only) | contact form |
@@ -44,10 +45,10 @@
 
 | Route | Page file (Velo) | Render | Source | Notes |
 |---|---|---|---|---|
-| `/spring-sale` | `Sale.js` (variant) | `ISR(1800)` | `@wix/data` → `Landings` (filter `slug="spring-sale"`) + `@wix/stores` sale collection | Hero + featured-products block. |
+| `/spring-sale` | `Sale.js` (variant) | `ISR(1800)` tag=`landings` | `@wix/data` → **`Landings`** (filter `slug="spring-sale"`) + `@wix/stores` sale collection | `Landings` collection missing — blaidd seeds. |
 | `/newsletter` | `Newsletter.js` | `static` + client form | `newsletterService.subscribeToNewsletter` webMethod | Double opt-in already wired server-side. |
-| `/press` | — (new Velo page TBD) | `static` | `@wix/data` → `PressMentions` + `PressKitAssets` | If `PressMentions` not seeded, Phase 5 creates seed script. |
-| `/winback` | — (new) | `ISR(1800)` | `@wix/data` → `Landings` (filter `slug="winback"`); UTM passthrough to `analyticsHelpers.recordUtmTouch` | UTM params → fire `events.js` emit → automation engine picks up. |
+| `/press` | — (new) | `ISR(1800)` tag=`landings` | `@wix/data` → **`PressMentions`** + **`PressKitAssets`** + **`Landings`** (filter `slug="press"`) | All 3 collections missing. Launch with roadmap treatment (no placements yet). See `CMS-COLLECTION-AUDIT.md` §5. |
+| `/winback` | — (new) | `ISR(1800)` tag=`landings` | `@wix/data` → **`Landings`** (filter `slug="winback"`); UTM passthrough to `analyticsHelpers.recordUtmTouch` | UTM params → fire `events.js` emit → automation engine picks up. |
 | `/404` | `masterPage.js` error route | `static` | — | Brand shell + search widget. |
 | `/search` | `Search Results.js` | `SSR` (reads `?q=`) | `@wix/stores` product search + `@wix/blog` `queryPosts().contains('title', q)` | Merge results client-side. |
 | `/sitemap.xml` | — (generated) | route handler | Stores products + blog slugs + static routes list | Build at request time; cache 1h. |
@@ -57,11 +58,12 @@
 
 | Collection | Read access | Write access | Used by |
 |---|---|---|---|
-| `Landings` | Anyone | Editors | `/spring-sale`, `/winback`, any future campaign URL |
-| `PressMentions` | Anyone | Editors | `/press` |
-| `PressKitAssets` | Anyone | Editors | `/press` downloads |
-| `Subscribers` | — | webMethod | newsletter |
-| `Unsubscribes` | — | webMethod | newsletter + blog digest |
+| `Landings` | Anyone | Admin | `/spring-sale`, `/winback`, `/press`, any future campaign — **missing, blaidd seeds** |
+| `PressMentions` | Anyone | Admin | `/press` — **missing, blaidd seeds** (empty on launch) |
+| `PressKitAssets` | Anyone | Admin | `/press` downloads — **missing, blaidd seeds** (coord w/ godfrey for assets) |
+| `NewsletterSubscribers` | — | webMethod | newsletter — exists ✓ |
+| `NewsletterRateLimit` | — | webMethod | newsletter rate limit — exists ✓ |
+| `Unsubscribes` | — | webMethod | newsletter + blog digest — exists ✓ |
 
 ---
 
@@ -101,12 +103,13 @@ Every webMethod we call from the Next.js client goes through a thin `app/api/*` 
 
 ---
 
-## Open questions for Phase 1 / Melania
+## Decisions (locked by melania 2026-04-17)
 
-1. **Route casing** — keep `/getting-it-home` (current) or switch to `/delivery`? Current Velo URL is live; SEO says keep.
-2. **Winback landing** — is the `Landings` collection already seeded with a `winback` row, or does Phase 5 own the seed?
-3. **Press page** — if `PressMentions` is empty, do we soft-launch with a "coming soon" stub or block the route?
-4. **Sitemap cache** — 1h ok, or do we need revalidate-on-publish? (Webhook from Wix → `revalidateTag('sitemap')`.)
+1. **Route casing** — keep `/getting-it-home`. `/delivery` may be added later as a 301 redirect if marketing asks.
+2. **Winback landing** — blaidd seeds. Hero/UTM defaults pulled from `docs/strategy/klaviyo-migration-spike.md`.
+3. **Press page** — soft-launch with roadmap treatment. `PressMentions` collection seeded empty; page renders "Want to feature us? Get in touch." CTA until outreach lands.
+4. **Sitemap revalidate** — on-demand via webhook (millicent owns the `/api/revalidate` route handler in Phase 0 infra PR). Tags: `products`, `blog`, `pages`, `landings`. Static TTL falls back to 1h if webhook misses.
+5. **Appointment booking** on `/contact` — **punted out of Phase 4**. Post-migration optimization if traffic justifies.
 
 ---
 

--- a/docs/cf-3qt/WIX-BLOG-API-RESEARCH.md
+++ b/docs/cf-3qt/WIX-BLOG-API-RESEARCH.md
@@ -1,0 +1,117 @@
+# Wix Blog API — Headless Research (cf-3qt Phase 4)
+
+**Owner:** blaidd
+**Phase:** cf-3qt.4 (content) — blog index + `/blog/[slug]`
+**Status:** prep (Phase 1 still blocked)
+**Decision summary:** Use the `@wix/blog` SDK via `@wix/sdk` client. Fall back to `@wix/data` queries on `Blog/Posts` only if a specific field (e.g. `richContent` rendering quirk) forces it.
+
+---
+
+## 1. Current Velo implementation (what we're replacing)
+
+`src/backend/blogService.web.js` uses `wix-blog-backend` (Velo-only, cannot run in Next.js):
+
+- `posts.listPosts({ paging: { limit, offset } })` — index listing, with `metaData.total`
+- Fallback static content in `backend/blogContent` (`getAllBlogPosts`, `getBlogPost(slug)`, `getBlogSlugs`, `getBlogFaqs`)
+- Normalizer flattens: `{ _id, title, slug, excerpt, publishedDate, coverImageUrl, category, authorName }`
+
+The Next.js build must reproduce that normalizer verbatim so downstream page props stay stable.
+
+---
+
+## 2. Headless equivalent — `@wix/blog`
+
+The Wix Headless SDK exposes the same Blog API surface as Velo's `wix-blog-backend`, but instantiated through a Wix client.
+
+### Install
+```
+npm i @wix/sdk @wix/blog
+```
+
+### Client construction (Next.js server-side)
+```js
+import { createClient } from '@wix/sdk';
+import { posts } from '@wix/blog';
+import { OAuthStrategy } from '@wix/sdk';
+
+export const wixBlog = createClient({
+  modules: { posts },
+  auth: OAuthStrategy({ clientId: process.env.WIX_CLIENT_ID }),
+});
+```
+
+Auth strategy TBD by Phase 1 (likely anonymous OAuth visitor token — blog read is public). `WIX_CLIENT_ID` lives in Vercel env (already in scope for cf-3qt.1).
+
+### Methods we need
+
+| Our use case | SDK call | Notes |
+|---|---|---|
+| Blog index (paginated) | `posts.listPosts({ paging: { limit, offset } })` | Mirrors current Velo call. Returns `{ posts, metaData: { total } }`. |
+| `/blog/[slug]` resolve | `posts.getPostBySlug(slug)` | Preferred over `getPost(id)` — avoids slug→id lookup. Returns 404-shaped error if missing. |
+| `generateStaticParams` (ISR) | `posts.queryPosts().find()` | Pull all slugs at build; re-revalidate on demand. |
+| Category filter (future) | `posts.queryPosts().eq('categoryIds', id)` | Not Phase 4 critical. |
+
+### Field availability (SDK)
+
+Confirmed available on the returned post (matches `Blog/Posts` collection):
+`_id, title, slug, excerpt, publishedDate, firstPublishedDate, media.wixMedia.image.url, categories[], mainCategory, plainContent, richContent, hashtags, author.authorName, viewCount, likeCount, seoData, memberId`.
+
+`richContent` is **Ricos JSON** (not HTML). Rendering options:
+- **Preferred:** `@wix/ricos-viewer` (React component, SSR-safe).
+- **Fallback:** `plainContent` wrapped in `<p>` if Ricos adds too much bundle weight — loses images/embeds, so only acceptable for excerpt cards.
+
+---
+
+## 3. Fallback: `@wix/data` on `Blog/Posts`
+
+If the SDK path is blocked (auth, quota, rendering), Wix exposes the raw collection via the CMS REST:
+
+```
+POST https://www.wixapis.com/wix-data/v2/items/query
+Body: { "dataCollectionId": "Blog/Posts", "query": {...} }
+```
+
+Same fields are readable. Trade-offs:
+- Pros: one dependency (`@wix/data`) covers blog + FAQ + About + Videos (see URL→CMS map).
+- Cons: must re-implement paging/sorting by hand; `richContent` still Ricos JSON.
+
+**Recommendation:** default to `@wix/blog`; reserve `@wix/data` for the non-blog collections that don't have a dedicated SDK.
+
+---
+
+## 4. Normalization contract (ports the Velo normalizer)
+
+Downstream pages expect this shape. Expose it from `lib/wix/blog.ts`:
+
+```ts
+export interface BlogPostCard {
+  _id: string;
+  title: string;
+  slug: string;
+  excerpt: string;
+  publishedDate: string;      // ISO
+  coverImageUrl: string;      // '' if none
+  category: string;           // '' if none (first label)
+  authorName: string;         // 'Carolina Futons Team' fallback
+}
+```
+
+Full post adds: `richContent: RicosDocument | null`, `plainContent: string`, `seoData`.
+
+---
+
+## 5. Open questions for Phase 1
+
+1. **Auth strategy** — anonymous OAuth visitor vs. API-key service token? (Blog reads are public; visitor token is simplest.)
+2. **ISR cadence** — `revalidate: 300` (5 min) for index + `/blog/[slug]`? Mayor/Melania to confirm SEO posture.
+3. **Ricos viewer** — adopt `@wix/ricos-viewer` now or spike a thin custom renderer? Bundle size check needed in Phase 1.
+4. **Image domains** — `next.config.js` `images.remotePatterns` must include `static.wixstatic.com`.
+
+---
+
+## 6. References
+
+- SDK: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/list-posts
+- `getPostBySlug`: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/get-post-by-slug
+- Collection fields (fallback path): https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/wix-app-collections/wix-blog-collections
+- Current Velo wrapper: `src/backend/blogService.web.js`

--- a/docs/cf-3qt/WIX-BLOG-API-RESEARCH.md
+++ b/docs/cf-3qt/WIX-BLOG-API-RESEARCH.md
@@ -100,12 +100,13 @@ Full post adds: `richContent: RicosDocument | null`, `plainContent: string`, `se
 
 ---
 
-## 5. Open questions for Phase 1
+## 5. Decisions (locked by melania 2026-04-17)
 
-1. **Auth strategy** — anonymous OAuth visitor vs. API-key service token? (Blog reads are public; visitor token is simplest.)
-2. **ISR cadence** — `revalidate: 300` (5 min) for index + `/blog/[slug]`? Mayor/Melania to confirm SEO posture.
-3. **Ricos viewer** — adopt `@wix/ricos-viewer` now or spike a thin custom renderer? Bundle size check needed in Phase 1.
+1. **Auth** — anonymous OAuth visitor token (`WIX_CLIENT_ID`) for content reads. Admin API key reserved for build-time sitemap/seed only.
+2. **ISR cadence** — `/blog` index = `revalidate: 300`, `/blog/[slug]` = `revalidate: 600`. Plus on-demand revalidation via webhook — see item 5.
+3. **Ricos viewer** — adopt `@wix/ricos-viewer`. Bundle-size check still required in Phase 1 (budget: ≤50KB gzip added to `/blog/[slug]` route).
 4. **Image domains** — `next.config.js` `images.remotePatterns` must include `static.wixstatic.com`.
+5. **Revalidate webhook** — millicent owns the Phase 0 `/api/revalidate` route handler. Wix `onPublish` hook POSTs HMAC-signed payload → `revalidateTag('blog')`. Blog data fetches must use `fetch(..., { next: { tags: ['blog'] } })` so tag invalidation propagates.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 4 (content) and Phase 5 (marketing+utility) are blocked on cf-3qt.1 (design system). This PR lands the prep research + specs so implementation is one-shot once Phase 1 primitives arrive.

Three deliverables under `docs/cf-3qt/`:

- **`WIX-BLOG-API-RESEARCH.md`** — `@wix/blog` SDK as primary path, `@wix/data` fallback, normalization contract matching current Velo `blogService`. Flags: auth strategy, ISR cadence, Ricos viewer bundle size, image domains.
- **`URL-CMS-MAP.md`** — every Phase 4/5 route mapped to its CMS collection or webMethod. Includes route-handler proxy table (`/api/contact`, `/api/newsletter/*`, `/api/delivery-zone`, `/api/search`), plus commerce routes for the sitemap generator.
- **`CONTACT-FORM-SPEC-NEXT.md`** — Next.js contact form reusing existing `sendEmail` + `submitContactForm` webMethods verbatim. Zod schema, route handler, accessibility, analytics, acceptance checklist. Appointment booking deferred post-migration — flagged to melania.

No code, no breaking change — pure docs under a new subdir.

## Phase ownership

- cf-3qt.4 (blaidd — content support)
- cf-3qt.5 (blaidd)
- Blocked on cf-3qt.1 (Phase 1 design system)

## Open questions surfaced (for melania)

- Auth: anonymous OAuth visitor token vs. admin API key?
- ISR cadence for blog (proposed 300s index, 600s post)
- `/getting-it-home` vs. `/delivery` route casing (SEO says keep current)
- `PressMentions` seeding — who owns?
- Sitemap revalidate-on-publish webhook?

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] No links broken — source-of-truth paths (`src/backend/*.web.js`) exist at the line numbers cited
- [ ] Acceptance checklists in each spec are actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)