### PR TITLE
chore(deps): ignore eslint >=9 until @wix/eslint-plugin-cli supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,13 @@ updates:
       - dependency-name: "vitest"
         update-types:
           - version-update:semver-major
+      # @wix/eslint-plugin-cli@1.0.2 pins eslint ^8.0.0 as a peer dep and has
+      # no published 9+/10+ compatible release. Dependabot opened #1004 for
+      # eslint 8→10; it's unmergeable until Wix publishes a newer plugin.
+      # Re-evaluate when @wix/eslint-plugin-cli accepts eslint >=9 as a peer.
+      - dependency-name: "eslint"
+        versions:
+          - ">=9"
 
   # Monitor GitHub Actions for version updates
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- Adds Dependabot ignore rule for eslint >=9 to stop repeated unmergeable 8→9/10 bumps.
- Root cause for closed #1004: `@wix/eslint-plugin-cli@1.0.2` (latest published) pins `eslint ^8.0.0` as a peer dep. No 9+ compatible release exists upstream.
- When Wix publishes a plugin version accepting eslint >=9, remove the ignore entry and let the upgrade land.

## Context
- Mayor directive: close #1004, file upstream, add ignore guard.
- Upstream caveat: `@wix/eslint-plugin-cli` is proprietary (no public `repository`/`bugs`/`homepage` on npm). Filing a literal upstream GitHub issue isn't possible; flagging to mayor for alternative escalation (direct Wix contact / internal ticket).

## Test plan
- [ ] Dependabot config lints (YAML parse via GitHub settings)
- [ ] Confirm Dependabot no longer re-opens eslint >=9 PRs on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)