### PR TITLE
fix(cf-zkj): SECURITY — 10 webMethods use non-canonical Permissions.Member

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ Every PR must include:
 
 ## Security
 
-- **webMethod permissions**: Always specify `Permissions.Anyone`, `Permissions.Member`, or `Permissions.Admin` explicitly. Never omit.
+- **webMethod permissions**: Always specify `Permissions.Anyone`, `Permissions.SiteMember`, or `Permissions.Admin` explicitly. Never omit. The canonical `@wix/web-methods` enum has exactly these three keys — `Permissions.Member` is NOT canonical and resolves to `undefined` at runtime, which the Velo server may coerce to `Anyone`, silently exposing member-only endpoints as public (see cf-zkj).
 - **suppressAuth**: Use `{ suppressAuth: true }` on wix-data queries that must bypass member permission gates (read-only public data).
 - **Input validation**: Validate all external inputs at system boundaries. Use `isWixMediaUrl()` from `src/backend/utils/sanitize.js` for media URLs.
 - **IDOR**: Never expose internal IDs or allow member A to read/write member B's data. All member-scoped queries must filter by `currentMember.getMember()`.

--- a/docs/superpowers/plans/2026-03-22-avatar-phase6.md
+++ b/docs/superpowers/plans/2026-03-22-avatar-phase6.md
@@ -397,7 +397,7 @@ function parseUnlockedIds(raw) {
 // ── getAvatarState ────────────────────────────────────────────────────────────
 
 export const getAvatarState = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId) => {
     if (checkRateLimit(memberId, 'getAvatarState', 10)) {
       return { error: 'rate_limited', retryAfterMs: 3600000 };
@@ -669,7 +669,7 @@ Add the `purchaseAccessory` webMethod:
 
 ```js
 export const purchaseAccessory = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId, accessoryId) => {
     if (checkRateLimit(memberId, 'purchaseAccessory', 5)) {
       return { error: 'rate_limited', retryAfterMs: 3600000 };
@@ -891,7 +891,7 @@ Expected: FAIL — `equipAccessory` not exported.
 
 ```js
 export const equipAccessory = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId, accessoryId) => {
     if (checkRateLimit(memberId, 'equipAccessory', 10)) {
       return { error: 'rate_limited', retryAfterMs: 3600000 };

--- a/docs/superpowers/plans/2026-03-22-challenges-phase4.md
+++ b/docs/superpowers/plans/2026-03-22-challenges-phase4.md
@@ -965,7 +965,7 @@ git commit -m "feat(phase4): new event types + challenge progress pipeline in re
 - Modify: `src/backend/gamificationEventReceiver.web.js`
 - Modify: `tests/gamificationEventReceiver.test.js`
 
-New exported `webMethod` (Permissions.Member). Rate limit: 10 calls/hr per member (same pattern as existing rate limiting in the receiver).
+New exported `webMethod` (Permissions.SiteMember). Rate limit: 10 calls/hr per member (same pattern as existing rate limiting in the receiver).
 
 - [ ] **Step 1: Write failing tests**
 
@@ -1107,7 +1107,7 @@ const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
  * @returns {Promise<{ challenges: Array } | { error: 429 }>}
  */
 export const getActiveChallenges = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId) => {
     if (!memberId) return { challenges: [] };
 

--- a/docs/superpowers/plans/2026-03-22-chatbot-phase3.md
+++ b/docs/superpowers/plans/2026-03-22-chatbot-phase3.md
@@ -4,7 +4,7 @@
 
 **Goal:** Implement a member-authenticated Claude-powered chatbot (`gamificationChatbot.web.js`) with per-member daily rate limits, session history, structured prompt-injection tool calls, and a pure-function frontend module (`ChatbotUI.js`), all behind a Wix Secrets Manager feature flag.
 
-**Architecture:** A new `gamificationChatbot.web.js` backend file exposes a single `chatWithAssistant` webMethod (Permissions.Member) that gates on a feature flag, enforces per-member daily message + token limits against the `ChatbotSessions` CMS collection, resolves tool intents via structured prompt injection (no Anthropic native tools API — Wix Velo does not support it), calls Claude via `wix-fetch`, and returns the reply with updated quota counts. A companion `ChatbotUI.js` frontend module provides pure functions for rendering the conversation thread, limit display, loading state, and reduced-motion fallback — no direct Wix API calls inside the module.
+**Architecture:** A new `gamificationChatbot.web.js` backend file exposes a single `chatWithAssistant` webMethod (Permissions.SiteMember) that gates on a feature flag, enforces per-member daily message + token limits against the `ChatbotSessions` CMS collection, resolves tool intents via structured prompt injection (no Anthropic native tools API — Wix Velo does not support it), calls Claude via `wix-fetch`, and returns the reply with updated quota counts. A companion `ChatbotUI.js` frontend module provides pure functions for rendering the conversation thread, limit display, loading state, and reduced-motion fallback — no direct Wix API calls inside the module.
 
 **Tech Stack:** Wix Velo JS (ES modules), wix-data, wix-fetch, wix-secrets-backend, wix-members-backend (currentMember), wix-web-module (webMethod + Permissions), vitest, existing mocks (`wix-data`, `wix-fetch`, `wix-secrets-backend`, `wix-members-backend`), `dateUtils.js` (shared ET date helpers from Phase 2).
 
@@ -35,19 +35,9 @@ Run all tests: `npx vitest run`
 - `wix-fetch.js` — `__setHandler(fn)`, `__reset()` — handler receives `(url, options)`, returns response-like object
 - `wix-secrets-backend.js` — `__setSecrets({ KEY: value })`, `__reset()` — `getSecret(key)` throws if key absent
 - `wix-members-backend.js` — `__setMember(member)`, `__reset()` — `currentMember.getMember()` returns the mock member
-- `wix-web-module.js` — `webMethod(_permission, fn)` returns `fn` directly; `Permissions.Member` must be added to the mock
+- `wix-web-module.js` — `webMethod(_permission, fn)` returns `fn` directly; exports the canonical `Permissions` enum (`Anyone`, `SiteMember`, `Admin`)
 
-**Important:** The `wix-web-module` mock only defines `Permissions.Anyone`, `Permissions.SiteMember`, `Permissions.Admin`. Before writing tests that reference `Permissions.Member`, add it to the mock:
-
-```js
-// tests/__mocks__/wix-web-module.js — add Member to the Permissions object
-export const Permissions = {
-  Anyone: 'Anyone',
-  SiteMember: 'SiteMember',
-  Member: 'Member',   // add this line
-  Admin: 'Admin',
-};
-```
+**Important:** The canonical `@wix/web-methods` enum is exactly `Permissions.Anyone`, `Permissions.SiteMember`, `Permissions.Admin`. `Permissions.Member` is NOT canonical — it resolves to `undefined` at runtime and the Velo server may coerce it to `Anyone`, silently exposing member-only endpoints as public (see cf-zkj).
 
 ---
 
@@ -56,30 +46,11 @@ export const Permissions = {
 **Files:**
 - Create: `src/backend/gamificationChatbot.web.js` (stub, then full logic)
 - Create: `tests/gamificationChatbot.test.js`
-- Modify: `tests/__mocks__/wix-web-module.js` (add `Member` to `Permissions`)
-
 This task covers the foundational pure logic: feature flag gating, input validation, daily message limit, daily token limit, hourly rate limit, and daily reset. Session history and Claude calls come in Tasks 2–4.
 
-### Step 1: Add `Permissions.Member` to the wix-web-module mock
+> **Note (cf-zkj):** An earlier revision of this plan added a non-canonical `Member` key to the mock. That step is dropped — the canonical enum is `{Anyone, SiteMember, Admin}` and matches the runtime. Use `Permissions.SiteMember` directly.
 
-Edit `tests/__mocks__/wix-web-module.js`:
-
-```js
-export const Permissions = {
-  Anyone: 'Anyone',
-  SiteMember: 'SiteMember',
-  Member: 'Member',
-  Admin: 'Admin',
-};
-
-export function webMethod(_permission, fn) {
-  return fn;
-}
-```
-
-- [ ] Edit `tests/__mocks__/wix-web-module.js` — add `Member: 'Member'` to `Permissions`
-
-### Step 2: Write failing tests (feature flag + rate limits)
+### Step 1: Write failing tests (feature flag + rate limits)
 
 Create `tests/gamificationChatbot.test.js`:
 
@@ -635,7 +606,7 @@ export const getChatbotEnabled = webMethod(
 );
 
 export const chatWithAssistant = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (message, memberId) => {
     return { stub: true };
   }
@@ -737,7 +708,7 @@ async function callClaude(messages, apiKey) {
 }
 
 export const chatWithAssistant = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (message, _clientMemberId) => {
     // 1. Feature flag
     let flagEnabled = false;

--- a/docs/superpowers/plans/2026-03-22-spin-wheel-phase1.md
+++ b/docs/superpowers/plans/2026-03-22-spin-wheel-phase1.md
@@ -498,7 +498,7 @@
    * @property {string} [error]
    */
   export const spinWheel = webMethod(
-    Permissions.Member,
+    Permissions.SiteMember,
     async (memberId, todayET) => {
       if (!memberId) {
         return { eligible: false, error: 'memberId is required' };
@@ -1345,7 +1345,7 @@ Extend the test file to cover points award, non-points prize insert, and bonus s
    * Used by the frontend on page load to set initial UI state.
    */
   export const getSpinEligibility = webMethod(
-    Permissions.Member,
+    Permissions.SiteMember,
     async (memberId, todayET) => {
       if (!memberId) return { eligible: false, error: 'memberId is required' };
       const spinDate = todayET || getETDateString();

--- a/docs/superpowers/plans/2026-03-22-streak-multipliers-phase2.md
+++ b/docs/superpowers/plans/2026-03-22-streak-multipliers-phase2.md
@@ -860,7 +860,7 @@ import wixData from 'wix-data';
 // ... keep existing constants ...
 
 export const receiveGamificationEvent = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (eventName, payload, memberId) => {
     if (!memberId) {
       return { success: false, error: 'memberId is required' };

--- a/docs/superpowers/specs/2026-03-22-chatbot-phase3.md
+++ b/docs/superpowers/specs/2026-03-22-chatbot-phase3.md
@@ -42,7 +42,7 @@ The flag check is the first operation inside `chatWithAssistant`, before auth, r
 
 ## Authentication
 
-Member authentication is required. Anonymous visitors cannot call `chatWithAssistant`. The webMethod uses `Permissions.Member` (not `Permissions.Anyone`).
+Member authentication is required. Anonymous visitors cannot call `chatWithAssistant`. The webMethod uses `Permissions.SiteMember` (not `Permissions.Anyone`).
 
 If a non-authenticated request reaches the method: return `{ error: 'auth_required' }` with HTTP 401. The frontend must check auth state before rendering the input controls and display a "Sign in to chat" prompt for logged-out visitors.
 
@@ -168,7 +168,7 @@ Keep replies under 200 words unless the member asks for detail.
 
 ### `chatWithAssistant(message, memberId)` webMethod
 
-**Permissions:** `Permissions.Member`
+**Permissions:** `Permissions.SiteMember`
 
 **Signature:** `chatWithAssistant(message: string, memberId: string)`
 

--- a/src/backend/crossRigEventReceiver.web.js
+++ b/src/backend/crossRigEventReceiver.web.js
@@ -48,7 +48,7 @@ const SUPPORTED_EVENTS = new Set([
  * @returns {Promise<{success: boolean, status?: number, error?: string}>}
  */
 export const crossRigEvent = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (body) => {
     // ── Schema validation ──────────────────────────────────────────────────
     if (!body?.schemaVersion) {

--- a/src/backend/gamificationChatbot.web.js
+++ b/src/backend/gamificationChatbot.web.js
@@ -110,7 +110,7 @@ export const getChatGreeting = webMethod(
 );
 
 export const chatWithAssistant = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (message, _clientMemberId) => {
     // 1. Feature flag
     let flagEnabled = false;

--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -98,7 +98,7 @@ const FIXED_AWARD_EVENTS = new Set([
  *   pointsEarned?: number, badgeUnlocked?: string|null, error?: string}>}
  */
 export const receiveGamificationEvent = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (eventName, payload, memberId) => {
     if (!memberId) {
       return { success: false, error: 'memberId is required' };
@@ -724,7 +724,7 @@ export async function recordWishlistAdd(memberId, todayET) {
  * @returns {Promise<{ challenges: Array } | { status: 429, error: string }>}
  */
 export const getActiveChallenges = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId) => {
     if (!memberId) return { challenges: [] };
 
@@ -829,7 +829,7 @@ export const getActiveChallenges = webMethod(
  *                  | { status: 429, error: string }>}
  */
 export const recordChallengeProgress = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async ({ memberId, challengeId } = {}) => {
     if (!memberId) return { success: false, error: 'memberId is required' };
     if (!challengeId) return { success: false, error: 'challengeId is required' };
@@ -970,7 +970,7 @@ const STREAK_RECOVERY_COOLDOWN_DAYS = 30;
  * @returns {Promise<{ success: boolean, newTotal?: number, currentStreakDays?: number, error?: string }>}
  */
 export const recoverStreak = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId) => {
     if (!memberId) {
       return { success: false, error: 'memberId is required' };

--- a/src/backend/spinWheel.web.js
+++ b/src/backend/spinWheel.web.js
@@ -183,7 +183,7 @@ async function decrementBonusSpin(memberId) {
  * @returns {Promise<{eligible: boolean, spinType?: string, reason?: string, bonusSpinsRemaining?: number, nextETMidnightMs?: number}>}
  */
 export const getSpinEligibility = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId) => {
     if (!memberId) return { eligible: false, reason: 'NO_MEMBER' };
     try {
@@ -217,7 +217,7 @@ export const getSpinEligibility = webMethod(
  * @returns {Promise<{success: boolean, spinType?: string, prize?: Object, historyId?: string, eventId?: string, isFallback?: boolean, nextETMidnightMs?: number, error?: string}>}
  */
 export const spinWheel = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async (memberId) => {
     if (!memberId) return { success: false, error: 'memberId is required' };
     try {

--- a/src/backend/swatchKitService.web.js
+++ b/src/backend/swatchKitService.web.js
@@ -153,7 +153,7 @@ export const recordSwatchKitPurchase = webMethod(
  * @returns {{ hasPendingCredit: boolean, creditId?: string, expiresAt?: Date }}
  */
 export const getSwatchKitCreditStatus = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async () => {
     const member = await currentMember.getMember();
     const cleanId = sanitize(member?._id || '', 64);

--- a/src/backend/wishlistShare.web.js
+++ b/src/backend/wishlistShare.web.js
@@ -54,7 +54,7 @@ function clampExpiryDays(raw) {
  * >}
  */
 export const addShareToken = webMethod(
-  Permissions.Member,
+  Permissions.SiteMember,
   async ({ expiryDays } = {}) => {
     // Authenticate
     let member;

--- a/src/pages/Product Page.js
+++ b/src/pages/Product Page.js
@@ -287,7 +287,7 @@ async function initProductPage() {
         await initPDPSocialProofBadge($w, state, getNeighborCount, { zipPrefix });
       }, critical: false },
       // CF-e0y2: Gamification chat widget — cold visitors see greeting; members get full chat.
-      // getChatGreeting is Permissions.Anyone; chatWithAssistant is Permissions.Member.
+      // getChatGreeting is Permissions.Anyone; chatWithAssistant is Permissions.SiteMember.
       // Non-member send → auth_required → promptLogin modal.
       { name: 'chatWidget', init: async () => {
         const { getChatGreeting, chatWithAssistant: sendChat } = await import('backend/gamificationChatbot.web');

--- a/tests/__mocks__/wix-web-module.js
+++ b/tests/__mocks__/wix-web-module.js
@@ -1,9 +1,11 @@
 // Mock for wix-web-module
-// webMethod(permission, fn) just returns fn — strips the Wix permission wrapper
+// webMethod(permission, fn) just returns fn — strips the Wix permission wrapper.
+// Permissions MUST match the canonical runtime enum (Anyone, Admin, SiteMember).
+// Do not add keys here — a typo that resolves to undefined in prod would be
+// silently masked by tests. See cf-zkj.
 export const Permissions = {
   Anyone: 'Anyone',
   SiteMember: 'SiteMember',
-  Member: 'Member',
   Admin: 'Admin',
 };
 

--- a/tests/challengeOfTheWeek.test.js
+++ b/tests/challengeOfTheWeek.test.js
@@ -52,7 +52,7 @@ vi.mock('wix-data', () => ({
 }));
 
 vi.mock('wix-web-module', () => ({
-  Permissions: { Admin: 'Admin', Anyone: 'Anyone', SiteMember: 'SiteMember', Member: 'Member' },
+  Permissions: { Admin: 'Admin', Anyone: 'Anyone', SiteMember: 'SiteMember' },
   webMethod: (_perm, fn) => fn,
 }));
 

--- a/tests/recordChallengeProgressMemberPointsFields.test.js
+++ b/tests/recordChallengeProgressMemberPointsFields.test.js
@@ -39,7 +39,7 @@ vi.mock('wix-data', () => ({
 }));
 
 vi.mock('wix-web-module', () => ({
-  Permissions: { Admin: 'Admin', Anyone: 'Anyone', Member: 'Member', SiteMember: 'SiteMember' },
+  Permissions: { Admin: 'Admin', Anyone: 'Anyone', SiteMember: 'SiteMember' },
   webMethod: (_perm, fn) => fn,
 }));
 

--- a/tests/webMethodPermissions.test.js
+++ b/tests/webMethodPermissions.test.js
@@ -1,0 +1,34 @@
+/**
+ * Tests that every webMethod() call in src/backend/*.web.js uses only the
+ * canonical Permissions enum values: Anyone, Admin, SiteMember.
+ *
+ * Background: the @wix/web-methods runtime exports Permissions as a plain
+ * object with exactly those three keys (per
+ * https://dev.wix.com/docs/sdk/core-modules/web-methods/web-method).
+ * A typo like Permissions.Member resolves to undefined at runtime, which the
+ * Velo server may coerce to Permissions.Anyone — silently exposing member-only
+ * endpoints as public. Tests previously masked this by defining an extra
+ * `Member` key in the wix-web-module mock. See cf-zkj.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const CANONICAL = new Set(['Anyone', 'Admin', 'SiteMember']);
+const BACKEND_DIR = join(__dirname, '..', 'src', 'backend');
+const PERMISSION_RE = /Permissions\.(\w+)/g;
+
+const webMethodFiles = readdirSync(BACKEND_DIR)
+  .filter((f) => f.endsWith('.web.js'))
+  .map((f) => join(BACKEND_DIR, f));
+
+describe('webMethod permissions — canonical enum enforcement', () => {
+  it.each(webMethodFiles)('%s uses only canonical Permissions keys', (file) => {
+    const src = readFileSync(file, 'utf8');
+    const nonCanonical = [];
+    for (const m of src.matchAll(PERMISSION_RE)) {
+      if (!CANONICAL.has(m[1])) nonCanonical.push(m[1]);
+    }
+    expect(nonCanonical, `non-canonical Permissions keys found in ${file}`).toEqual([]);
+  });
+});

--- a/tests/webMethodPermissions.test.js
+++ b/tests/webMethodPermissions.test.js
@@ -18,9 +18,17 @@ const CANONICAL = new Set(['Anyone', 'Admin', 'SiteMember']);
 const BACKEND_DIR = join(__dirname, '..', 'src', 'backend');
 const PERMISSION_RE = /Permissions\.(\w+)/g;
 
-const webMethodFiles = readdirSync(BACKEND_DIR)
-  .filter((f) => f.endsWith('.web.js'))
-  .map((f) => join(BACKEND_DIR, f));
+function findWebMethodFiles(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...findWebMethodFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.web.js')) found.push(full);
+  }
+  return found;
+}
+
+const webMethodFiles = findWebMethodFiles(BACKEND_DIR);
 
 describe('webMethod permissions — canonical enum enforcement', () => {
   it.each(webMethodFiles)('%s uses only canonical Permissions keys', (file) => {


### PR DESCRIPTION
## Summary

**P1 security fix.** 10 production webMethods declared permissions using `Permissions.Member`, a value that does NOT exist in the canonical `@wix/web-methods` Permissions enum. At runtime the value resolves to `undefined` and the Velo server likely coerces it to `Anyone`, silently exposing member-only endpoints as public — a latent IDOR risk.

Canonical enum per [dev.wix.com/docs/sdk/core-modules/web-methods/web-method](https://dev.wix.com/docs/sdk/core-modules/web-methods/web-method): `{ Anyone, Admin, SiteMember }`. No `Member`.

### Affected webMethods (swapped to `Permissions.SiteMember`)

- `gamificationCore`: `receiveGamificationEvent`, `getActiveChallenges`, `recordChallengeProgress`, `recoverStreak`
- `spinWheel`: `getSpinEligibility`, `spinWheel`
- `gamificationChatbot`: `chatWithAssistant`
- `wishlistShare`: `addShareToken`
- `crossRigEventReceiver`: `crossRigEvent`
- `swatchKitService`: `getSwatchKitCreditStatus`

### Root cause

`tests/__mocks__/wix-web-module.js` shipped a non-canonical `Member: 'Member'` key so tests passed against a mock that didn't match the runtime. `CONTRIBUTING.md:213` then documented `Permissions.Member` as valid, perpetuating the pattern through new webMethods and 6 superpowers design docs.

### Fix

1. **Swap** `Permissions.Member` → `Permissions.SiteMember` in all 10 prod sites.
2. **Align mocks** — remove `Member` from shared + 2 per-test mocks; enum now matches the runtime.
3. **Fix CONTRIBUTING.md:213** with the canonical enum + warning about the typo.
4. **Regression test** `tests/webMethodPermissions.test.js` — parses every `src/backend/*.web.js` and asserts each `Permissions.X` reference uses only canonical keys.
5. **Update 6 design docs** that prescribed the anti-pattern; delete chatbot-phase3 plan's "Step 1: Add Permissions.Member to the mock" section.

### Origin

Found during peer-audit of cf-3qt Phase 3 (Wix Headless SDK migration path) — full audit report in nudges to mayor 2026-04-17 14:00–14:10.

## Test plan

- [x] Regression test RED on pre-fix state (6 files, 10 call sites flagged)
- [x] Post-fix: `vitest run` → 1099/1099 files, 40044/40049 tests pass (5 todo)
- [x] `eslint` clean on all touched files
- [ ] Post-merge: live curl repro against one method (e.g. `getSwatchKitCreditStatus`) without auth — confirm 401/403 vs prior 200
- [ ] Post-merge: spot-check Wix runtime logs for pre-fix anonymous calls to any of the 10 methods (evidence of exploitation)

## Follow-ups (not in this PR)

- Consider an ESLint custom rule: flag `Permissions\\.(?!Anyone|Admin|SiteMember)\\w+` anywhere in `.web.js`. The regression test covers backend; a lint rule would surface it at edit time.
- Audit `suppressAuth: true` sites in `gamificationCore` — some may have been workarounds for the broken permission flag.

Bead: cf-zkj (P1, owner: miquella)