### PR TITLE
fix(cf-2ag): swatchKitService null-member guard — surface auth_required

### DIFF
--- a/src/backend/swatchKitService.web.js
+++ b/src/backend/swatchKitService.web.js
@@ -157,7 +157,15 @@ export const getSwatchKitCreditStatus = webMethod(
   async () => {
     const member = await currentMember.getMember();
     const cleanId = sanitize(member?._id || '', 64);
-    if (!cleanId) return { hasPendingCredit: false };
+    if (!cleanId) {
+      // Permissions.SiteMember should gate anonymous callers before we get
+      // here; reaching this branch means Velo let an unauthenticated request
+      // through (stale session, misconfiguration). Surface it as a distinct
+      // error instead of returning "no credit" — that's silent-failure
+      // masquerade. See cf-2ag.
+      console.warn('[swatchKitService] getSwatchKitCreditStatus: no member on session (cf-2ag)');
+      return { hasPendingCredit: false, error: 'auth_required' };
+    }
 
     try {
       const res = await wixData.query(SWATCH_KIT_ORDERS)

--- a/src/pages/Swatch Kit.js
+++ b/src/pages/Swatch Kit.js
@@ -37,6 +37,9 @@ export async function initPage($w) {
     if (member?._id) {
       const { getSwatchKitCreditStatus } = await import('backend/swatchKitService.web');
       const creditStatus = await getSwatchKitCreditStatus();
+      if (creditStatus?.error === 'auth_required') {
+        console.warn('[swatchKit] backend reported auth_required despite frontend session — session may be stale (cf-2ag)');
+      }
       const statusText = buildCreditStatusText(creditStatus);
       if (statusText) {
         $w('#creditStatusBanner').text = statusText;

--- a/tests/swatchKitService.test.js
+++ b/tests/swatchKitService.test.js
@@ -254,20 +254,12 @@ describe('getSwatchKitCreditStatus', () => {
     expect(result).toEqual({ hasPendingCredit: false });
   });
 
-  it('returns auth_required + warns when getMember returns null (cf-2ag)', async () => {
+  it.each([
+    ['null', null],
+    ['no _id', {}],
+  ])('returns auth_required + warns when getMember returns %s (cf-2ag)', async (_label, memberValue) => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    mockGetMember.mockResolvedValue(null);
-    const result = await getSwatchKitCreditStatus();
-    expect(result).toEqual({ hasPendingCredit: false, error: 'auth_required' });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[swatchKitService] getSwatchKitCreditStatus: no member on session'),
-    );
-    warnSpy.mockRestore();
-  });
-
-  it('returns auth_required + warns when getMember resolves with no _id (cf-2ag)', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    mockGetMember.mockResolvedValue({});
+    mockGetMember.mockResolvedValue(memberValue);
     const result = await getSwatchKitCreditStatus();
     expect(result).toEqual({ hasPendingCredit: false, error: 'auth_required' });
     expect(warnSpy).toHaveBeenCalledWith(

--- a/tests/swatchKitService.test.js
+++ b/tests/swatchKitService.test.js
@@ -265,11 +265,14 @@ describe('getSwatchKitCreditStatus', () => {
     warnSpy.mockRestore();
   });
 
-  it('returns auth_required when getMember resolves with no _id (cf-2ag)', async () => {
+  it('returns auth_required + warns when getMember resolves with no _id (cf-2ag)', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockGetMember.mockResolvedValue({});
     const result = await getSwatchKitCreditStatus();
     expect(result).toEqual({ hasPendingCredit: false, error: 'auth_required' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[swatchKitService] getSwatchKitCreditStatus: no member on session'),
+    );
     warnSpy.mockRestore();
   });
 

--- a/tests/swatchKitService.test.js
+++ b/tests/swatchKitService.test.js
@@ -254,10 +254,23 @@ describe('getSwatchKitCreditStatus', () => {
     expect(result).toEqual({ hasPendingCredit: false });
   });
 
-  it('returns hasPendingCredit: false when getMember returns no id', async () => {
+  it('returns auth_required + warns when getMember returns null (cf-2ag)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     mockGetMember.mockResolvedValue(null);
     const result = await getSwatchKitCreditStatus();
-    expect(result).toEqual({ hasPendingCredit: false });
+    expect(result).toEqual({ hasPendingCredit: false, error: 'auth_required' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[swatchKitService] getSwatchKitCreditStatus: no member on session'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('returns auth_required when getMember resolves with no _id (cf-2ag)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGetMember.mockResolvedValue({});
+    const result = await getSwatchKitCreditStatus();
+    expect(result).toEqual({ hasPendingCredit: false, error: 'auth_required' });
+    warnSpy.mockRestore();
   });
 
   it('returns pending credit details when found', async () => {

--- a/tests/swatchKitWidget.test.js
+++ b/tests/swatchKitWidget.test.js
@@ -165,6 +165,15 @@ describe('buildCreditStatusText', () => {
     expect(buildCreditStatusText(null)).toBe('');
   });
 
+  it('returns empty string for auth_required response (cf-2ag)', () => {
+    // Backend signals stale session by returning { hasPendingCredit: false,
+    // error: 'auth_required' }. Banner must stay hidden rather than showing
+    // the pending-credit text to an unauthenticated viewer.
+    expect(
+      buildCreditStatusText({ hasPendingCredit: false, error: 'auth_required' }),
+    ).toBe('');
+  });
+
   it('returns text with amount when pending credit has no expiry', () => {
     const text = buildCreditStatusText({ hasPendingCredit: true, amount: 5 });
     expect(text).toContain('$5');


### PR DESCRIPTION
## Summary

- cf-zkj (PR #1086) landed Permissions.SiteMember on getSwatchKitCreditStatus, making the null-member fallback reachable.
- Previously the handler returned { hasPendingCredit: false } on null member — silent-failure-hunter flagged this as masquerading an auth gap as "no credit."
- Now returns { hasPendingCredit: false, error: 'auth_required' } with a warn log; buildCreditStatusText already no-ops on non-pending results, so no user-facing regression.

## Test plan

- [x] vitest 40060 passed (2 new cf-2ag regression tests: null member → auth_required, empty member → auth_required)
- [x] Existing behavior preserved: valid session + no pending credit still returns { hasPendingCredit: false }
- [ ] Post-merge: spot-check Wix runtime logs for any '[swatchKitService] getSwatchKitCreditStatus: no member on session' warnings — presence would indicate Velo's SiteMember gate is leaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)