### PR TITLE
fix(cf-1y7): gamificationCore null-member guards — surface auth_required (cf-zkj cascade)

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -726,7 +726,15 @@ export async function recordWishlistAdd(memberId, todayET) {
 export const getActiveChallenges = webMethod(
   Permissions.SiteMember,
   async (memberId) => {
-    if (!memberId) return { challenges: [] };
+    if (!memberId) {
+      // Permissions.SiteMember should gate anonymous callers before we get
+      // here; reaching this branch means Velo let an unauthenticated request
+      // through (stale session, misconfiguration). Surface it as a distinct
+      // error instead of returning "no challenges" — that's silent-failure
+      // masquerade. See cf-1y7 (cf-2ag cascade).
+      console.warn('[gamificationCore] getActiveChallenges: no memberId on session (cf-1y7)');
+      return { challenges: [], error: 'auth_required' };
+    }
 
     // Rate limit: 10 calls/hr per member
     const now = Date.now();
@@ -1046,6 +1054,13 @@ export const recoverStreak = webMethod(
 export const getStreakData = webMethod(
   Permissions.SiteMember,
   async (memberId) => {
+    if (!memberId) {
+      // Velo SiteMember gate leak — distinguishable from "authed but no streak
+      // yet" (which also returns zeros, but without the error field).
+      // See cf-1y7 (cf-2ag cascade).
+      console.warn('[gamificationCore] getStreakData: no memberId on session (cf-1y7)');
+      return { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
+    }
     const record = await findMemberRecord(memberId);
     if (!record) {
       return { currentStreak: 0, longestStreak: 0, lastActivityDate: null };
@@ -1158,6 +1173,13 @@ export function computeTierInfo(totalPoints) {
 export const getMemberTier = webMethod(
   Permissions.SiteMember,
   async (memberId) => {
+    if (!memberId) {
+      // Velo SiteMember gate leak — return the baseline Trail Blazer shape
+      // but signal the auth anomaly so widgets can gate tier benefits display.
+      // See cf-1y7 (cf-2ag cascade).
+      console.warn('[gamificationCore] getMemberTier: no memberId on session (cf-1y7)');
+      return { ...computeTierInfo(0), error: 'auth_required' };
+    }
     const record = await findMemberRecord(memberId);
     return computeTierInfo(record ? record.totalPoints : 0);
   }
@@ -1191,7 +1213,19 @@ export const getActivityFeed = webMethod(
   async (memberId, limit = 10) => {
     const { currentMember } = await import('wix-members-backend');
     const caller = await currentMember.getMember();
-    if (!caller?._id || caller._id !== memberId) return [];
+    if (!caller?._id) {
+      // Velo SiteMember gate leak. Array return preserved for consumer compat;
+      // observability lives in the warn so Wix runtime logs surface the leak.
+      // See cf-1y7 (cf-2ag cascade).
+      console.warn('[gamificationCore] getActivityFeed: no member on session (auth_required) (cf-1y7)');
+      return [];
+    }
+    if (caller._id !== memberId) {
+      // Cross-member read attempt. Keep defense-in-depth (empty array) but
+      // warn distinctly so the two failure modes are separable in logs.
+      console.warn('[gamificationCore] getActivityFeed: caller/memberId mismatch (forbidden) (cf-1y7)');
+      return [];
+    }
 
     const result = await wixData
       .query('AnalyticsEvents')

--- a/tests/gamificationCoreWebMethods.test.js
+++ b/tests/gamificationCoreWebMethods.test.js
@@ -93,6 +93,7 @@ import {
   getLeaderboard,
   getMemberTier,
   getActivityFeed,
+  getActiveChallenges,
   computeTierInfo,
 } from '../src/backend/gamificationCore.web.js';
 
@@ -278,5 +279,115 @@ describe('getActivityFeed', () => {
     __mockMemberId = null;
     const result = await getActivityFeed('mem-1');
     expect(result).toEqual([]);
+  });
+});
+
+// ── cf-1y7: silent null-member guard observability (cf-2ag cascade) ───
+
+describe('cf-1y7 null-member guard cascade', () => {
+  describe('getStreakData', () => {
+    it('returns zero-streak baseline + error: auth_required + warns when memberId is null', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await getStreakData(null);
+      expect(result).toEqual({
+        currentStreak: 0,
+        longestStreak: 0,
+        lastActivityDate: null,
+        error: 'auth_required',
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[gamificationCore] getStreakData: no memberId on session'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('returns zero-streak baseline + error: auth_required + warns when memberId is undefined', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await getStreakData();
+      expect(result.error).toBe('auth_required');
+      expect(result.currentStreak).toBe(0);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('omits error field on successful authenticated read', async () => {
+      seed('MemberPoints', [{ memberId: 'mem-ok', currentStreakDays: 3 }]);
+      const result = await getStreakData('mem-ok');
+      expect(result.error).toBeUndefined();
+      expect(result.currentStreak).toBe(3);
+    });
+  });
+
+  describe('getMemberTier', () => {
+    it('returns lowest-tier baseline + error: auth_required + warns when memberId is null', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await getMemberTier(null);
+      expect(result.tierName).toBe('Trail Blazer'); // computeTierInfo(0) baseline preserved
+      expect(result.error).toBe('auth_required');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[gamificationCore] getMemberTier: no memberId on session'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('omits error field on successful authenticated read', async () => {
+      seed('MemberPoints', [{ memberId: 'mem-ok', totalPoints: 500 }]);
+      const result = await getMemberTier('mem-ok');
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe('getActiveChallenges', () => {
+    it('returns { challenges: [], error: auth_required } + warns when memberId is null', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await getActiveChallenges(null);
+      expect(result).toEqual({ challenges: [], error: 'auth_required' });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[gamificationCore] getActiveChallenges: no memberId on session'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('omits error field on successful authenticated call', async () => {
+      // Valid call path — no seeded ActiveChallenges, so empty but error-free
+      const result = await getActiveChallenges('mem-ok');
+      expect(result.error).toBeUndefined();
+      expect(Array.isArray(result.challenges)).toBe(true);
+    });
+  });
+
+  describe('getActivityFeed (Array-return, warn-only observability)', () => {
+    // Consumer compat: this handler returns Array, so error-object shape would
+    // be a breaking change. We preserve Array return but add dev-only warns at
+    // the two silent branches so auth/IDOR leaks surface in Wix runtime logs.
+    it('warns distinctly when no member is authenticated (auth_required)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      __mockMemberId = null;
+      const result = await getActivityFeed('mem-1');
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[gamificationCore] getActivityFeed: no member on session (auth_required)'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('warns distinctly when caller does not match memberId (forbidden)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      __mockMemberId = 'other-member';
+      const result = await getActivityFeed('mem-1');
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[gamificationCore] getActivityFeed: caller/memberId mismatch (forbidden)'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('does NOT warn on legitimate authenticated call', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      __mockMemberId = 'mem-1';
+      await getActivityFeed('mem-1');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Four webMethods in `src/backend/gamificationCore.web.js` silently swallowed unauthenticated/mismatched-caller calls, hiding IDOR + auth regressions in runtime logs (cf-zkj cascade, bead **cf-1y7**). Applied the cf-2ag discriminable-error pattern:

- `getActiveChallenges` — `{ challenges: [] }` → `{ challenges: [], error: 'auth_required' }` + warn
- `getStreakData` — new null-memberId guard: zero-streak baseline + `error: 'auth_required'` + warn
- `getMemberTier` — new null-memberId guard: Trail Blazer baseline + `error: 'auth_required'` + warn
- `getActivityFeed` — split the single silent `return []` into two distinct warn branches (`auth_required` vs `forbidden`). Array return preserved for consumer compat — this handler gets warn-only observability, not an error field, to avoid breaking 12 call sites.

All warns are tagged `[gamificationCore] <handlerName>: ... (cf-1y7)` so they're greppable in Wix runtime logs.

## Consumer compat

Grepped the 12 consumers (LoyaltyTierBanner.js, StreakTrackerWidget.js, RewardsTierWidget.js, ChallengesDisplay.js, Member Page.js, etc.). All use `try { x = await fn(id); } catch { x = null; }` or destructure only the fields they need — the added `error` key is additive, existing keys preserved. Non-breaking.

## Tests

+10 cascade tests in `tests/gamificationCoreWebMethods.test.js` (`cf-1y7 null-member guard cascade` describe block):
- 3× `getStreakData` (null / undefined / success-no-error)
- 2× `getMemberTier` (null / success-no-error)
- 2× `getActiveChallenges` (null / success)
- 3× `getActivityFeed` (auth_required warn / forbidden warn / legitimate no-warn)

## Test plan

- [x] Full suite: 40071 pass / 5 todo, zero regressions (25.37s)
- [x] File-local: 26/26 pass
- [x] TDD RED verified pre-fix: 6 guard tests failed as expected
- [x] Consumer grep: 12 files, all backward-compat
- [ ] 5-agent PR review (radahn-dispatched) per mayor directive
- [ ] Melania gate

Closes cf-1y7 (cf-zkj silent-failure-masquerade cascade, sibling of cf-2ag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)