### PR TITLE
chore(cf-ugo): skip codecov upload for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,11 @@ jobs:
         run: npx vitest run --coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == 22
+        # Dependabot PRs run with restricted GITHUB_TOKEN and cannot read
+        # repository secrets, so CODECOV_TOKEN is empty and the upload fails
+        # the whole job. Skip for dependabot — coverage still uploads on
+        # push to main and on every non-dependabot PR. (cf-ugo)
+        if: matrix.node-version == 22 && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info


### PR DESCRIPTION
## Summary

Dependabot PRs run with a restricted `GITHUB_TOKEN` that cannot read repository secrets, so `CODECOV_TOKEN` is empty and the Upload-Codecov step fails the whole `test (22)` check even though vitest passed cleanly. Casual reviewers read the red X as a real test regression, and it blocks dependabot merge momentum.

Fix: guard the existing `Upload coverage to Codecov` step with `github.actor != 'dependabot[bot]'`. Coverage continues to upload on push to `main` and on every non-dependabot PR. Dependabot PRs turn green when tests pass.

## What's not changed

- `nightly-integration` Codecov upload — job is gated to `schedule` / `workflow_dispatch`, never triggered by dependabot.
- Coverage thresholds + fail_ci_if_error contract for real PRs — unchanged.

## Test plan

- [x] Edit verified against ci.yml L79-91
- [ ] Next dependabot PR turns green on test (22) instead of red
- [ ] Coverage still posts on a real feature PR (e.g. the next non-dependabot merge)
- [ ] Push to main still uploads coverage

## Source

Surfaced during PR #1066 review by radahn, confirmed by miquella. Bead: **cf-ugo**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)