### PR TITLE
fix(cf-afx): don't render fake streak/tier UI to unauthed viewers (cf-1y7 follow-up)

### DIFF
--- a/src/public/RewardsTierWidget.js
+++ b/src/public/RewardsTierWidget.js
@@ -38,7 +38,12 @@ export async function initRewardsTierWidget(memberId, opts = {}) {
     data = null;
   }
 
-  if (!data) {
+  // cf-afx: treat the cf-1y7 auth_required baseline as "no tier data" so we
+  // don't render a fake Trail Blazer badge + progress-to-Mountain-Guide copy
+  // to an unauthenticated viewer. The handler still returns computeTierInfo(0)
+  // for consumer compat, but the `error` field signals the viewer isn't in
+  // the loyalty program yet.
+  if (!data || data.error === 'auth_required') {
     try { $w('#tierError').show(); } catch {}
     try { $w('#tierBadge').hide(); } catch {}
     try { $w('#tierName').hide(); } catch {}

--- a/src/public/StreakTrackerWidget.js
+++ b/src/public/StreakTrackerWidget.js
@@ -33,7 +33,11 @@ export async function initStreakTrackerWidget(memberId, opts = {}) {
     data = null;
   }
 
-  if (!data) {
+  // cf-afx: treat the cf-1y7 auth_required baseline as "no streak data" so
+  // we don't render a fake "0 day streak" to an unauthenticated viewer. The
+  // handler still returns a zero-streak object for consumer compat, but the
+  // `error` field signals the viewer isn't actually tracking anything yet.
+  if (!data || data.error === 'auth_required') {
     try { $w('#noStreakMsg').show(); } catch {}
     try { $w('#streakCount').hide(); } catch {}
     try { $w('#longestStreak').hide(); } catch {}

--- a/tests/rewardsTierWidget.test.js
+++ b/tests/rewardsTierWidget.test.js
@@ -248,4 +248,43 @@ describe('error handling', () => {
     const opts = { $w, getMemberTier: vi.fn().mockRejectedValue(new Error('fail')) };
     await expect(initRewardsTierWidget(MEMBER_ID, opts)).resolves.not.toThrow();
   });
+
+  // cf-afx — don't render a fake "Trail Blazer" badge to unauthenticated viewers.
+  // The cf-1y7 guard on getMemberTier surfaces `error: 'auth_required'` alongside
+  // the computeTierInfo(0) baseline; pre-cf-afx the widget treated that like real
+  // data and showed tier benefits + "500 more points to Mountain Guide" copy.
+  describe('cf-afx auth_required branch', () => {
+    it('shows #tierError when data carries error: auth_required', async () => {
+      const $w = make$w();
+      const data = { ...makeTierData({ pointsInTier: 0, pointsToNextTier: 500 }), error: 'auth_required' };
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, data));
+      expect($w._els['#tierError'].show).toHaveBeenCalled();
+    });
+
+    it('hides tier UI when data carries error: auth_required', async () => {
+      const $w = make$w();
+      const data = { ...makeTierData({ pointsInTier: 0, pointsToNextTier: 500 }), error: 'auth_required' };
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, data));
+      expect($w._els['#tierBadge'].hide).toHaveBeenCalled();
+      expect($w._els['#tierName'].hide).toHaveBeenCalled();
+      expect($w._els['#tierProgress'].hide).toHaveBeenCalled();
+      expect($w._els['#tierPointsNeeded'].hide).toHaveBeenCalled();
+      expect($w._els['#tierBenefitsRepeater'].hide).toHaveBeenCalled();
+      expect($w._els['#tierNextBenefits'].hide).toHaveBeenCalled();
+    });
+
+    it('does not set tier name when error: auth_required', async () => {
+      const $w = make$w();
+      const data = { ...makeTierData({ tierName: 'Trail Blazer' }), error: 'auth_required' };
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, data));
+      expect($w._els['#tierName'].text).toBe('');
+    });
+
+    it('renders normally when error field is absent', async () => {
+      const $w = make$w();
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, makeTierData()));
+      expect($w._els['#tierName'].text).toBe('Trail Blazer');
+      expect($w._els['#tierError'].show).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/streakTrackerWidget.test.js
+++ b/tests/streakTrackerWidget.test.js
@@ -199,3 +199,40 @@ describe('error handling', () => {
     await expect(initStreakTrackerWidget(MEMBER_ID, opts)).resolves.not.toThrow();
   });
 });
+
+// cf-afx — don't render a fake "0 day streak" to unauthenticated viewers.
+// The cf-1y7 guard on getStreakData surfaces `error: 'auth_required'` alongside
+// a zero-streak baseline; pre-cf-afx the widget treated that like real data and
+// rendered the misleading number.
+describe('cf-afx auth_required branch', () => {
+  it('shows #noStreakMsg when data carries error: auth_required', async () => {
+    const $w = make$w();
+    const data = { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, data));
+    expect($w._els['#noStreakMsg'].show).toHaveBeenCalled();
+  });
+
+  it('hides streak elements when data carries error: auth_required', async () => {
+    const $w = make$w();
+    const data = { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, data));
+    expect($w._els['#streakCount'].hide).toHaveBeenCalled();
+    expect($w._els['#longestStreak'].hide).toHaveBeenCalled();
+    expect($w._els['#streakFlameIcon'].hide).toHaveBeenCalled();
+    expect($w._els['#streakMultiplierLabel'].hide).toHaveBeenCalled();
+  });
+
+  it('does not set #streakCount text to "0 day streak" when error: auth_required', async () => {
+    const $w = make$w();
+    const data = { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, data));
+    expect($w._els['#streakCount'].text).toBe('');
+  });
+
+  it('renders normally when error field is absent', async () => {
+    const $w = make$w();
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, makeStreakData({ currentStreak: 0 })));
+    expect($w._els['#streakCount'].text).toBe('0 day streak');
+    expect($w._els['#noStreakMsg'].show).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

PR #1088 (cf-1y7) added an additive `error: 'auth_required'` field to the handler returns for `getStreakData` and `getMemberTier`. The widgets still treated the zero-point baseline as real data — rendering a misleading **"0 day streak"** on `StreakTrackerWidget` and a fake **"Trail Blazer"** badge + **"500 more points to Mountain Guide"** progress copy on `RewardsTierWidget` for unauthenticated viewers.

This PR flips both widgets to treat `data.error === 'auth_required'` through the existing hide-everything / show-error-state path that null data already took. No new Wix-editor elements required; reuses existing `#noStreakMsg` and `#tierError` elements.

## Scope discipline — out-of-scope findings

From the silent-failure-hunter review on PR #1088, two widgets were flagged but need **no change**:

- `ChallengesDisplay.initChallengesDisplay` already hides its section when `challenges.length === 0`, so cf-1y7's `{ challenges: [], error: 'auth_required' }` is handled correctly by construction.
- `ActivityFeedWidget` already hides the repeater and shows an empty state when `activities.length === 0`, which is cf-1y7's Array-return shape. Adding a distinct sign-in CTA would require a new `$w` element in the Wix editor — out of scope for this bead.

## Tests

+8 tests (4 per widget):
- `error: 'auth_required'` triggers the empty-state path
- streak elements / tier elements are hidden
- `#streakCount` text / `#tierName` text are NOT set
- regression guard: widget still renders normally when `error` field is absent

Local file-local vitest: **46/46 pass** in 220 ms on the two widget test files. Full-suite verification via CI.

## Test plan

- [x] Local narrow vitest: streakTrackerWidget + rewardsTierWidget — 46/46
- [ ] CI test (20) + test (22) green
- [ ] Melania gate

Closes cf-afx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)