### PR TITLE
fix(cf-8qc): widen widget error-field guard to truthy data.error

### DIFF
--- a/src/public/RewardsTierWidget.js
+++ b/src/public/RewardsTierWidget.js
@@ -41,8 +41,8 @@ export async function initRewardsTierWidget(memberId, opts = {}) {
   // cf-afx/cf-8qc: treat any cf-1y7 error baseline as "no tier data" so we
   // don't render a fake Trail Blazer badge + progress-to-Mountain-Guide copy
   // to viewers who couldn't be served real data. The handler always returns
-  // computeTierInfo(0) for consumer compat (avoids NPE on data.currentTier
-  // reads), so the `error` field is the only honest signal that the values
+  // computeTierInfo(0) to keep the response shape stable for non-gating
+  // consumers, so the `error` field is the only honest signal that the values
   // are placeholder. Truthy-check (not ===) so future codes (forbidden,
   // rate_limited, ...) don't re-open the silent class.
   if (!data || data.error) {

--- a/src/public/RewardsTierWidget.js
+++ b/src/public/RewardsTierWidget.js
@@ -38,12 +38,14 @@ export async function initRewardsTierWidget(memberId, opts = {}) {
     data = null;
   }
 
-  // cf-afx: treat the cf-1y7 auth_required baseline as "no tier data" so we
+  // cf-afx/cf-8qc: treat any cf-1y7 error baseline as "no tier data" so we
   // don't render a fake Trail Blazer badge + progress-to-Mountain-Guide copy
-  // to an unauthenticated viewer. The handler still returns computeTierInfo(0)
-  // for consumer compat, but the `error` field signals the viewer isn't in
-  // the loyalty program yet.
-  if (!data || data.error === 'auth_required') {
+  // to viewers who couldn't be served real data. The handler always returns
+  // computeTierInfo(0) for consumer compat (avoids NPE on data.currentTier
+  // reads), so the `error` field is the only honest signal that the values
+  // are placeholder. Truthy-check (not ===) so future codes (forbidden,
+  // rate_limited, ...) don't re-open the silent class.
+  if (!data || data.error) {
     try { $w('#tierError').show(); } catch {}
     try { $w('#tierBadge').hide(); } catch {}
     try { $w('#tierName').hide(); } catch {}

--- a/src/public/StreakTrackerWidget.js
+++ b/src/public/StreakTrackerWidget.js
@@ -35,8 +35,8 @@ export async function initStreakTrackerWidget(memberId, opts = {}) {
 
   // cf-afx/cf-8qc: treat any cf-1y7 error baseline as "no streak data" so we
   // don't render a fake "0 day streak" to viewers who couldn't be served real
-  // data. The handler always returns a zero-streak object for consumer compat
-  // (avoids NPE on data.currentStreak reads), so the `error` field is the only
+  // data. The handler always returns a zero-streak object to keep the response
+  // shape stable for non-gating consumers, so the `error` field is the only
   // honest signal that the numbers are placeholder. Truthy-check (not ===) so
   // future codes (forbidden, rate_limited, ...) don't re-open the silent class.
   if (!data || data.error) {

--- a/src/public/StreakTrackerWidget.js
+++ b/src/public/StreakTrackerWidget.js
@@ -33,11 +33,13 @@ export async function initStreakTrackerWidget(memberId, opts = {}) {
     data = null;
   }
 
-  // cf-afx: treat the cf-1y7 auth_required baseline as "no streak data" so
-  // we don't render a fake "0 day streak" to an unauthenticated viewer. The
-  // handler still returns a zero-streak object for consumer compat, but the
-  // `error` field signals the viewer isn't actually tracking anything yet.
-  if (!data || data.error === 'auth_required') {
+  // cf-afx/cf-8qc: treat any cf-1y7 error baseline as "no streak data" so we
+  // don't render a fake "0 day streak" to viewers who couldn't be served real
+  // data. The handler always returns a zero-streak object for consumer compat
+  // (avoids NPE on data.currentStreak reads), so the `error` field is the only
+  // honest signal that the numbers are placeholder. Truthy-check (not ===) so
+  // future codes (forbidden, rate_limited, ...) don't re-open the silent class.
+  if (!data || data.error) {
     try { $w('#noStreakMsg').show(); } catch {}
     try { $w('#streakCount').hide(); } catch {}
     try { $w('#longestStreak').hide(); } catch {}

--- a/tests/rewardsTierWidget.test.js
+++ b/tests/rewardsTierWidget.test.js
@@ -287,4 +287,33 @@ describe('error handling', () => {
       expect($w._els['#tierError'].show).not.toHaveBeenCalled();
     });
   });
+
+  // cf-8qc — widen guard to any truthy data.error. Narrow equality check
+  // would silently let fake "Trail Blazer" UI through if cf-1y7 ever surfaces
+  // 'forbidden', 'rate_limited', or other error codes.
+  describe('cf-8qc truthy-error branch', () => {
+    it('shows #tierError when data.error is "forbidden"', async () => {
+      const $w = make$w();
+      const data = { ...makeTierData({ pointsInTier: 0, pointsToNextTier: 500 }), error: 'forbidden' };
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, data));
+      expect($w._els['#tierError'].show).toHaveBeenCalled();
+      expect($w._els['#tierName'].text).toBe('');
+    });
+
+    it('shows #tierError when data.error is "rate_limited"', async () => {
+      const $w = make$w();
+      const data = { ...makeTierData({ pointsInTier: 0, pointsToNextTier: 500 }), error: 'rate_limited' };
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, data));
+      expect($w._els['#tierError'].show).toHaveBeenCalled();
+      expect($w._els['#tierName'].text).toBe('');
+    });
+
+    it('shows #tierError when data.error is any arbitrary string', async () => {
+      const $w = make$w();
+      const data = { ...makeTierData({ tierName: 'Trail Blazer' }), error: 'some-future-code' };
+      await initRewardsTierWidget(MEMBER_ID, makeOpts($w, data));
+      expect($w._els['#tierError'].show).toHaveBeenCalled();
+      expect($w._els['#tierName'].text).toBe('');
+    });
+  });
 });

--- a/tests/streakTrackerWidget.test.js
+++ b/tests/streakTrackerWidget.test.js
@@ -204,6 +204,10 @@ describe('error handling', () => {
 // The cf-1y7 guard on getStreakData surfaces `error: 'auth_required'` alongside
 // a zero-streak baseline; pre-cf-afx the widget treated that like real data and
 // rendered the misleading number.
+//
+// cf-8qc widens the guard from `=== 'auth_required'` to any truthy `data.error`,
+// so future cf-1y7 extensions (forbidden, rate_limited, ...) don't re-introduce
+// the silent-failure class.
 describe('cf-afx auth_required branch', () => {
   it('shows #noStreakMsg when data carries error: auth_required', async () => {
     const $w = make$w();
@@ -234,5 +238,34 @@ describe('cf-afx auth_required branch', () => {
     await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, makeStreakData({ currentStreak: 0 })));
     expect($w._els['#streakCount'].text).toBe('0 day streak');
     expect($w._els['#noStreakMsg'].show).not.toHaveBeenCalled();
+  });
+});
+
+// cf-8qc — widen guard to any truthy data.error (not just auth_required).
+// Future cf-1y7 extensions may surface 'forbidden', 'rate_limited', etc.;
+// narrow equality check would silently let fake data through.
+describe('cf-8qc truthy-error branch', () => {
+  it('shows #noStreakMsg when data.error is "forbidden"', async () => {
+    const $w = make$w();
+    const data = { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'forbidden' };
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, data));
+    expect($w._els['#noStreakMsg'].show).toHaveBeenCalled();
+    expect($w._els['#streakCount'].text).toBe('');
+  });
+
+  it('shows #noStreakMsg when data.error is "rate_limited"', async () => {
+    const $w = make$w();
+    const data = { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'rate_limited' };
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, data));
+    expect($w._els['#noStreakMsg'].show).toHaveBeenCalled();
+    expect($w._els['#streakCount'].text).toBe('');
+  });
+
+  it('shows #noStreakMsg when data.error is any arbitrary string', async () => {
+    const $w = make$w();
+    const data = { currentStreak: 5, longestStreak: 10, lastActivityDate: null, error: 'some-future-code' };
+    await initStreakTrackerWidget(MEMBER_ID, makeOpts($w, data));
+    expect($w._els['#noStreakMsg'].show).toHaveBeenCalled();
+    expect($w._els['#streakCount'].text).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- Widens `data.error === 'auth_required'` → truthy `data.error` in StreakTrackerWidget + RewardsTierWidget
- Any cf-1y7 error baseline → no-data branch (hide happy-path UI, show sign-in/error messaging)
- +6 tests (3/widget) covering `forbidden`, `rate_limited`, arbitrary future code

## Why
Convergent followup from 5-agent review on PR #1090 (cf-afx). Silent-failure-hunter + pr-test-analyzer both flagged that the narrow `=== 'auth_required'` guard would silently let fake UI through if cf-1y7 is ever extended to emit `forbidden`, `rate_limited`, `unauthenticated`, etc.

The backend always returns a zero-streak / computeTierInfo(0) baseline for consumer compat (avoids NPE on `data.currentStreak` / `data.currentTier` reads). The `error` field is the only honest signal that the values are placeholder. Treating ANY truthy error as no-data is the safe default.

## Scope
- `src/public/StreakTrackerWidget.js` — predicate widened
- `src/public/RewardsTierWidget.js` — predicate widened
- `tests/streakTrackerWidget.test.js` — +3 tests in new `cf-8qc truthy-error branch` describe
- `tests/rewardsTierWidget.test.js` — +3 tests in new `cf-8qc truthy-error branch` describe

## Test plan
- [x] Local narrow vitest: **52/52 pass** (2 widget files, 224ms)
- [ ] CI green (test 20/22, lint, hookup-assistant, element-id-sync, CodeQL, codecov/patch)
- [ ] 5-agent review pass
- [ ] melania gate

## Closes
cf-8qc (filed post-merge of PR #1090)

🤖 Generated with [Claude Code](https://claude.com/claude-code)