### PR TITLE
fix(cf-4yp): widen Loyalty widget tier guard to truthy tier.error

### DIFF
--- a/src/public/LoyaltyBadgeWidget.js
+++ b/src/public/LoyaltyBadgeWidget.js
@@ -58,7 +58,12 @@ export async function initLoyaltyBadge(opts = {}) {
   const tier = tierResult.status === 'fulfilled' ? tierResult.value : null;
   const streak = streakResult.status === 'fulfilled' ? streakResult.value : null;
 
-  if (!tier) return; // tier fetch failed — keep container hidden
+  // cf-4yp: cf-1y7 returns a shape-stable computeTierInfo(0) baseline +
+  // `error: 'auth_required'` (or 'forbidden', 'rate_limited', ...) when it
+  // can't serve real data. Pre-cf-4yp we rendered the fake Trail Blazer
+  // badge to viewers who shouldn't see one. Truthy-check `tier.error` (not
+  // ===) so new codes don't re-open the silent class. Mirrors cf-afx/cf-8qc.
+  if (!tier || tier.error) return;
 
   // ── Tier badge ───────────────────────────────────────────────────────────────
   try {

--- a/src/public/LoyaltyTierBanner.js
+++ b/src/public/LoyaltyTierBanner.js
@@ -75,7 +75,12 @@ export async function initLoyaltyTierBanner(opts = {}) {
   const tier   = tierResult.status   === 'fulfilled' ? tierResult.value   : null;
   const streak = streakResult.status === 'fulfilled' ? streakResult.value : null;
 
-  if (!tier) return; // tier fetch failed — keep banner hidden
+  // cf-4yp: cf-1y7 returns a shape-stable computeTierInfo(0) baseline +
+  // `error: 'auth_required'` (or 'forbidden', 'rate_limited', ...) when it
+  // can't serve real data. Pre-cf-4yp we rendered that fake "Trail Blazer"
+  // banner to viewers who shouldn't see one. Truthy-check `tier.error` (not
+  // ===) so new codes don't re-open the silent class. Mirrors cf-afx/cf-8qc.
+  if (!tier || tier.error) return;
 
   // ── Tier badge icon ───────────────────────────────────────────────────────
 

--- a/tests/LoyaltyBadgeWidget.test.js
+++ b/tests/LoyaltyBadgeWidget.test.js
@@ -181,4 +181,75 @@ describe('initLoyaltyBadge', () => {
     });
     expect(getStreakData).toHaveBeenCalledWith('mem-xyz');
   });
+
+  // ── cf-4yp: cf-1y7 truthy-error baseline ──────────────────────────────────
+  // The getMemberTier handler returns computeTierInfo(0) + `error: 'auth_required'`
+  // to keep the response shape stable for non-gating consumers. Pre-cf-4yp the
+  // badge widget treated that payload as real data and rendered a fake Trail
+  // Blazer badge to viewers who couldn't be served real data. Truthy-check (not
+  // ===) so future codes (forbidden, rate_limited, ...) don't re-open the
+  // silent class. Mirrors cf-afx/cf-8qc pattern.
+  describe('cf-4yp truthy-error branch', () => {
+    it('keeps container hidden when tier carries error: auth_required', async () => {
+      await initLoyaltyBadge({
+        $w,
+        getCurrentMember: async () => ({ _id: 'mem-1' }),
+        getMemberTier: async () => ({ ...makeTier(), error: 'auth_required' }),
+        getStreakData: async () => makeStreak(),
+      });
+      expect($w('#loyaltyBadgeContainer').show).not.toHaveBeenCalled();
+    });
+
+    it('keeps container hidden when tier carries error: forbidden', async () => {
+      await initLoyaltyBadge({
+        $w,
+        getCurrentMember: async () => ({ _id: 'mem-1' }),
+        getMemberTier: async () => ({ ...makeTier(), error: 'forbidden' }),
+        getStreakData: async () => makeStreak(),
+      });
+      expect($w('#loyaltyBadgeContainer').show).not.toHaveBeenCalled();
+    });
+
+    it('keeps container hidden when tier carries error: rate_limited', async () => {
+      await initLoyaltyBadge({
+        $w,
+        getCurrentMember: async () => ({ _id: 'mem-1' }),
+        getMemberTier: async () => ({ ...makeTier(), error: 'rate_limited' }),
+        getStreakData: async () => makeStreak(),
+      });
+      expect($w('#loyaltyBadgeContainer').show).not.toHaveBeenCalled();
+    });
+
+    it('keeps container hidden when tier carries any arbitrary error string', async () => {
+      await initLoyaltyBadge({
+        $w,
+        getCurrentMember: async () => ({ _id: 'mem-1' }),
+        getMemberTier: async () => ({ ...makeTier(), error: 'some-future-code' }),
+        getStreakData: async () => makeStreak(),
+      });
+      expect($w('#loyaltyBadgeContainer').show).not.toHaveBeenCalled();
+    });
+
+    it('does not set tier badge text when tier carries truthy error', async () => {
+      await initLoyaltyBadge({
+        $w,
+        getCurrentMember: async () => ({ _id: 'mem-1' }),
+        getMemberTier: async () => ({ ...makeTier({ tierName: 'Trail Blazer' }), error: 'auth_required' }),
+        getStreakData: async () => makeStreak(),
+      });
+      const el = $w('#loyaltyTierBadge');
+      expect(el.html).toBe('');
+      expect(el.text).toBe('');
+    });
+
+    it('renders normally when tier.error field is absent', async () => {
+      await initLoyaltyBadge({
+        $w,
+        getCurrentMember: async () => ({ _id: 'mem-1' }),
+        getMemberTier: async () => makeTier({ tierName: 'Mountain Guide' }),
+        getStreakData: async () => makeStreak({ currentStreak: 0 }),
+      });
+      expect($w('#loyaltyBadgeContainer').show).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/loyaltyTierBanner.test.js
+++ b/tests/loyaltyTierBanner.test.js
@@ -376,3 +376,74 @@ describe('initLoyaltyTierBanner — streak chip', () => {
     expect(mockShouldShowStreakChip).toHaveBeenCalledWith(0);
   });
 });
+
+// ── cf-4yp: cf-1y7 truthy-error baseline ─────────────────────────────────────
+// The getMemberTier handler returns computeTierInfo(0) + `error: 'auth_required'`
+// to keep the response shape stable for non-gating consumers. Pre-cf-4yp the
+// banner treated that payload as real data and rendered a fake Trail Blazer
+// badge + "500 XP to Mountain Guide" copy to viewers who couldn't be served
+// real data. Truthy-check (not ===) so future codes (forbidden, rate_limited,
+// ...) don't re-open the silent class. Mirrors cf-afx/cf-8qc widget pattern.
+describe('initLoyaltyTierBanner — cf-4yp truthy-error branch', () => {
+  it('keeps banner hidden when tier carries error: auth_required', async () => {
+    const { $w, elements } = makeElements();
+    await initLoyaltyTierBanner({
+      $w,
+      getCurrentMember: vi.fn().mockResolvedValue({ _id: 'mem-1' }),
+      getMemberTier:    vi.fn().mockResolvedValue({ ...makeTier(), error: 'auth_required' }),
+      getStreakData:     vi.fn().mockResolvedValue(makeStreak()),
+    });
+    expect(elements['#tierBannerSection'].show).not.toHaveBeenCalled();
+  });
+
+  it('keeps banner hidden when tier carries error: forbidden', async () => {
+    const { $w, elements } = makeElements();
+    await initLoyaltyTierBanner({
+      $w,
+      getCurrentMember: vi.fn().mockResolvedValue({ _id: 'mem-1' }),
+      getMemberTier:    vi.fn().mockResolvedValue({ ...makeTier(), error: 'forbidden' }),
+      getStreakData:     vi.fn().mockResolvedValue(makeStreak()),
+    });
+    expect(elements['#tierBannerSection'].show).not.toHaveBeenCalled();
+  });
+
+  it('keeps banner hidden when tier carries error: rate_limited', async () => {
+    const { $w, elements } = makeElements();
+    await initLoyaltyTierBanner({
+      $w,
+      getCurrentMember: vi.fn().mockResolvedValue({ _id: 'mem-1' }),
+      getMemberTier:    vi.fn().mockResolvedValue({ ...makeTier(), error: 'rate_limited' }),
+      getStreakData:     vi.fn().mockResolvedValue(makeStreak()),
+    });
+    expect(elements['#tierBannerSection'].show).not.toHaveBeenCalled();
+  });
+
+  it('keeps banner hidden when tier carries any arbitrary error string', async () => {
+    const { $w, elements } = makeElements();
+    await initLoyaltyTierBanner({
+      $w,
+      getCurrentMember: vi.fn().mockResolvedValue({ _id: 'mem-1' }),
+      getMemberTier:    vi.fn().mockResolvedValue({ ...makeTier(), error: 'some-future-code' }),
+      getStreakData:     vi.fn().mockResolvedValue(makeStreak()),
+    });
+    expect(elements['#tierBannerSection'].show).not.toHaveBeenCalled();
+  });
+
+  it('does not set tier name when tier carries truthy error', async () => {
+    const { $w, elements } = makeElements();
+    await initLoyaltyTierBanner({
+      $w,
+      getCurrentMember: vi.fn().mockResolvedValue({ _id: 'mem-1' }),
+      getMemberTier:    vi.fn().mockResolvedValue({ ...makeTier({ tierName: 'Trail Blazer' }), error: 'auth_required' }),
+      getStreakData:     vi.fn().mockResolvedValue(makeStreak()),
+    });
+    expect(elements['#tierName'].text).toBe('');
+  });
+
+  it('renders normally when tier.error field is absent', async () => {
+    const { opts, elements } = makeOpts({ tierName: 'Mountain Guide' });
+    await initLoyaltyTierBanner(opts);
+    expect(elements['#tierName'].text).toBe('Mountain Guide');
+    expect(elements['#tierBannerSection'].show).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Widens the tier-error guard in `LoyaltyTierBanner` and `LoyaltyBadgeWidget` from `if (!tier)` to `if (!tier || tier.error)`, mirroring the cf-afx/cf-8qc pattern applied to StreakTracker + RewardsTier widgets in #1090 and #1091.

## Why

cf-1y7 hardened `getMemberTier` to return a **shape-stable** `computeTierInfo(0)` baseline alongside `error: 'auth_required'` when it can't serve real data. Non-gating consumers depend on the stable shape, so the `error` field is the only honest signal the numbers are placeholder.

Pre-cf-4yp, both widgets treated the baseline like real tier data and rendered:
- **LoyaltyTierBanner** — fake "Trail Blazer" badge + "500 XP to Mountain Guide" banner
- **LoyaltyBadgeWidget** — fake Trail Blazer badge on collection + category pages

Surfaced by silent-failure-hunter during the #1091 review. Same class as cf-afx / cf-8qc.

## Changes

- `src/public/LoyaltyTierBanner.js` — widen line 78 guard + cf-4yp comment
- `src/public/LoyaltyBadgeWidget.js` — widen line 61 guard + cf-4yp comment
- `tests/LoyaltyTierBanner.test.js` — +6 tests (auth_required, forbidden, rate_limited, arbitrary, no-render, renders-normal)
- `tests/LoyaltyBadgeWidget.test.js` — +6 tests (same matrix)

## Truthy-check, not strict equality

Same rationale as #1091: future cf-1y7 extensions (`forbidden`, `rate_limited`, quota codes, ...) shouldn't re-open the silent-failure class by narrow `=== 'auth_required'`.

## Test plan

- [x] `npx vitest run tests/LoyaltyTierBanner.test.js tests/LoyaltyBadgeWidget.test.js` — 55 passed
- [ ] 5-agent review (code-reviewer, silent-failure-hunter, code-simplifier, comment-analyzer, pr-test-analyzer) — radahn dispatched
- [ ] melania gate

## Related

- cf-1y7 (parent silent-failure-masquerade cascade)
- cf-afx to #1090 (StreakTracker + RewardsTier initial guard)
- cf-8qc to #1091 (StreakTracker + RewardsTier truthy-widen)
- cf-4yp (this PR)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>