### PR TITLE
fix(cf-16h): replace silent catches in getActiveChallengeOfWeek + add progressStatus

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -1258,6 +1258,10 @@ export const getActivityFeed = webMethod(
  * The CMS editor marks a challenge as featured by setting `isFeatured: true`
  * on the Challenges collection item.
  *
+ * progressStatus lets callers distinguish between "real 0 from a member",
+ * "default 0 because the caller is a visitor", and "default 0 because the
+ * progress query failed" — all three used to be indistinguishable.
+ *
  * @returns {Promise<{
  *   challengeId: string,
  *   title: string,
@@ -1267,6 +1271,7 @@ export const getActivityFeed = webMethod(
  *   rewardPoints: number,
  *   progressValue: number,
  *   completedAt: string|null,
+ *   progressStatus: 'member'|'visitor'|'unavailable',
  *   expiresAt: string,
  *   ctaUrl: string|null,
  * } | null>}
@@ -1296,10 +1301,15 @@ export const getActiveChallengeOfWeek = webMethod(
         const { currentMember: cm } = await import('wix-members-backend');
         const member = await cm.getMember();
         memberId = member?._id ?? null;
-      } catch { /* visitor or unauthenticated — progress stays 0 */ }
+      } catch (err) {
+        // Expected when the caller is an unauthenticated visitor. Keep the
+        // structured entry for aggregation but skip console noise.
+        logError('getActiveChallengeOfWeek — member lookup unavailable', err, { silent: true });
+      }
 
       let progressValue = 0;
       let completedAt = null;
+      let progressStatus = memberId ? 'member' : 'visitor';
 
       if (memberId) {
         try {
@@ -1314,7 +1324,10 @@ export const getActiveChallengeOfWeek = webMethod(
             progressValue = rec.progressValue ?? 0;
             completedAt = rec.completedAt ?? null;
           }
-        } catch { /* progress unavailable — return 0 */ }
+        } catch (err) {
+          logError(`getActiveChallengeOfWeek — progress lookup failed for ${memberId}`, err, { silent: true });
+          progressStatus = 'unavailable';
+        }
       }
 
       return {
@@ -1326,6 +1339,7 @@ export const getActiveChallengeOfWeek = webMethod(
         rewardPoints: challenge.rewardPoints ?? 0,
         progressValue,
         completedAt,
+        progressStatus,
         expiresAt: challenge.expiresAt instanceof Date
           ? challenge.expiresAt.toISOString()
           : challenge.expiresAt,

--- a/tests/gamificationCoreWebMethods.test.js
+++ b/tests/gamificationCoreWebMethods.test.js
@@ -94,6 +94,7 @@ import {
   getMemberTier,
   getActivityFeed,
   getActiveChallenges,
+  getActiveChallengeOfWeek,
   computeTierInfo,
 } from '../src/backend/gamificationCore.web.js';
 
@@ -389,5 +390,99 @@ describe('cf-1y7 null-member guard cascade', () => {
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
+  });
+});
+
+// ── cf-16h getActiveChallengeOfWeek ─────────────────────────────────────────
+
+describe('getActiveChallengeOfWeek (cf-16h: discriminable progressStatus)', () => {
+  const FUTURE_ISO = new Date(Date.now() + 86_400_000).toISOString();
+
+  beforeEach(() => {
+    seed('Challenges', [{
+      _id: 'chall-db-1',
+      challengeId: 'chall-1',
+      title: 'Weekly walk',
+      description: '10k steps',
+      conditionType: 'steps',
+      targetCount: 10000,
+      rewardPoints: 50,
+      active: true,
+      isFeatured: true,
+      expiresAt: FUTURE_ISO,
+      ctaUrl: '/walk',
+    }]);
+  });
+
+  it('returns null when no featured challenge is active', async () => {
+    _collections = {};
+    const result = await getActiveChallengeOfWeek();
+    expect(result).toBeNull();
+  });
+
+  it('returns visitor status with zero progress for unauthenticated caller', async () => {
+    __mockMemberId = null;
+    const result = await getActiveChallengeOfWeek();
+    expect(result).not.toBeNull();
+    expect(result.challengeId).toBe('chall-1');
+    expect(result.progressValue).toBe(0);
+    expect(result.completedAt).toBeNull();
+    expect(result.progressStatus).toBe('visitor');
+  });
+
+  it('returns member status + real progress when the member has a record', async () => {
+    __mockMemberId = 'mem-7';
+    seed('MemberChallengeProgress', [{
+      memberId: 'mem-7',
+      challengeId: 'chall-1',
+      progressValue: 4200,
+      completedAt: null,
+    }]);
+    const result = await getActiveChallengeOfWeek();
+    expect(result.progressValue).toBe(4200);
+    expect(result.progressStatus).toBe('member');
+  });
+
+  it('returns member status with zero progress when member has no progress row', async () => {
+    __mockMemberId = 'mem-new';
+    const result = await getActiveChallengeOfWeek();
+    expect(result.progressValue).toBe(0);
+    expect(result.progressStatus).toBe('member');
+  });
+
+  it('reports unavailable when the progress query throws for an authenticated member', async () => {
+    __mockMemberId = 'mem-broken';
+    const wixData = (await import('wix-data')).default;
+    const origQuery = wixData.query;
+    let call = 0;
+    wixData.query = (col) => {
+      call += 1;
+      if (col === 'MemberChallengeProgress') {
+        return {
+          eq() { return this; },
+          gt() { return this; },
+          descending() { return this; },
+          limit() { return this; },
+          find() { throw new Error('connection reset'); },
+        };
+      }
+      return origQuery(col);
+    };
+    try {
+      const result = await getActiveChallengeOfWeek();
+      expect(result.progressValue).toBe(0);
+      expect(result.progressStatus).toBe('unavailable');
+    } finally {
+      wixData.query = origQuery;
+      void call;
+    }
+  });
+
+  it('does not spam the console for the expected visitor path', async () => {
+    __mockMemberId = null;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await getActiveChallengeOfWeek();
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Replace two empty `catch {}` blocks in `getActiveChallengeOfWeek` with tagged `logError(..., { silent: true })` so the expected visitor path stays quiet but aggregation still sees structured entries (CLAUDE.md silent-catch rule).
- Add `progressStatus: 'member' | 'visitor' | 'unavailable'` to the return shape so callers can distinguish "real 0 from a member", "default 0 for a visitor", and "default 0 because the progress query threw" — these three were indistinguishable.
- 6 new test cases cover all three status paths, a null-challenge early return, and a no-console-noise guarantee for the visitor path.

## Test plan
- [x] `node_modules/.bin/vitest run` → 1100 files / 40084 tests green
- [x] `node_modules/.bin/vitest run tests/gamificationCoreWebMethods.test.js` → 32 tests green (was 27)
- [ ] ChallengeOfTheWeekWidget still renders on live site (visitor path previously rendered, now explicitly `progressStatus: 'visitor'` — widget ignores the new field, backwards-compatible)

Source: silent-failure-hunter on PR #1088 (radahn 2026-04-17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)