### PR TITLE
chore(cf-863): remove phantom react 19.2.5 devDep from root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0",
         "puppeteer": "^24.41.0",
-        "react": "19.2.5",
         "vitest": "^4.1.2"
       },
       "engines": {
@@ -4286,16 +4285,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "playwright": "^1.59.1",
     "pngjs": "^7.0.0",
     "puppeteer": "^24.41.0",
-    "react": "19.2.5",
     "vitest": "^4.1.2"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- Drops `"react": "19.2.5"` from root `package.json` (and lockfile entry)
- Nothing at the repo root imports react; the only React consumer is `packages/hookup-assistant` which pins its own `react@^18.2.0`
- Eliminates the 19.2.5-vs-18.2.0 version mismatch at install time and shrinks the lockfile

## Test plan
- [x] `grep -r "from eact\\|require(eact\)" .` at root returns 0 matches outside `packages/hookup-assistant/` and `node_modules/`
- [x] Full vitest suite: 1100 files / 40078 tests / 5 todo — all green
- [x] Lockfile diff: only react entry removed

Closes cf-863.