### PR TITLE
fix(cf-n54): reclassify member-lookup throw + widget progressStatus branch + silent-mute downgrade

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -248,10 +248,12 @@ export const receiveGamificationEvent = webMethod(
       // Cross-rig event bus — web→mobile dispatch (best-effort)
       const totalDelta = newTotal - oldTotal;
       if (totalDelta !== 0) {
-        try { await dispatchBusEvent({ event: 'points_earned', userId: memberId, delta: totalDelta, newTotal }); } catch (_) {}
+        try { await dispatchBusEvent({ event: 'points_earned', userId: memberId, delta: totalDelta, newTotal }); }
+        catch (err) { logError(`gamificationEventReceiver — bus dispatch (points_earned) failed for ${memberId}`, err, { silent: true }); }
       }
       if (tierChanged) {
-        try { await dispatchBusEvent({ event: 'tier_upgraded', userId: memberId, newTier, previousTier: oldTier }); } catch (_) {}
+        try { await dispatchBusEvent({ event: 'tier_upgraded', userId: memberId, newTier, previousTier: oldTier }); }
+        catch (err) { logError(`gamificationEventReceiver — bus dispatch (tier_upgraded) failed for ${memberId}`, err, { silent: true }); }
         // CF-c6el.2: Auto-deliver tier perks (coupon codes, emails, booking links)
         try {
           const { deliverTierPerks } = await import('backend/rewardEngine.web');
@@ -329,10 +331,12 @@ export const receiveGamificationEvent = webMethod(
 
       // CF-1faf: Cross-rig bus — badge + streak events (best-effort)
       if (badgeUnlocked) {
-        try { await dispatchBusEvent({ event: 'badge_earned', userId: memberId, badgeId: badgeUnlocked }); } catch (_) {}
+        try { await dispatchBusEvent({ event: 'badge_earned', userId: memberId, badgeId: badgeUnlocked }); }
+        catch (err) { logError(`gamificationEventReceiver — bus dispatch (badge_earned) failed for ${memberId}`, err, { silent: true }); }
       }
       if (streakState.currentStreakDays > prevStreakDays) {
-        try { await dispatchBusEvent({ event: 'streak_extended', userId: memberId, currentStreakDays: streakState.currentStreakDays }); } catch (_) {}
+        try { await dispatchBusEvent({ event: 'streak_extended', userId: memberId, currentStreakDays: streakState.currentStreakDays }); }
+        catch (err) { logError(`gamificationEventReceiver — bus dispatch (streak_extended) failed for ${memberId}`, err, { silent: true }); }
       }
 
       return {
@@ -952,7 +956,8 @@ export const recordChallengeProgress = webMethod(
       }
 
       if (completed) {
-        try { await dispatchBusEvent({ event: 'challenge_completed', userId: memberId, challengeId }); } catch (_) {}
+        try { await dispatchBusEvent({ event: 'challenge_completed', userId: memberId, challengeId }); }
+        catch (err) { logError(`recordChallengeProgress — bus dispatch (challenge_completed) failed for ${memberId}`, err, { silent: true }); }
       }
 
       return { success: true, newProgress, completed, pointsAwarded };
@@ -1297,19 +1302,23 @@ export const getActiveChallengeOfWeek = webMethod(
       const cId = challenge.challengeId || challenge._id;
 
       let memberId = null;
+      let memberLookupFailed = false;
       try {
         const { currentMember: cm } = await import('wix-members-backend');
         const member = await cm.getMember();
         memberId = member?._id ?? null;
       } catch (err) {
-        // Expected when the caller is an unauthenticated visitor. Keep the
-        // structured entry for aggregation but skip console noise.
-        logError('getActiveChallengeOfWeek — member lookup unavailable', err, { silent: true });
+        memberLookupFailed = true;
+        logError('getActiveChallengeOfWeek — member lookup threw', err, { silent: true });
       }
 
       let progressValue = 0;
       let completedAt = null;
-      let progressStatus = memberId ? 'member' : 'visitor';
+      let progressStatus = memberLookupFailed
+        ? 'unavailable'
+        : memberId
+          ? 'member'
+          : 'visitor';
 
       if (memberId) {
         try {

--- a/src/backend/utils/errorHandler.js
+++ b/src/backend/utils/errorHandler.js
@@ -10,8 +10,10 @@
  * @param {string} context - Where the error occurred (e.g., 'cartRecovery.recordAbandonedCart')
  * @param {Error|string} error - The error to log
  * @param {Object} [options]
- * @param {boolean} [options.silent=false] - If true, suppress console.error output
- * @returns {{ context: string, message: string, timestamp: string, stack?: string }}
+ * @param {boolean} [options.silent=false] - If true, downgrade to console.warn
+ *   (not full mute) so Wix runtime logs still capture the trace without
+ *   surfacing as a red error in dashboards.
+ * @returns {{ context: string, message: string, timestamp: string, stack?: string, silent?: boolean }}
  */
 export function logError(context, error, { silent = false } = {}) {
   const entry = {
@@ -19,8 +21,13 @@ export function logError(context, error, { silent = false } = {}) {
     message: error?.message || String(error),
     timestamp: new Date().toISOString(),
     stack: error?.stack || undefined,
+    ...(silent ? { silent: true } : {}),
   };
-  if (!silent) console.error(`[${context}]`, entry.message);
+  if (silent) {
+    console.warn(`[${context}] (silent)`, entry.message);
+  } else {
+    console.error(`[${context}]`, entry.message);
+  }
   return entry;
 }
 

--- a/src/public/ChallengeOfTheWeekWidget.js
+++ b/src/public/ChallengeOfTheWeekWidget.js
@@ -165,13 +165,21 @@ async function _renderFeaturedChallenge($w, getActiveChallengeOfWeek) {
   try { $w('#cotwTitle').text = challenge.title; } catch {}
   try { $w('#cotwDesc').text = challenge.description ?? ''; } catch {}
 
-  // Member progress bar
-  const progress = challenge.progressValue ?? 0;
-  const target = challenge.targetCount || 1; // guard division by zero
-  const pct = Math.min(Math.round((progress / target) * 100), 100);
+  // Member progress bar — suppress when backend could not resolve progress
+  // so callers don't misread a real-0 as a failed member-lookup.
+  if (challenge.progressStatus === 'unavailable') {
+    try { $w('#cotwProgressText').text = 'Progress temporarily unavailable'; } catch {}
+    try { $w('#cotwProgressBar').style.width = '0%'; } catch {}
+    try { $w('#cotwProgressBar').hide(); } catch {}
+  } else {
+    try { $w('#cotwProgressBar').show(); } catch {}
+    const progress = challenge.progressValue ?? 0;
+    const target = challenge.targetCount || 1; // guard division by zero
+    const pct = Math.min(Math.round((progress / target) * 100), 100);
 
-  try { $w('#cotwProgressText').text = `${progress.toLocaleString()} / ${target.toLocaleString()}`; } catch {}
-  try { $w('#cotwProgressBar').style.width = `${pct}%`; } catch {}
+    try { $w('#cotwProgressText').text = `${progress.toLocaleString()} / ${target.toLocaleString()}`; } catch {}
+    try { $w('#cotwProgressBar').style.width = `${pct}%`; } catch {}
+  }
 
   // Reward
   if (challenge.rewardPoints > 0) {

--- a/tests/challengeOfTheWeekWidget.test.js
+++ b/tests/challengeOfTheWeekWidget.test.js
@@ -321,6 +321,57 @@ describe('ChallengeOfTheWeekWidget — featured challenge section (cf-rsr)', () 
     await init();
     expect(getEl('#cotwDesc').text).toBe('');
   });
+
+  // cf-n54: widget must branch on progressStatus so consumers can distinguish
+  // a real-0 from a backend that couldn't resolve progress for this member.
+  describe('cf-n54 progressStatus consumer', () => {
+    it('renders unavailable fallback + hides bar when progressStatus is "unavailable"', async () => {
+      getActiveChallengeOfWeek.mockResolvedValue({
+        ...FEATURED,
+        progressValue: 0,
+        progressStatus: 'unavailable',
+      });
+      await init();
+      expect(getEl('#cotwProgressText').text).toBe('Progress temporarily unavailable');
+      expect(getEl('#cotwProgressBar').hide).toHaveBeenCalled();
+    });
+
+    it('renders normal progress when progressStatus is "member"', async () => {
+      getActiveChallengeOfWeek.mockResolvedValue({
+        ...FEATURED,
+        progressValue: 3,
+        targetCount: 6,
+        progressStatus: 'member',
+      });
+      await init();
+      expect(getEl('#cotwProgressText').text).toBe('3 / 6');
+      expect(getEl('#cotwProgressBar').style.width).toBe('50%');
+      expect(getEl('#cotwProgressBar').show).toHaveBeenCalled();
+    });
+
+    it('renders normal progress when progressStatus is "visitor" (0/target)', async () => {
+      getActiveChallengeOfWeek.mockResolvedValue({
+        ...FEATURED,
+        progressValue: 0,
+        targetCount: 1,
+        progressStatus: 'visitor',
+      });
+      await init();
+      expect(getEl('#cotwProgressText').text).toBe('0 / 1');
+      expect(getEl('#cotwProgressBar').style.width).toBe('0%');
+    });
+
+    it('renders normal progress when progressStatus is absent (back-compat)', async () => {
+      getActiveChallengeOfWeek.mockResolvedValue({
+        ...FEATURED,
+        progressValue: 2,
+        targetCount: 4,
+      });
+      await init();
+      expect(getEl('#cotwProgressText').text).toBe('2 / 4');
+      expect(getEl('#cotwProgressBar').style.width).toBe('50%');
+    });
+  });
 });
 
 // ── getChallengeOfTheWeek homepage section (cf-1he) ─────────────────────────

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -30,16 +30,43 @@ describe('logError', () => {
     spy.mockRestore();
   });
 
-  it('suppresses console output when silent', () => {
+  it('suppresses console.error when silent', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     logError('myModule', new Error('test'), { silent: true });
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  // cf-n54: silent mode downgrades to console.warn rather than full mute so
+  // Wix runtime logs still capture the trace (no more complete silent-failure).
+  it('downgrades to console.warn when silent (not full mute)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logError('myModule', new Error('test err'), { silent: true });
+    expect(warnSpy).toHaveBeenCalledWith('[myModule] (silent)', 'test err');
+    warnSpy.mockRestore();
+  });
+
+  it('marks silent entries with silent:true flag', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const entry = logError('test', new Error('x'), { silent: true });
+    expect(entry.silent).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('does not mark non-silent entries with silent flag', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const entry = logError('test', new Error('x'));
+    expect(entry.silent).toBeUndefined();
+    errSpy.mockRestore();
   });
 
   it('includes ISO timestamp', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const entry = logError('test', 'err', { silent: true });
     expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    warnSpy.mockRestore();
   });
 });
 

--- a/tests/gamificationCoreWebMethods.test.js
+++ b/tests/gamificationCoreWebMethods.test.js
@@ -485,4 +485,25 @@ describe('getActiveChallengeOfWeek (cf-16h: discriminable progressStatus)', () =
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
+
+  // cf-n54: a member-lookup that *throws* (not just resolves null) must not be
+  // mis-classified as a visitor — it's a backend failure, not an unauth caller.
+  it('classifies member-lookup throw as "unavailable", not "visitor"', async () => {
+    const membersMod = await import('wix-members-backend');
+    const origGetMember = membersMod.currentMember.getMember;
+    membersMod.currentMember.getMember = vi.fn(() =>
+      Promise.reject(new Error('wix-members-backend transient failure')),
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await getActiveChallengeOfWeek();
+      expect(result.progressStatus).toBe('unavailable');
+      expect(result.progressValue).toBe(0);
+      // errorHandler silent-mute downgrades to console.warn (cf-n54)
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      membersMod.currentMember.getMember = origGetMember;
+      warnSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Three fixes from morgott`s cf-16h review of PR #1094:

1. **Backend — member-lookup reclassification.** `getActiveChallengeOfWeek` in `gamificationCore.web.js` was mis-classifying a thrown import/getMember error as `visitor`. Added `memberLookupFailed` sentinel so lookup throws route to `unavailable` (distinguishes real backend failure from unauthenticated caller).
2. **Widget — progressStatus consumer.** `ChallengeOfTheWeekWidget.js:169` now branches on `progressStatus === unavailable` to render `Progress temporarily unavailable` fallback + hide bar. Normal/back-compat paths untouched.
3. **errorHandler silent-mute downgrade.** `silent: true` previously fully muted; now downgrades to `console.warn([ctx] (silent), msg)` so Wix runtime logs still capture the trace. Entry carries `silent: true` flag for aggregators. Also replaced 5 bare `catch (_) {}` blocks around `dispatchBusEvent` calls (lines 251/254/332/335/955) with silent-logged catches.

## Test plan
- [x] +4 widget tests covering each progressStatus branch
- [x] +1 backend test: member-lookup throw → `unavailable`
- [x] +3 errorHandler tests locking in silent-warn + entry marker
- [x] Full vitest: 1100 files / 40104 tests / 5 todo — all green

Closes cf-n54.