### PR TITLE
fix(cf-eip): CORS origin-rejection observability + options_health tests

### DIFF
--- a/src/backend/utils/cors.js
+++ b/src/backend/utils/cors.js
@@ -1,3 +1,5 @@
+import { logError } from 'backend/utils/errorHandler';
+
 // CORS allowlist + helpers for Velo HTTP Functions (/_functions/*).
 //
 // The carolina-futons-web Next.js app (and its Vercel preview URLs) needs to
@@ -51,6 +53,19 @@ export function allowOrigin(request) {
   return null;
 }
 
+// Distinguishes a request with no Origin header (same-origin / server-to-server)
+// from one whose Origin was present but not allowlisted. Only the latter is
+// an observability signal — emit a log so rejected cross-origin traffic shows
+// up in the Velo console without polluting normal same-origin traffic.
+function _checkOrigin(request, scope) {
+  const raw = request?.headers?.origin || request?.headers?.Origin || null;
+  const allowed = allowOrigin(request);
+  if (!allowed && raw) {
+    logError(`cors.originRejected.${scope}`, `Origin not in allowlist: ${raw}`);
+  }
+  return allowed;
+}
+
 /**
  * Returns a headers object with CORS fields populated if the request's origin
  * is allowed. Merges with any extra headers (e.g., Content-Type).
@@ -65,7 +80,7 @@ export function allowOrigin(request) {
  * @returns {Record<string, string>}
  */
 export function corsHeaders(request, extraHeaders = {}) {
-  const origin = allowOrigin(request);
+  const origin = _checkOrigin(request, 'headers');
   if (!origin) return { ...extraHeaders };
   return {
     'Access-Control-Allow-Origin': origin,
@@ -84,7 +99,7 @@ export function corsHeaders(request, extraHeaders = {}) {
  * @returns {{ status: number, headers: Record<string, string> }}
  */
 export function corsPreflight(request) {
-  const origin = allowOrigin(request);
+  const origin = _checkOrigin(request, 'preflight');
   if (!origin) {
     return { status: 403, headers: { 'Content-Type': 'text/plain' }, body: 'Origin not allowed' };
   }

--- a/tests/cors.test.js
+++ b/tests/cors.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   allowOrigin,
   corsHeaders,
@@ -87,6 +87,40 @@ describe('corsPreflight', () => {
     const r = corsPreflight(req('https://evil.example.com'));
     expect(r.status).toBe(403);
     expect(r.headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+});
+
+describe('origin-rejection observability', () => {
+  let spy;
+  beforeEach(() => { spy = vi.spyOn(console, 'error').mockImplementation(() => {}); });
+  afterEach(() => { spy.mockRestore(); });
+
+  it('logs when corsHeaders sees a disallowed Origin header', () => {
+    corsHeaders(req('https://evil.example.com'));
+    expect(spy).toHaveBeenCalledWith(
+      '[cors.originRejected.headers]',
+      expect.stringContaining('https://evil.example.com'),
+    );
+  });
+
+  it('logs when corsPreflight sees a disallowed Origin header', () => {
+    corsPreflight(req('https://evil.example.com'));
+    expect(spy).toHaveBeenCalledWith(
+      '[cors.originRejected.preflight]',
+      expect.stringContaining('https://evil.example.com'),
+    );
+  });
+
+  it('does not log when no Origin header is present (same-origin/server-to-server)', () => {
+    corsHeaders(req(null));
+    corsPreflight(req(null));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not log when the origin is allowed', () => {
+    corsHeaders(req('http://localhost:3000'));
+    corsPreflight(req('http://localhost:3000'));
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/httpFunctions.test.js
+++ b/tests/httpFunctions.test.js
@@ -7,6 +7,7 @@ import { __setMember, __reset as resetMembers, currentMember as membersMock } fr
 import { _resetActiveChallengesRateLimit, _resetRecordChallengeProgressRateLimit } from '../src/backend/gamificationEventReceiver.web.js';
 import {
   get_health,
+  options_health,
   get_productSitemap,
   get_blogSitemap,
   get_facebookCatalogFeed,
@@ -102,6 +103,35 @@ describe('get_health', () => {
   it('returns JSON content type', () => {
     const result = get_health();
     expect(result.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('echoes CORS headers when called with an allowed Origin', () => {
+    const request = { headers: { origin: 'http://localhost:3000' } };
+    const result = get_health(request);
+    expect(result.headers['Access-Control-Allow-Origin']).toBe('http://localhost:3000');
+    expect(result.headers['Access-Control-Allow-Credentials']).toBe('true');
+    expect(result.headers.Vary).toBe('Origin');
+  });
+});
+
+// ── options_health ──────────────────────────────────────────────────
+
+describe('options_health', () => {
+  it('returns 204 + preflight headers for an allowed Origin', () => {
+    const request = { headers: { origin: 'http://localhost:3000' } };
+    const result = options_health(request);
+    expect(result.status).toBe(204);
+    expect(result.headers['Access-Control-Allow-Origin']).toBe('http://localhost:3000');
+    expect(result.headers['Access-Control-Allow-Methods']).toMatch(/GET.*POST.*OPTIONS/);
+    expect(result.headers['Access-Control-Allow-Headers']).toMatch(/Content-Type/);
+    expect(result.headers['Access-Control-Max-Age']).toBe('86400');
+  });
+
+  it('returns 403 for a disallowed Origin', () => {
+    const request = { headers: { origin: 'https://evil.example.com' } };
+    const result = options_health(request);
+    expect(result.status).toBe(403);
+    expect(result.headers['Access-Control-Allow-Origin']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- `cors.js`: `corsHeaders()` / `corsPreflight()` now call `logError('cors.originRejected.<scope>', ...)` when an `Origin` header is present but not in the allowlist — rejected cross-origin traffic is now visible in the Velo console. No-origin requests (same-origin / server-to-server) still pass through silently.
- `http-functions.js`: added coverage for `options_health` (allowed + disallowed) and extended `get_health` to assert CORS headers are echoed for an allowed `Origin`. Closes the observability gap morgott's 5-agent review flagged on PR #1092.

## Test plan
- [x] `npx vitest run tests/cors.test.js` — 19/19 (4 new rejection-observability cases)
- [x] `npx vitest run tests/httpFunctions.test.js` — 3 new cases + existing green
- [x] `npx vitest run` full suite — 1100 files, 40118 tests, 0 failures

Bead: cf-eip (P2, follow-up to cf-3qt.4 / PR #1092)