### PR TITLE
fix(cf-9lp.1): GET /activeChallenges returns 503 on internal_error

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -1924,6 +1924,14 @@ export async function get_activeChallenges(request) {
       return response({ status: 429, body: json({ error: 'Rate limit exceeded' }), headers: jsonHeaders });
     }
 
+    // cf-9lp.1: surface cf-tlt's `internal_error` shape as 503 so generic REST
+    // consumers and monitoring probes don't treat a DB failure as success.
+    // The webMethod still preserves the { challenges: [] } field for mobile-app
+    // clients that read the body — shape is unchanged; only the status differs.
+    if (result.error === 'internal_error') {
+      return response({ status: 503, body: json(result), headers: jsonHeaders });
+    }
+
     return ok({ body: json(result), headers: jsonHeaders });
   } catch (err) {
     console.error(`HTTP function error (activeChallenges): memberId=${memberId || 'unknown'}:`, err);

--- a/tests/httpFunctions.test.js
+++ b/tests/httpFunctions.test.js
@@ -1662,6 +1662,30 @@ describe('get_activeChallenges', () => {
     const result = await get_activeChallenges(makeActiveChallengesRequest('mem-rl'));
     expect(result.status).toBe(429);
   });
+
+  // cf-9lp.1: when the webMethod returns { challenges: [], error: 'internal_error' }
+  // (the cf-tlt DB-failure shape), the HTTP endpoint MUST return 503, not 200 OK.
+  // Prior behavior was 200 OK with the error body — generic REST consumers and
+  // monitoring probes saw "success" when the backend had failed.
+  describe('cf-9lp.1 503 on internal_error', () => {
+    it('returns 503 when the webMethod surfaces error: "internal_error"', async () => {
+      __setMember({ _id: 'mem-db-fail' });
+      __setQueryError('Challenges', new Error('connection reset'));
+      const result = await get_activeChallenges(makeActiveChallengesRequest('mem-db-fail'));
+      expect(result.status).toBe(503);
+      const body = JSON.parse(result.body);
+      expect(body.error).toBe('internal_error');
+    });
+
+    it('preserves 200 OK for empty-but-authed (no error field)', async () => {
+      __setMember({ _id: 'mem-empty' });
+      const result = await get_activeChallenges(makeActiveChallengesRequest('mem-empty'));
+      expect(result.status).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.error).toBeUndefined();
+      expect(body.challenges).toEqual([]);
+    });
+  });
 });
 
 // ── POST /_functions/challengeProgress ───────────────────────────────────────


### PR DESCRIPTION
Widens get_activeChallenges HTTP handler to return 503 Service Unavailable when the underlying webMethod returns { challenges: [], error: 'internal_error' } (the cf-tlt DB-failure shape). Preserves 200 OK for empty-but-authed and 429 for rate-limit. Body shape unchanged. Slice 1/4 for cf-9lp. Based on fix/cf-tlt-db-error-shape — auto-retargets to main when #1099 merges. Closes cf-jwz.