### PR TITLE
fix(cf-9lp.1): GET /activeChallenges returns 503 on internal_error

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -1924,6 +1924,14 @@ export async function get_activeChallenges(request) {
       return response({ status: 429, body: json({ error: 'Rate limit exceeded' }), headers: jsonHeaders });
     }
 
+    // cf-9lp.1: surface cf-tlt's `internal_error` shape as 503 so generic REST
+    // consumers and monitoring probes don't treat a DB failure as success.
+    // The webMethod still preserves the { challenges: [] } field for mobile-app
+    // clients that read the body — shape is unchanged; only the status differs.
+    if (result.error === 'internal_error') {
+      return response({ status: 503, body: json(result), headers: jsonHeaders });
+    }
+
     return ok({ body: json(result), headers: jsonHeaders });
   } catch (err) {
     console.error(`HTTP function error (activeChallenges): memberId=${memberId || 'unknown'}:`, err);

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -1925,9 +1925,15 @@ export async function get_activeChallenges(request) {
     }
 
     // cf-9lp.1: surface cf-tlt's `internal_error` shape as 503 so generic REST
-    // consumers and monitoring probes don't treat a DB failure as success.
-    // The webMethod still preserves the { challenges: [] } field for mobile-app
-    // clients that read the body — shape is unchanged; only the status differs.
+    // consumers and monitoring probes stop treating a DB failure as success.
+    // Behavior change for existing consumers:
+    //   • Mobile app (cfutons_mobile wixClient.rawRequest) throws on non-2xx
+    //     and has isRetryableError→true for 5xx, so a transient DB blip now
+    //     triggers a retry instead of surfacing a silent empty list. This is
+    //     the desired UX — previously the user saw "no challenges" on failure.
+    //   • Generic REST / monitoring probes now see 503 and alert correctly.
+    // Body is still emitted ({ challenges: [], error: 'internal_error' }) for
+    // diagnostics, but callers that branch on status are the primary audience.
     if (result.error === 'internal_error') {
       return response({ status: 503, body: json(result), headers: jsonHeaders });
     }

--- a/tests/httpFunctions.test.js
+++ b/tests/httpFunctions.test.js
@@ -1705,6 +1705,7 @@ describe('get_activeChallenges', () => {
       expect(result.status).toBe(503);
       const body = JSON.parse(result.body);
       expect(body.error).toBe('internal_error');
+      expect(body.challenges).toEqual([]);  // pin preserved-field regression
     });
 
     it('preserves 200 OK for empty-but-authed (no error field)', async () => {

--- a/tests/httpFunctions.test.js
+++ b/tests/httpFunctions.test.js
@@ -1692,6 +1692,30 @@ describe('get_activeChallenges', () => {
     const result = await get_activeChallenges(makeActiveChallengesRequest('mem-rl'));
     expect(result.status).toBe(429);
   });
+
+  // cf-9lp.1: when the webMethod returns { challenges: [], error: 'internal_error' }
+  // (the cf-tlt DB-failure shape), the HTTP endpoint MUST return 503, not 200 OK.
+  // Prior behavior was 200 OK with the error body — generic REST consumers and
+  // monitoring probes saw "success" when the backend had failed.
+  describe('cf-9lp.1 503 on internal_error', () => {
+    it('returns 503 when the webMethod surfaces error: "internal_error"', async () => {
+      __setMember({ _id: 'mem-db-fail' });
+      __setQueryError('Challenges', new Error('connection reset'));
+      const result = await get_activeChallenges(makeActiveChallengesRequest('mem-db-fail'));
+      expect(result.status).toBe(503);
+      const body = JSON.parse(result.body);
+      expect(body.error).toBe('internal_error');
+    });
+
+    it('preserves 200 OK for empty-but-authed (no error field)', async () => {
+      __setMember({ _id: 'mem-empty' });
+      const result = await get_activeChallenges(makeActiveChallengesRequest('mem-empty'));
+      expect(result.status).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.error).toBeUndefined();
+      expect(body.challenges).toEqual([]);
+    });
+  });
 });
 
 // ── POST /_functions/challengeProgress ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Widens `get_activeChallenges` HTTP handler to return **503 Service Unavailable** when the underlying webMethod returns `{ challenges: [], error: 'internal_error' }` (the cf-tlt DB-failure shape). Preserves 200 OK for empty-but-authed and 429 for rate-limit.

Replaces #1101 (auto-closed when cf-tlt base branch `fix/cf-tlt-db-error-shape` was deleted post-merge of PR #1099). Rebased onto main cleanly — only the 2 cf-9lp.1 commits.

## Why

cf-tlt (PR #1099, merged in `5e4b23ba`) surfaced a distinguishable `error: 'internal_error'` on DB failure, but the HTTP endpoint wrapped it in `ok(...)`. Generic REST consumers and monitoring probes saw 200 OK on real failures — the exact silent-failure class cf-tlt existed to eliminate.

Behavioral effects:
- Mobile client (`cfutons_mobile wixClient.rawRequest`) throws on non-2xx and retries 5xx via `isRetryableError` — so transient DB blips now trigger retries instead of silent empty lists. **Desired UX improvement.**
- Generic REST / monitoring probes see 503 and alert correctly.
- Body still emitted for diagnostics.

Slice 1 of 4 for cf-9lp (cf-jwz / n3e / 0z4 / 3be).

## Review history

Full 5-agent peer review completed on closed PR #1101:
- code-reviewer: APPROVE
- silent-failure-hunter: APPROVE
- code-simplifier: APPROVE
- comment-analyzer: REQUEST_CHANGES → addressed in `d4524697` (comment justification rewritten re: mobile-client retry behavior)
- pr-test-analyzer: APPROVE with nit → addressed (added `challenges: []` regression pin)

## Test plan

- [x] 8/8 `get_activeChallenges` HTTP tests pass locally
- [x] RED-first: 503 test originally failed with 200 before fix
- [x] Preserves 200 OK on empty-but-authed
- [x] Preserves 429 on rate-limit

Closes cf-jwz (cf-9lp.1).

Generated with Claude Code