### PR TITLE
feat(cf-nq7.1): Wix CMS → cfw HMAC revalidate webhook

### DIFF
--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -445,6 +445,7 @@ export async function wixStores_onProductUpdated(event) {
   const newPrice = product.price?.amount ?? product.price ?? null;
   const oldPrice = previous.price?.amount ?? previous.price ?? null;
 
+  // Revalidate on every product update (name, image, stock, price) — intentional.
   await _postRevalidateWebhook({ collectionId: 'products', itemId: productId, eventType: 'onProductUpdated' });
 
   // Only trigger price-drop content orchestration on actual price drops

--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -23,6 +23,34 @@
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 
+// ── CWF ISR Revalidate Helper ─────────────────────────────────────────
+
+async function _postRevalidateWebhook(body) {
+  try {
+    const { getSecret } = await import('wix-secrets-backend');
+    const [url, secret] = await Promise.all([
+      getSecret('VERCEL_REVALIDATE_URL'),
+      getSecret('WIX_WEBHOOK_SECRET'),
+    ]);
+    if (!url || !secret) return;
+
+    const payload = JSON.stringify(body);
+    const { createHmac } = await import('node:crypto');
+    const sig = 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-wix-signature': sig },
+      body: payload,
+    });
+    if (!res.ok) {
+      console.warn('[events] revalidate webhook returned', res.status);
+    }
+  } catch (err) {
+    console.warn('[events] revalidate webhook failed (non-fatal):', err?.message ?? err);
+  }
+}
+
 // ── Dead-Letter Queue Helper ─────────────────────────────────────────
 
 /**
@@ -376,6 +404,8 @@ export async function wixStores_onProductCreated(event) {
     return;
   }
 
+  await _postRevalidateWebhook({ collectionId: 'products', itemId: productId, eventType: 'onProductCreated' });
+
   try {
     const { getSecret } = await import('wix-secrets-backend');
     const eventSecret = await getSecret('CONTENT_EVENT_KEY');
@@ -415,7 +445,9 @@ export async function wixStores_onProductUpdated(event) {
   const newPrice = product.price?.amount ?? product.price ?? null;
   const oldPrice = previous.price?.amount ?? previous.price ?? null;
 
-  // Only trigger on actual price drops (not increases, not identical)
+  await _postRevalidateWebhook({ collectionId: 'products', itemId: productId, eventType: 'onProductUpdated' });
+
+  // Only trigger price-drop content orchestration on actual price drops
   if (oldPrice == null || newPrice == null || newPrice >= oldPrice) return;
 
   try {
@@ -563,4 +595,27 @@ export async function wixMembers_onMemberUpdated(event) {
       impact: `Birthday fields not synced for member ${memberId} — birthday cron may skip this member`,
     });
   }
+}
+
+// ── CWF ISR Revalidate Hooks ─────────────────────────────────────────
+
+export async function wixBlog_onPostPublished(event) {
+  const post = event.entity || event;
+  const postId = post._id || post.id || '';
+  await _postRevalidateWebhook({
+    collectionId: 'blog/Posts',
+    itemId: postId || undefined,
+    eventType: 'onPostPublished',
+  });
+}
+
+export async function wixData_onDataItemUpdated(event) {
+  const collectionId = event.collectionId || event.dataCollectionId || '';
+  const itemId = event.item?._id || event.itemId || '';
+  if (!collectionId) return;
+  await _postRevalidateWebhook({
+    collectionId,
+    itemId: itemId || undefined,
+    eventType: 'onDataItemUpdated',
+  });
 }

--- a/tests/events-revalidate.test.js
+++ b/tests/events-revalidate.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+
+// ── Wix platform mock ────────────────────────────────────────────────
+
+const mockGetSecret = vi.fn();
+vi.mock('wix-secrets-backend', () => ({ getSecret: (...a) => mockGetSecret(...a) }));
+vi.mock('wix-data', () => ({ default: { insert: vi.fn(), get: vi.fn(), update: vi.fn() } }));
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (v) => v }));
+vi.mock('backend/contentOrchestrator.web', () => ({ triggerEventOrchestration: vi.fn() }));
+vi.mock('backend/emailAutomation.web', () => ({ triggerRestockNotifications: vi.fn() }));
+
+// ── fetch mock ────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const TEST_URL = 'https://cfw.example.com/api/revalidate';
+const TEST_SECRET = 'test-hmac-secret';
+
+function expectedSig(body) {
+  return 'sha256=' + createHmac('sha256', TEST_SECRET).update(body).digest('hex');
+}
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+function okResponse() {
+  return { ok: true, status: 200 };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────
+
+describe('_postRevalidateWebhook (via wixStores_onProductUpdated)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue(okResponse());
+    mockGetSecret.mockImplementation((key) => {
+      if (key === 'VERCEL_REVALIDATE_URL') return Promise.resolve(TEST_URL);
+      if (key === 'WIX_WEBHOOK_SECRET') return Promise.resolve(TEST_SECRET);
+      return Promise.resolve('unused');
+    });
+  });
+
+  it('POSTs HMAC-signed JSON to VERCEL_REVALIDATE_URL on product update', async () => {
+    const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
+    await wixStores_onProductUpdated({ entity: { _id: 'prod-1', name: 'Sofa' } });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe(TEST_URL);
+    expect(opts.method).toBe('POST');
+
+    const body = opts.body;
+    const parsed = JSON.parse(body);
+    expect(parsed.collectionId).toBe('products');
+    expect(parsed.itemId).toBe('prod-1');
+    expect(parsed.eventType).toBe('onProductUpdated');
+
+    expect(opts.headers['x-wix-signature']).toBe(expectedSig(body));
+  });
+
+  it('POSTs on product created', async () => {
+    const { wixStores_onProductCreated } = await import('../src/backend/events.js');
+    await wixStores_onProductCreated({ entity: { _id: 'prod-2', name: 'Futon' } });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsed.collectionId).toBe('products');
+    expect(parsed.itemId).toBe('prod-2');
+    expect(parsed.eventType).toBe('onProductCreated');
+  });
+
+  it('does NOT call fetch when VERCEL_REVALIDATE_URL is empty', async () => {
+    mockGetSecret.mockImplementation((key) => {
+      if (key === 'VERCEL_REVALIDATE_URL') return Promise.resolve('');
+      return Promise.resolve(TEST_SECRET);
+    });
+    const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
+    await wixStores_onProductUpdated({ entity: { _id: 'p1' } });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when fetch rejects (non-fatal)', async () => {
+    mockFetch.mockRejectedValue(new Error('network error'));
+    const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
+    await expect(
+      wixStores_onProductUpdated({ entity: { _id: 'p1' } }),
+    ).resolves.not.toThrow();
+  });
+
+  it('logs a warning (not error) when fetch returns non-ok', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
+    await wixStores_onProductUpdated({ entity: { _id: 'p1' } });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[events] revalidate webhook returned'),
+      500,
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+describe('wixBlog_onPostPublished', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue(okResponse());
+    mockGetSecret.mockImplementation((key) => {
+      if (key === 'VERCEL_REVALIDATE_URL') return Promise.resolve(TEST_URL);
+      if (key === 'WIX_WEBHOOK_SECRET') return Promise.resolve(TEST_SECRET);
+      return Promise.resolve('unused');
+    });
+  });
+
+  it('POSTs blog/Posts revalidate on post publish', async () => {
+    const { wixBlog_onPostPublished } = await import('../src/backend/events.js');
+    await wixBlog_onPostPublished({ entity: { _id: 'post-abc', title: 'Hello' } });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsed.collectionId).toBe('blog/Posts');
+    expect(parsed.itemId).toBe('post-abc');
+    expect(parsed.eventType).toBe('onPostPublished');
+  });
+
+  it('still POSTs when post has no _id', async () => {
+    const { wixBlog_onPostPublished } = await import('../src/backend/events.js');
+    await wixBlog_onPostPublished({ entity: {} });
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsed.collectionId).toBe('blog/Posts');
+    expect(parsed.itemId).toBeUndefined();
+  });
+});
+
+describe('wixData_onDataItemUpdated', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue(okResponse());
+    mockGetSecret.mockImplementation((key) => {
+      if (key === 'VERCEL_REVALIDATE_URL') return Promise.resolve(TEST_URL);
+      if (key === 'WIX_WEBHOOK_SECRET') return Promise.resolve(TEST_SECRET);
+      return Promise.resolve('unused');
+    });
+  });
+
+  it('POSTs revalidate with collectionId and itemId', async () => {
+    const { wixData_onDataItemUpdated } = await import('../src/backend/events.js');
+    await wixData_onDataItemUpdated({
+      collectionId: 'FAQ',
+      item: { _id: 'faq-1' },
+    });
+
+    const parsed = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsed.collectionId).toBe('FAQ');
+    expect(parsed.itemId).toBe('faq-1');
+    expect(parsed.eventType).toBe('onDataItemUpdated');
+  });
+
+  it('skips POST when collectionId is missing', async () => {
+    const { wixData_onDataItemUpdated } = await import('../src/backend/events.js');
+    await wixData_onDataItemUpdated({ item: { _id: 'x' } });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/events-revalidate.test.js
+++ b/tests/events-revalidate.test.js
@@ -81,6 +81,16 @@ describe('_postRevalidateWebhook (via wixStores_onProductUpdated)', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('does NOT call fetch when WIX_WEBHOOK_SECRET is empty', async () => {
+    mockGetSecret.mockImplementation((key) => {
+      if (key === 'WIX_WEBHOOK_SECRET') return Promise.resolve('');
+      return Promise.resolve(TEST_URL);
+    });
+    const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
+    await wixStores_onProductUpdated({ entity: { _id: 'p1' } });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('does not throw when fetch rejects (non-fatal)', async () => {
     mockFetch.mockRejectedValue(new Error('network error'));
     const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
@@ -164,5 +174,13 @@ describe('wixData_onDataItemUpdated', () => {
     const { wixData_onDataItemUpdated } = await import('../src/backend/events.js');
     await wixData_onDataItemUpdated({ item: { _id: 'x' } });
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to dataCollectionId when collectionId is absent', async () => {
+    const { wixData_onDataItemUpdated } = await import('../src/backend/events.js');
+    await wixData_onDataItemUpdated({ dataCollectionId: 'Videos', item: { _id: 'v1' } });
+    const parsed = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsed.collectionId).toBe('Videos');
+    expect(parsed.itemId).toBe('v1');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `_postRevalidateWebhook(body)` helper to `events.js` — HMAC-signs a JSON payload and POSTs to `VERCEL_REVALIDATE_URL` on Wix Secrets Manager
- Wires into `wixStores_onProductCreated` and `wixStores_onProductUpdated` (products collection)
- Adds `wixBlog_onPostPublished` handler (blog/Posts collection)
- Adds `wixData_onDataItemUpdated` handler (any CMS collection, skips if no collectionId)
- Best-effort: errors are caught and `console.warn`'d — a missed revalidate means stale cache, not a broken event handler

Requires Wix Secrets: `VERCEL_REVALIDATE_URL`, `WIX_WEBHOOK_SECRET`

cfw route already exists: `src/app/api/revalidate/route.ts` (PR #1, merged)

## Test plan
- [x] 9 tests in `tests/events-revalidate.test.js` — all green
- [x] HMAC signature matches `sha256=<hex>` with correct secret
- [x] Skips `fetch` when `VERCEL_REVALIDATE_URL` is empty string
- [x] Does not throw on network error (non-fatal path)
- [x] `console.warn` (not `console.error`) on non-ok response status
- [x] Blog post publish → `blog/Posts` collectionId
- [x] CMS item update → passes through `collectionId`; skips when missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)