### PR TITLE
fix(cf-9lp.3): getActiveChallengeOfWeek outer catch returns internal_error shape

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -1367,9 +1367,9 @@ export const getActiveChallengeOfWeek = webMethod(
     } catch (err) {
       // cf-9lp.3: surface internal_error instead of bare null so callers can
       // distinguish a DB/internal failure from the legitimate no-featured-
-      // challenge-this-week case (line 1303). Same cf-2ag pattern as cf-tlt
-      // (getActiveChallenges) and the cascade in cf-9lp.1/.2; uses the
-      // project-wide `internal_error` convention.
+      // challenge-this-week case (the `result.items.length === 0` branch
+      // above). Mirrors cf-tlt (getActiveChallenges) and the cascade in
+      // cf-9lp.1/.2; uses the project-wide `internal_error` convention.
       logError('getActiveChallengeOfWeek — failed', err);
       return { error: 'internal_error' };
     }

--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -1271,6 +1271,12 @@ export const getActivityFeed = webMethod(
  * "default 0 because the caller is a visitor", and "default 0 because the
  * progress query failed" — all three used to be indistinguishable.
  *
+ * Return discriminant (cf-9lp.3):
+ *   • Challenge object → found a featured challenge, render it
+ *   • null → no featured challenge this week (legitimate)
+ *   • { error: 'internal_error' } → outer catch fired (DB/internal failure);
+ *     callers must check `result?.error` before treating as a challenge.
+ *
  * @returns {Promise<{
  *   challengeId: string,
  *   title: string,
@@ -1283,7 +1289,7 @@ export const getActivityFeed = webMethod(
  *   progressStatus: 'member'|'visitor'|'unavailable',
  *   expiresAt: string,
  *   ctaUrl: string|null,
- * } | null>}
+ * } | null | { error: 'internal_error' }>}
  */
 export const getActiveChallengeOfWeek = webMethod(
   Permissions.Anyone,
@@ -1359,8 +1365,13 @@ export const getActiveChallengeOfWeek = webMethod(
         ctaUrl: challenge.ctaUrl || null,
       };
     } catch (err) {
+      // cf-9lp.3: surface internal_error instead of bare null so callers can
+      // distinguish a DB/internal failure from the legitimate no-featured-
+      // challenge-this-week case (line 1303). Same cf-2ag pattern as cf-tlt
+      // (getActiveChallenges) and the cascade in cf-9lp.1/.2; uses the
+      // project-wide `internal_error` convention.
       logError('getActiveChallengeOfWeek — failed', err);
-      return null;
+      return { error: 'internal_error' };
     }
   }
 );

--- a/src/public/ChallengeOfTheWeekWidget.js
+++ b/src/public/ChallengeOfTheWeekWidget.js
@@ -153,6 +153,16 @@ async function _renderFeaturedChallenge($w, getActiveChallengeOfWeek) {
     return;
   }
 
+  // cf-9lp.3: backend now returns { error: 'internal_error' } on DB failure
+  // instead of null (null stays reserved for legitimate "no featured challenge
+  // this week"). Truthy-check on `error` (cf-8qc pattern) so future error codes
+  // route here automatically. Same UI path as a reject.
+  if (challenge && challenge.error) {
+    try { $w('#cotwError').show(); } catch {}
+    try { $w('#cotwContainer').collapse(); } catch {}
+    return;
+  }
+
   if (!challenge) {
     try { $w('#cotwContainer').collapse(); } catch {}
     return;

--- a/tests/challengeOfTheWeek.test.js
+++ b/tests/challengeOfTheWeek.test.js
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ── In-memory collections ────────────────────────────────────────────
 
 let _collections = {};
+let _throwOnQuery = null;
 
 function seed(collection, items) {
   _collections[collection] = items.map((item, i) => ({ _id: `id-${i}`, ...item }));
@@ -48,7 +49,12 @@ function buildQueryChain(collection) {
 }
 
 vi.mock('wix-data', () => ({
-  default: { query: (col) => buildQueryChain(col) },
+  default: {
+    query: (col) => {
+      if (_throwOnQuery) throw _throwOnQuery;
+      return buildQueryChain(col);
+    },
+  },
 }));
 
 vi.mock('wix-web-module', () => ({
@@ -101,6 +107,7 @@ function featuredChallenge(overrides = {}) {
 beforeEach(() => {
   _collections = {};
   _mockMemberId = null;
+  _throwOnQuery = null;
   vi.clearAllMocks();
 });
 
@@ -198,5 +205,29 @@ describe('getActiveChallengeOfWeek (cf-rsr)', () => {
     const result = await getActiveChallengeOfWeek();
     expect(typeof result.expiresAt).toBe('string');
     expect(result.expiresAt).toBe(dateObj.toISOString());
+  });
+});
+
+// cf-9lp.3: outer catch must surface `internal_error` instead of bare null,
+// which was indistinguishable from the legitimate "no featured challenge this
+// week" case (line 1303). Cascade continuation of cf-tlt (PR #1099) and the
+// cf-9lp.1/.2 slices (PRs #1102 / #1104).
+describe('getActiveChallengeOfWeek — cf-9lp.3 error surfacing', () => {
+  it('returns { error: "internal_error" } when the outer query throws', async () => {
+    _throwOnQuery = new Error('simulated DB failure');
+    const result = await getActiveChallengeOfWeek();
+    expect(result).toEqual({ error: 'internal_error' });
+  });
+
+  it('distinguishes internal_error from legitimate null (no featured challenge)', async () => {
+    // Sanity: empty collection (no seed) still returns null, NOT the error shape.
+    const noChallenge = await getActiveChallengeOfWeek();
+    expect(noChallenge).toBeNull();
+
+    // Force a DB throw — result must diverge from the null case.
+    _throwOnQuery = new Error('db outage');
+    const errored = await getActiveChallengeOfWeek();
+    expect(errored).not.toBeNull();
+    expect(errored.error).toBe('internal_error');
   });
 });

--- a/tests/challengeOfTheWeek.test.js
+++ b/tests/challengeOfTheWeek.test.js
@@ -210,8 +210,8 @@ describe('getActiveChallengeOfWeek (cf-rsr)', () => {
 
 // cf-9lp.3: outer catch must surface `internal_error` instead of bare null,
 // which was indistinguishable from the legitimate "no featured challenge this
-// week" case (line 1303). Cascade continuation of cf-tlt (PR #1099) and the
-// cf-9lp.1/.2 slices (PRs #1102 / #1104).
+// week" case (the `result.items.length === 0` early-return). Cascade
+// continuation of cf-tlt (PR #1099) and the cf-9lp.1/.2 slices (PRs #1102 / #1104).
 describe('getActiveChallengeOfWeek — cf-9lp.3 error surfacing', () => {
   it('returns { error: "internal_error" } when the outer query throws', async () => {
     _throwOnQuery = new Error('simulated DB failure');

--- a/tests/challengeOfTheWeekWidget.test.js
+++ b/tests/challengeOfTheWeekWidget.test.js
@@ -328,11 +328,13 @@ describe('ChallengeOfTheWeekWidget — featured challenge section (cf-rsr)', () 
   });
 
   it('does NOT attempt to render challenge fields when result.error is set', async () => {
-    // If we tried to render, setting $w('#cotwTitle').text = undefined would
-    // blow up or show a blank title. Pin the invariant: no title write.
+    // Pin the invariant behaviorally: success-render-branch calls
+    // (#cotwError.hide + #cotwContainer.expand) must NOT fire. These survive
+    // mock-shape refactors better than asserting on the default '' string.
     getActiveChallengeOfWeek.mockResolvedValue({ error: 'internal_error' });
     await init();
-    expect(getEl('#cotwTitle').text).toBe(''); // never set (default)
+    expect(getEl('#cotwError').hide).not.toHaveBeenCalled();
+    expect(getEl('#cotwContainer').expand).not.toHaveBeenCalled();
   });
 
   it('guards against targetCount of 0 (no NaN in width)', async () => {

--- a/tests/challengeOfTheWeekWidget.test.js
+++ b/tests/challengeOfTheWeekWidget.test.js
@@ -310,6 +310,31 @@ describe('ChallengeOfTheWeekWidget — featured challenge section (cf-rsr)', () 
     await expect(init()).resolves.toBeUndefined();
   });
 
+  // cf-9lp.3: backend now returns { error: 'internal_error' } instead of null
+  // on DB failure. Must route to the same error UI as a reject; must NOT try
+  // to render it as a challenge (no title → would throw accessing .title, etc).
+  it('shows #cotwError and collapses when backend returns { error: "internal_error" }', async () => {
+    getActiveChallengeOfWeek.mockResolvedValue({ error: 'internal_error' });
+    await init();
+    expect(getEl('#cotwError').show).toHaveBeenCalled();
+    expect(getEl('#cotwContainer').collapse).toHaveBeenCalled();
+  });
+
+  it('routes any truthy error code to the error UI (future-proof)', async () => {
+    getActiveChallengeOfWeek.mockResolvedValue({ error: 'some-future-code' });
+    await init();
+    expect(getEl('#cotwError').show).toHaveBeenCalled();
+    expect(getEl('#cotwContainer').collapse).toHaveBeenCalled();
+  });
+
+  it('does NOT attempt to render challenge fields when result.error is set', async () => {
+    // If we tried to render, setting $w('#cotwTitle').text = undefined would
+    // blow up or show a blank title. Pin the invariant: no title write.
+    getActiveChallengeOfWeek.mockResolvedValue({ error: 'internal_error' });
+    await init();
+    expect(getEl('#cotwTitle').text).toBe(''); // never set (default)
+  });
+
   it('guards against targetCount of 0 (no NaN in width)', async () => {
     getActiveChallengeOfWeek.mockResolvedValue({ ...FEATURED, targetCount: 0, progressValue: 0 });
     await init();


### PR DESCRIPTION
## Summary

Slice 3 of 4 for the cf-9lp cascade. Closes bead **cf-3be**.

The outer catch in `getActiveChallengeOfWeek` previously returned bare `null`, which is also the value returned when no featured challenge is configured for the week. A DB outage and a quiet week looked identical to the widget. This PR widens the error return to the `{ error: 'internal_error' }` shape established by cf-tlt (#1099) and propagated through cf-9lp.1 (#1102) / cf-9lp.2 (#1104), and teaches the sole widget consumer to route the discriminant to the error UI.

## Return discriminant (documented in JSDoc)

| Return | Meaning |
|---|---|
| Challenge object | Found a featured challenge |
| null | No featured challenge this week (legitimate) |
| { error: 'internal_error' } | Outer catch fired (DB / internal failure) |

## Widget consumer (ChallengeOfTheWeekWidget.js)

Added a truthy-error branch before the existing !challenge null-branch. Routes to the same #cotwError / #cotwContainer.collapse() path as a fn reject — UX-identical for the user, but now users see a real error state instead of a deceptively empty widget.

## Tests

- Backend (2 new): outer-catch returns error shape; error shape is distinct from the null no-challenge case.
- Widget (3 new): { error: 'internal_error' } routes to error UI; future truthy codes route the same way; no attempt to render challenge fields when error is set.
- Backend test harness gains _throwOnQuery hook (reset in beforeEach).
- 69/69 tests pass across tests/challengeOfTheWeek.test.js + tests/challengeOfTheWeekWidget.test.js.

## Cascade status

- cf-tlt (#1099) — merged
- cf-9lp.1 (#1102) — merged (HTTP 503 on internal_error)
- cf-9lp.2 (#1104) — merged (ChallengesDisplay error surfacing)
- cf-9lp.3 (this PR) — getActiveChallengeOfWeek widening
- cf-9lp.4 (next) — challengeDiscovery chip (cf-0z4)

## Test plan
- [x] 69/69 passing tests across both test files
- [x] Backend RED-first verified before implementing GREEN
- [x] JSDoc return type reflects the widening
- [ ] 5-agent review
- [ ] Merge gate via melania

🤖 Generated with [Claude Code](https://claude.com/claude-code)