### PR TITLE
feat(cf-nq7.1.F2): include ts in HMAC payload to enable replay protection

### DIFF
--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -34,7 +34,7 @@ async function _postRevalidateWebhook(body) {
     ]);
     if (!url || !secret) return;
 
-    const payload = JSON.stringify(body);
+    const payload = JSON.stringify({ ...body, ts: Date.now() });
     const { createHmac } = await import('node:crypto');
     const sig = 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
 

--- a/tests/events-revalidate.test.js
+++ b/tests/events-revalidate.test.js
@@ -56,6 +56,8 @@ describe('_postRevalidateWebhook (via wixStores_onProductUpdated)', () => {
     expect(parsed.collectionId).toBe('products');
     expect(parsed.itemId).toBe('prod-1');
     expect(parsed.eventType).toBe('onProductUpdated');
+    expect(typeof parsed.ts).toBe('number');
+    expect(parsed.ts).toBeCloseTo(Date.now(), -3); // within ~1s
 
     expect(opts.headers['x-wix-signature']).toBe(expectedSig(body));
   });


### PR DESCRIPTION
## Summary
- `_postRevalidateWebhook` now signs `{ ...body, ts: Date.now() }` — timestamp is part of the HMAC-protected payload
- Tests updated to assert `typeof parsed.ts === 'number'` and `parsed.ts` within 1s of `Date.now()`
- Companion to carolina-futons-web PR that validates the window on the receiver side

## Test plan
- [ ] 11 events-revalidate tests pass (3 describe blocks)
- [ ] `ts` field included in every signed POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)