### PR TITLE
test(cf-nq7.1.F3): pin revalidate fires on every update, not only price drops

### DIFF
--- a/tests/events-revalidate.test.js
+++ b/tests/events-revalidate.test.js
@@ -62,6 +62,22 @@ describe('_postRevalidateWebhook (via wixStores_onProductUpdated)', () => {
     expect(opts.headers['x-wix-signature']).toBe(expectedSig(body));
   });
 
+  it('fires revalidate even when price has NOT dropped (regression pin)', async () => {
+    // Pins that _postRevalidateWebhook is called unconditionally on every update,
+    // not only when price decreases. A future refactor sliding the webhook call
+    // back inside a price-drop guard would break ISR for name/image/stock changes.
+    const { wixStores_onProductUpdated } = await import('../src/backend/events.js');
+    await wixStores_onProductUpdated({
+      entity: { _id: 'prod-no-drop', price: { amount: 100 } },
+      previousEntity: { _id: 'prod-no-drop', price: { amount: 100 } },
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(parsed.eventType).toBe('onProductUpdated');
+    expect(parsed.itemId).toBe('prod-no-drop');
+  });
+
   it('POSTs on product created', async () => {
     const { wixStores_onProductCreated } = await import('../src/backend/events.js');
     await wixStores_onProductCreated({ entity: { _id: 'prod-2', name: 'Futon' } });


### PR DESCRIPTION
## Summary
- Adds regression pin: `wixStores_onProductUpdated` with equal before/after price (no drop) still calls `_postRevalidateWebhook` once
- Guards against future refactors sliding the webhook back inside a price-change guard, which would silently break ISR for name/image/stock updates
- Test-only change (no source modifications)

## Test plan
- [ ] 12 events-revalidate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)