### PR TITLE
fix(cf-9lp.4): challengeDiscovery chip discriminates internal_error

### DIFF
--- a/src/public/challengeDiscovery.js
+++ b/src/public/challengeDiscovery.js
@@ -61,6 +61,18 @@ export async function initChallengeDiscoveryChip(elements, memberId, getActiveCh
 
   try {
     const result = await getActiveChallengesFn(memberId);
+
+    // cf-9lp.4: discriminate backend errors from a clean empty result. The
+    // cf-tlt shape `{ challenges: [], error: 'internal_error' }` (or any
+    // truthy error code) previously slipped through as an empty list, so a DB
+    // failure hid silently — indistinguishable from "no matching challenge".
+    // UX stays ambient (chip hides either way), but we log so ops can see it.
+    if (result?.error) {
+      console.error('[challengeDiscovery] backend returned error:', result.error);
+      _hideChip($chip);
+      return;
+    }
+
     const challenges = result?.challenges ?? [];
 
     const match = challenges.find(c =>

--- a/tests/challengeDiscovery.test.js
+++ b/tests/challengeDiscovery.test.js
@@ -194,3 +194,58 @@ describe('initChallengeDiscoveryChip', () => {
     expect(elements.$chipTitle.text).toBe('Second chance');
   });
 });
+
+// cf-9lp.4: chip previously treated `{ challenges: [], error: 'internal_error' }`
+// (cf-tlt shape) identically to a clean empty result — users' chip silently
+// hid on DB failure, indistinguishable from "no matching challenge". Cascade
+// continuation of cf-tlt (PR #1099), cf-9lp.1 (PR #1102), cf-9lp.2 (PR #1104),
+// cf-9lp.3 (PR #1105). UX note: chip stays hidden on error (ambient UI, no
+// intrusive error state), but observability improves — discriminate + log.
+describe('initChallengeDiscoveryChip — cf-9lp.4 error discrimination', () => {
+  let elements;
+  let mockGetActiveChallenges;
+  let errorSpy;
+
+  beforeEach(() => {
+    elements = makeElements();
+    mockGetActiveChallenges = vi.fn();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    errorSpy.mockClear();
+  });
+
+  it('hides chip AND logs when result.error is "internal_error" (even with empty challenges)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [], error: 'internal_error' });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('hides chip AND logs when result.error is truthy even with matching challenges (no partial render)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [ADD_TO_CART_CHALLENGE], error: 'internal_error' });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(elements.$chip.show).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('routes any truthy error code to the same hide+log path (future-proof)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [], error: 'some-future-code' });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('does NOT log when result is a normal empty-but-authed response (no error field)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [] });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log on normal happy-path render', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [ADD_TO_CART_CHALLENGE] });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.show).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Final slice of the **cf-9lp cascade** — surface `internal_error` discriminant to the challenge discovery chip.

- `src/public/challengeDiscovery.js` now branches on truthy `result.error` BEFORE treating `result.challenges` as empty. Before, the cf-tlt shape `{ challenges: [], error: 'internal_error' }` slipped through identically to a clean empty response — a silent-failure masquerade on every product/catalog page.
- UX preserved: chip stays hidden either way (ambient UI, peripheral to the page — intrusive error state would be hostile here). Observability restored: `console.error` logs the error code so ops can see the underlying failure class.
- Truthy-check (cf-8qc widget-layer precedent) so future error codes route through the same path automatically.

## Cascade context

Closes the final silent-hide entry point for the `{ error: 'internal_error' }` shape:

| Slice | Site | PR | Status |
|-------|------|-----|--------|
| cf-9lp.1 | http-functions `GET /activeChallenges` → 503 | #1102 | merged |
| cf-9lp.2 | `ChallengesDisplay.js` → error container | #1104 | merged |
| cf-9lp.3 | `getActiveChallengeOfWeek` outer catch | #1105 | merged |
| **cf-9lp.4** | **`challengeDiscovery.js` chip → hide + log** | **this PR** | **open** |

## Test plan

- [x] Local: `npx vitest run tests/challengeDiscovery.test.js` — **20/20 passing**
- [x] 5 new RED-first tests under `describe('initChallengeDiscoveryChip — cf-9lp.4 error discrimination')`:
  - hides chip + logs on `{ challenges: [], error: 'internal_error' }`
  - hides chip + logs even when `challenges` contains a match (no partial render)
  - routes any truthy error code through the same hide+log path (future-proof)
  - does NOT log on normal empty-but-authed response
  - does NOT log on happy-path render
- [x] Rebased on main cleanly
- [ ] CI green
- [ ] 5-agent review (code-reviewer, silent-failure-hunter, code-simplifier, comment-analyzer, pr-test-analyzer)
- [ ] melania admin-merge gate

Closes **cf-0z4**. Completes the cf-9lp umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)