### PR TITLE
test(cf-vl9): mockRestore over mockClear workaround in cf-9lp.4 tests

### DIFF
--- a/tests/challengeDiscovery.test.js
+++ b/tests/challengeDiscovery.test.js
@@ -3,7 +3,7 @@
  * @description TDD tests for CF-fh5: challenge discovery chip on product/catalog pages.
  * Covers initChallengeDiscoveryChip — show, hide, context filtering.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { initChallengeDiscoveryChip } from '../src/public/challengeDiscovery.js';
 
 /** Build a minimal Wix element stub. */
@@ -210,7 +210,13 @@ describe('initChallengeDiscoveryChip — cf-9lp.4 error discrimination', () => {
     elements = makeElements();
     mockGetActiveChallenges = vi.fn();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    errorSpy.mockClear();
+  });
+
+  // vi.spyOn on an already-spied property returns the same spy — mockImplementation
+  // does NOT reset call history. Restore between tests so each beforeEach gets a
+  // truly fresh spy, not one carrying forward prior tests' console.error calls.
+  afterEach(() => {
+    errorSpy.mockRestore();
   });
 
   it('hides chip AND logs when result.error is "internal_error" (even with empty challenges)', async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #1108 (cf-9lp.4). Replaces the `errorSpy.mockClear()` band-aid with a proper `afterEach(() => errorSpy.mockRestore())`.

**The trap**: `vi.spyOn(console, 'error')` on an already-spied property returns the *same* spy. `mockImplementation()` doesn't reset call history. So a fresh-looking `beforeEach` was actually carrying forward prior tests' `console.error` calls — my tests 4 and 5 (non-regression "should NOT log") were spuriously failing until I added `mockClear()`.

**Real fix**: fully restore the original `console.error` between tests. Next beforeEach's `vi.spyOn` then creates a truly fresh spy.

## Scope decision (documented on bead)

Both pr-test-analyzer and code-simplifier agents flagged the `mockClear()` as band-aid and suggested `restoreMocks: true` in `vitest.config.js`. Considered and **rejected** — ~hundreds of test files use spy/mock patterns; flipping globally could un-spy `beforeAll`-scoped spies and break unrelated tests. Risk/reward wrong for a 5-test footprint.

If the trap recurs elsewhere, we file a dedicated cross-cutting bead (with full-suite verification on pop-os).

## Test plan

- [x] `npx vitest run tests/challengeDiscovery.test.js` — **20/20 passing**
- [x] Rebased on main cleanly
- [ ] CI green

Closes **cf-vl9** (cf-9lp.4.F2 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)