### PR TITLE
fix(cf-yc1v): broaden challengeDiscovery error-shape coverage (cf-9lp.4.F1)

### DIFF
--- a/src/public/challengeDiscovery.js
+++ b/src/public/challengeDiscovery.js
@@ -62,13 +62,17 @@ export async function initChallengeDiscoveryChip(elements, memberId, getActiveCh
   try {
     const result = await getActiveChallengesFn(memberId);
 
-    // cf-9lp.4: discriminate backend errors from a clean empty result. The
-    // cf-tlt shape `{ challenges: [], error: 'internal_error' }` (or any
-    // truthy error code) previously slipped through as an empty list, so a DB
-    // failure hid silently — indistinguishable from "no matching challenge".
-    // UX stays ambient (chip hides either way), but we log so ops can see it.
-    if (result?.error) {
-      console.error('[challengeDiscovery] backend returned error:', result.error);
+    // cf-9lp.4 + cf-9lp.4.F1: discriminate backend errors from a clean empty
+    // result. The cf-tlt shape `{ challenges: [], error: 'internal_error' }`
+    // previously slipped through as an empty list — DB failure hid silently.
+    // cf-9lp.4.F1 broadens to 2 adjacent shapes silent-failure-hunter flagged
+    // as realistic near-term contract risk: `errors` (plural, non-empty array)
+    // and `ok: false`. Singular `error` still wins when multiple keys set.
+    // UX stays ambient (chip hides either way); log carries the shape key so
+    // contract drift is visible.
+    const errorShape = _errorShape(result);
+    if (errorShape) {
+      console.error('[challengeDiscovery] backend error shape=' + errorShape.kind + ':', errorShape.value);
       _hideChip($chip);
       return;
     }
@@ -90,6 +94,19 @@ export async function initChallengeDiscoveryChip(elements, memberId, getActiveCh
     console.error('[challengeDiscovery] initChallengeDiscoveryChip failed', err);
     _hideChip($chip);
   }
+}
+
+// cf-9lp.4.F1: discriminate any of 3 backend error shapes. Priority order:
+// singular `error` wins over plural `errors` wins over `ok: false`. `kind` is
+// logged so contract drift stays visible if the backend mixes shapes later.
+function _errorShape(result) {
+  if (!result) return null;
+  if (result.error) return { kind: 'error', value: result.error };
+  if (Array.isArray(result.errors) && result.errors.length > 0) {
+    return { kind: 'errors', value: result.errors };
+  }
+  if (result.ok === false) return { kind: 'ok_false', value: false };
+  return null;
 }
 
 function _hideChip($chip) {

--- a/tests/challengeDiscovery.test.js
+++ b/tests/challengeDiscovery.test.js
@@ -255,3 +255,67 @@ describe('initChallengeDiscoveryChip — cf-9lp.4 error discrimination', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });
+
+// cf-9lp.4.F1 (cf-yc1v): silent-failure-hunter (PR #1108 review) flagged that
+// `result?.error` singular misses 2 common alternative shapes seen in adjacent
+// code: `errors` plural (list of {code,message}) and `ok: false` (boolean flag).
+// Narrow broaden — not a full defensive widening. Matches only the shapes the
+// hunter named as realistic near-term contract risk. Log carries the shape key
+// so future contract drift stays visible.
+describe('initChallengeDiscoveryChip — cf-9lp.4.F1 broadened error shapes', () => {
+  let elements;
+  let mockGetActiveChallenges;
+  let errorSpy;
+
+  beforeEach(() => {
+    elements = makeElements();
+    mockGetActiveChallenges = vi.fn();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('hides chip AND logs when result.errors (plural) is a non-empty array', async () => {
+    mockGetActiveChallenges.mockResolvedValue({
+      challenges: [],
+      errors: [{ code: 'internal_error', message: 'db down' }],
+    });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('hides chip AND logs when result.ok === false', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [], ok: false });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('does NOT trip on empty errors array (empty is not an error signal)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [], errors: [] });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT trip on ok: true (non-regression)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({ challenges: [ADD_TO_CART_CHALLENGE], ok: true });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.show).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('singular result.error still wins when both singular and plural set (precedence)', async () => {
+    mockGetActiveChallenges.mockResolvedValue({
+      challenges: [],
+      error: 'internal_error',
+      errors: [{ code: 'other' }],
+    });
+    await initChallengeDiscoveryChip(elements, 'mem-1', mockGetActiveChallenges, 'add_to_cart');
+    expect(elements.$chip.hide).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Bead: cf-yc1v (aliased as cf-9lp.4.F1 per melania's slice plan)
- Follow-up to PR #1108 (cf-9lp.4) — silent-failure-hunter flagged that `result?.error` singular misses 2 alternative shapes seen in adjacent code: `errors` plural and `ok: false`
- **Narrow** broaden — only the 2 shapes explicitly named, not a full defensive widening
- New `_errorShape` helper returns `{kind, value} | null` with priority: singular `error` > plural `errors` > `ok: false`. Log carries `kind` for contract-drift visibility

## Tests
- 5 new tests in new describe block: plural errors, ok:false, empty-errors non-regression, ok:true non-regression, precedence
- 25/25 GREEN on `tests/challengeDiscovery.test.js`

## Test plan
- [x] RED: 2 failures on new `errors` + `ok:false` expectations
- [x] GREEN: `_errorShape` helper + call site replacement — 25/25
- [x] Non-regression: singular-error path still wins when multiple keys set

---
Narrow scope, small diff. Requesting admin-merge precedent (PR #1109 pattern) — happy to run 5-agent review if melania prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)