### PR TITLE
feat(cf-3qt.4.6): Velo /_functions/contactSubmissions HTTP endpoint

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -2550,20 +2550,29 @@ export async function get_weeklyBlogDigestCron(request) {
 
 // ── /_functions/contactSubmissions ───────────────────────────────────
 //
-// cf-3qt.4.6: HTTP wrapper around emailService.sendEmail so external
-// front-ends (carolina-futons-web Next.js) can submit the contact form
-// through the same Velo path that powers the legacy Wix Studio site —
-// preserving the existing rate-limit + Stilgar-notification pipeline
-// and removing the standalone nodemailer SMTP dep on the Next side.
+// HTTP wrapper around emailService.sendEmail so external front-ends
+// (carolina-futons-web Next.js) submit the contact form through the
+// same Velo path that powers the legacy Wix Studio site — reusing the
+// existing rate-limit + site-owner triggered-email pipeline.
 //
-// Body shape mirrors emailService.sendEmail:
-//   { name, email, phone?, subject, message }
-// CORS: emits permissive headers via shared corsHeaders() helper so
-// browser-side fallback fetches work; primary caller is server-side.
+// CORS allowlist (see backend/utils/cors): prod Vercel domain,
+// project-scoped Vercel domain, branch preview URLs, localhost dev.
 
 /**
  * @function post_contactSubmissions
  * @route POST /_functions/contactSubmissions
+ * @param {Object} request.body.json
+ * @param {string} request.body.json.name    — required, ≤200 chars
+ * @param {string} request.body.json.email   — required, ≤254 chars, valid format
+ * @param {string} [request.body.json.phone] — optional, ≤20 chars
+ * @param {string} [request.body.json.subject] — optional, ≤300 chars
+ * @param {string} request.body.json.message — required, ≤2000 chars
+ * @returns {Promise<{status: number, body: string, headers: object}>}
+ *   200 { success: true } on send;
+ *   400 { success: false, error } on validation;
+ *   429 { success: false, error } on per-email rate limit (3/hour);
+ *   500 { success: false, error } on transport failure or sendEmail
+ *   returning a non-object (webMethod proxy fault).
  */
 export async function post_contactSubmissions(request) {
   const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
@@ -2572,7 +2581,8 @@ export async function post_contactSubmissions(request) {
     try {
       const bodyText = await request.body.text();
       body = JSON.parse(bodyText);
-    } catch (_) {
+    } catch (parseErr) {
+      console.warn('[contactSubmissions] body parse failed:', parseErr?.message ?? parseErr);
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
@@ -2584,9 +2594,33 @@ export async function post_contactSubmissions(request) {
       message: body.message,
     });
 
-    if (!result || result.success !== true) {
-      return badRequest({
-        body: JSON.stringify({ success: false, error: result?.message || 'Submission rejected' }),
+    // Defensive: webMethod proxy can theoretically resolve to undefined on
+    // backend infrastructure failures. Treat as 500 — it's not a client bug.
+    if (!result) {
+      console.error('[contactSubmissions] sendEmail resolved without a result envelope');
+      return serverError({
+        body: JSON.stringify({ success: false, error: 'Internal server error' }),
+        headers: JSON_HEADERS,
+      });
+    }
+
+    if (result.success !== true) {
+      // Distinguish rate-limit (429) and transport failure (500) from
+      // validation (400). sendEmail's outer catch returns success:false
+      // with a "Failed to send message…" message — that is an infra
+      // outage, not a client validation error. Other handlers in this
+      // file already return 429 explicitly for rate-limit so the cfw
+      // client can back off (e.g., L1867, L2183, L2255).
+      const message = result.message ?? '';
+      const lowered = message.toLowerCase();
+      const status = lowered.includes('too many requests')
+        ? 429
+        : lowered.startsWith('failed to send')
+        ? 500
+        : 400;
+      return response({
+        status,
+        body: JSON.stringify({ success: false, error: message || 'Submission rejected' }),
         headers: JSON_HEADERS,
       });
     }

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -7,6 +7,7 @@ import { resolveTierFromPoints } from 'backend/utils/loyaltyData';
 import { generateFeed } from 'backend/googleMerchantFeed.web';
 import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationService.web';
+import { sendEmail } from 'backend/emailService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
 import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence, getCampaignAnalytics } from 'backend/emailAutomation.web';
 import { scanAndTriggerWinback, runReviewRequestEmails } from 'backend/marketingSequences.web';
@@ -2545,4 +2546,58 @@ export async function get_weeklyBlogDigestCron(request) {
       headers: JSON_HEADERS,
     });
   }
+}
+
+// ── /_functions/contactSubmissions ───────────────────────────────────
+//
+// cf-3qt.4.6: HTTP wrapper around emailService.sendEmail so external
+// front-ends (carolina-futons-web Next.js) can submit the contact form
+// through the same Velo path that powers the legacy Wix Studio site —
+// preserving the existing rate-limit + Stilgar-notification pipeline
+// and removing the standalone nodemailer SMTP dep on the Next side.
+//
+// Body shape mirrors emailService.sendEmail:
+//   { name, email, phone?, subject, message }
+// CORS: emits permissive headers via shared corsHeaders() helper so
+// browser-side fallback fetches work; primary caller is server-side.
+
+/**
+ * @function post_contactSubmissions
+ * @route POST /_functions/contactSubmissions
+ */
+export async function post_contactSubmissions(request) {
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
+  try {
+    let body;
+    try {
+      const bodyText = await request.body.text();
+      body = JSON.parse(bodyText);
+    } catch (_) {
+      return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
+    }
+
+    const result = await sendEmail({
+      name: body.name,
+      email: body.email,
+      phone: body.phone,
+      subject: body.subject,
+      message: body.message,
+    });
+
+    if (!result || result.success !== true) {
+      return badRequest({
+        body: JSON.stringify({ success: false, error: result?.message || 'Submission rejected' }),
+        headers: JSON_HEADERS,
+      });
+    }
+
+    return ok({ body: JSON.stringify({ success: true }), headers: JSON_HEADERS });
+  } catch (err) {
+    console.error('HTTP function error (contactSubmissions):', err);
+    return serverError({ body: JSON.stringify({ success: false, error: 'Internal server error' }), headers: JSON_HEADERS });
+  }
+}
+
+export function options_contactSubmissions(request) {
+  return response(corsPreflight(request));
 }

--- a/tests/httpFunctionsCoverage.test.js
+++ b/tests/httpFunctionsCoverage.test.js
@@ -13,6 +13,11 @@ import {
   __setInsertError,
 } from './__mocks__/wix-data.js';
 import { __setSecrets } from './__mocks__/wix-secrets-backend.js';
+import {
+  __reset as crmReset,
+  __getEmailLog as crmEmailLog,
+  __failNextEmail as crmFailNextEmail,
+} from './__mocks__/wix-crm-backend.js';
 import { __setMember, __reset as resetMembers } from './__mocks__/wix-members-backend.js';
 import { __setAccount, __reset as resetLoyalty } from './__mocks__/wix-loyalty.v2.js';
 import {
@@ -928,9 +933,9 @@ describe('get_cleanupRateLimitCron', () => {
 describe('post_contactSubmissions', () => {
   const goodOrigin = 'https://carolina-futons-web.vercel.app';
 
-  function buildReq({ body, origin = goodOrigin }) {
+  function buildReq({ body, origin = goodOrigin } = {}) {
     return {
-      headers: origin ? { origin } : {},
+      headers: { origin },
       body: { text: async () => body },
     };
   }
@@ -938,6 +943,7 @@ describe('post_contactSubmissions', () => {
   beforeEach(() => {
     __setSecrets({ SITE_OWNER_CONTACT_ID: 'owner-1' });
     __seed('EmailRateLimit', []);
+    crmReset();
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -948,10 +954,10 @@ describe('post_contactSubmissions', () => {
     expect(parsed.error).toMatch(/Invalid JSON/i);
   });
 
-  it('returns 400 when sendEmail rejects (missing required field)', async () => {
-    // sendEmail validates {name, email, subject, message} as required;
-    // omitting message reproduces a real client misuse without needing to
-    // mock the email transport.
+  it('returns 400 when sendEmail rejects required-field validation', async () => {
+    // sendEmail requires {name, email, message}; subject/phone are optional.
+    // Omitting `message` reproduces a real client misuse without engaging
+    // the triggeredEmails mock.
     const result = await post_contactSubmissions(
       buildReq({
         body: JSON.stringify({
@@ -982,6 +988,62 @@ describe('post_contactSubmissions', () => {
     expect(JSON.parse(result.body).success).toBe(false);
   });
 
+  it('returns 200 + emits triggered email on a fully valid submission', async () => {
+    const result = await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          phone: '828-555-0100',
+          subject: 'Frame question',
+          message: 'Do you ship to Hendersonville?',
+        }),
+      }),
+    );
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ success: true });
+    expect(result.headers['Access-Control-Allow-Origin']).toBe(goodOrigin);
+    const log = crmEmailLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].contactId).toBe('owner-1');
+  });
+
+  it('returns 429 when sendEmail surfaces a rate-limit message', async () => {
+    // 4th submission within the 1-hour window trips _checkEmailRateLimit
+    // (max 3 — see emailService.web.js EMAIL_RATE_LIMIT_MAX).
+    const valid = JSON.stringify({
+      name: 'Stilgar',
+      email: 'stilgar@example.com',
+      subject: 'Repeated ping',
+      message: 'Hi',
+    });
+    for (let i = 0; i < 3; i++) {
+      const ok = await post_contactSubmissions(buildReq({ body: valid }));
+      expect(ok.status).toBe(200);
+    }
+    const limited = await post_contactSubmissions(buildReq({ body: valid }));
+    expect(limited.status).toBe(429);
+    const parsed = JSON.parse(limited.body);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/too many requests/i);
+  });
+
+  it('returns 500 when triggered email transport throws', async () => {
+    crmFailNextEmail();
+    const result = await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Outage probe',
+          message: 'Hi',
+        }),
+      }),
+    );
+    expect(result.status).toBe(500);
+    expect(JSON.parse(result.body).success).toBe(false);
+  });
+
   it('echoes Access-Control-Allow-Origin for allowlisted origin on error', async () => {
     const result = await post_contactSubmissions(buildReq({ body: '{ bad' }));
     expect(result.headers['Access-Control-Allow-Origin']).toBe(goodOrigin);
@@ -1006,6 +1068,7 @@ describe('options_contactSubmissions', () => {
       'https://carolina-futons-web.vercel.app',
     );
     expect(result.headers['Access-Control-Allow-Methods']).toMatch(/POST/);
+    expect(result.headers['Access-Control-Allow-Methods']).toMatch(/OPTIONS/);
   });
 
   it('returns 403 for disallowed origin', () => {

--- a/tests/httpFunctionsCoverage.test.js
+++ b/tests/httpFunctionsCoverage.test.js
@@ -26,6 +26,8 @@ import {
   post_trackReferral,
   get_bundles,
   post_addBundleToCart,
+  post_contactSubmissions,
+  options_contactSubmissions,
   get_productQA,
   post_submitQuestion,
   post_answerQuestion,
@@ -918,5 +920,98 @@ describe('get_cleanupRateLimitCron', () => {
     ]);
     const result = await get_cleanupRateLimitCron(cronReq('cleanup-key'));
     expect(result.status).toBe(200);
+  });
+});
+
+// ── post_contactSubmissions / options_contactSubmissions ─────────────────────
+
+describe('post_contactSubmissions', () => {
+  const goodOrigin = 'https://carolina-futons-web.vercel.app';
+
+  function buildReq({ body, origin = goodOrigin }) {
+    return {
+      headers: origin ? { origin } : {},
+      body: { text: async () => body },
+    };
+  }
+
+  beforeEach(() => {
+    __setSecrets({ SITE_OWNER_CONTACT_ID: 'owner-1' });
+    __seed('EmailRateLimit', []);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const result = await post_contactSubmissions(buildReq({ body: '{ bad json' }));
+    expect(result.status).toBe(400);
+    const parsed = JSON.parse(result.body);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/Invalid JSON/i);
+  });
+
+  it('returns 400 when sendEmail rejects (missing required field)', async () => {
+    // sendEmail validates {name, email, subject, message} as required;
+    // omitting message reproduces a real client misuse without needing to
+    // mock the email transport.
+    const result = await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Frame question',
+        }),
+      }),
+    );
+    expect(result.status).toBe(400);
+    const parsed = JSON.parse(result.body);
+    expect(parsed.success).toBe(false);
+    expect(typeof parsed.error).toBe('string');
+  });
+
+  it('returns 400 for invalid email format', async () => {
+    const result = await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'not-an-email',
+          subject: 'Frame question',
+          message: 'Do you ship to Hendersonville?',
+        }),
+      }),
+    );
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body).success).toBe(false);
+  });
+
+  it('echoes Access-Control-Allow-Origin for allowlisted origin on error', async () => {
+    const result = await post_contactSubmissions(buildReq({ body: '{ bad' }));
+    expect(result.headers['Access-Control-Allow-Origin']).toBe(goodOrigin);
+    expect(result.headers['Vary']).toBe('Origin');
+  });
+
+  it('omits Access-Control-Allow-Origin for disallowed origin', async () => {
+    const result = await post_contactSubmissions(
+      buildReq({ body: '{ bad', origin: 'https://attacker.example.com' }),
+    );
+    expect(result.headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+});
+
+describe('options_contactSubmissions', () => {
+  it('returns 204 with CORS headers for allowlisted origin', () => {
+    const result = options_contactSubmissions({
+      headers: { origin: 'https://carolina-futons-web.vercel.app' },
+    });
+    expect(result.status).toBe(204);
+    expect(result.headers['Access-Control-Allow-Origin']).toBe(
+      'https://carolina-futons-web.vercel.app',
+    );
+    expect(result.headers['Access-Control-Allow-Methods']).toMatch(/POST/);
+  });
+
+  it('returns 403 for disallowed origin', () => {
+    const result = options_contactSubmissions({
+      headers: { origin: 'https://attacker.example.com' },
+    });
+    expect(result.status).toBe(403);
   });
 });


### PR DESCRIPTION
## Why
Phase 4.6 of cf-3qt: the carolina-futons-web Next.js app needs to submit the /contact form through the existing Velo path so notifications continue to flow to BUSINESS.email via the shared rate-limit + triggered-email plumbing — not via a parallel nodemailer SMTP transport on the Next side.

## What
New HTTP function in src/backend/http-functions.js:
- POST /_functions/contactSubmissions — JSON body { name, email, phone?, subject, message } → delegates to emailService.sendEmail (handles validation, sanitization, 3/hour rate limit, triggered email to SITE_OWNER_CONTACT_ID)
- OPTIONS /_functions/contactSubmissions — CORS preflight via shared backend/utils/cors

Origin allowlist already covers: prod Vercel domain, project-scoped Vercel domain, per-branch preview URLs, and localhost:3000.

## Coordination — Stilgar
Per cf-3qt.4.6 acceptance criteria: \"Stilgar receives test email through existing Velo path; coordinate with stilgar before flipping.\"

This PR adds the **endpoint only** (additive — does not change any existing behavior). The companion PR in carolina-futons-web will flip /contact actions.ts from nodemailer to fetch this endpoint. **Hold flipping until Stilgar confirms a real test email arrives via this path on staging.**

## Tests
+7 cases in tests/httpFunctionsCoverage.test.js: invalid JSON / missing message / invalid email / ACAO allowlist hit / ACAO miss + observability log / OPTIONS 204 for allowed / OPTIONS 403 for blocked. Full file: 92/92 green.

## Risk
Pure addition. Existing webMethod surface untouched; existing nodemailer path on cfw side untouched until companion PR.

## Follow-up
- carolina-futons-web PR: replace nodemailer in src/app/contact/actions.ts with fetch \`${WIX_VELO_SITE_URL}/_functions/contactSubmissions\`
- Drop nodemailer dep + SMTP env vars from cfw .env.example after companion PR ships