### PR TITLE
fix(cf-nqq): remove duplicate challengeOfTheWeek section from Home.js

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -64,7 +64,6 @@ $w.onReady(async function () {
   // Deferred sections: below-fold content loaded during idle time
   const sections = [
     { name: 'heroAnimation', init: initHeroAnimation, critical: true },
-    { name: 'challengeOfTheWeek', init: initChallengeSection, critical: false },
     { name: 'featuredProducts', init: loadFeaturedProducts, critical: false },
     { name: 'categoryShowcase', init: initCategoryShowcase, critical: true },
     { name: 'trustBar', init: initTrustBar, critical: true },
@@ -147,18 +146,6 @@ $w.onReady(async function () {
     try { loadFeaturedProducts(); } catch (e) {}
   });
 });
-
-// ── Challenge of the Week Section (cf-nqq) ──────────────────────────
-
-/**
- * Initialize the ChallengeOfTheWeek section below the hero.
- * Delegates to the widget which fetches the active community challenge and
- * collapses #weeklyContainer automatically when no challenge is available.
- * @returns {Promise<void>}
- */
-async function initChallengeSection() {
-  await initChallengeOfTheWeekWidget({ $w });
-}
 
 // ── Featured Products ("Our Favorite Finds") ────────────────────────
 

--- a/tests/homeHandlers.test.js
+++ b/tests/homeHandlers.test.js
@@ -299,6 +299,13 @@ describe('Home page onReady', () => {
     expect(deferred).toHaveLength(18);
   });
 
+  it('has no duplicate section names', async () => {
+    await onReadyHandler();
+    const sections = prioritizeSections.mock.calls[0][0];
+    const names = sections.map(s => s.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
   it('every section has a name and init function', async () => {
     await onReadyHandler();
     const sections = prioritizeSections.mock.calls[0][0];


### PR DESCRIPTION
## Summary
- `cf-nqq` added `challengeOfTheWeek` twice: once via `initChallengeSection` wrapper (PR #1023) and once via a direct `initChallengeOfTheWeekWidget` call (33ccdb66)
- Both entries run identical logic — the widget call is duplicated
- Removes the dead `initChallengeSection` wrapper function and its stale section entry
- Restores `homeHandlers` section count to 3 critical + 18 deferred, unblocking main CI and PR #1114

## Test plan
- [ ] `tests/homeHandlers.test.js` — all 19 tests pass (verified locally)
- [ ] Main CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)