### PR TITLE
feat(cf-3qt.5.5): mailingListSignups Velo HTTP endpoint — footer newsletter Velo path

### DIFF
--- a/docs/cf-3qt/URL-CMS-MAP.md
+++ b/docs/cf-3qt/URL-CMS-MAP.md
@@ -93,11 +93,11 @@ These are Phase 2/3 territory. Listed so the sitemap generator has the full rout
 
 Every webMethod we call from the Next.js client goes through a thin `app/api/*` proxy (to keep secrets + OAuth server-side). Phase 4/5 needs:
 
-| Next.js route handler | Proxies to webMethod | Method |
+| Next.js route handler | Proxies to Velo endpoint | Method |
 |---|---|---|
-| `POST /api/contact` | `contactSubmissions.submitContactForm` | POST |
-| `POST /api/newsletter/subscribe` | `newsletterService.subscribeToNewsletter` | POST |
-| `POST /api/newsletter/unsubscribe` | `newsletterService.unsubscribeFromESP` | POST |
+| `POST /api/contact` | `/_functions/contactSubmissions` → `emailService.sendEmail` | POST |
+| `POST /api/newsletter/subscribe` | `/_functions/mailingListSignups` → `newsletterService.subscribeToNewsletter` | POST |
+| `POST /api/newsletter/unsubscribe` | `newsletterService.unsubscribeFromESP` (webMethod, direct SDK) | POST |
 | `GET  /api/delivery-zone?zip=` | `storeLocatorService` distance calc (or inline `lib/delivery/zones.ts`) | GET |
 | `GET  /api/search?q=` | fan-out to stores + blog | GET |
 

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -30,6 +30,7 @@ export { post_getLeaderboard } from 'backend/leaderboard-http';
 import { validateIncomingEvent, logEventTrace } from 'backend/utils/eventBus';
 import { runGarbageCollection } from 'backend/cmsGarbageCollector.web';
 import { getSecret } from 'wix-secrets-backend';
+import { subscribeToNewsletter } from 'backend/newsletterService.web';
 
 /**
  * Fetch all products from the Stores/Products collection, paginating
@@ -2633,5 +2634,76 @@ export async function post_contactSubmissions(request) {
 }
 
 export function options_contactSubmissions(request) {
+  return response(corsPreflight(request));
+}
+
+// ── /_functions/mailingListSignups ────────────────────────────────────────
+//
+// Velo HTTP wrapper for newsletterService.subscribeToNewsletter so the
+// Next.js frontend (carolina-futons-web) uses the same backend path as
+// the Wix Studio footer — reusing rate-limit, dedup, ESP-sync, and
+// audit-log pipelines.
+//
+// Called by: Next.js POST /api/newsletter/subscribe route handler.
+// Server Action can still serve as client-side fallback if this path fails.
+//
+// CORS allowlist: prod Vercel domain, project-scoped preview URLs, localhost.
+
+/**
+ * @function post_mailingListSignups
+ * @route POST /_functions/mailingListSignups
+ * @param {Object} request.body.json
+ * @param {string} request.body.json.email    — required, ≤254 chars, valid format
+ * @param {string} [request.body.json.source] — optional, ≤50 chars, defaults to 'footer_newsletter'
+ * @param {string} [request.body.json.honeypot] — optional bot-trap; non-empty → silent 200
+ * @returns {Promise<{status: number, body: string, headers: object}>}
+ *   200 { success: true, discountCode } on subscribe or duplicate;
+ *   400 { success: false, error } on validation;
+ *   429 { success: false, error } on per-email rate limit (3/hour);
+ *   500 { success: false, error } on unexpected backend failure.
+ */
+export async function post_mailingListSignups(request) {
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
+  try {
+    let body;
+    try {
+      const bodyText = await request.body.text();
+      body = JSON.parse(bodyText);
+    } catch (parseErr) {
+      console.warn('[mailingListSignups] body parse failed:', parseErr?.message ?? parseErr);
+      return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
+    }
+
+    const result = await subscribeToNewsletter(body.email, {
+      source: body.source || 'footer_newsletter',
+      honeypot: body.honeypot,
+    });
+
+    if (!result) {
+      console.error('[mailingListSignups] subscribeToNewsletter resolved without a result envelope');
+      return serverError({
+        body: JSON.stringify({ success: false, error: 'Internal server error' }),
+        headers: JSON_HEADERS,
+      });
+    }
+
+    if (result.success !== true) {
+      const message = result.message ?? '';
+      const status = message.toLowerCase().includes('too many requests') ? 429 : 400;
+      return response({
+        status,
+        body: JSON.stringify({ success: false, error: message || 'Subscription rejected' }),
+        headers: JSON_HEADERS,
+      });
+    }
+
+    return ok({ body: JSON.stringify({ success: true, discountCode: result.discountCode }), headers: JSON_HEADERS });
+  } catch (err) {
+    console.error('HTTP function error (mailingListSignups):', err);
+    return serverError({ body: JSON.stringify({ success: false, error: 'Internal server error' }), headers: JSON_HEADERS });
+  }
+}
+
+export function options_mailingListSignups(request) {
   return response(corsPreflight(request));
 }

--- a/tests/mailingListSignups.http.test.js
+++ b/tests/mailingListSignups.http.test.js
@@ -1,0 +1,134 @@
+/**
+ * @file mailingListSignups.http.test.js
+ * @description TDD tests for POST /_functions/mailingListSignups — Velo HTTP wrapper
+ * that proxies footer/landing newsletter signups to newsletterService.subscribeToNewsletter.
+ *
+ * cf-3qt.5.5: re-wire footer newsletter from Server Action to Velo path so the
+ * Next.js frontend calls the same rate-limit + dedup + ESP-sync pipeline.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __reset as resetData, __seed } from './__mocks__/wix-data.js';
+
+vi.mock('backend/newsletterService.web', () => ({
+  subscribeToNewsletter: vi.fn(),
+}));
+
+import { subscribeToNewsletter } from 'backend/newsletterService.web';
+import { post_mailingListSignups, options_mailingListSignups } from '../src/backend/http-functions.js';
+
+function makeRequest(body = {}) {
+  const json = JSON.stringify(body);
+  return {
+    body: {
+      text: async () => json,
+      json: async () => body,
+    },
+    headers: { origin: 'https://carolina-futons-web.vercel.app' },
+  };
+}
+
+beforeEach(() => {
+  resetData();
+  vi.clearAllMocks();
+  subscribeToNewsletter.mockResolvedValue({ success: true, discountCode: 'WELCOME10' });
+});
+
+// ── Happy path ────────────────────────────────────────────────────────────────
+
+describe('post_mailingListSignups — success', () => {
+  it('returns 200 with discountCode on valid email', async () => {
+    const res = await post_mailingListSignups(makeRequest({ email: 'test@example.com' }));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+    expect(body.discountCode).toBe('WELCOME10');
+  });
+
+  it('passes source to subscribeToNewsletter', async () => {
+    await post_mailingListSignups(makeRequest({ email: 'a@b.com', source: 'newsletter_landing' }));
+    expect(subscribeToNewsletter).toHaveBeenCalledWith('a@b.com', expect.objectContaining({ source: 'newsletter_landing' }));
+  });
+
+  it('defaults source to footer_newsletter when omitted', async () => {
+    await post_mailingListSignups(makeRequest({ email: 'a@b.com' }));
+    expect(subscribeToNewsletter).toHaveBeenCalledWith('a@b.com', expect.objectContaining({ source: 'footer_newsletter' }));
+  });
+
+  it('passes honeypot field through to subscribeToNewsletter', async () => {
+    await post_mailingListSignups(makeRequest({ email: 'a@b.com', honeypot: 'bot-value' }));
+    expect(subscribeToNewsletter).toHaveBeenCalledWith('a@b.com', expect.objectContaining({ honeypot: 'bot-value' }));
+  });
+
+  it('returns 200 for duplicate subscriber (subscribeToNewsletter returns success:true)', async () => {
+    subscribeToNewsletter.mockResolvedValue({ success: true, discountCode: 'WELCOME10' });
+    const res = await post_mailingListSignups(makeRequest({ email: 'existing@example.com' }));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── Validation errors ─────────────────────────────────────────────────────────
+
+describe('post_mailingListSignups — validation', () => {
+  it('returns 400 on invalid JSON body', async () => {
+    const req = {
+      body: { text: async () => 'not-json', json: async () => { throw new Error('bad json'); } },
+      headers: {},
+    };
+    const res = await post_mailingListSignups(req);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Invalid JSON/i);
+  });
+
+  it('returns 400 when subscribeToNewsletter returns success:false (invalid email)', async () => {
+    subscribeToNewsletter.mockResolvedValue({ success: false, message: 'Invalid email format' });
+    const res = await post_mailingListSignups(makeRequest({ email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).success).toBe(false);
+    expect(JSON.parse(res.body).error).toMatch(/Invalid email/i);
+  });
+
+  it('returns 400 when subscribeToNewsletter returns success:false without message', async () => {
+    subscribeToNewsletter.mockResolvedValue({ success: false });
+    const res = await post_mailingListSignups(makeRequest({ email: 'a@b.com' }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBeTruthy();
+  });
+});
+
+// ── Rate limiting ─────────────────────────────────────────────────────────────
+
+describe('post_mailingListSignups — rate limiting', () => {
+  it('returns 429 when subscribeToNewsletter reports rate limit', async () => {
+    subscribeToNewsletter.mockResolvedValue({ success: false, message: 'Too many requests. Please try again later.' });
+    const res = await post_mailingListSignups(makeRequest({ email: 'spammer@example.com' }));
+    expect(res.status).toBe(429);
+    expect(JSON.parse(res.body).success).toBe(false);
+  });
+});
+
+// ── Server errors ─────────────────────────────────────────────────────────────
+
+describe('post_mailingListSignups — server errors', () => {
+  it('returns 500 when subscribeToNewsletter resolves to null/undefined', async () => {
+    subscribeToNewsletter.mockResolvedValue(null);
+    const res = await post_mailingListSignups(makeRequest({ email: 'a@b.com' }));
+    expect(res.status).toBe(500);
+    expect(JSON.parse(res.body).success).toBe(false);
+  });
+
+  it('returns 500 on unexpected thrown exception', async () => {
+    subscribeToNewsletter.mockRejectedValue(new Error('Wix DB timeout'));
+    const res = await post_mailingListSignups(makeRequest({ email: 'a@b.com' }));
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── CORS preflight ────────────────────────────────────────────────────────────
+
+describe('options_mailingListSignups', () => {
+  it('returns a response object for CORS preflight', async () => {
+    const res = await options_mailingListSignups({ headers: { origin: 'https://carolina-futons-web.vercel.app' } });
+    expect(res).toBeDefined();
+    expect(typeof res.status).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /_functions/mailingListSignups` to `src/backend/http-functions.js` — Velo HTTP function wrapping `newsletterService.subscribeToNewsletter` for Next.js access
- Next.js footer can now POST to `/_functions/mailingListSignups` instead of a bare Server Action, hitting the same rate-limit + dedup + ESP-sync + audit-log pipeline as the Wix Studio footer
- Server Action stays as client-side fallback per bead AC
- 12 tests in `tests/mailingListSignups.http.test.js`: happy path, source defaulting, honeypot passthrough, duplicate subscriber, validation, rate-limit 429, null-result 500, thrown exception, CORS preflight
- `docs/cf-3qt/URL-CMS-MAP.md` updated to show the actual Velo HTTP path

**Bead:** cf-3qt.5.5

## Test plan

- [x] `npx vitest run tests/mailingListSignups.http.test.js` — 12/12 pass
- [x] No regressions: pre-existing failures in `funnelTracker` and `homeHandlers` confirmed on clean main
- [ ] Live verification: `POST https://www.carolinafutons.com/_functions/mailingListSignups` creates `NewsletterSubscribers` entry in Wix dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)