### PR TITLE
feat(cf-2g6f): Getting It Home — assembly guides + care tips + delivery prep repeaters

### DIFF
--- a/src/pages/Getting It Home.js
+++ b/src/pages/Getting It Home.js
@@ -6,7 +6,7 @@ import { trackEvent } from 'public/engagementTracker';
 import { initBackToTop } from 'public/mobileHelpers';
 import { makeClickable } from 'public/a11yHelpers.js';
 import { initPageSeo } from 'public/pageSeo.js';
-import { getIntroText, getServiceTiers, getDeliveryRates } from 'public/deliveryHelpers.js';
+import { getIntroText, getServiceTiers, getDeliveryRates, getAssemblyGuides, getCareTips, getCareTipCategories, getDeliveryPrepInstructions, getDeliveryTierOptions, buildShippingSchemaHtml } from 'public/deliveryHelpers.js';
 import { to } from 'wix-location-frontend';
 
 $w.onReady(function () {
@@ -15,6 +15,11 @@ $w.onReady(function () {
   initIntro();
   initServiceTiers();
   initDeliveryRates();
+  initAssemblyGuides();
+  initCareTips();
+  initDeliveryPrep();
+  initScheduleDelivery();
+  initShippingSchema();
   initNavLinks();
   trackEvent('page_view', { page: 'getting-it-home' });
 });
@@ -38,6 +43,60 @@ function initDeliveryRates() {
   const rates = getDeliveryRates();
   $w('#deliveryMinCharge').text = `Minimum local charge (up to approx. ${rates.minimumRadius} radius from our store) ${rates.minimumCharge}`;
   $w('#deliveryRateNote').text = rates.note;
+}
+
+function initAssemblyGuides() {
+  const repeater = $w('#assemblyGuidesRepeater');
+  repeater.accessibility.ariaLabel = 'Step-by-step assembly guides';
+  repeater.onItemReady(($item, itemData) => {
+    $item('#guideTitle').text = itemData.title;
+    $item('#guideTime').text = itemData.time;
+    $item('#guideTools').text = itemData.tools;
+    $item('#guideSteps').text = itemData.steps;
+    $item('#guideExpandBtn').onClick(() => {
+      const stepsEl = $item('#guideSteps');
+      if (stepsEl.collapsed) {
+        stepsEl.expand();
+      } else {
+        stepsEl.collapse();
+      }
+    });
+  });
+  repeater.data = getAssemblyGuides();
+}
+
+function initCareTips() {
+  const repeater = $w('#careTipsRepeater');
+  const dropdown = $w('#careCategoryDropdown');
+
+  repeater.accessibility.ariaLabel = 'Furniture care tips';
+  repeater.onItemReady(($item, itemData) => {
+    $item('#careTipTitle').text = itemData.title;
+    $item('#careTipContent').text = itemData.content;
+  });
+  repeater.data = getCareTips(null);
+
+  const categories = getCareTipCategories();
+  dropdown.options = categories.map(c => ({ label: c.label, value: c.id }));
+  dropdown.onChange((event) => {
+    repeater.data = getCareTips(event.target.value);
+  });
+}
+
+function initDeliveryPrep() {
+  const dropdown = $w('#deliveryTierDropdown');
+  dropdown.options = getDeliveryTierOptions().map(o => ({ label: o.label, value: o.id }));
+  dropdown.onChange((event) => {
+    $w('#deliveryPrepInstructions').text = getDeliveryPrepInstructions(event.target.value);
+  });
+}
+
+function initScheduleDelivery() {
+  $w('#scheduleDeliveryBtn').onClick(() => to('/contact?topic=schedule-delivery'));
+}
+
+function initShippingSchema() {
+  $w('#shippingSchemaHtml').html = buildShippingSchemaHtml();
 }
 
 function initNavLinks() {

--- a/src/public/deliveryHelpers.js
+++ b/src/public/deliveryHelpers.js
@@ -65,3 +65,177 @@ export function getServiceTiers() {
 export function getDeliveryRates() {
   return DELIVERY_RATES;
 }
+
+// ── Assembly Guides ─────────────────────────────────────────────────
+
+const ASSEMBLY_GUIDES = [
+  {
+    _id: 'futon-frame',
+    title: 'Futon Frame Assembly',
+    time: '20–30 min',
+    tools: 'Allen wrench (included), rubber mallet',
+    steps: '1. Lay out all parts and hardware. 2. Attach the side rails to the rear frame using the provided bolts. 3. Insert the deck slats across the frame. 4. Attach the arm covers and click them into place. 5. Test the bi-fold mechanism — it should fold and flatten smoothly.',
+  },
+  {
+    _id: 'platform-bed',
+    title: 'Platform Bed Assembly',
+    time: '30–45 min',
+    tools: 'Allen wrench (included), Phillips screwdriver',
+    steps: '1. Attach the headboard brackets to the headboard. 2. Connect the side rails to the headboard and footboard. 3. Lay the center support slats across the rails. 4. Tighten all bolts — do not over-torque. 5. Place mattress and verify no rocking.',
+  },
+  {
+    _id: 'bunk-loft',
+    title: 'Bunk / Loft Bed Assembly',
+    time: '45–60 min',
+    tools: 'Allen wrench (included), Phillips screwdriver, level',
+    steps: '1. Build the lower bunk first — connect rails, headboard, and footboard. 2. Attach the upper-bunk posts to the lower frame. 3. Install the upper guardrails before lifting the upper deck. 4. Install the ladder on the preferred side. 5. Check that all bolts are finger-tight before fully tightening.',
+  },
+];
+
+/**
+ * Get all assembly guides.
+ * @returns {Array<{_id, title, time, tools, steps}>}
+ */
+export function getAssemblyGuides() {
+  return ASSEMBLY_GUIDES;
+}
+
+// ── Care Tips ───────────────────────────────────────────────────────
+
+const CARE_TIPS = [
+  {
+    _id: 'frame-bolts',
+    category: 'frame',
+    title: 'Tighten Hardware Periodically',
+    content: 'Check and re-tighten all bolts and connections every 3–6 months. Normal use causes slight loosening over time. Use the included Allen wrench.',
+  },
+  {
+    _id: 'frame-mechanism',
+    category: 'frame',
+    title: 'Lubricate the Mechanism',
+    content: 'Apply a light spray of WD-40 or silicone lubricant to the bi-fold pivot points once a year — more often if the fold feels stiff or squeaky.',
+  },
+  {
+    _id: 'mattress-rotate',
+    category: 'mattress',
+    title: 'Rotate Your Mattress',
+    content: "Rotate your futon mattress 180° every 3 months to prevent body impressions and extend its life. Some mattresses can also be flipped — check your model's care tag.",
+  },
+  {
+    _id: 'mattress-protector',
+    category: 'mattress',
+    title: 'Use a Mattress Protector',
+    content: 'A washable mattress protector guards against spills, allergens, and skin oils that break down foam and fiber over time. Machine wash monthly.',
+  },
+  {
+    _id: 'cover-washing',
+    category: 'cover',
+    title: 'Washing Your Cover',
+    content: 'Most futon covers are machine-washable in cold water on a gentle cycle. Air-dry or tumble-dry on low. Never use bleach — it weakens the fabric weave.',
+  },
+  {
+    _id: 'cover-sunfading',
+    category: 'cover',
+    title: 'Prevent Sun Fading',
+    content: 'Direct sunlight fades fabric colors over time. Position your futon away from windows that get prolonged direct sun, or use UV-blocking window film.',
+  },
+];
+
+const CARE_CATEGORIES = [
+  { id: 'all', label: 'All Tips' },
+  { id: 'frame', label: 'Frame' },
+  { id: 'mattress', label: 'Mattress' },
+  { id: 'cover', label: 'Cover' },
+];
+
+/**
+ * Get all care tips, optionally filtered by category.
+ * @param {string|null} category
+ * @returns {Array<{_id, category, title, content}>}
+ */
+export function getCareTips(category) {
+  if (!category || category === 'all') return CARE_TIPS;
+  return CARE_TIPS.filter(t => t.category === category);
+}
+
+/**
+ * Get care tip dropdown options.
+ * @returns {Array<{id, label}>}
+ */
+export function getCareTipCategories() {
+  return CARE_CATEGORIES;
+}
+
+// ── Delivery Prep Instructions ──────────────────────────────────────
+
+const DELIVERY_PREP = {
+  diy: 'Measure your doorways, hallways, and stairwells before pickup. Most futon frames ship flat-packed and fit through a standard 30" door when unassembled. Bring a friend — even flat-packed frames can be awkward solo. Check our FAQ for assembly video links.',
+  dropoff: 'Clear a path from your front door to the room where the furniture will go — remove rugs, shoe racks, and fragile items from hallways. Let us know about any narrow doorways (under 32") or stairwells in advance so we can bring the right equipment.',
+  instore: 'No prep needed at home — we\'ll assemble in the store. Once assembled, measure your vehicle or arrange a truck rental. A full-size assembled futon frame typically requires a 6-foot truck bed. Call us before pickup to confirm dimensions.',
+  whiteglove: 'Clear the room where the furniture will go — move out smaller items and make 3–4 feet of working space. Identify any stair handrails that could block large pieces. Note any parking restrictions for our delivery van. We\'ll handle the rest.',
+};
+
+/**
+ * Get delivery prep instructions for a service tier.
+ * @param {string} tierId - 'diy' | 'dropoff' | 'instore' | 'whiteglove'
+ * @returns {string}
+ */
+export function getDeliveryPrepInstructions(tierId) {
+  return DELIVERY_PREP[tierId] ?? 'Select a service tier above to see your delivery preparation checklist.';
+}
+
+/**
+ * Get dropdown options for the delivery tier selector.
+ * @returns {Array<{id, label}>}
+ */
+export function getDeliveryTierOptions() {
+  return [
+    { id: 'diy', label: 'Do It Yourself (Pickup)' },
+    { id: 'dropoff', label: 'Home Drop Off' },
+    { id: 'instore', label: 'In-Store Assembly + Pickup' },
+    { id: 'whiteglove', label: 'Premium White Glove Service' },
+  ];
+}
+
+// ── Shipping Schema JSON-LD ─────────────────────────────────────────
+
+/**
+ * Build schema.org OfferShippingDetails JSON-LD for the page.
+ * Returns a <script> tag string ready for injection into an HTML element.
+ * @returns {string}
+ */
+export function buildShippingSchemaHtml() {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'OfferShippingDetails',
+        shippingRate: { '@type': 'MonetaryAmount', value: '0', currency: 'USD' },
+        shippingDestination: { '@type': 'DefinedRegion', addressCountry: 'US' },
+        deliveryTime: {
+          '@type': 'ShippingDeliveryTime',
+          handlingTime: { '@type': 'QuantitativeValue', minValue: 1, maxValue: 2, unitCode: 'DAY' },
+          transitTime: { '@type': 'QuantitativeValue', minValue: 5, maxValue: 7, unitCode: 'DAY' },
+        },
+        name: 'Standard Shipping — Free on orders $500+',
+      },
+      {
+        '@type': 'OfferShippingDetails',
+        shippingRate: { '@type': 'MonetaryAmount', value: '75', currency: 'USD' },
+        shippingDestination: {
+          '@type': 'DefinedRegion',
+          addressCountry: 'US',
+          addressRegion: 'NC',
+          description: 'Local zone — within 25 miles of Hendersonville, NC',
+        },
+        deliveryTime: {
+          '@type': 'ShippingDeliveryTime',
+          handlingTime: { '@type': 'QuantitativeValue', minValue: 0, maxValue: 1, unitCode: 'DAY' },
+          transitTime: { '@type': 'QuantitativeValue', minValue: 1, maxValue: 3, unitCode: 'DAY' },
+        },
+        name: 'Local Delivery — In-home placement',
+      },
+    ],
+  };
+  return `<script type="application/ld+json">${JSON.stringify(schema)}</script>`;
+}

--- a/tests/gettingItHome.test.js
+++ b/tests/gettingItHome.test.js
@@ -186,4 +186,154 @@ describe('Getting It Home Page', () => {
       expect(contactLink.onClick).toHaveBeenCalled();
     });
   });
+
+  // ── Assembly Guides Repeater ──────────────────────────────────────
+
+  describe('assembly guides', () => {
+    it('populates assemblyGuidesRepeater with guide items', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#assemblyGuidesRepeater');
+      expect(repeater.data.length).toBeGreaterThan(0);
+    });
+
+    it('sets accessible label on assemblyGuidesRepeater', async () => {
+      await onReadyHandler();
+      expect(getEl('#assemblyGuidesRepeater').accessibility.ariaLabel).toBeTruthy();
+    });
+
+    it('onItemReady wires guideTitle text from item data', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#assemblyGuidesRepeater');
+      const cb = repeater.onItemReady.mock.calls[0][0];
+      const $item = (sel) => getEl(`_guide_${sel}`);
+      cb($item, { _id: 'frame', title: 'Frame Assembly', time: '30 min', tools: 'Allen wrench', steps: 'Step 1. Step 2.' });
+      expect(getEl('_guide_#guideTitle').text).toBe('Frame Assembly');
+    });
+
+    it('onItemReady wires guideTime text from item data', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#assemblyGuidesRepeater');
+      const cb = repeater.onItemReady.mock.calls[0][0];
+      const $item = (sel) => getEl(`_guide_${sel}`);
+      cb($item, { _id: 'frame', title: 'Frame Assembly', time: '30 min', tools: 'Allen wrench', steps: 'Step 1.' });
+      expect(getEl('_guide_#guideTime').text).toBe('30 min');
+    });
+
+    it('onItemReady wires guideTools text from item data', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#assemblyGuidesRepeater');
+      const cb = repeater.onItemReady.mock.calls[0][0];
+      const $item = (sel) => getEl(`_guide_${sel}`);
+      cb($item, { _id: 'frame', title: 'Frame Assembly', time: '30 min', tools: 'Allen wrench', steps: 'Step 1.' });
+      expect(getEl('_guide_#guideTools').text).toBe('Allen wrench');
+    });
+
+    it('onItemReady wires guideSteps text from item data', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#assemblyGuidesRepeater');
+      const cb = repeater.onItemReady.mock.calls[0][0];
+      const $item = (sel) => getEl(`_guide_${sel}`);
+      cb($item, { _id: 'frame', title: 'Frame Assembly', time: '30 min', tools: 'Allen wrench', steps: 'Step 1. Step 2.' });
+      expect(getEl('_guide_#guideSteps').text).toBe('Step 1. Step 2.');
+    });
+
+    it('onItemReady wires guideExpandBtn click to toggle steps visibility', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#assemblyGuidesRepeater');
+      const cb = repeater.onItemReady.mock.calls[0][0];
+      const $item = (sel) => getEl(`_guide2_${sel}`);
+      cb($item, { _id: 'mattress', title: 'Mattress Setup', time: '10 min', tools: 'None', steps: 'Unbox.' });
+      expect(getEl('_guide2_#guideExpandBtn').onClick).toHaveBeenCalled();
+    });
+  });
+
+  // ── Care Tips Repeater ────────────────────────────────────────────
+
+  describe('care tips', () => {
+    it('populates careTipsRepeater with care tip items', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#careTipsRepeater');
+      expect(repeater.data.length).toBeGreaterThan(0);
+    });
+
+    it('sets accessible label on careTipsRepeater', async () => {
+      await onReadyHandler();
+      expect(getEl('#careTipsRepeater').accessibility.ariaLabel).toBeTruthy();
+    });
+
+    it('careCategoryDropdown has options set', async () => {
+      await onReadyHandler();
+      const dropdown = getEl('#careCategoryDropdown');
+      expect(dropdown.options).toBeDefined();
+      expect(dropdown.options.length).toBeGreaterThan(0);
+    });
+
+    it('careCategoryDropdown onChange filters careTipsRepeater', async () => {
+      await onReadyHandler();
+      const dropdown = getEl('#careCategoryDropdown');
+      const repeater = getEl('#careTipsRepeater');
+      const onChangeCb = dropdown.onChange.mock.calls[0]?.[0];
+      expect(onChangeCb).toBeInstanceOf(Function);
+      // Simulate selection
+      onChangeCb({ target: { value: 'frame' } });
+      expect(repeater.data.length).toBeGreaterThan(0);
+    });
+
+    it('onItemReady wires care tip title and content', async () => {
+      await onReadyHandler();
+      const repeater = getEl('#careTipsRepeater');
+      const cb = repeater.onItemReady.mock.calls[0][0];
+      const $item = (sel) => getEl(`_care_${sel}`);
+      cb($item, { _id: 'tip1', title: 'Tighten Bolts', content: 'Check bolts monthly.', category: 'frame' });
+      expect(getEl('_care_#careTipTitle').text).toBe('Tighten Bolts');
+      expect(getEl('_care_#careTipContent').text).toBe('Check bolts monthly.');
+    });
+  });
+
+  // ── Delivery Prep Instructions ────────────────────────────────────
+
+  describe('delivery prep instructions', () => {
+    it('deliveryTierDropdown has options set', async () => {
+      await onReadyHandler();
+      const dropdown = getEl('#deliveryTierDropdown');
+      expect(dropdown.options).toBeDefined();
+      expect(dropdown.options.length).toBeGreaterThan(0);
+    });
+
+    it('deliveryTierDropdown onChange updates deliveryPrepInstructions text', async () => {
+      await onReadyHandler();
+      const dropdown = getEl('#deliveryTierDropdown');
+      const onChangeCb = dropdown.onChange.mock.calls[0]?.[0];
+      expect(onChangeCb).toBeInstanceOf(Function);
+      onChangeCb({ target: { value: 'diy' } });
+      const prepEl = getEl('#deliveryPrepInstructions');
+      expect(prepEl.text.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Schedule Delivery Button ──────────────────────────────────────
+
+  describe('schedule delivery button', () => {
+    it('scheduleDeliveryBtn onClick navigates to contact form', async () => {
+      await onReadyHandler();
+      const btn = getEl('#scheduleDeliveryBtn');
+      expect(btn.onClick).toHaveBeenCalled();
+    });
+  });
+
+  // ── Shipping Schema JSON-LD ───────────────────────────────────────
+
+  describe('shipping schema JSON-LD', () => {
+    it('sets shippingSchemaHtml with schema.org markup', async () => {
+      await onReadyHandler();
+      const schemaEl = getEl('#shippingSchemaHtml');
+      expect(schemaEl.html).toContain('schema.org');
+    });
+
+    it('shipping schema contains OfferShippingDetails type', async () => {
+      await onReadyHandler();
+      const schemaEl = getEl('#shippingSchemaHtml');
+      expect(schemaEl.html).toContain('OfferShippingDetails');
+    });
+  });
 });

--- a/tests/gettingItHomeHandlers.test.js
+++ b/tests/gettingItHomeHandlers.test.js
@@ -70,6 +70,22 @@ vi.mock('public/deliveryHelpers.js', () => ({
     minimumCharge: '$79',
     note: 'Rates vary by distance',
   })),
+  getAssemblyGuides: vi.fn(() => [
+    { _id: 'guide-1', title: 'Sofa Assembly', time: '30 min', tools: 'Allen wrench', steps: 'Step 1...' },
+  ]),
+  getCareTips: vi.fn(() => [
+    { _id: 'care-1', title: 'Fabric Care', content: 'Spot clean only' },
+  ]),
+  getCareTipCategories: vi.fn(() => [
+    { id: 'fabric', label: 'Fabric' },
+    { id: 'frame', label: 'Frame' },
+  ]),
+  getDeliveryPrepInstructions: vi.fn(() => 'Clear a path to the room'),
+  getDeliveryTierOptions: vi.fn(() => [
+    { id: 'curbside', label: 'Curbside Drop-off' },
+    { id: 'room', label: 'Room of Choice' },
+  ]),
+  buildShippingSchemaHtml: vi.fn(() => '<script type="application/ld+json">{}</script>'),
 }));
 
 vi.mock('wix-location-frontend', () => ({


### PR DESCRIPTION
## Summary

Fills content gaps in `/getting-it-home` identified by the cf-93rb Phase D richness audit:

- **assemblyGuidesRepeater** — 3 step-by-step guides (futon frame, platform bed, bunk/loft). Each item wires `#guideTitle`, `#guideTime`, `#guideTools`, `#guideSteps`, and `#guideExpandBtn` (toggle collapse/expand on steps).
- **careTipsRepeater + careCategoryDropdown** — 6 tips across frame / mattress / cover categories. Dropdown onChange re-filters the repeater data.
- **deliveryTierDropdown → deliveryPrepInstructions** — 4 tier options (DIY, Drop Off, In-Store, White Glove); dropdown selection updates prep instructions text.
- **scheduleDeliveryBtn** — onClick navigates to `/contact?topic=schedule-delivery`.
- **shippingSchemaHtml** — injects `schema.org OfferShippingDetails` JSON-LD (standard + local delivery tiers).

All static data lives in `deliveryHelpers.js` alongside the existing `SERVICE_TIERS` / `DELIVERY_RATES`.

## Test plan

- [x] 30/30 tests pass in `tests/gettingItHome.test.js` (18 new, 12 existing)
- [x] Zero regressions in full suite (2 pre-existing failures in `funnelTracker` / `homeHandlers` confirmed on clean main)
- [x] `tests/gettingItHomeHelpers.test.js` — 43/43 pass

**Bead:** cf-2g6f — all 5 ACs covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)