### PR TITLE
feat(cf-3qt.4.4): delivery zone distance calc + GET /_functions/deliveryZone

### DIFF
--- a/src/backend/deliveryZoneService.web.js
+++ b/src/backend/deliveryZoneService.web.js
@@ -1,0 +1,115 @@
+// deliveryZoneService.web.js — Delivery zone resolution for /getting-it-home.
+// Zip → distance (Haversine) → zone tier + rate.
+// cf-3qt.4.4: exposes getDeliveryZone for both Velo pages and HTTP endpoint.
+import { Permissions, webMethod } from 'wix-web-module';
+
+// Store location: 824 Locust St Ste 200, Hendersonville, NC 28792
+const STORE = { lat: 35.3187, lon: -82.4612 };
+
+// Zone tier definitions (distance in miles from store)
+const ZONES = [
+  { zone: 'local',    label: 'Local',    minMi: 0,  maxMi: 10,  rate: 25, eta: '1-2 business days' },
+  { zone: 'regional', label: 'Regional', minMi: 11, maxMi: 30,  rate: 45, eta: '1-2 business days' },
+  { zone: 'extended', label: 'Extended', minMi: 31, maxMi: 60,  rate: 65, eta: '2-3 business days' },
+];
+
+// Static lookup: western NC zip codes with approximate centroids.
+// Covers the realistic delivery service area. Unknown zips use outofrange.
+const ZIP_COORDS = {
+  '28792': { lat: 35.3187, lon: -82.4612 }, // Hendersonville (store)
+  '28791': { lat: 35.3280, lon: -82.4712 }, // Hendersonville N
+  '28790': { lat: 35.2600, lon: -82.4850 }, // Tuxedo
+  '28731': { lat: 35.2945, lon: -82.4305 }, // East Flat Rock
+  '28739': { lat: 35.4290, lon: -82.4966 }, // Fletcher
+  '28726': { lat: 35.2677, lon: -82.5500 }, // Columbus
+  '28748': { lat: 35.5050, lon: -82.8180 }, // Leicester
+  '28715': { lat: 35.5229, lon: -82.6776 }, // Candler
+  '28756': { lat: 35.3530, lon: -82.2050 }, // Mill Spring
+  '28772': { lat: 35.2270, lon: -82.2970 }, // Saluda
+  '28787': { lat: 35.5020, lon: -82.4270 }, // Weaverville
+  '28801': { lat: 35.5951, lon: -82.5515 }, // Asheville downtown
+  '28803': { lat: 35.5421, lon: -82.5321 }, // Asheville S
+  '28804': { lat: 35.6309, lon: -82.5549 }, // Asheville N
+  '28805': { lat: 35.5782, lon: -82.4693 }, // Asheville E
+  '28806': { lat: 35.5657, lon: -82.6085 }, // Asheville W
+  '28711': { lat: 35.4530, lon: -82.3270 }, // Black Mountain
+  '28730': { lat: 35.4400, lon: -82.3380 }, // Fairview
+  '28734': { lat: 35.1450, lon: -83.3850 }, // Franklin
+  '28779': { lat: 35.3080, lon: -83.1900 }, // Sylva
+  '28786': { lat: 35.4580, lon: -82.9930 }, // Waynesville
+  '28202': { lat: 35.2271, lon: -80.8431 }, // Charlotte downtown — out of range
+  '28204': { lat: 35.2063, lon: -80.8314 }, // Charlotte E
+  '28205': { lat: 35.2201, lon: -80.7928 }, // Charlotte NE
+  '28206': { lat: 35.2452, lon: -80.8375 }, // Charlotte N
+  '28226': { lat: 35.0762, lon: -80.8451 }, // Charlotte S
+};
+
+function haversineMiles(lat1, lon1, lat2, lon2) {
+  const R = 3958.8; // Earth radius in miles
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function toRad(deg) { return (deg * Math.PI) / 180; }
+
+function resolveZone(miles) {
+  for (const tier of ZONES) {
+    if (miles >= tier.minMi && miles <= tier.maxMi) return tier;
+  }
+  return null;
+}
+
+/**
+ * Resolve a 5-digit zip code to a delivery zone, rate, and ETA.
+ *
+ * @param {string} zip - 5-digit US zip code
+ * @returns {{ zone: string, label: string, rate: number|null, eta: string|null,
+ *             distanceMiles: number, message?: string, error?: string }}
+ */
+export const getDeliveryZone = webMethod(
+  Permissions.Anyone,
+  async (zip) => {
+    const clean = String(zip || '').trim().replace(/\D/g, '').slice(0, 5);
+    if (!clean || clean.length !== 5) {
+      return { error: 'Please enter a valid 5-digit zip code.' };
+    }
+
+    const coords = ZIP_COORDS[clean];
+    if (!coords) {
+      return {
+        zone: 'outofrange',
+        label: 'Out of Range',
+        rate: null,
+        eta: null,
+        distanceMiles: null,
+        message: 'We deliver within 60 miles of our Hendersonville, NC showroom. Contact us for a delivery quote.',
+      };
+    }
+
+    const distanceMiles = Math.round(haversineMiles(STORE.lat, STORE.lon, coords.lat, coords.lon));
+    const tier = resolveZone(distanceMiles);
+
+    if (!tier) {
+      return {
+        zone: 'outofrange',
+        label: 'Out of Range',
+        rate: null,
+        eta: null,
+        distanceMiles,
+        message: 'We deliver within 60 miles of our Hendersonville, NC showroom. Contact us for a delivery quote.',
+      };
+    }
+
+    return {
+      zone: tier.zone,
+      label: tier.label,
+      rate: tier.rate,
+      eta: tier.eta,
+      distanceMiles,
+    };
+  }
+);

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -23,6 +23,7 @@ import { sanitize, validateEmail, validateSlug, validateId } from 'backend/utils
 import { getEnhancedCatalogFields, exportCustomerAudienceData } from 'backend/facebookCatalog.web';
 import { timingSafeEqual, decodeHtmlEntities, stripHtmlSafe, escapeXml } from 'backend/utils/httpHelpers';
 import { corsHeaders, corsPreflight } from 'backend/utils/cors';
+import { getDeliveryZone as _getDeliveryZone } from 'backend/deliveryZoneService.web';
 import { CLUSTERS, SITE_URL } from 'backend/utils/topicClusterData';
 import { listBundles, getBundleBySlug, addBundleToCart } from 'backend/bundleDeals.web';
 import { receiveGamificationEvent, getActiveChallenges as _getActiveChallengesWebMethod, recordChallengeProgress as _recordChallengeProgressWebMethod } from 'backend/gamificationEventReceiver.web';
@@ -2941,5 +2942,33 @@ export async function post_unsubscribe(request) {
 }
 
 export function options_unsubscribe(request) {
+  return response(corsPreflight(request));
+}
+
+// ── /_functions/deliveryZone ──────────────────────────────────────────────
+//
+// Delivery zone resolution for /getting-it-home page + Next.js frontend.
+// URL: GET https://www.carolinafutons.com/_functions/deliveryZone?zip=28792
+// cf-3qt.4.4: proxies to getDeliveryZone webMethod (distance calc + zone lookup).
+
+export async function get_deliveryZone(request) {
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
+  const zip = (request.query?.zip || '').trim();
+  if (!zip || !/^\d{5}$/.test(zip)) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'Missing or invalid zip parameter (must be 5 digits)' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  try {
+    const result = await _getDeliveryZone(zip);
+    return ok({ body: JSON.stringify({ success: true, ...result }), headers: JSON_HEADERS });
+  } catch (err) {
+    console.error('HTTP function error (deliveryZone):', err);
+    return serverError({ body: JSON.stringify({ success: false, error: 'Internal server error' }), headers: JSON_HEADERS });
+  }
+}
+
+export function options_deliveryZone(request) {
   return response(corsPreflight(request));
 }

--- a/tests/deliveryZone.test.js
+++ b/tests/deliveryZone.test.js
@@ -1,0 +1,101 @@
+/**
+ * @file deliveryZone.test.js
+ * @description TDD tests for GET /_functions/deliveryZone HTTP endpoint.
+ *
+ * cf-3qt.4.4: Next.js GET /api/delivery-zone?zip= proxies to this Velo endpoint.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('backend/deliveryZoneService.web', () => ({
+  getDeliveryZone: vi.fn(),
+}));
+
+import { getDeliveryZone } from 'backend/deliveryZoneService.web';
+import { get_deliveryZone, options_deliveryZone } from '../src/backend/http-functions.js';
+
+function makeRequest(query = {}) {
+  return {
+    query,
+    headers: { origin: 'https://carolina-futons-web.vercel.app' },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('get_deliveryZone — success', () => {
+  it('returns 200 with zone data on valid zip', async () => {
+    getDeliveryZone.mockResolvedValue({ zone: 'local', rate: 25, eta: '1-2 business days', distanceMiles: 0 });
+    const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.zone).toBe('local');
+  });
+
+  it('returns CORS headers', async () => {
+    getDeliveryZone.mockResolvedValue({ zone: 'local', rate: 25, eta: '1-2 business days', distanceMiles: 0 });
+    const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
+    expect(res.headers).toHaveProperty('Access-Control-Allow-Origin');
+  });
+
+  it('includes rate in response body', async () => {
+    getDeliveryZone.mockResolvedValue({ zone: 'regional', rate: 45, eta: '1-2 business days', distanceMiles: 22 });
+    const res = await get_deliveryZone(makeRequest({ zip: '28801' }));
+    const body = JSON.parse(res.body);
+    expect(body.rate).toBe(45);
+  });
+
+  it('includes distanceMiles in response body', async () => {
+    getDeliveryZone.mockResolvedValue({ zone: 'regional', rate: 45, eta: '1-2 business days', distanceMiles: 22 });
+    const res = await get_deliveryZone(makeRequest({ zip: '28801' }));
+    const body = JSON.parse(res.body);
+    expect(body.distanceMiles).toBe(22);
+  });
+
+  it('includes success:true in response body', async () => {
+    getDeliveryZone.mockResolvedValue({ zone: 'local', rate: 25, eta: '1-2 business days', distanceMiles: 0 });
+    const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+  });
+});
+
+describe('get_deliveryZone — validation', () => {
+  it('returns 400 when zip is missing', async () => {
+    const res = await get_deliveryZone(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error).toMatch(/zip/i);
+  });
+
+  it('returns 400 when zip is empty string', async () => {
+    const res = await get_deliveryZone(makeRequest({ zip: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when zip is not 5 digits', async () => {
+    const res = await get_deliveryZone(makeRequest({ zip: '123' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when zip contains letters', async () => {
+    const res = await get_deliveryZone(makeRequest({ zip: 'ABCDE' }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('get_deliveryZone — error handling', () => {
+  it('returns 500 when webMethod throws', async () => {
+    getDeliveryZone.mockRejectedValue(new Error('DB error'));
+    const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('options_deliveryZone — CORS preflight', () => {
+  it('returns 204 for preflight', async () => {
+    const res = await options_deliveryZone(makeRequest());
+    expect(res.status).toBe(204);
+  });
+});

--- a/tests/deliveryZoneService.test.js
+++ b/tests/deliveryZoneService.test.js
@@ -1,0 +1,87 @@
+/**
+ * @file deliveryZoneService.test.js
+ * @description TDD unit tests for the getDeliveryZone webMethod.
+ *
+ * cf-3qt.4.4: AC — zip input returns correct zone for Hendersonville, Asheville, Charlotte.
+ */
+import { describe, it, expect } from 'vitest';
+import { getDeliveryZone } from '../src/backend/deliveryZoneService.web.js';
+
+describe('getDeliveryZone — Hendersonville (store city, zone 1)', () => {
+  it('resolves zip 28792 to zone "local"', async () => {
+    const result = await getDeliveryZone('28792');
+    expect(result.zone).toBe('local');
+  });
+
+  it('returns a positive rate for local zone', async () => {
+    const result = await getDeliveryZone('28792');
+    expect(result.rate).toBeGreaterThan(0);
+  });
+
+  it('returns an ETA for local zone', async () => {
+    const result = await getDeliveryZone('28792');
+    expect(result.eta).toBeTruthy();
+  });
+
+  it('returns distanceMiles of 0 for store zip', async () => {
+    const result = await getDeliveryZone('28792');
+    expect(result.distanceMiles).toBe(0);
+  });
+});
+
+describe('getDeliveryZone — Asheville (regional, zone 2)', () => {
+  it('resolves zip 28801 to zone "regional"', async () => {
+    const result = await getDeliveryZone('28801');
+    expect(result.zone).toBe('regional');
+  });
+
+  it('returns a positive rate for regional zone', async () => {
+    const result = await getDeliveryZone('28801');
+    expect(result.rate).toBeGreaterThan(0);
+  });
+
+  it('distance from store to Asheville is 11-30 miles', async () => {
+    const result = await getDeliveryZone('28801');
+    expect(result.distanceMiles).toBeGreaterThan(10);
+    expect(result.distanceMiles).toBeLessThanOrEqual(30);
+  });
+});
+
+describe('getDeliveryZone — Charlotte (out of range)', () => {
+  it('resolves zip 28202 to zone "outofrange"', async () => {
+    const result = await getDeliveryZone('28202');
+    expect(result.zone).toBe('outofrange');
+  });
+
+  it('returns null rate for out-of-range zone', async () => {
+    const result = await getDeliveryZone('28202');
+    expect(result.rate).toBeNull();
+  });
+
+  it('returns a contact message for out-of-range', async () => {
+    const result = await getDeliveryZone('28202');
+    expect(result.message).toBeTruthy();
+  });
+});
+
+describe('getDeliveryZone — validation', () => {
+  it('returns error for empty zip', async () => {
+    const result = await getDeliveryZone('');
+    expect(result.error).toBeTruthy();
+  });
+
+  it('returns error for non-numeric zip', async () => {
+    const result = await getDeliveryZone('ABCDE');
+    expect(result.error).toBeTruthy();
+  });
+
+  it('returns outofrange for unknown US zip', async () => {
+    const result = await getDeliveryZone('90210');
+    expect(result.zone).toBe('outofrange');
+  });
+
+  it('returns outofrange for a Charlotte zip', async () => {
+    const result = await getDeliveryZone('28204');
+    expect(result.zone).toBe('outofrange');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `getDeliveryZone(zip)` webMethod in `src/backend/deliveryZoneService.web.js` — Haversine distance from Hendersonville showroom, static NC zip lookup table
- Zones: local (0-10mi, $25), regional (11-30mi, $45), extended (31-60mi, $65), outofrange
- Adds `GET /_functions/deliveryZone?zip=` HTTP endpoint for Next.js `/api/delivery-zone?` proxy (cf-3qt.4 phase)

## AC verification

| Test case | Zip | Expected zone | Result |
|---|---|---|---|
| Hendersonville | 28792 | local | ✓ |
| Asheville | 28801 | regional | ✓ |
| Charlotte | 28202 | outofrange | ✓ |

## Test plan

- [x] 25 TDD tests in `tests/deliveryZone.test.js` (HTTP endpoint) and `tests/deliveryZoneService.test.js` (webMethod unit)
- [x] Full suite: 40,188 passed, 15 pre-existing funnelTracker failures (unrelated)
- [x] TDD: RED confirmed before implementation, GREEN after

Generated with Claude Code