### PR TITLE
fix(cf-i9kn): add welcome_series_4 + welcome_series_5 to TEMPLATE_REGISTRY

### DIFF
--- a/src/backend/emailTemplates.web.js
+++ b/src/backend/emailTemplates.web.js
@@ -54,6 +54,26 @@ const TEMPLATE_REGISTRY = {
     variables: ['firstName', 'discountCode', 'email'],
     category: 'onboarding',
   },
+  welcome_series_4: {
+    id: 'welcome_series_4',
+    name: 'Welcome — Day 14 Browse Reminder',
+    sequence: 'welcome',
+    step: 4,
+    subjectLine: 'Still exploring? Let us help you find the perfect futon',
+    previewText: 'Day 14 check-in — helpful tips to make your decision easier.',
+    variables: ['firstName', 'email'],
+    category: 'onboarding',
+  },
+  welcome_series_5: {
+    id: 'welcome_series_5',
+    name: 'Welcome — Day 21 Final Value Email',
+    sequence: 'welcome',
+    step: 5,
+    subjectLine: 'Families across the Carolinas trust us — here\'s why',
+    previewText: 'Real stories from real customers. A final note from our team.',
+    variables: ['firstName', 'email'],
+    category: 'onboarding',
+  },
 
   // Abandoned Cart Recovery
   cart_recovery_1: {

--- a/tests/emailTemplates.test.js
+++ b/tests/emailTemplates.test.js
@@ -19,10 +19,10 @@ beforeEach(() => {
 // ── Template Registry ───────────────────────────────────────────────
 
 describe('_TEMPLATE_REGISTRY', () => {
-  it('contains welcome series templates (3 steps)', () => {
+  it('contains welcome series templates (5 steps)', () => {
     const welcome = Object.values(_TEMPLATE_REGISTRY).filter(t => t.sequence === 'welcome');
-    expect(welcome).toHaveLength(3);
-    expect(welcome.map(t => t.step)).toEqual([1, 2, 3]);
+    expect(welcome).toHaveLength(5);
+    expect(welcome.map(t => t.step)).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('contains cart recovery templates (3 steps)', () => {
@@ -126,9 +126,9 @@ describe('_TEMPLATE_REGISTRY', () => {
 describe('getTemplatesBySequence', () => {
   it('returns welcome templates sorted by step', async () => {
     const templates = await getTemplatesBySequence('welcome');
-    expect(templates).toHaveLength(3);
+    expect(templates).toHaveLength(5);
     expect(templates[0].step).toBe(1);
-    expect(templates[2].step).toBe(3);
+    expect(templates[4].step).toBe(5);
   });
 
   it('returns cart_recovery templates', async () => {
@@ -224,9 +224,9 @@ describe('getTemplateIndex', () => {
     expect(index).toHaveProperty('reengagement');
   });
 
-  it('welcome has 3 template IDs', async () => {
+  it('welcome has 5 template IDs', async () => {
     const index = await getTemplateIndex();
-    expect(index.welcome).toHaveLength(3);
+    expect(index.welcome).toHaveLength(5);
   });
 
   it('cart_recovery has 3 template IDs', async () => {

--- a/tests/emailTemplatesDeep.test.js
+++ b/tests/emailTemplatesDeep.test.js
@@ -56,10 +56,10 @@ beforeEach(async () => {
 describe('getTemplatesBySequence', () => {
   it('returns welcome series templates sorted by step', async () => {
     const r = await mod.getTemplatesBySequence('welcome');
-    expect(r.length).toBe(3);
+    expect(r.length).toBe(5);
     expect(r[0].id).toBe('welcome_series_1');
     expect(r[1].step).toBe(2);
-    expect(r[2].step).toBe(3);
+    expect(r[4].step).toBe(5);
   });
 
   it('returns cart recovery templates', async () => {
@@ -91,7 +91,7 @@ describe('getTemplate', () => {
 describe('getTemplateIndex', () => {
   it('returns grouped template IDs', async () => {
     const r = await mod.getTemplateIndex();
-    expect(r.welcome).toHaveLength(3);
+    expect(r.welcome).toHaveLength(5);
     expect(r.cart_recovery).toHaveLength(3);
     expect(r.post_purchase).toHaveLength(5);
     expect(r.promotional.length).toBeGreaterThanOrEqual(3);

--- a/tests/emailTemplatesDeepen.test.js
+++ b/tests/emailTemplatesDeepen.test.js
@@ -71,11 +71,11 @@ describe('_TEMPLATE_REGISTRY structure', () => {
 describe('getTemplatesBySequence', () => {
   it('returns welcome templates sorted by step', async () => {
     const result = await getTemplatesBySequence('welcome');
-    expect(result).toHaveLength(3);
-    expect(result[0].step).toBe(1);
-    expect(result[1].step).toBe(2);
-    expect(result[2].step).toBe(3);
+    expect(result).toHaveLength(5);
+    expect(result.map(t => t.step)).toEqual([1, 2, 3, 4, 5]);
     expect(result[0].id).toBe('welcome_series_1');
+    expect(result[3].id).toBe('welcome_series_4');
+    expect(result[4].id).toBe('welcome_series_5');
   });
 
   it('returns empty array for unknown sequence', async () => {
@@ -86,7 +86,7 @@ describe('getTemplatesBySequence', () => {
   it('sanitizes input (strips HTML)', async () => {
     const result = await getTemplatesBySequence('<script>welcome</script>');
     // sanitize strips tags -> "welcome"
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(5);
   });
 });
 


### PR DESCRIPTION
## Summary

Steps 4 and 5 of the welcome email sequence were configured in \`emailAutomation.web.js\` but their template IDs were absent from the \`TEMPLATE_REGISTRY\`, causing \`undefined\` lookups and silent send failures at queue processing time.

- Added \`welcome_series_4\`: Day 14 browse reminder
- Added \`welcome_series_5\`: Day 21 final value email + social proof

## Test plan
- [x] \`getTemplatesBySequence('welcome')\` returns 5 templates with steps [1,2,3,4,5]
- [x] 95/95 tests green

Closes cf-i9kn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)