### PR TITLE
fix(cf-nbu4): gate promo lightbox with wix-storage-frontend session scope

### DIFF
--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -505,7 +505,9 @@ async function initPromoLightbox() {
     $w('#promoOverlay').show('fade', { duration: 300 });
     _promoDialog.open();
   } catch (e) {
-    // Promo lightbox is non-critical — never block the page
+    // Promo lightbox is non-critical — never block the page, but log so
+    // Wix monitoring captures storage/API failures that silently prevent display.
+    console.error('[masterPage] initPromoLightbox failed:', e?.message);
   }
 }
 

--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -14,6 +14,7 @@ import { trackEvent } from 'public/engagementTracker';
 import { fireCustomEvent, initScrollDepthTracking } from 'public/ga4Tracking';
 import { colors, typography, spacing } from 'public/designTokens.js';
 import { captureInstallPrompt, canShowInstallPrompt, showInstallPrompt, isInstalledPWA } from 'public/pwaHelpers';
+import { session as wixSession } from 'wix-storage-frontend';
 import { initAppDownloadBanner } from 'public/AppDownloadBanner';
 import { reportMetrics } from 'backend/coreWebVitals.web';
 import { initFooter, initMountainDividerWithSkyWiring } from 'public/FooterSection';
@@ -475,15 +476,11 @@ async function initPromoLightbox() {
     const promo = await getActivePromotion();
     if (!promo) return;
 
-    // Check if user already dismissed this promotion in this session
+    // Check if user already dismissed this promotion in this session.
+    // Uses wix-storage-frontend session scope so the gate persists across
+    // Wix client-side page navigations (browser sessionStorage resets per nav).
     const dismissKey = `promo_dismissed_${promo._id}`;
-    if (typeof sessionStorage !== 'undefined') {
-      try {
-        if (sessionStorage.getItem(dismissKey)) return;
-      } catch (e) {
-        // sessionStorage may not be available
-      }
-    }
+    if (wixSession.getItem(dismissKey)) return;
 
     populatePromoLightbox(promo);
     initPromoCountdown(promo.endDate);
@@ -605,11 +602,7 @@ function dismissLightbox(dismissKey) {
     $w('#promoOverlay').hide('fade', { duration: 200 });
   } catch (e) {}
 
-  if (typeof sessionStorage !== 'undefined') {
-    try {
-      sessionStorage.setItem(dismissKey, '1');
-    } catch (e) {}
-  }
+  wixSession.setItem(dismissKey, '1');
 }
 
 function initPromoDismiss(promoId, dismissKey) {

--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -602,7 +602,7 @@ function dismissLightbox(dismissKey) {
     $w('#promoOverlay').hide('fade', { duration: 200 });
   } catch (e) {}
 
-  wixSession.setItem(dismissKey, '1');
+  try { wixSession.setItem(dismissKey, '1'); } catch (e) {}
 }
 
 function initPromoDismiss(promoId, dismissKey) {

--- a/tests/importBudget.test.js
+++ b/tests/importBudget.test.js
@@ -24,7 +24,7 @@ const KNOWN_OVERBUDGET = {
   'Category Page.js': 27,
   'Home.js': 21, // cf-nqq: +1 initChallengeOfTheWeekWidget
   'Product Page.js': 29, // CF-7byz: +1 getProductVideos; CF-06xu: +1 getProductStructuredData; hq-kgno: +1 wix-data; CF-wzv8: +1 subscribeAndSave; CF-qgg0: +1 renderSimplePrice
-  'masterPage.js': 22, // CF-qgg0: +1 formatCardPrice/renderSimplePrice from productCardHelpers; CF-e2ib: +1 initAppDownloadBanner
+  'masterPage.js': 23, // CF-qgg0: +1 formatCardPrice/renderSimplePrice from productCardHelpers; CF-e2ib: +1 initAppDownloadBanner; cf-nbu4: +1 wix-storage-frontend (promo lightbox session gate)
   'Thank You Page.js': 23, // CF-2zr3: +1 getSoftPromptConfig; CF-y7lp: +2 getWhiteGloveSlots + wixLocationFrontend
 };
 

--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -105,6 +105,7 @@ import { reportMetrics } from 'backend/coreWebVitals.web';
 import { isInstalledPWA, canShowInstallPrompt } from 'public/pwaHelpers';
 import { submitContactForm } from 'backend/contactSubmissions.web';
 import { initConsentGate, fireTrackedTikTokEvent } from 'public/pixelConsentService';
+import { session as wixSession } from 'wix-storage-frontend';
 const { mockIsMobile, mockGetViewport } = vi.hoisted(() => ({
   mockIsMobile: vi.fn(() => false),
   mockGetViewport: vi.fn(() => 'desktop'),
@@ -1637,6 +1638,8 @@ describe('masterPage.js', () => {
   // ── Promotional Lightbox ──────────────────────────────────────────
 
   describe('promotional lightbox', () => {
+    afterEach(() => { wixSession.clear(); });
+
     it('populates promo lightbox when active promotion exists', async () => {
       getActivePromotion.mockResolvedValueOnce({
         _id: 'promo-1',
@@ -1728,14 +1731,13 @@ describe('masterPage.js', () => {
         products: [],
       });
       // Simulate prior dismissal via wix-storage-frontend session storage
-      globalThis.sessionStorage.setItem('promo_dismissed_promo-gate-1', '1');
+      wixSession.setItem('promo_dismissed_promo-gate-1', '1');
       vi.useFakeTimers();
       elements.clear();
       await onReadyHandler();
       vi.advanceTimersByTime(3000);
       await vi.advanceTimersByTimeAsync(100);
       expect(getEl('#promoOverlay').show).not.toHaveBeenCalled();
-      globalThis.sessionStorage.clear();
       vi.useRealTimers();
     });
 
@@ -1759,8 +1761,7 @@ describe('masterPage.js', () => {
       const overlayHandler = getEl('#promoOverlay').onClick.mock.calls[0]?.[0];
       if (overlayHandler) overlayHandler();
       await vi.advanceTimersByTimeAsync(50);
-      expect(globalThis.sessionStorage.getItem('promo_dismissed_promo-gate-2')).toBe('1');
-      globalThis.sessionStorage.clear();
+      expect(wixSession.getItem('promo_dismissed_promo-gate-2')).toBe('1');
       vi.useRealTimers();
     });
 

--- a/tests/masterPage.test.js
+++ b/tests/masterPage.test.js
@@ -1718,6 +1718,52 @@ describe('masterPage.js', () => {
       vi.useRealTimers();
     });
 
+    it('does not show lightbox when promo already dismissed this session', async () => {
+      getActivePromotion.mockResolvedValueOnce({
+        _id: 'promo-gate-1',
+        title: 'Spring Sale',
+        subtitle: 'Save 20%',
+        discountCode: 'SPRING20',
+        endDate: new Date(Date.now() + 86400000).toISOString(),
+        products: [],
+      });
+      // Simulate prior dismissal via wix-storage-frontend session storage
+      globalThis.sessionStorage.setItem('promo_dismissed_promo-gate-1', '1');
+      vi.useFakeTimers();
+      elements.clear();
+      await onReadyHandler();
+      vi.advanceTimersByTime(3000);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(getEl('#promoOverlay').show).not.toHaveBeenCalled();
+      globalThis.sessionStorage.clear();
+      vi.useRealTimers();
+    });
+
+    it('sets session dismiss key when lightbox is dismissed via close button', async () => {
+      getActivePromotion.mockResolvedValueOnce({
+        _id: 'promo-gate-2',
+        title: 'Spring Sale',
+        subtitle: 'Save 20%',
+        discountCode: 'SPRING20',
+        endDate: new Date(Date.now() + 86400000).toISOString(),
+        products: [],
+      });
+      vi.useFakeTimers();
+      elements.clear();
+      await onReadyHandler();
+      vi.advanceTimersByTime(3000);
+      await vi.waitFor(() => {
+        expect(getEl('#promoOverlay').show).toHaveBeenCalled();
+      });
+      // Simulate overlay click (dismiss)
+      const overlayHandler = getEl('#promoOverlay').onClick.mock.calls[0]?.[0];
+      if (overlayHandler) overlayHandler();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(globalThis.sessionStorage.getItem('promo_dismissed_promo-gate-2')).toBe('1');
+      globalThis.sessionStorage.clear();
+      vi.useRealTimers();
+    });
+
     it('renders promo countdown timer', async () => {
       getActivePromotion.mockResolvedValueOnce({
         _id: 'promo-4',


### PR DESCRIPTION
## Summary

- **Root cause**: `masterPage.js` used browser `sessionStorage` to gate the promotional lightbox. Wix re-initializes the master page context on each client-side page navigation, resetting `sessionStorage` and causing the lightbox to fire every time.
- **Fix**: Replace raw `sessionStorage` with `wix-storage-frontend`'s `session` scope, which Wix persists across client-side page navigations within the same browser tab — the same pattern used by `MembershipPrompt.js` and `recentlyViewed.js`.
- Removes the `typeof sessionStorage !== 'undefined'` guard (no longer needed; `wix-storage-frontend` handles availability internally).

## Test Plan

- [x] New test: lightbox suppressed when `wixSession.getItem(dismissKey)` returns truthy (prior dismissal)
- [x] New test: dismiss key written to `wixSession` on overlay click
- [x] Existing 8 promo lightbox tests continue to pass (mock wires through `globalThis.sessionStorage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)