### PR TITLE
feat(cf-0s4l): add Sustainability CMS collections to provision manifest

### DIFF
--- a/scripts/provisionCmsCollections.js
+++ b/scripts/provisionCmsCollections.js
@@ -440,7 +440,7 @@ const COLLECTION_MANIFEST = [
     displayName: 'Sustainability Story',
     fields: [
       field('heading', 'Heading', 'TEXT'),
-      field('body', 'Body', 'RICH_TEXT'),
+      field('body', 'Body', 'TEXT'),
       field('imageUrl', 'Image URL', 'URL'),
       field('imageAlt', 'Image Alt', 'TEXT'),
       field('sortOrder', 'Sort Order', 'NUMBER'),

--- a/scripts/provisionCmsCollections.js
+++ b/scripts/provisionCmsCollections.js
@@ -434,6 +434,41 @@ const COLLECTION_MANIFEST = [
     ],
     permissions: ADMIN_ONLY,
   },
+  // ── cf-0s4l Sustainability page collections ────────────────────────────────
+  {
+    id: 'SustainabilityStory',
+    displayName: 'Sustainability Story',
+    fields: [
+      field('heading', 'Heading', 'TEXT'),
+      field('body', 'Body', 'RICH_TEXT'),
+      field('imageUrl', 'Image URL', 'URL'),
+      field('imageAlt', 'Image Alt', 'TEXT'),
+      field('sortOrder', 'Sort Order', 'NUMBER'),
+    ],
+    permissions: PUBLIC_READ,
+  },
+  {
+    id: 'SustainabilityCertification',
+    displayName: 'Sustainability Certification',
+    fields: [
+      field('name', 'Name', 'TEXT'),
+      field('body', 'Body', 'TEXT'),
+      field('sortOrder', 'Sort Order', 'NUMBER'),
+    ],
+    permissions: PUBLIC_READ,
+  },
+  {
+    id: 'SustainabilityMaterial',
+    displayName: 'Sustainability Material',
+    fields: [
+      field('title', 'Title', 'TEXT'),
+      field('description', 'Description', 'TEXT'),
+      field('imageUrl', 'Image URL', 'URL'),
+      field('imageAlt', 'Image Alt', 'TEXT'),
+      field('sortOrder', 'Sort Order', 'NUMBER'),
+    ],
+    permissions: PUBLIC_READ,
+  },
   // ── cf-3qt Phase 4/5 content collections ───────────────────────────────────
   {
     id: 'Landings',

--- a/tests/provisionCmsCollections.test.js
+++ b/tests/provisionCmsCollections.test.js
@@ -32,8 +32,8 @@ function makeCollection(overrides = {}) {
 // ─── Manifest Structure ───────────────────────────────────────────────────────
 
 describe('COLLECTION_MANIFEST', () => {
-  it('should contain exactly 31 collections', () => {
-    expect(COLLECTION_MANIFEST).toHaveLength(31);
+  it('should contain exactly 34 collections', () => {
+    expect(COLLECTION_MANIFEST).toHaveLength(34);
   });
 
   it('should have unique collection IDs', () => {
@@ -358,8 +358,8 @@ describe('provisionCollections', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     const { results } = await provisionCollections({ apiKey: 'test', siteId: 'test' });
-    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(31);
-    expect(mockFetch).toHaveBeenCalledTimes(32); // 1 list + 31 creates
+    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(34);
+    expect(mockFetch).toHaveBeenCalledTimes(35); // 1 list + 34 creates
   });
 
   it('should respect dryRun flag', async () => {
@@ -380,7 +380,7 @@ describe('provisionCollections', () => {
 
     const { results } = await provisionCollections({ apiKey: 'test', siteId: 'test' });
     expect(results.filter((r) => r.status === 'ERROR')).toHaveLength(1);
-    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(30);
+    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(33);
   });
 
   it('should send correct request body structure to Wix API', async () => {
@@ -456,8 +456,8 @@ describe('provisionCollections', () => {
 
     const { results } = await provisionCollections({ apiKey: 'test', siteId: 'test' });
     expect(results.filter((r) => r.status === 'EXISTS')).toHaveLength(8);
-    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(23);
-    expect(results).toHaveLength(31);
+    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(26);
+    expect(results).toHaveLength(34);
   });
 
   it('should guard res.text() failure in error path', async () => {

--- a/tests/scripts/provisionCmsCollections.test.js
+++ b/tests/scripts/provisionCmsCollections.test.js
@@ -42,8 +42,8 @@ function getFieldKeys(id) {
 // ─── Manifest Structure ───────────────────────────────────────────────────────
 
 describe('COLLECTION_MANIFEST', () => {
-  it('should contain exactly 31 collections', () => {
-    expect(COLLECTION_MANIFEST).toHaveLength(31);
+  it('should contain exactly 34 collections', () => {
+    expect(COLLECTION_MANIFEST).toHaveLength(34);
   });
 
   it('should have unique collection IDs', () => {
@@ -457,15 +457,15 @@ describe('provisionCollections', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('should create all 31 missing collections', async () => {
+  it('should create all 34 missing collections', async () => {
     const mockFetch = vi.fn()
       .mockResolvedValueOnce(mockListResponse([]))
       .mockResolvedValue(mockCreateSuccess());
     vi.stubGlobal('fetch', mockFetch);
 
     const { results } = await provisionCollections({ apiKey: 'test', siteId: 'test' });
-    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(31);
-    expect(mockFetch).toHaveBeenCalledTimes(32); // 1 list + 31 creates
+    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(34);
+    expect(mockFetch).toHaveBeenCalledTimes(35); // 1 list + 34 creates
   });
 
   it('should respect dryRun flag', async () => {
@@ -486,7 +486,7 @@ describe('provisionCollections', () => {
 
     const { results } = await provisionCollections({ apiKey: 'test', siteId: 'test' });
     expect(results.filter((r) => r.status === 'ERROR')).toHaveLength(1);
-    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(30);
+    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(33);
   });
 
   it('should handle mixed existing and missing collections', async () => {
@@ -498,8 +498,8 @@ describe('provisionCollections', () => {
 
     const { results } = await provisionCollections({ apiKey: 'test', siteId: 'test' });
     expect(results.filter((r) => r.status === 'EXISTS')).toHaveLength(10);
-    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(21);
-    expect(results).toHaveLength(31);
+    expect(results.filter((r) => r.status === 'CREATED')).toHaveLength(24);
+    expect(results).toHaveLength(34);
   });
 
   it('should throw when apiKey or siteId is missing', async () => {


### PR DESCRIPTION
## Summary

- Adds `SustainabilityStory`, `SustainabilityCertification`, and `SustainabilityMaterial` to `COLLECTION_MANIFEST` in `scripts/provisionCmsCollections.js`
- All three use `PUBLIC_READ` (editorial content, anonymous read)
- Field schemas match the TypeScript types in `src/app/sustainability/page.tsx` (cf-isno / PR #301)
- `SustainabilityStory.body` is `TEXT` (not `RICH_TEXT`) — page renders body as a plain React child; Wix RICH_TEXT returns a DraftJS object that would display as `[object Object]`
- Test count assertions updated to 34 collections

## Context

The `/sustainability` page (PR #301) already calls `listCollectionItems()` for these three collections with static fallbacks for when the collections don't exist. This manifest change enables `--provision` to create the collections in Wix so editors can populate content without a deploy.

**Note:** `SustainabilityStory` includes an `imageUrl` field in the schema, but `page.tsx` does not yet render story images (uses a placeholder div). That's a pre-existing gap in the page code — tracked separately.

## Test plan

- [x] `node scripts/provisionCmsCollections.js --manifest` — three Sustainability collections appear in output
- [x] `node -e "const {validateManifest,COLLECTION_MANIFEST}=require('./scripts/provisionCmsCollections.js'); const r=validateManifest(COLLECTION_MANIFEST); console.log(r.valid)"` — prints `true`
- [x] 169 vitest tests pass (both `tests/provisionCmsCollections.test.js` and `tests/scripts/provisionCmsCollections.test.js`)
- [ ] Once WIX_API_KEY + WIX_SITE_ID are available: `node scripts/provisionCmsCollections.js --status` shows the three collections as missing (expected), `--provision` creates them

🤖 Generated with [Claude Code](https://claude.com/claude-code)