### PR TITLE
fix(cf-foo0): preserve sizeOfInterest in contactSubmissions HTTP wrapper

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -2624,6 +2624,19 @@ export async function get_weeklyBlogDigestCron(request) {
 // CORS allowlist (see backend/utils/cors): prod Vercel domain,
 // project-scoped Vercel domain, branch preview URLs, localhost dev.
 
+// Whitelist of accepted bed sizes — mirrors cfw `BedSize` type
+// (src/lib/contact/contact-schema.ts). The wrapper rejects any other value
+// silently (treats it as if `sizeOfInterest` were absent) so a malicious
+// client can't smuggle arbitrary text into the subject prefix.
+const SIZE_OF_INTEREST_WHITELIST = new Set(['twin', 'full', 'queen', 'king']);
+
+// sendEmail caps the subject at 300 chars via validateSchema. The size prefix
+// (`[Size: queen] ` = 14 chars max) plus a max-length subject would exceed
+// that cap and fail validation — the user would see a generic 400. Truncate
+// the combined subject so the prefix is preserved end-to-end and only the
+// trailing user copy is clipped if necessary.
+const SUBJECT_MAX_LEN = 300;
+
 /**
  * @function post_contactSubmissions
  * @route POST /_functions/contactSubmissions
@@ -2633,12 +2646,22 @@ export async function get_weeklyBlogDigestCron(request) {
  * @param {string} [request.body.json.phone] — optional, ≤20 chars
  * @param {string} [request.body.json.subject] — optional, ≤300 chars
  * @param {string} request.body.json.message — required, ≤2000 chars
+ * @param {('twin'|'full'|'queen'|'king')} [request.body.json.sizeOfInterest]
+ *   — optional bed size from cfw contact form size radio. When present, the
+ *   wrapper prepends `[Size: <value>] ` to the subject so the store sees it
+ *   in the triggered email + ContactSubmissions CMS row. Anything outside
+ *   the whitelist is silently dropped.
  * @returns {Promise<{status: number, body: string, headers: object}>}
  *   200 { success: true } on send;
  *   400 { success: false, error } on validation;
  *   429 { success: false, error } on per-email rate limit (3/hour);
  *   500 { success: false, error } on transport failure or sendEmail
  *   returning a non-object (webMethod proxy fault).
+ *
+ * Field passthrough audit (cfw `ContactRequest` ↔ this wrapper):
+ *   name, email, phone, subject, message — forwarded as-is to sendEmail.
+ *   sizeOfInterest                       — folded into the subject prefix.
+ *   No other cfw fields are silently dropped.
  */
 export async function post_contactSubmissions(request) {
   const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
@@ -2652,13 +2675,19 @@ export async function post_contactSubmissions(request) {
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
-    // cfw ContactRequest carries an optional `sizeOfInterest` (twin/full/queen/king)
-    // from the contact form size radio. sendEmail's signature has no first-class
-    // size field, so prepend it to the subject so the store sees it in the
-    // triggered-email body and the ContactSubmissions CMS row.
+    // sendEmail has no first-class size field, so fold sizeOfInterest into
+    // the subject. Whitelist values (see SIZE_OF_INTEREST_WHITELIST above)
+    // — unknown sizes are silently dropped to avoid prefix smuggling. The
+    // combined subject is truncated to SUBJECT_MAX_LEN so it never trips
+    // sendEmail's validateSchema cap.
     const rawSubject = typeof body.subject === 'string' ? body.subject : '';
-    const size = typeof body.sizeOfInterest === 'string' ? body.sizeOfInterest.trim() : '';
-    const subject = size ? `[Size: ${size}] ${rawSubject}`.trim() : rawSubject;
+    const sizeRaw = typeof body.sizeOfInterest === 'string'
+      ? body.sizeOfInterest.trim().toLowerCase()
+      : '';
+    const size = SIZE_OF_INTEREST_WHITELIST.has(sizeRaw) ? sizeRaw : '';
+    const subject = size
+      ? `[Size: ${size}] ${rawSubject}`.trim().slice(0, SUBJECT_MAX_LEN)
+      : rawSubject;
 
     const result = await sendEmail({
       name: body.name,

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -2652,11 +2652,19 @@ export async function post_contactSubmissions(request) {
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
+    // cfw ContactRequest carries an optional `sizeOfInterest` (twin/full/queen/king)
+    // from the contact form size radio. sendEmail's signature has no first-class
+    // size field, so prepend it to the subject so the store sees it in the
+    // triggered-email body and the ContactSubmissions CMS row.
+    const rawSubject = typeof body.subject === 'string' ? body.subject : '';
+    const size = typeof body.sizeOfInterest === 'string' ? body.sizeOfInterest.trim() : '';
+    const subject = size ? `[Size: ${size}] ${rawSubject}`.trim() : rawSubject;
+
     const result = await sendEmail({
       name: body.name,
       email: body.email,
       phone: body.phone,
-      subject: body.subject,
+      subject,
       message: body.message,
     });
 

--- a/tests/httpFunctionsCoverage.test.js
+++ b/tests/httpFunctionsCoverage.test.js
@@ -1008,6 +1008,39 @@ describe('post_contactSubmissions', () => {
     expect(log[0].contactId).toBe('owner-1');
   });
 
+  it('prepends [Size: <sizeOfInterest>] to the subject so the store sees it', async () => {
+    const result = await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Frame question',
+          message: 'Do you have queen futons in stock?',
+          sizeOfInterest: 'queen',
+        }),
+      }),
+    );
+    expect(result.status).toBe(200);
+    const log = crmEmailLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].options.variables.subject).toBe('[Size: queen] Frame question');
+  });
+
+  it('omits the size prefix when sizeOfInterest is absent', async () => {
+    await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Frame question',
+          message: 'Hello',
+        }),
+      }),
+    );
+    const log = crmEmailLog();
+    expect(log[0].options.variables.subject).toBe('Frame question');
+  });
+
   it('returns 429 when sendEmail surfaces a rate-limit message', async () => {
     // 4th submission within the 1-hour window trips _checkEmailRateLimit
     // (max 3 — see emailService.web.js EMAIL_RATE_LIMIT_MAX).

--- a/tests/httpFunctionsCoverage.test.js
+++ b/tests/httpFunctionsCoverage.test.js
@@ -11,6 +11,7 @@ import {
   __seed,
   __setQueryError,
   __setInsertError,
+  __getInserted,
 } from './__mocks__/wix-data.js';
 import { __setSecrets } from './__mocks__/wix-secrets-backend.js';
 import {
@@ -1039,6 +1040,80 @@ describe('post_contactSubmissions', () => {
     );
     const log = crmEmailLog();
     expect(log[0].options.variables.subject).toBe('Frame question');
+  });
+
+  it('persists the prefixed subject on the ContactSubmissions CMS row', async () => {
+    __seed('ContactSubmissions', []);
+    await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Mattress recommendation',
+          message: 'Looking for a queen-size mattress for daily sleep.',
+          sizeOfInterest: 'queen',
+        }),
+      }),
+    );
+    const rows = __getInserted('ContactSubmissions');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].subject).toBe('[Size: queen] Mattress recommendation');
+  });
+
+  it('truncates the combined subject at the 300-char cap (no validation 400)', async () => {
+    // sendEmail.validateSchema rejects subject >300 chars. With a max-length
+    // raw subject, the prefix would push the total to 314 — would 400 if
+    // not truncated. Verify happy 200 + truncation preserves the prefix.
+    const longSubject = 'x'.repeat(300);
+    const result = await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: longSubject,
+          message: 'Hello',
+          sizeOfInterest: 'queen',
+        }),
+      }),
+    );
+    expect(result.status).toBe(200);
+    const log = crmEmailLog();
+    expect(log[0].options.variables.subject.length).toBe(300);
+    expect(log[0].options.variables.subject.startsWith('[Size: queen] ')).toBe(true);
+  });
+
+  it('drops sizeOfInterest values outside the {twin,full,queen,king} whitelist', async () => {
+    // Defensive: don't let a non-cfw caller smuggle arbitrary text into the
+    // subject prefix. Anything not in the whitelist is treated as absent.
+    await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Question',
+          message: 'Hi',
+          sizeOfInterest: '<script>alert(1)</script>',
+        }),
+      }),
+    );
+    const log = crmEmailLog();
+    expect(log[0].options.variables.subject).toBe('Question');
+  });
+
+  it('normalises sizeOfInterest casing/whitespace before applying the whitelist', async () => {
+    await post_contactSubmissions(
+      buildReq({
+        body: JSON.stringify({
+          name: 'Stilgar',
+          email: 'stilgar@example.com',
+          subject: 'Question',
+          message: 'Hi',
+          sizeOfInterest: '  Queen  ',
+        }),
+      }),
+    );
+    const log = crmEmailLog();
+    expect(log[0].options.variables.subject).toBe('[Size: queen] Question');
   });
 
   it('returns 429 when sendEmail surfaces a rate-limit message', async () => {


### PR DESCRIPTION
## Summary

Per @melania review on the Velo PR (DreadPirateRobertz/carolina-futons-stage3-velo#15): the cfw `ContactRequest` carries an optional `sizeOfInterest` (twin/full/queen/king) from the contact form's size radio, and `post_contactSubmissions` was silently dropping it before calling `sendEmail`. Store needs to see size in their inbox so they can respond meaningfully.

**Fix:** when `sizeOfInterest` is a non-empty string, prepend `[Size: <value>] ` to the subject. `sendEmail` has no first-class size field, but the subject flows through to both the triggered email body (Wix Triggered Email variable) and the ContactSubmissions CMS row.

## Tests

`tests/httpFunctionsCoverage.test.js` — added 2 cases in the `post_contactSubmissions` describe block:
- `prepends [Size: <sizeOfInterest>] to the subject so the store sees it` — asserts `crmEmailLog()[0].options.variables.subject === '[Size: queen] Frame question'`
- `omits the size prefix when sizeOfInterest is absent` — backstops the conditional

All 10 `post_contactSubmissions` tests pass locally (`vitest run -t 'post_contactSubmissions'`).

## Companion PR

The Velo deploy repo (`carolina-futons-stage3-velo`) has the same one-liner amended onto its open PR #15. They must land together for the fix to take effect — the cfutons monorepo edit alone won't reach production until the velo repo publishes via Wix CLI.

## Out of scope (per melania)

- (2) phone-length cap mismatch (cfw uncapped vs backend 20 char) — file as cfw-* follow-up bead.
- (3) standalone wrapper test (this PR adds 2 in the existing coverage file; if a separate file is preferred, follow-up).

Closes follow-up review on cf-foo0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)