### PR TITLE
fix(cf-jmmk): wire wixEcom_onOrderDelivered in events.js (P0)

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -257,11 +257,14 @@ export function wixEcom_onFulfillmentCreated(event) {
 }
 
 /**
- * Triggered when an order is marked as delivered.
- * Sends a delivery confirmation email and queues the post-purchase care sequence.
- * Trigger for CF-nkau Day 3/7/30 drip: starts countdown from actual delivery date.
+ * Order-delivered fan-out: confirmation email, post-purchase care sequence,
+ * Day-14 review reward prompt, and NPS survey.
+ *
+ * cf-jmmk: Wix only fires events from events.js, so the Wix-shaped wrapper
+ * lives there and delegates to this helper. Each downstream call catches
+ * its own error so a single failure can't drop the others.
  */
-export function wixEcom_onOrderDelivered(event) {
+export function handleOrderDelivered(event) {
   const order = event.entity || event;
   const email = order.buyerInfo?.email || '';
   const firstName = order.billingInfo?.firstName || order.buyerInfo?.firstName || '';
@@ -277,12 +280,12 @@ export function wixEcom_onOrderDelivered(event) {
     email,
     firstName,
     orderNumber: String(orderNumber),
-  }).catch(err => logError('wixEcom_onOrderDelivered:confirmation', err));
+  }).catch(err => logError('handleOrderDelivered:confirmation', err));
 
   // CF-nkau: Queue post-purchase care sequence starting from delivery date
   // Day 3: care guide, Day 7: review request, Day 30: cross-sell recommendations
   triggerPostPurchaseSequence(contactId, email, firstName, String(orderNumber), total, lineItems)
-    .catch(err => logError('wixEcom_onOrderDelivered:postPurchaseCare', err));
+    .catch(err => logError('handleOrderDelivered:postPurchaseCare', err));
 
   // CF-qy79: Queue Day-14 review prompt with points reward
   const productNames = lineItems
@@ -291,7 +294,7 @@ export function wixEcom_onOrderDelivered(event) {
     .join(', ');
   const primarySlug = extractPrimarySlug(lineItems);
   triggerReviewRewardPrompt(contactId, email, firstName, String(orderNumber), productNames, primarySlug)
-    .catch(err => logError('wixEcom_onOrderDelivered:reviewReward', err));
+    .catch(err => logError('handleOrderDelivered:reviewReward', err));
 
   // CF-1mlj: Queue 7-day NPS survey — fires after delivery, non-fatal
   scheduleSurvey({
@@ -299,8 +302,16 @@ export function wixEcom_onOrderDelivered(event) {
     orderId: order._id || String(orderNumber),
     email,
     deliveredAt: new Date(),
-  }).catch(err => logError('wixEcom_onOrderDelivered:survey', err));
+  }).catch(err => logError('handleOrderDelivered:survey', err));
 }
+
+/**
+ * @deprecated Wix events only dispatch from events.js — this name remains
+ * exported so existing unit tests that imported the function directly still
+ * work. New code should call `handleOrderDelivered` (and prod dispatch goes
+ * through events.js#wixEcom_onOrderDelivered).
+ */
+export const wixEcom_onOrderDelivered = handleOrderDelivered;
 
 /**
  * Triggered when an order is cancelled.

--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -363,6 +363,23 @@ export async function wixEcom_onOrderFulfilled(event) {
 }
 
 /**
+ * Fired when an order is marked as delivered.
+ * Delegates to emailAutomation for delivery confirmation, post-purchase care
+ * sequence, Day-14 review reward, and NPS survey scheduling.
+ *
+ * cf-jmmk: previously defined only in emailAutomation.web.js, which Wix never
+ * dispatched events to (events.js is the only event-handler entry point).
+ */
+export async function wixEcom_onOrderDelivered(event) {
+  try {
+    const { handleOrderDelivered } = await import('backend/emailAutomation.web');
+    handleOrderDelivered(event);
+  } catch (err) {
+    console.error('[events] Error handling order delivered:', err);
+  }
+}
+
+/**
  * Fired when an order is cancelled.
  * Delegates to emailAutomation to cancel pending post-purchase care emails.
  */

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -10,11 +10,13 @@ const mockTriggerRestockNotifications = vi.fn().mockResolvedValue({ success: tru
 const mockTriggerWelcomeSequence = vi.fn().mockResolvedValue({ success: true, queued: 3 });
 const mockTriggerPostPurchaseSequence = vi.fn().mockResolvedValue({ success: true, queued: 3 });
 const mockCancelSequenceForOrder = vi.fn().mockResolvedValue({ success: true, cancelled: 1 });
+const mockHandleOrderDelivered = vi.fn();
 vi.mock('backend/emailAutomation.web', () => ({
   triggerRestockNotifications: mockTriggerRestockNotifications,
   triggerWelcomeSequence: mockTriggerWelcomeSequence,
   triggerPostPurchaseSequence: mockTriggerPostPurchaseSequence,
   cancelSequenceForOrder: mockCancelSequenceForOrder,
+  handleOrderDelivered: mockHandleOrderDelivered,
 }));
 
 vi.mock('backend/utils/sanitize', () => ({
@@ -41,6 +43,7 @@ import {
   wixEcom_onOrderCreated,
   wixEcom_onOrderCanceled,
   wixEcom_onOrderApproved,
+  wixEcom_onOrderDelivered,
 } from '../src/backend/events.js';
 
 beforeEach(() => {
@@ -469,6 +472,50 @@ describe('wixEcom_onOrderCanceled', () => {
         entity: { number: 'ORD-ERR', buyerInfo: { email: 'err@test.com' } },
       })
     ).resolves.not.toThrow();
+  });
+});
+
+// ── wixEcom_onOrderDelivered (cf-jmmk) ──────────────────────────────
+
+describe('wixEcom_onOrderDelivered (cf-jmmk)', () => {
+  it('delegates to handleOrderDelivered with the dispatched event', async () => {
+    const event = {
+      entity: {
+        number: 'ORD-D-1',
+        buyerInfo: { email: 'buyer@test.com', contactId: 'cid-1' },
+        billingInfo: { firstName: 'Buyer' },
+        lineItems: [{ name: 'Eureka Futon', slug: 'eureka' }],
+        priceSummary: { total: { amount: 549 } },
+      },
+    };
+
+    await wixEcom_onOrderDelivered(event);
+
+    expect(mockHandleOrderDelivered).toHaveBeenCalledTimes(1);
+    expect(mockHandleOrderDelivered).toHaveBeenCalledWith(event);
+  });
+
+  it('does not throw when handleOrderDelivered throws', async () => {
+    mockHandleOrderDelivered.mockImplementationOnce(() => {
+      throw new Error('downstream broken');
+    });
+
+    await expect(
+      wixEcom_onOrderDelivered({
+        entity: { number: 'ORD-D-ERR', buyerInfo: { email: 'err@test.com' } },
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it('still delegates when buyer email is empty (handler decides whether to skip)', async () => {
+    // Skipping is the helper's responsibility — events.js delegates regardless
+    // so a stricter helper rule (e.g. anonymized memberId-only orders) doesn't
+    // require an events.js change.
+    await wixEcom_onOrderDelivered({
+      entity: { number: 'ORD-D-NOEMAIL', buyerInfo: {} },
+    });
+
+    expect(mockHandleOrderDelivered).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Bug
Three transactional emails depended on \`wixEcom_onOrderDelivered\` — none fired in production:
- \`delivery_confirmation\` — sent on order delivered
- \`post_purchase_review_reward\` (Day-14 cron)
- NPS survey (chained off delivery)

Root cause (per cf-icww audit): the handler was defined ONLY in \`src/backend/emailAutomation.web.js\`. Wix dispatches events exclusively from \`events.js\`.

## Fix
- Add \`wixEcom_onOrderDelivered\` to \`events.js\`, delegating to the helper via dynamic import (same pattern as \`wixEcom_onOrderCanceled\`).
- Rename the helper from \`wixEcom_onOrderDelivered\` to \`handleOrderDelivered\` in \`emailAutomation.web.js\` so the role is unambiguous.
- Keep \`wixEcom_onOrderDelivered\` as a deprecated alias re-export so the 3 existing direct-import test files (cf-1mlj-survey-email-trigger / cf-nkau-post-purchase-care / transactionalEmailAudit) continue to pass without churn.

## Tests
- 3 new cases in \`tests/events.test.js\`:
  1. delegates to \`handleOrderDelivered\` with the dispatched event
  2. swallows downstream throws (does not break Wix dispatch)
  3. delegates regardless of buyer email (skip logic stays in helper)
- 94 existing tests across cf-1mlj / cf-nkau / transactionalEmailAudit / emailAutomation still pass

## Acceptance
- [x] events.js#wixEcom_onOrderDelivered dispatches delivery_confirmation immediately + schedules Day-14 + NPS (all chained inside handleOrderDelivered, covered by the existing helper-level tests)
- [x] Dead handler relocated (alias retained for test backward compat)
- [x] Unit test covers all 3 chained outcomes (via existing helper tests + new delegation tests)
- [x] No new errors

## Refs
Bead: cf-jmmk (P0). Audit: docs/email-audit-2026-05-04.md (F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)