### PR TITLE
docs(cf-qdxi): EDITOR_HOOKUP_GUIDE v4.5 → v4.6 — post-cf-3qt session refresh

### DIFF
--- a/EDITOR-HOOKUP-GUIDE.md
+++ b/EDITOR-HOOKUP-GUIDE.md
@@ -1,6 +1,6 @@
 # Editor Hookup Guide — Element ID Map & Manual Work Queue
 
-**Generated**: 2026-03-15 | **Last Updated**: 2026-04-17 (v4.5 — CMS collections 32→36: added Landings, PressMentions, PressKitAssets, ComparisonFeatures to provisioning manifest + setup guide for cf-3qt Phase 4/5 migration. Dashboard needed: provision 4 new collections on STAGING_SITE (cf-3qt). Previous: v4.4 — CMS collections 28→32: added PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog. v4.3 — Phase 8 COMPLETE. v4.2 — Night shift 5 merges.)
+**Generated**: 2026-03-15 | **Last Updated**: 2026-05-05 (v4.6 — Post-cf-3qt session refresh: (a) confirmed PushTokens / SpinGrants / MobileChallengeCompletions / CrossRigSyncLog present on STAGING_SITE per Wix Data API verification 2026-05-05; (b) flagged cf-c6g5 — STAGING_SITE Triggered Emails dashboard is empty, 20 templates need batch-copy from prod, all email touchpoints currently 500; (c) added Diagnostic Endpoints section (`/_functions/contactSubmissionsDiagnostic`, /api/auth/diag pending quartz); (d) added Repo Drift lessons from cf-w1lg (cfutons monorepo ↔ carolina-futons-stage3-velo divergence — cfw → Velo HTTP calls 404 until publish); (e) Hookup-coverage snapshot from cf-ah0m + cf-o2kq parity audit: 255 features, 201✓ / 28~ / 25✗ / 1?; (f) Phase 8 cutover prep link. Previous: v4.5 — CMS collections 32→36: added Landings, PressMentions, PressKitAssets, ComparisonFeatures (cf-3qt Phase 4/5). v4.4 — CMS 28→32: PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog. v4.3 — Phase 8 COMPLETE. v4.2 — Night shift 5 merges.)
 **Purpose**: Persistent reference for wiring Wix Studio editor elements to Velo code
 **Approach**: Skeleton-first — place elements with correct IDs, code + CSS + CMS handle the rest
 
@@ -21,7 +21,8 @@ All required dashboard/API configurations are now in place for editor hookup:
 | **UPS carrier** | CONFIGURED | Live rates + $49.99 fallback |
 | **Local Pickup** | CONFIGURED | $0 (Hendersonville showroom) |
 | **Local Delivery** | CONFIGURED | $49.99 flat rate |
-| **CMS collections** | 36 TOTAL | 32 provisioned on staging; cf-3qt adds Landings, PressMentions, PressKitAssets, ComparisonFeatures (manifest updated; dashboard provisioning pending) |
+| **CMS collections** | 36 TOTAL | 36 confirmed on STAGING_SITE 2026-05-05 — earlier 4 (PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog) verified via Wix Data API; cf-3qt 4 (Landings, PressMentions, PressKitAssets, ComparisonFeatures) confirmed too. Dashboard provisioning complete. |
+| **Triggered Emails** | EMPTY | ⚠️ STAGING_SITE dashboard has NO sender + NO templates (cf-c6g5). 20 templates need batch-copy from prod by Stilgar. Every `triggeredEmails.emailContact()` call → 500. Blocks contact form, welcome series, order/shipping/delivery confirms, abandoned cart, re-engagement, NPS, swatch confirm. See "Triggered Email Templates Required (cf-c6g5)" below. |
 | **Back In Stock** | BLOCKED | API returns NOT_SUPPORTED — needs manual dashboard toggle |
 | **Wix Payments** | CONNECTED | Credit/Debit, Apple Pay, Google Pay, PayPal, Afterpay, Affirm — activates at Premium upgrade |
 | **Manual Payments** | CONNECTED | In-store cash/check at Hendersonville showroom |
@@ -82,6 +83,157 @@ All write endpoints with `Permissions.Anyone` are rate-limited using the shared 
 | `TrackingRateLimit` | `subscribeToNotifications` | 5/hr per email |
 
 **Security fix applied (v1.0.0)**: Anonymous bucket DoS vector was patched — rate limit keys now use the caller's email/memberId, never `'anonymous'` as a fallback that creates a shared bucket across all callers.
+
+---
+
+## 📨 Triggered Email Templates Required (cf-c6g5 — added 2026-05-05)
+
+> **Status (2026-05-05)**: STAGING_SITE Wix Studio Dashboard → Triggered Emails is **EMPTY**. No sender, no templates. Every `triggeredEmails.emailContact()` call resolves to *"Not Found: the requested item no longer exists"* and the Velo wrapper turns that into 500. The contact form, every welcome / order / shipping / delivery email, abandoned-cart, browse-recovery, re-engagement, NPS, post-purchase, swatch-confirmation, and recovery-discount flows are all silently broken on staging behind 500s.
+>
+> **Fix path (preferred)**: Stilgar logs into PROD `carolinafutons.com` Wix Studio dashboard → Triggered Emails → exports each template (or copies HTML + variables) → recreates on STAGING_SITE. ~30–60 min manual work.
+>
+> **Verify**: godfrey's `/_functions/contactSubmissionsDiagnostic` (see Diagnostic Endpoints section below) returns `{ ok: true }` on both schema-validate + emailContact steps.
+
+### 20 templates needed (batch-copy from prod)
+
+| # | Template ID | Purpose / Trigger |
+|---|---|---|
+| 1 | `contact_form_submission` | Owner notification for /contact form (also linked to swatch request) |
+| 2 | `welcome_series_1` | Member onboarding step 1 (`wixMembers_onMemberCreated`) |
+| 3 | `welcome_series_2` | Member onboarding step 2 (T+1 day) |
+| 4 | `welcome_series_3` | Member onboarding step 3 (T+3 day) |
+| 5 | `welcome_series_4` | Member onboarding step 4 (T+7 day) |
+| 6 | `welcome_series_5` | Member onboarding step 5 (T+14 day) |
+| 7 | `order_confirmation` | Buyer confirmation (`wixEcom_onOrderCreated`) |
+| 8 | `order_shipped` | Parcel/UPS shipping notification |
+| 9 | `freight_shipped` | LTL freight shipping notification (PRO number) |
+| 10 | `delivery_confirmation` | `wixEcom_onOrderDelivered` |
+| 11 | `post_purchase_review_reward` | Day-14 review-and-earn-points |
+| 12 | `nps_survey` | Post-purchase NPS prompt |
+| 13 | `swatch_confirmation` | Customer confirmation for swatch requests |
+| 14 | `abandoned_cart_recovery` | `cartRecoveryService.web` — coupon + cart-restore link |
+| 15 | `browse_recovery` | Anonymous browse-recovery flow |
+| 16 | `reengagement_1` | Inactive-member re-engagement step 1 |
+| 17 | `reengagement_2` | Re-engagement step 2 |
+| 18 | `reengagement_3` | Re-engagement step 3 |
+| 19 | `post_purchase_care` | Care-guide nudge ~T+30 day |
+| 20 | `recovery_discount` | Last-chance discount in re-engagement chain |
+
+### Required template variables (intersection across templates)
+
+`customerName` · `customerEmail` · `customerPhone` · `subject` · `message` · `submittedAt` · `firstName` · `orderNumber` · `total` · `itemSummary` · `itemCount` · `estimatedDays` · `trackingNumber` · `trackingUrl` · `proNumber` · `carrier` · `productName` · `swatchList` · `estimatedArrival` · `couponCode` · `cartRestoreUrl`
+
+### Sender configuration
+
+Sender email: `carolinafutons@gmail.com` (preferred) or `noreply@carolinafutons.com` (if SPF/DKIM are configured for that subdomain).
+
+### Acceptance
+
+- [ ] Sender configured on STAGING_SITE
+- [ ] All 20 templates created + published with the variables above
+- [ ] `contactSubmissionsDiagnostic` returns `{ ok: true }` on both steps
+- [ ] cfw end-to-end against staging: contact form, newsletter, swatch request all return 200 + email arrives at `halworker85+test@gmail.com`
+
+---
+
+## 🩺 Diagnostic Endpoints (added 2026-05-05)
+
+Self-rotating diagnostic endpoints used by godfrey + quartz to verify infra health from the cfw side without touching the dashboard.
+
+| Endpoint | Repo | Purpose | Status |
+|---|---|---|---|
+| `/_functions/contactSubmissionsDiagnostic` | `carolina-futons-stage3-velo` (Velo) | Two-step probe: (1) schema-validate a fixture payload through `validateContactRequest` + `validateSchema`; (2) attempt `triggeredEmails.emailContact('contact_form_submission', siteOwnerContactId, { variables: fixture })` and report the raw error. Output is JSON with `{ ok, step, error? }`. | Live; currently fails on step 2 — see cf-c6g5. |
+| `/api/auth/diag` | `carolina-futons-web` (Next.js) | Verify the Wix Members auth flow (member-create → JWT → CRM lookup) without exercising the UI. Returns `{ ok, member: { _id, loginEmail }, jwt: { iss, exp } }`. | **Pending quartz ship.** |
+
+### Self-rotating tokens
+
+Both endpoints are guarded by a per-environment static token (`DIAG_TOKEN`) that is rotated weekly from the GitHub Actions secret store. Caller passes `?token=<value>` (Velo) or `Authorization: Bearer <value>` (Next.js).
+
+- Token rotation cadence: every Sunday 00:00 UTC, automated via the `rotate-diag-tokens.yml` workflow (cf-quartz).
+- Old + new token both accepted for a 24-hour overlap window so in-flight CI runs don't break.
+- On rotation, GH secret `DIAG_TOKEN_CFW` is updated; Vercel and Wix env vars are updated by the workflow's deploy step.
+
+### Self-test invocation
+
+```bash
+# Velo diagnostic (cf-foo0 / cf-c6g5 verification)
+curl -sS "https://chrisdealglass.wixstudio.com/my-site/_functions/contactSubmissionsDiagnostic?token=$DIAG_TOKEN_CFW" | jq
+
+# Next.js auth diagnostic (when quartz ships)
+curl -sS -H "Authorization: Bearer $DIAG_TOKEN_CFW" \
+  https://carolina-futons-web.vercel.app/api/auth/diag | jq
+```
+
+---
+
+## 🔀 Repo Drift Lessons — cfutons monorepo ↔ stage3-velo (cf-w1lg, added 2026-05-05)
+
+> **Lesson**: We have **two** repos that look like Velo source. Only one publishes to the live site. They drift, and every drift becomes a 404 or a stale handler in production.
+
+### Topology
+
+| Repo | Role | Wix CLI publish? |
+|---|---|---|
+| [`DreadPirateRobertz/carolina-futons`](https://github.com/DreadPirateRobertz/carolina-futons) | cfutons monorepo (this repo) — Velo source-of-truth, plus all docs, audit reports, parity manifests, ops runbooks | **No** |
+| [`DreadPirateRobertz/carolina-futons-stage3-velo`](https://github.com/DreadPirateRobertz/carolina-futons-stage3-velo) | Wix CLI deploy target — what `wix preview` and `wix publish` actually read | **Yes** |
+
+### What goes wrong
+
+When a `/_functions/<name>` HTTP function or a `*.web.js` webMethod is added to the cfutons monorepo and not mirrored into stage3-velo, the cfw Next.js app hits a **404** from the live Velo URL — even though the code "exists". Symptoms:
+
+- `POST /_functions/contactSubmissions` → 404 → cfw `/contact` shows generic transport error (cf-foo0, cf-9ieq)
+- `POST /_functions/sampleRequests` → 404 → swatch-request flow fails silently
+- `POST /_functions/mailingListSignups` → 404 → newsletter footer "couldn't sign up"
+- `GET /_functions/deliveryZone` → 404 → PDP delivery estimator shows fallback band
+- `GET /_functions/unsubscribe` → 404 → 1-click email unsubscribe broken
+
+### Convergence in flight
+
+- **PR #15** on `carolina-futons-stage3-velo`: ports `post_contactSubmissions` + `backend/utils/cors.js` (cf-foo0). Reviewed; awaiting Stilgar Wix Publish.
+- **`fix/cf-w1lg-velo-convergence-4-endpoints`** branch: ports the remaining 4 (`sampleRequests`, `mailingListSignups`, `deliveryZone`, `unsubscribe`). Stacked on top of #15.
+- After both publish, drift backlog is empty and we have clean parity for the contact / swatch / newsletter / delivery-zone / unsubscribe surfaces.
+
+### Standing rule
+
+Every PR that touches `src/backend/http-functions.js` or `src/backend/*.web.js` in the cfutons monorepo MUST also produce a stage3-velo PR before it counts as "merged" for cfw consumers. CI gate proposed in cf-w1lg follow-up.
+
+### Long-term
+
+Investigate publishing from the cfutons monorepo directly so there's only one source-of-truth. Tracked in cf-3qt Phase 9 follow-up.
+
+---
+
+## 📊 Hookup Coverage Snapshot — cfw vs Wix Editor (cf-ah0m / cf-o2kq, 2026-05-05)
+
+Automated parity audit of THIS guide vs `https://carolina-futons-web.vercel.app/`. Source: `cfw-parity-audit-2026-05-04.md` (PR #1139, v2 commit `0a288781`).
+
+| | count | % |
+|---|---:|---:|
+| ✓ feature present in cfw | 201 | 78.8% |
+| ~ partial / ambiguous | 28 | 11.0% |
+| ✗ no cfw evidence | 25 | 9.8% |
+| ? unknown / out-of-scope | 1 | 0.4% |
+| **total parsed from this guide** | **255** | 100% |
+
+**Page-level 404s on cfw (guide enumerates, no Vercel route):**
+`/wishlist`, `/wishlist-share`, `/price-match-guarantee`, `/fabric-swatches`, `/sign-in`. Each needs a deprecate-or-rebuild decision before Wix Editor retirement.
+
+**Forward-drift (cfw has, guide doesn't mention):** 18 `data-slot` values, 20 `data-testid` values, 60 component basenames. Largest clusters: mascot scenes (StargazingHero, MascotFooterDivider, FogScene, FallsScene, EasterEggBear), analytics tags (GA4Tag, MetaPixel, PinterestTag, ConsentMode), PDP add-ons (PdpComfortBand, PdpNotifyMe, PdpInteractive), MegaMenu, page-transition.
+
+The audit scripts live in `scripts/cf-ah0m/` (parser + alias map + DOM probe + report builder) — regenerable from this guide + `carolina-futons-web/src`. Re-run after every guide refresh.
+
+---
+
+## 🚀 Phase 8 Cutover Prep (added 2026-05-05)
+
+Prep work for the Wix Editor → Vercel cutover lives at `cf-roadmap-2026-05-05.md` (TBD — Stilgar to author after the email-infra unblock from cf-c6g5). Until that ships, the operational blockers tracked here are:
+
+1. **cf-c6g5** — STAGING_SITE Triggered Emails dashboard population (P0).
+2. **cf-w1lg** — stage3-velo HTTP-function convergence (P1, in flight).
+3. **cf-ah0m / cf-o2kq follow-ups** — five `/wishlist`, `/wishlist-share`, `/price-match-guarantee`, `/fabric-swatches`, `/sign-in` page-route decisions; UGC GALLERY scope triage.
+4. **cf-oi01** — End-to-end real shipping + payments test on the Vercel preview before cutover (Melania driving).
+
+Every item above must be ✓ before cf-3qt Phase 9 (Wix Studio retirement) is unblocked.
 
 ---
 

--- a/EDITOR_HOOKUP_GUIDE.html
+++ b/EDITOR_HOOKUP_GUIDE.html
@@ -365,7 +365,7 @@ body.focus-mode .page-section.focus-visible { display: block; }
   <div class="header-top">
     <div>
       <h1>Carolina Futons — Editor Hookup Guide</h1>
-      <div class="header-subtitle">Wix Studio element placement reference · v4.5 · Updated 2026-04-17 — CMS collections 32→36: added Landings, PressMentions, PressKitAssets, ComparisonFeatures to provisioning manifest + setup guide for cf-3qt Phase 4/5 migration. Dashboard needed: provision 4 new collections on STAGING_SITE (cf-3qt). Previous: v4.4 — CMS collections 28→32: added PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog. v4.3 — Phase 8 COMPLETE.</div>
+      <div class="header-subtitle">Wix Studio element placement reference · v4.6 · Updated 2026-05-05 — Post-cf-3qt session refresh: 36 CMS collections confirmed on STAGING_SITE; cf-c6g5 flagged (STAGING_SITE Triggered Emails dashboard EMPTY — 20 templates need Stilgar batch-copy from prod; every email touchpoint currently 500); diagnostic endpoints (<code>/_functions/contactSubmissionsDiagnostic</code> + pending <code>/api/auth/diag</code>) documented; cf-w1lg repo-drift lessons (cfutons monorepo ↔ stage3-velo) added; cfw parity snapshot from cf-ah0m/cf-o2kq (255 features 201✓/28~/25✗/1?). Previous: v4.5 — CMS 32→36 (Landings, PressMentions, PressKitAssets, ComparisonFeatures); v4.4 — CMS 28→32 (PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog); v4.3 — Phase 8 COMPLETE.</div>
     </div>
     <div class="header-stats" id="headerStats">
       <span class="stat-chip" id="statTotal">0 total</span>
@@ -6547,6 +6547,52 @@ document.getElementById('priorityFilter').addEventListener('change', render);
 // Initial render
 render();
 </script>
+
+<section style="max-width:1200px;margin:32px auto;padding:24px;background:var(--off-white);border:1px solid var(--espresso-light);border-radius:var(--radius-lg);font-family:var(--font-body);color:var(--espresso);">
+  <h2 style="font-family:var(--font-heading);margin-top:0;">v4.6 Refresh — 2026-05-05 (cf-qdxi)</h2>
+  <p style="font-size:0.95em;line-height:1.5;">Post-cf-3qt session findings. The full prose lives in <code>EDITOR-HOOKUP-GUIDE.md</code> at the matching headings; this is the visible-on-render condensation so Stilgar doesn't bounce off a blank screen.</p>
+
+  <h3 id="cms-collections-confirmed-2026-05-05" style="color:var(--espresso);">36 CMS collections confirmed on STAGING_SITE (2026-05-05)</h3>
+  <p style="font-size:0.92em;">Wix Data API verification round confirms all 36 collections are present and queryable: 28 base + 4 mobile/spin (PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog) + 4 cf-3qt (Landings, PressMentions, PressKitAssets, ComparisonFeatures). Phase 6 + cf-3qt manifest is now backed by reality, not aspiration.</p>
+
+  <h3 id="triggered-emails-cf-c6g5" style="color:var(--danger);">⚠️ STAGING_SITE Triggered Emails — EMPTY (cf-c6g5, P0)</h3>
+  <p style="font-size:0.92em;">Wix Studio Dashboard → Triggered Emails on STAGING_SITE has <strong>NO sender configured and NO templates</strong>. Every <code>triggeredEmails.emailContact()</code> call resolves to <em>"Not Found: the requested item no longer exists"</em>; the Velo wrapper turns that into 500. Contact form, welcome series, order/shipping/delivery confirmations, abandoned-cart, browse-recovery, re-engagement, NPS, post-purchase, swatch-confirmation, and recovery-discount flows are <strong>all silently broken on staging</strong>.</p>
+  <p style="font-size:0.92em;"><strong>20 templates need batch-copy from prod by Stilgar</strong> (~30–60 min): <code>contact_form_submission</code>, <code>welcome_series_1..5</code>, <code>order_confirmation</code>, <code>order_shipped</code>, <code>freight_shipped</code>, <code>delivery_confirmation</code>, <code>post_purchase_review_reward</code>, <code>nps_survey</code>, <code>swatch_confirmation</code>, <code>abandoned_cart_recovery</code>, <code>browse_recovery</code>, <code>reengagement_1..3</code>, <code>post_purchase_care</code>, <code>recovery_discount</code>. Sender: <code>carolinafutons@gmail.com</code>. Verify via godfrey's <code>/_functions/contactSubmissionsDiagnostic</code>.</p>
+
+  <h3 id="diagnostic-endpoints" style="color:var(--espresso);">🩺 Diagnostic endpoints</h3>
+  <ul style="font-size:0.92em;">
+    <li><code>/_functions/contactSubmissionsDiagnostic</code> (Velo, live) — two-step probe: schema-validate fixture → attempt <code>triggeredEmails.emailContact</code>. Currently fails on step 2 (cf-c6g5).</li>
+    <li><code>/api/auth/diag</code> (Next.js, pending quartz ship) — verify Wix Members auth → JWT → CRM lookup without UI.</li>
+    <li>Both endpoints guarded by <code>DIAG_TOKEN</code> rotated weekly via <code>rotate-diag-tokens.yml</code> GH Action; 24-hour overlap window for in-flight CI runs.</li>
+  </ul>
+
+  <h3 id="repo-drift-cf-w1lg" style="color:var(--espresso);">🔀 Repo drift — cfutons monorepo ↔ stage3-velo (cf-w1lg)</h3>
+  <p style="font-size:0.92em;">The <code>carolina-futons</code> monorepo is the Velo source-of-truth, but <code>carolina-futons-stage3-velo</code> is what <code>wix preview</code> and <code>wix publish</code> actually read. When a <code>/_functions/&lt;name&gt;</code> handler is added to the monorepo and not mirrored into stage3-velo, the cfw Next.js app gets a 404 from production. Caught for <code>contactSubmissions</code>, <code>sampleRequests</code>, <code>mailingListSignups</code>, <code>deliveryZone</code>, <code>unsubscribe</code> — all in flight via stage3-velo PR #15 (cf-foo0) + branch <code>fix/cf-w1lg-velo-convergence-4-endpoints</code> (cf-w1lg).</p>
+  <p style="font-size:0.92em;"><strong>Standing rule:</strong> every PR that touches <code>src/backend/http-functions.js</code> or <code>src/backend/*.web.js</code> in the monorepo MUST also produce a stage3-velo PR before it counts as "merged" for cfw consumers.</p>
+
+  <h3 id="hookup-coverage-cf-ah0m" style="color:var(--espresso);">📊 Hookup coverage snapshot — cf-ah0m / cf-o2kq</h3>
+  <p style="font-size:0.92em;">Automated parity audit of THIS guide vs <code>https://carolina-futons-web.vercel.app/</code>. From <code>cfw-parity-audit-2026-05-04.md</code> (PR #1139 v2 commit <code>0a288781</code>):</p>
+  <table style="width:100%;max-width:560px;border-collapse:collapse;font-size:0.9em;">
+    <tr style="background:#e8d5b7;"><th style="text-align:left;padding:6px 10px;border:1px solid #c8b89a;">verdict</th><th style="text-align:right;padding:6px 10px;border:1px solid #c8b89a;">count</th><th style="text-align:right;padding:6px 10px;border:1px solid #c8b89a;">%</th></tr>
+    <tr><td style="padding:6px 10px;border:1px solid #ddd;">✓ feature present in cfw</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">201</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">78.8%</td></tr>
+    <tr style="background:#fafaf8;"><td style="padding:6px 10px;border:1px solid #ddd;">~ partial / ambiguous</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">28</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">11.0%</td></tr>
+    <tr><td style="padding:6px 10px;border:1px solid #ddd;">✗ no cfw evidence</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">25</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">9.8%</td></tr>
+    <tr style="background:#fafaf8;"><td style="padding:6px 10px;border:1px solid #ddd;">? unknown / out-of-scope</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">1</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">0.4%</td></tr>
+    <tr style="font-weight:600;"><td style="padding:6px 10px;border:1px solid #ddd;">total parsed</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">255</td><td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">100%</td></tr>
+  </table>
+  <p style="font-size:0.92em;margin-top:12px;"><strong>Page-level 404s on cfw</strong> (guide enumerates, no Vercel route): <code>/wishlist</code>, <code>/wishlist-share</code>, <code>/price-match-guarantee</code>, <code>/fabric-swatches</code>, <code>/sign-in</code> — each needs a deprecate-or-rebuild decision before Wix Editor retirement.</p>
+  <p style="font-size:0.92em;"><strong>Forward-drift</strong> (cfw has, this guide doesn't mention): 18 <code>data-slot</code> values, 20 <code>data-testid</code> values, 60 component basenames. Largest clusters: mascot scenes (StargazingHero, MascotFooterDivider, FogScene, FallsScene, EasterEggBear), analytics tags (GA4Tag, MetaPixel, PinterestTag, ConsentMode), PDP add-ons (PdpComfortBand, PdpNotifyMe, PdpInteractive), MegaMenu, page-transition.</p>
+
+  <h3 id="phase-8-cutover-prep" style="color:var(--espresso);">🚀 Phase 8 cutover prep</h3>
+  <p style="font-size:0.92em;">Roadmap doc <code>cf-roadmap-2026-05-05.md</code> is pending — Stilgar to author after the cf-c6g5 email-infra unblock. Operational blockers tracked here:</p>
+  <ol style="font-size:0.92em;">
+    <li><strong>cf-c6g5</strong> — STAGING_SITE Triggered Emails dashboard population (P0).</li>
+    <li><strong>cf-w1lg</strong> — stage3-velo HTTP-function convergence (P1, in flight).</li>
+    <li><strong>cf-ah0m / cf-o2kq follow-ups</strong> — five page-route decisions; UGC GALLERY scope triage.</li>
+    <li><strong>cf-oi01</strong> — End-to-end real shipping + payments test on the Vercel preview before cutover (Melania driving).</li>
+  </ol>
+  <p style="font-size:0.92em;">Every item above must be ✓ before cf-3qt Phase 9 (Wix Studio retirement) is unblocked.</p>
+</section>
 
 <section style="max-width:1200px;margin:32px auto;padding:24px;background:var(--off-white);border:1px solid var(--espresso-light);border-radius:var(--radius-lg);font-family:var(--font-body);color:var(--espresso);">
   <h2 style="font-family:var(--font-heading);margin-top:0;">Feature Log</h2>


### PR DESCRIPTION
## Summary
v4.6 refresh of the EDITOR_HOOKUP_GUIDE (markdown + HTML in lockstep). Captures the post-cf-3qt session findings Stilgar surfaced, fixes the stale "32 collections + 4 pending" line, and adds operational sections that didn't exist.

## What's new
1. **CMS collections**: 36 confirmed on STAGING_SITE per Wix Data API verification 2026-05-05 (was "32 + 4 pending"). PushTokens / SpinGrants / MobileChallengeCompletions / CrossRigSyncLog all verified.
2. **Triggered Emails (cf-c6g5)** — full new section. STAGING_SITE dashboard is EMPTY: no sender, no templates. Every `triggeredEmails.emailContact()` resolves to *Not Found* → 500. Lists all **20 templates** that need batch-copy from prod by Stilgar, the variable intersection, sender config, and acceptance criteria.
3. **Diagnostic Endpoints** — new section. `/_functions/contactSubmissionsDiagnostic` (Velo, live) and `/api/auth/diag` (Next.js, pending quartz). Self-rotating `DIAG_TOKEN` rotated weekly via `rotate-diag-tokens.yml`, 24h overlap window.
4. **Repo Drift (cf-w1lg)** — new section. cfutons monorepo ↔ stage3-velo divergence pattern, the 5 missing endpoints in flight (`contactSubmissions`, `sampleRequests`, `mailingListSignups`, `deliveryZone`, `unsubscribe`), and the standing rule that every monorepo backend PR must produce a stage3-velo PR.
5. **Hookup Coverage Snapshot (cf-ah0m / cf-o2kq)** — 255 parsed features, 201✓ / 28~ / 25✗ / 1?. Page-level 404 list (`/wishlist`, `/wishlist-share`, `/price-match-guarantee`, `/fabric-swatches`, `/sign-in`) and forward-drift summary (mascot scenes, analytics tags, PDP add-ons).
6. **Phase 8 Cutover Prep** — operational blocker list (cf-c6g5 / cf-w1lg / cf-ah0m follow-ups / cf-oi01) gating Wix Studio retirement. `cf-roadmap-2026-05-05.md` marked TBD until Stilgar authors.

## Blank-screen audit
Ran a tag-balance + empty-heading + template-literal lint over the HTML.
- div / section / table / tr / td / ul / ol / p / h2-4 / li / code / span / button: **all balanced**
- 0 empty-heading-followed-by-heading patterns
- 4 "odd backtick count" lines flagged were intentional multi-line JS template literals (closing tick on a later line) — not real defects.

Conclusion: no structural HTML issue causing the blank rendering. If Stilgar sees one in practice, hard-reload first; if it persists, send the section name and we can scope-bisect.

## Diff
- `EDITOR-HOOKUP-GUIDE.md`: +156 / −3
- `EDITOR_HOOKUP_GUIDE.html`: +48 / −3 (header subtitle + new "v4.6 Refresh" visible section above Feature Log)

## Test plan
- [x] Markdown renders end-to-end on GitHub
- [x] HTML loads in browser without blank section
- [x] Cross-references to cf-c6g5 / cf-w1lg / cf-ah0m / cf-o2kq / cf-oi01 / cf-foo0 verified live
- [ ] (deferred) Once Stilgar populates Triggered Emails, edit the v4.6 cf-c6g5 row from "EMPTY" → "POPULATED — 20/20 templates"

Refs cf-qdxi.