### PR TITLE
fix(cf-89xn): get_deliveryZone — don't spread service error envelope into 200 (cf-tvbi lying-status)

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -3004,7 +3004,12 @@ export async function get_deliveryZone(request) {
     // { error: '...' } on its own input validation, which when spread into a
     // 200 envelope produces { success: true, error: '...' } (cf-tvbi
     // lying-status pattern). Surface as 400 so cfw can branch on status.
-    if (result && typeof result.error === 'string') {
+    // Truthy check rejects empty-string `error` (which falls through to 200
+    // since an empty string isn't a real service rejection signal). Logged
+    // so ops can distinguish wrapper-validation 400s from service-validation
+    // 400s without a stack.
+    if (result && typeof result.error === 'string' && result.error.length > 0) {
+      console.warn('[deliveryZone] service emitted error envelope:', result.error);
       return badRequest({
         body: JSON.stringify({ success: false, error: result.error }),
         headers: JSON_HEADERS,

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -3000,6 +3000,16 @@ export async function get_deliveryZone(request) {
   }
   try {
     const result = await _getDeliveryZone(zip);
+    // cf-89xn: don't spread service result blindly — `getDeliveryZone` returns
+    // { error: '...' } on its own input validation, which when spread into a
+    // 200 envelope produces { success: true, error: '...' } (cf-tvbi
+    // lying-status pattern). Surface as 400 so cfw can branch on status.
+    if (result && typeof result.error === 'string') {
+      return badRequest({
+        body: JSON.stringify({ success: false, error: result.error }),
+        headers: JSON_HEADERS,
+      });
+    }
     return ok({ body: JSON.stringify({ success: true, ...result }), headers: JSON_HEADERS });
   } catch (err) {
     console.error('HTTP function error (deliveryZone):', err);

--- a/tests/deliveryZone.test.js
+++ b/tests/deliveryZone.test.js
@@ -91,6 +91,19 @@ describe('get_deliveryZone — error handling', () => {
     const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
     expect(res.status).toBe(500);
   });
+
+  it('returns 400 + success:false when service returns { error } envelope (cf-89xn lying-status)', async () => {
+    // The webMethod has its own input-validation branch that returns
+    // { error: 'Please enter a valid 5-digit zip code.' }. Spreading that
+    // into the 200 envelope used to produce { success: true, error: '...' } —
+    // exact cf-tvbi lying-status pattern. Wrapper now surfaces 400.
+    getDeliveryZone.mockResolvedValue({ error: 'Please enter a valid 5-digit zip code.' });
+    const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
+    expect(res.status).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/5-digit zip/i);
+  });
 });
 
 describe('options_deliveryZone — CORS preflight', () => {

--- a/tests/deliveryZone.test.js
+++ b/tests/deliveryZone.test.js
@@ -104,6 +104,40 @@ describe('get_deliveryZone — error handling', () => {
     expect(body.success).toBe(false);
     expect(body.error).toMatch(/5-digit zip/i);
   });
+
+  it('keeps the OUT-OF-RANGE envelope (no `error` field) at 200 + success:true', async () => {
+    // Regression guard for cf-89xn: the lying-status fix narrows the 400
+    // branch to results with a non-empty `error` STRING. Out-of-range
+    // results carry a `message` field but no `error` — those are legitimate
+    // success responses (zip is valid, just not deliverable) and must keep
+    // the 200 + success:true envelope so cfw can render the "out of range"
+    // copy without branching on status.
+    getDeliveryZone.mockResolvedValue({
+      zone: 'outofrange',
+      label: 'Out of Range',
+      rate: null,
+      eta: null,
+      distanceMiles: 120,
+      message: 'We deliver within 60 miles of our Hendersonville, NC showroom.',
+    });
+    const res = await get_deliveryZone(makeRequest({ zip: '99999' }));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+    expect(body.zone).toBe('outofrange');
+    expect(body.message).toMatch(/60 miles/i);
+    expect(body.error).toBeUndefined();
+  });
+
+  it('falls through to 200 when service result has empty-string `error` (defensive)', async () => {
+    // Empty string isn't a real service-rejection signal; treat as no-error.
+    getDeliveryZone.mockResolvedValue({ zone: 'local', rate: 25, eta: '1-2 business days', distanceMiles: 0, error: '' });
+    const res = await get_deliveryZone(makeRequest({ zip: '28792' }));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+    expect(body.zone).toBe('local');
+  });
 });
 
 describe('options_deliveryZone — CORS preflight', () => {


### PR DESCRIPTION
## Summary

Per cf-89xn (radahn's 5-agent review on PR #18 of stage3-velo). The webMethod `getDeliveryZone` has an input-validation branch returning `{ error: '...' }`. The wrapper's `ok({ body: JSON.stringify({ success: true, ...result }) })` spreads that into the success envelope — so a service rejection produced HTTP 200 + `{ success: true, error: '...' }`, the exact cf-tvbi lying-status pattern.

**Fix:** when `result.error` is a string, return 400 + `{ success: false, error: result.error }` so cfw can branch on status. Successful zone shapes (zone/label/rate/eta/distanceMiles, plus the `outofrange` zone with its `message` field) keep producing 200 + `success:true`.

## Reachability

The wrapper already validates `zip` format before calling the service (`/^\d{5}$/`), so the service's own validation branch is currently unreachable from cfw in production. Defensive handling is warranted because:
- The cfutons monorepo's twin in stage3-velo had the same bug actively flagged in radahn's review.
- Future callers / tests may construct service results directly.
- Cost is one if-block.

## Tests

`tests/deliveryZone.test.js` — added 1 case asserting the service `{ error }` envelope path returns 400 + `success:false`. 12/12 pass locally.

## Companion PR
- stage3-velo (paired): `fix/cf-89xn-stage3-followups` — covers all 5 cf-89xn issues including this same deliveryZone fix. Both must land before next Wix CLI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)