### PR TITLE
chore(cf-hv00): drop stale post_importProductOptions ref in diagnostic comment

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -3115,7 +3115,7 @@ export function options_sampleRequests(request) {
 //   (3) other CRM resolution gap
 // is the actual cause.
 //
-// Inline-auth gated (mirrors post_importProductOptions pattern, cf-44mq).
+// Inline-auth gated via Bearer token in the Authorization header.
 // REMOVE in follow-up cleanup PR once cf-9ieq closes.
 
 export async function post_contactSubmissionsDiagnostic(request) {


### PR DESCRIPTION
## Summary
- Single-line comment edit: \`post_importProductOptions\` was removed from the codebase, but a comment in \`http-functions.js:3118\` still cites it as a pattern reference. Replace with a direct description of the inline-auth gate.

## Why
godfrey cf-89xn follow-up #4 (comment-analyzer) — stale doc reference. \`post_importProductOptions\` no longer exists; the comment misleads future readers.

## Verified
\`grep post_importProductOptions src/\` post-fix returns nothing.

## Refs
Bead: cf-hv00 (P3, comment cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)