### PR TITLE
docs(cf-ubxu): Brenda admin guide — Wix Studio common owner edits

### DIFF
--- a/docs/brenda-admin-guide.md
+++ b/docs/brenda-admin-guide.md
@@ -1,0 +1,351 @@
+# Brenda's Quick Guide to Editing the Carolina Futons Site
+
+Hey Brenda — this guide walks you through the seven things you'll do most often on the Wix Studio dashboard. Every section follows the same pattern:
+
+1. **What you're doing** (one sentence)
+2. **Where to click** (with screenshots — every blue-highlighted area is what to click next)
+3. **Step-by-step**
+4. **Save / publish** — what to press, and how to know it worked
+5. **If you get stuck** — what to email Stilgar with
+
+You don't need to be a "tech person" to use this — every section is self-contained, so you can jump straight to whichever one you need.
+
+> **Heads up about the screenshots:** the first version of this guide ships with placeholders. Stilgar will sit with you for a half-hour the first time you log in and we'll capture the real screenshots from your dashboard so the visuals match what *you* see, not a stock account. The written steps are accurate today.
+
+---
+
+## Before you start: logging in
+
+1. Go to <https://www.wix.com/my-account/login>
+2. Use the email Stilgar set up for you (yours: ends in `@carolinafutons.com`).
+3. Once you're in, you'll land on the **My Sites** page. Click **carolinafutons.com**.
+4. That opens the **Wix Studio dashboard** — the home base for everything in this guide.
+
+If you ever land somewhere unfamiliar, the **Carolina Futons logo top-left** always brings you back to this dashboard.
+
+> **First-time login?** Wix may ask you to set up two-factor authentication. Use your phone number, not the email — the SMS code is faster. Stilgar already enabled this on the account; you just confirm it on first login.
+
+![Login screen with email field highlighted](brenda-admin-guide/01-login.png)
+*Screenshot pending capture — Stilgar to grab during onboarding session.*
+
+---
+
+## 1. Edit a product's name, price, or photos
+
+**When you'd do this:** new spring pricing, a typo in the product description, a better hero photo of the Kingston futon, etc.
+
+### Where to click
+
+From the dashboard:
+
+1. Left sidebar → **Wix Stores**
+2. Then → **Catalog** → **Products**
+3. Click the product you want to edit (e.g. "Kingston Futon Frame")
+
+![Sidebar nav with Wix Stores → Catalog → Products highlighted](brenda-admin-guide/02-products-nav.png)
+*Screenshot pending capture.*
+
+### Step-by-step
+
+1. **Name** — top of the page. Click in the title field, type your change. There's a character limit; the field will stop you if you hit it.
+2. **Price** — middle-right of the page, under "Pricing". Type the new price *with no dollar sign* (e.g. `849.00`). If you're putting it on sale, use the **Compare at Price** field for the original price and **Price** for the sale price — that makes the strikethrough work on the website.
+3. **Photos** —
+   - Scroll to the **Media** section.
+   - To **add** a photo: click the `+` tile, then **Upload from computer** (or pick from existing media if you've used the photo before).
+   - To **reorder**: hover a photo and drag it. The first photo is the one customers see in search results and on the category page — make it the strongest hero shot.
+   - To **delete**: hover a photo, click the trash icon.
+
+![Product edit page with name / price / photos sections highlighted](brenda-admin-guide/03-product-edit.png)
+*Screenshot pending capture.*
+
+### Save / publish
+
+- Click **Save** top-right (it'll say "Saved" with a green check when it's done).
+- Changes show on the live site within **1–2 minutes**. If you don't see them after 5 minutes, hard-refresh your browser (`Cmd + Shift + R` on Mac).
+
+### If you get stuck
+
+Email Stilgar with:
+- The product name
+- A screenshot of what you're seeing
+- What you wanted to change
+
+---
+
+## 2. Hide a product (out of season, sold out, discontinued)
+
+**When you'd do this:** the Murphy bed line is on hiatus until fall, or a frame style is permanently retired.
+
+### Where to click
+
+1. Same nav as above: **Wix Stores → Catalog → Products**
+2. Click the product
+3. Scroll to the top-right of the product page
+
+### Step-by-step
+
+There's a toggle near the product title called **Visible**. Two options:
+
+- **Visible** (toggle ON, blue) — product shows on the website and customers can buy it.
+- **Hidden** (toggle OFF, grey) — product disappears from the catalog page and search results immediately. The product page itself returns "page not found" if a customer has the link bookmarked.
+
+![Visibility toggle highlighted on the product detail page](brenda-admin-guide/04-product-visibility.png)
+*Screenshot pending capture.*
+
+### Save / publish
+
+The toggle is "live" — there's no separate save button. Flipping it OFF hides the product the moment you click it. Flipping it back ON restores it.
+
+> **Heads up:** hiding a product does NOT delete it. Inventory, photos, and pricing all stick around so you can flip it back on next season without re-entering anything.
+
+### If you get stuck
+
+If a hidden product is still showing on the website 5+ minutes after you flipped the toggle, email Stilgar with the product name and a link to where you're still seeing it.
+
+---
+
+## 3. Edit a Guide article (the "Buying Guides" / "Care Guides" section)
+
+**When you'd do this:** correcting a typo, refreshing a seasonal article, adding a new "How to choose your futon" guide.
+
+### Where to click
+
+1. Left sidebar → **CMS** (sometimes labelled **Content Manager**)
+2. Click the **Guides** collection
+3. To edit an existing article: click its row.
+4. To add a new one: click **+ Add Item** top-right.
+
+![CMS collections list with Guides highlighted](brenda-admin-guide/05-cms-guides.png)
+*Screenshot pending capture.*
+
+### Step-by-step (editing an existing article)
+
+Each article has these fields:
+
+| Field | What goes in it |
+| --- | --- |
+| **Title** | The article headline. Keep it under 60 characters so it doesn't get cut off in Google results. |
+| **Slug** | The URL ending — auto-fills from the title, but you can edit if you want a shorter URL. **Don't change a slug after publishing** — it breaks any external links pointing to the article. |
+| **Hero image** | The big photo at the top. Upload by clicking the field; recommended size 1600 × 900. |
+| **Body** | The article itself. Use the toolbar for headings (H2, H3), bold, links. Don't paste from Word — it brings junk styling; paste from a plain text editor or use the **paste as plain text** option. |
+| **Author** | Pick from the dropdown. |
+| **Published date** | Sets the order on the Guides index page. Newest first. |
+| **Status** | Draft / Published. Set to **Published** when you're ready for it to be live. |
+
+![Article edit form with key fields highlighted](brenda-admin-guide/06-guide-article-edit.png)
+*Screenshot pending capture.*
+
+### Save / publish
+
+- **Save** top-right keeps your work but the article isn't live until **Status = Published**.
+- A published article shows on `/guides` within ~2 minutes.
+- An unpublished article (Draft) is invisible to customers — useful for working on a half-finished piece.
+
+### If you get stuck
+
+The most common problem is the article looking weird because of styling pasted in from Word. If your text looks "different" from the others, email Stilgar — it's a 30-second fix on his end.
+
+---
+
+## 4. Add a customer photo to the gallery
+
+**When you'd do this:** a customer emails you a beautiful shot of their Kingston futon in their cabin and you want to share it on the **Community Gallery** page.
+
+### Where to click
+
+1. Left sidebar → **CMS** (or **Content Manager**)
+2. Click the **CommunityPhotos** collection
+3. Click **+ Add Item** top-right
+
+![CMS collections list with CommunityPhotos highlighted](brenda-admin-guide/07-cms-community-photos.png)
+*Screenshot pending capture.*
+
+### Step-by-step
+
+Fill in these fields:
+
+| Field | What goes in it |
+| --- | --- |
+| **image** | Upload the customer's photo. Wix will resize automatically. |
+| **customerName** | First name + last initial (e.g. "Sarah M."). Don't put full last names — privacy. |
+| **location** | "City, ST" format (e.g. "Asheville, NC"). |
+| **productSlug** | If the photo features a specific product, paste its slug (e.g. `kingston-futon-frame`). You can find slugs by going to **Wix Stores → Catalog → Products → click the product → look at the URL field**. Leave blank if it's a generic room photo. |
+| **caption** | A short sentence or two from the customer if they sent one. Keep it casual; don't rewrite their words unless there's a clear typo. |
+
+![CommunityPhotos edit form with all five fields highlighted](brenda-admin-guide/08-community-photo-edit.png)
+*Screenshot pending capture.*
+
+### Save / publish
+
+Click **Save** top-right. Photos appear on `/community-gallery` within ~1 hour (the page caches for performance — this is normal).
+
+### Important — get permission first
+
+Always email the customer back to confirm: *"Mind if we share this on our website? We'd credit you as 'Sarah M., Asheville'."* If they don't reply, don't post. A short reply that says "yes" is enough — save it in your inbox.
+
+### If you get stuck
+
+If a photo is uploaded but isn't appearing on the website after an hour, email Stilgar with the customer's name (or the slug you used) so he can check the cache.
+
+---
+
+## 5. Edit website text (hero, footer, hours)
+
+**When you'd do this:** changing the holiday hours banner, swapping out the homepage tagline, updating the phone number in the footer.
+
+> **🚧 This section is parked.** Right now, most of these texts are still hard-coded in the website itself, which means a developer (Stilgar) has to change them. The team is building a **SiteContent** collection in CMS that will let you edit them yourself — once that ships (cfw-66o.1), this section will fill in.
+>
+> **For now**, email Stilgar with:
+> - What you want to change (e.g. "homepage hero subhead")
+> - The new text
+>
+> He'll have it live within a day.
+
+When SiteContent lands, this section will cover:
+
+- Editing the homepage hero (title + subtitle + CTA label)
+- Editing footer copy (showroom hours, tagline)
+- Editing the announcement bar (the strip at the very top)
+- Phone / email / address (these live in a separate **business-info** collection so they update everywhere — footer, contact page, structured data — at once).
+
+---
+
+## 6. Reply to a contact form / view inquiries
+
+**When you'd do this:** every morning. Customers send questions through the **Contact** page and any **Notify Me** signups on out-of-stock products.
+
+### Where to click
+
+1. Left sidebar → **Inbox** (envelope icon)
+2. Inbox is divided into channels:
+   - **All** — everything
+   - **Email** — anything that came in via the Contact page
+   - **Form submissions** — Notify Me, swatch requests, etc.
+
+![Inbox with channels listed and a sample message highlighted](brenda-admin-guide/09-inbox.png)
+*Screenshot pending capture.*
+
+### Step-by-step
+
+1. Click a message to open it. The customer's question appears on the right; their previous orders (if any) appear on the left as context.
+2. To reply:
+   - Type in the reply box at the bottom.
+   - Use **canned replies** (the bookmark icon, top-right of the reply box) for common questions — Stilgar set up a few starters: "Showroom hours," "Delivery quote," "Mattress comparison." Click one to insert it, then personalize.
+3. Click **Send**.
+
+### Save / publish
+
+There's no separate publish step — clicking **Send** delivers the email immediately. The thread stays in the Inbox so you can find it later.
+
+### Triage tips
+
+- **Star** anything Stilgar should see (top-right of the message).
+- **Resolve** a thread when you're done (button under the message). Resolved threads still show up in search but don't clutter the active inbox.
+- **Spam / promotional** — there's a "Mark as spam" option in the three-dot menu. Use it freely; the filter improves over time.
+
+### If you get stuck
+
+If a message looks like a *real* technical issue ("the website crashed when I tried to check out"), forward it to Stilgar by clicking **More → Forward to teammate → stilgar@carolinafutons.com**. Don't try to debug — that's his job.
+
+---
+
+## 7. View orders
+
+**When you'd do this:** every morning, plus whenever a customer calls asking about their order status.
+
+### Where to click
+
+1. Left sidebar → **Wix Stores**
+2. Then → **Orders**
+
+![Orders list with status / total / customer columns highlighted](brenda-admin-guide/10-orders-list.png)
+*Screenshot pending capture.*
+
+### Step-by-step
+
+The orders list shows the most recent orders at the top. Each row has:
+
+| Column | What it means |
+| --- | --- |
+| **Order #** | The unique number — what the customer references on the phone. |
+| **Customer** | Name + email. |
+| **Date** | When it came in. |
+| **Total** | What they paid. |
+| **Status** | New → Approved → Fulfilled → Shipped → Delivered. (You won't change this manually for most orders — the delivery team updates Shipped/Delivered.) |
+| **Payment** | Paid / Pending / Failed. Anything other than "Paid" is a flag for Stilgar. |
+
+To view a single order: click the row. You'll see the line items, the shipping address, the customer's notes (if any), and a payment receipt.
+
+![Single order detail with line items and address highlighted](brenda-admin-guide/11-order-detail.png)
+*Screenshot pending capture.*
+
+### Common things customers ask about
+
+| Customer says… | Where to look |
+| --- | --- |
+| "Did my order go through?" | Status column. If "Approved" or beyond, yes. |
+| "When will it ship?" | Open the order — there's a fulfillment date estimate, OR check with the delivery team. |
+| "Can I add the matching ottoman to my order?" | Email Stilgar — adding to an existing order requires a manual edit. |
+| "I want to cancel" | Email Stilgar same-day if possible — refunds are easier before fulfillment. |
+| "Where's my tracking number?" | Bottom of the order detail page, under "Fulfillment." |
+
+### Save / publish
+
+You don't usually edit orders — this section is mostly read-only. If you do change something (e.g. add an order note), there's a **Save** button at the top-right of the order detail page.
+
+### If you get stuck
+
+Anything that involves money (refunds, order cancellations, payment issues) — email Stilgar **before** you do anything in the dashboard. It's a 10-minute conversation that saves a 2-hour cleanup.
+
+---
+
+## When to email Stilgar (anytime is fine!)
+
+Don't worry about whether something is "small enough" to email about — Stilgar has explicitly said: when in doubt, ask. The fastest way to get help:
+
+1. Email **stilgar@carolinafutons.com**
+2. Subject line: short and specific — e.g. "Photo not showing on Kingston PDP" beats "Quick question"
+3. In the body:
+   - **What you were trying to do** ("hide the Maple Daybed for the season")
+   - **What happened** ("the toggle moved but it's still showing on the site")
+   - **Screenshot** if anything visual is involved (`Cmd + Shift + 4` on Mac selects an area to screenshot; the image saves to your Desktop)
+
+---
+
+## Quick reference — the seven sections in one table
+
+| You want to… | Where to go | This guide section |
+| --- | --- | --- |
+| Change a product's name, price, or photos | Wix Stores → Catalog → Products | §1 |
+| Hide a product (out of season) | Wix Stores → Catalog → Products → toggle | §2 |
+| Edit a Guide article | CMS → Guides | §3 |
+| Add a customer photo to the gallery | CMS → CommunityPhotos | §4 |
+| Edit website text (hero / footer / hours) | (parked — email Stilgar for now) | §5 |
+| Reply to a customer inquiry | Inbox | §6 |
+| View orders | Wix Stores → Orders | §7 |
+
+---
+
+## Screenshot capture checklist (for Stilgar)
+
+The following screenshots ship with placeholders today and need to be captured with Brenda's account during the onboarding session:
+
+- [ ] `01-login.png` — Wix login screen
+- [ ] `02-products-nav.png` — sidebar with Wix Stores → Catalog → Products highlighted
+- [ ] `03-product-edit.png` — product edit page (name / price / photos sections highlighted)
+- [ ] `04-product-visibility.png` — visibility toggle
+- [ ] `05-cms-guides.png` — CMS collections list with Guides highlighted
+- [ ] `06-guide-article-edit.png` — Guides article edit form
+- [ ] `07-cms-community-photos.png` — CMS collections list with CommunityPhotos highlighted
+- [ ] `08-community-photo-edit.png` — CommunityPhotos add-item form
+- [ ] `09-inbox.png` — Inbox with channels and a sample message
+- [ ] `10-orders-list.png` — Orders list view
+- [ ] `11-order-detail.png` — single order detail page
+
+**Capture conventions:**
+- 1280 × 800 px viewport (matches Brenda's typical screen).
+- Annotate with **blue rounded rectangles** (3 px stroke, `#3e6b7e` cf-cta) around the active control. Optional thin numbered callouts (1, 2, 3) for sequences.
+- Crop to remove personal account info from sidebar avatars.
+- Save as PNG into `docs/brenda-admin-guide/` with the filenames above.
+
+Section 5 placeholder will fill in once **cfw-66o.1** ships the SiteContent collection.

--- a/docs/brenda-admin-guide/README.md
+++ b/docs/brenda-admin-guide/README.md
@@ -1,0 +1,11 @@
+# Brenda admin guide — screenshot directory
+
+Screenshots referenced from `docs/brenda-admin-guide.md`. They ship as placeholders today and will be captured during Brenda's onboarding session with Stilgar.
+
+See the **Screenshot capture checklist** at the bottom of `brenda-admin-guide.md` for the full list, naming convention, and annotation style.
+
+Conventions:
+- 1280 × 800 px viewport.
+- Annotate with `#3e6b7e` (cf-cta) rounded rectangles, 3 px stroke.
+- PNG, named `NN-name.png` per the checklist.
+- Crop personal/account avatars before saving.


### PR DESCRIPTION
## Summary
Hand-off guide for Brenda covering the 7 most common Wix Studio dashboard tasks. Sub-bead of cfw-66o.

Sections:
1. Edit a product's name / price / photos
2. Hide a product (out of season)
3. Edit a Guide article
4. Add a customer photo to the gallery
5. Edit website text (parked — waits on cfw-66o.1 SiteContent collection)
6. Reply to a customer inquiry
7. View orders

Each section: where to click → step-by-step → save/publish → "if you get stuck" with a clear email-Stilgar escalation. Tone is conversational and non-technical so a non-developer owner can self-serve.

### Screenshots
Ship as placeholders today; capture checklist + naming/annotation conventions live at the bottom of the doc and in \`docs/brenda-admin-guide/README.md\`, ready for Stilgar to fill in during Brenda's onboarding session with her real account.

Closes cf-ubxu.

## Test plan
- [x] Doc-only PR; no code changes.
- [ ] Stilgar walks through each section with Brenda; flags any step that doesn't match her actual screen.
- [ ] Screenshots captured during onboarding session and committed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)