### PR TITLE
fix(test): notifyMe — match wrapper's server_error envelope (CI on main was red)

### DIFF
--- a/tests/notifyMe.http.test.js
+++ b/tests/notifyMe.http.test.js
@@ -142,13 +142,19 @@ describe('post_notifyMe — validation', () => {
 // ── Downstream failure ────────────────────────────────────────────────────────
 
 describe('post_notifyMe — downstream failure', () => {
-  it('returns 500 when wixData.insert throws', async () => {
+  it('returns 500 with server_error code + errorId when wixData.insert throws', async () => {
     __setInsertError('NotifyMe', new Error('Wix Data store unavailable'));
     const res = await post_notifyMe(makeRequest());
     expect(res.status).toBe(500);
     const body = JSON.parse(res.body);
     expect(body.success).toBe(false);
-    expect(body.error).toMatch(/internal server error/i);
+    // Wrapper returns a stable `server_error` code + correlated `errorId`
+    // (silent-failure-hunter PR #18 follow-up) so cfw can echo the id back
+    // and ops can grep Velo logs by it. Regression guard against a future
+    // revert to a generic 'Internal server error' user-facing string.
+    expect(body.error).toBe('server_error');
+    expect(body.errorId).toEqual(expect.any(String));
+    expect(body.errorId.length).toBeGreaterThan(0);
   });
 
   it('still returns CORS headers on a 500 path so the browser can read the body', async () => {


### PR DESCRIPTION
## Summary

**P0 free grab.** CI on main has been red since 2026-05-09 because `tests/notifyMe.http.test.js > post_notifyMe — downstream failure > returns 500 when wixData.insert throws` expected `body.error` to match `/internal server error/i`, but the wrapper at `src/backend/http-functions.js:2955` actually returns:

```js
{ success: false, error: 'server_error', errorId: <uuid> }
```

The wrapper's stable code-string + errorId came from silent-failure-hunter's PR #18 follow-up — cfw echoes the errorId back so ops can grep Velo logs by it. The test was written against the legacy generic `'Internal server error'` user-facing string and never updated.

`/internal server error/i` never matches `"server_error"` → test (20) + test (22) red on main + on every open PR rebased against main, including #1157.

## Fix

Assert the wrapper's actual contract:

```js
expect(body.error).toBe('server_error');
expect(body.errorId).toEqual(expect.any(String));
expect(body.errorId.length).toBeGreaterThan(0);
```

Doubles as a regression guard against a future revert to a generic message.

## Verification

- [x] `node_modules/vitest/vitest.mjs run tests/notifyMe.http.test.js` — **18/18 pass** locally.
- [ ] CI test (20) + test (22) green after merge — should unblock all open PRs whose CI is currently red on this single failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)