### PR TITLE
chore(ci): ratchet coverage thresholds to new floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cfutons",
+  "name": "carolina-futons",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -72,7 +72,7 @@ export default defineConfig({
       thresholds: {
         statements: 90,
         branches: 85,
-        functions: 88,
+        functions: 89,
         lines: 91,
       },
     },


### PR DESCRIPTION
## Summary

First auto-ratchet from `.github/workflows/coverage-ratchet.yml` (#1158). The workflow detected coverage rose on main, computed the new floor, and pushed the bumped `vitest.config.js` to `chore/coverage-ratchet-bump`. The PR-creation step itself failed because `GitHub Actions is not permitted to create or approve pull requests` (same setting flagged in #1161).

Opening this by hand so the ratchet lands. Once the GH Actions setting is flipped, future ratchets self-open.

## Diff

- **`vitest.config.js`** — `functions: 88 → 89`. Statements/branches/lines all hold (floor of measured % equals current threshold).
- **`package-lock.json`** — unrelated benign drift: the lockfile's `name` field was `cfutons`, but `package.json` has no `name` field, so `npm install` rewrites the lockfile's name to the workspace directory name (`carolina-futons`). Will fix the workflow to use `npm ci` in a follow-up so future ratchets don't carry this drift.

## Owner-only follow-up

Still pending from #1161:
- Settings → Actions → General → Workflow permissions → enable **Allow GitHub Actions to create and approve pull requests** so future ratchets don't need this manual open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)