### PR TITLE
docs(cf-hpwy): Velo dead-route detector — 23 GAP-CFW-WANTS gap-finder report

### DIFF
--- a/docs/velo-dead-routes-2026-05-09.md
+++ b/docs/velo-dead-routes-2026-05-09.md
@@ -1,0 +1,172 @@
+# Velo Dead-Route Detector — 2026-05-09 (cf-hpwy)
+
+> Static-analysis sweep matching the cf-w1lg drift-discovery pattern: parse all `webMethod()` exports in `src/backend/**/*.web.js`, cross-reference against `src/backend/http-functions.js` HTTP wrappers AND `carolina-futons-web/src` consumer code, classify every webMethod into actionable buckets.
+>
+> Repo target: `cfutons` monorepo (Velo source-of-truth). No `carolina-futons-web` runtime impact (cfutons + stage3-velo don't deploy to Vercel).
+
+## Headline
+
+**23 webMethods are GAP-CFW-WANTS** — cfw calls them via `callVelo` or `/_functions/<name>` URL but no HTTP wrapper exists in `http-functions.js`. These calls 404 in production unless a generic Velo dispatcher exists (none found). All 23 cluster in **6 files**, all member-area features:
+
+| File | Methods | Notes |
+|---|---|---|
+| `loyaltyService.web.js` | 10 | `getMyLoyaltyAccount`, `getAvailableRewards`, `getLoyaltyTiers`, `getMyStreakData`, `getChallengeCatalog`, `getMyDailyQuests`, `getMyAchievements`, `getMyActivity`, `getMyBurnRate`, `getChallengeLeaderboard` |
+| `gamificationCore.web.js` | 4 | `recoverStreak`, `getStreakData`, `getMemberTier`, `getActivityFeed` |
+| `wishlistService.web.js` | 3 | `addToWishlist`, `getWishlist`, `getWishlistByMemberId` |
+| `styleQuiz.web.js` | 3 | `getQuizRecommendations`, `getPersonalizedCopy`, `captureQuizLead` |
+| `pushNotificationService.web.js` | 2 | `managePushPreferences`, `getMyPushPreferences` |
+| `rewardsStore.web.js` | 1 | `redeemReward` |
+
+cfw call sites are concentrated in `src/app/actions/{loyalty,gamification,preferences,style-quiz}.ts` using the `callVelo({ method: g("name") })` helper from `src/lib/wix/velo-client.ts`. The helper builds `/_functions/<MODULE>/<METHOD>` URLs which cannot resolve to any handler in http-functions.js (no `post_loyaltyService`, etc., and no namespace dispatcher).
+
+**Implication**: every member-area Velo call from cfw production currently 404s. This is exactly the cf-w1lg pattern at scale — fix once via a generic dispatcher OR per-method wrappers.
+
+## Full classification
+
+| Verdict | Count | Meaning |
+|---|---:|---|
+| 🚨 **GAP-CFW-WANTS** | **23** | cfw calls via `/_functions/*` or `callVelo` but no HTTP wrapper exists |
+| 🔴 UNUSED-CAN-DELETE | 518 | No caller anywhere in cfutons or cfw |
+| ⚪ VELO-INTERNAL | 383 | Used by Wix Studio pages (`src/pages/*`), `src/public/*`, events handlers, or other webModules |
+| 🟡 WRAPPED-NO-CONSUMER | 35 | HTTP wrapper exists but cfw doesn't call it |
+| 🟠 MAYBE-CFW-NAME-COLLISION | 28 | Bare `\bNAME\b` match in cfw, no URL or callVelo signal — possible name collision |
+| 🟢 OK-WIRED | 5 | HTTP wrapper exists AND cfw calls it via URL/callVelo |
+
+Total: 992 webMethods across 222 `.web.js` files; 54 HTTP wrappers in `http-functions.js`; 658 cfw source files scanned.
+
+## Detailed GAP-CFW-WANTS table
+
+| webMethod | File:Line | Permission | cfw call site (sample) |
+|---|---|---|---|
+| `getQuizRecommendations` | `styleQuiz.web.js:59` | Anyone | `src/lib/wix/style-quiz.ts` |
+| `getPersonalizedCopy` | `styleQuiz.web.js:285` | Anyone | `src/lib/wix/style-quiz.ts` |
+| `captureQuizLead` | `styleQuiz.web.js:310` | Anyone | `src/lib/wix/style-quiz.ts` |
+| `recoverStreak` | `gamificationCore.web.js:989` | SiteMember | `src/app/actions/gamification.ts` |
+| `getStreakData` | `gamificationCore.web.js:1063` | SiteMember | `src/app/actions/gamification.ts` |
+| `getMemberTier` | `gamificationCore.web.js:1182` | SiteMember | `src/app/actions/gamification.ts` |
+| `getActivityFeed` | `gamificationCore.web.js:1220` | SiteMember | `src/app/actions/gamification.ts` |
+| `getMyLoyaltyAccount` | `loyaltyService.web.js:53` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getAvailableRewards` | `loyaltyService.web.js:92` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getLoyaltyTiers` | `loyaltyService.web.js:174` | Anyone | `src/app/actions/loyalty.ts` |
+| `getMyStreakData` | `loyaltyService.web.js:205` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getChallengeCatalog` | `loyaltyService.web.js:310` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getMyDailyQuests` | `loyaltyService.web.js:475` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getMyAchievements` | `loyaltyService.web.js:634` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getMyActivity` | `loyaltyService.web.js:857` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getMyBurnRate` | `loyaltyService.web.js:929` | SiteMember | `src/app/actions/loyalty.ts` |
+| `getChallengeLeaderboard` | `loyaltyService.web.js:1040` | SiteMember | `src/app/actions/loyalty.ts` |
+| `redeemReward` | `rewardsStore.web.js:134` | SiteMember | `src/app/actions/loyalty.ts` |
+| `managePushPreferences` | `pushNotificationService.web.js:154` | SiteMember | `src/app/actions/preferences.ts` |
+| `getMyPushPreferences` | `pushNotificationService.web.js:209` | SiteMember | `src/app/actions/preferences.ts` |
+| `addToWishlist` | `wishlistService.web.js:47` | SiteMember | `src/app/actions/wishlist.ts` |
+| `getWishlist` | `wishlistService.web.js:142` | SiteMember | `src/app/actions/wishlist.ts` |
+| `getWishlistByMemberId` | `wishlistService.web.js:178` | Anyone | `src/app/wishlist-share/page.tsx` |
+
+### Suggested fix paths (in order of effort)
+
+**Option A — Generic namespaced dispatcher (lowest effort, highest blast radius)**
+
+Add `post_dispatch` to `http-functions.js` that takes `request.path` and dispatches to the named webMethod. Pseudocode:
+
+```js
+import * as gamificationCore from 'backend/gamificationCore.web';
+import * as loyaltyService from 'backend/loyaltyService.web';
+// ... etc.
+
+const MODULES = { gamificationCore, loyaltyService, /* ... */ };
+
+export async function post_dispatch(request) {
+  const [moduleName, methodName] = request.path;
+  const mod = MODULES[moduleName];
+  if (!mod || typeof mod[methodName] !== 'function') return notFound({ ... });
+  const { args } = JSON.parse(await request.body.text());
+  const result = await mod[methodName](...(args ?? []));
+  return ok({ body: JSON.stringify(result), headers: corsHeaders(request, ...) });
+}
+```
+
+Then update `velo-client.ts` to call `/_functions/dispatch/<module>/<method>` instead of `/_functions/<module>/<method>`. Closes 23 gaps in one PR. Caveat: every webMethod's `Permissions.X` is bypassed by HTTP — the dispatcher must enforce auth itself. Use the bearer-token Authorization the client already sends.
+
+**Option B — Per-method wrappers (cf-w1lg pattern)**
+
+Add 23 `post_<methodName>` exports to `http-functions.js`, one per gap. More verbose, more boilerplate, but mirrors the existing pattern for `contactSubmissions` / `sampleRequests` / `mailingListSignups` exactly. Each wrapper validates body, checks rate limit if Anyone-permissioned, calls the underlying webMethod, maps return-value to status. Estimated 200–300 LOC.
+
+**Option C — Drop the cfw-side calls**
+
+If member-area Velo calls are not actually used in production (e.g., the dashboard pages render but never fetch live data, or member features are gated behind unset env flags), rip out the call sites. `git log` on the call sites should reveal which.
+
+Recommended: **Option A** as a single follow-up PR. Wire all 23 with one dispatcher + auth check. cf-3qt Phase 9 retirement plan can then assume cfw → Velo member calls are infrastructure, not per-PR-effort.
+
+## WRAPPED-NO-CONSUMER (35) — possibly orphaned wrappers
+
+HTTP wrappers exist in `http-functions.js` but no cfw URL/callVelo reference. Some are intentionally Wix Studio-callable only (e.g., `runGarbageCollection`, `triggerAbandonedCartRecovery`); others may be orphans from cfw migration partial-rip-out:
+
+`sendWeeklyBlogDigest`, `triggerBrowseRecovery`, `addBundleToCart`, `listBundles`, `getBundleBySlug`, `runGarbageCollection`, `processContentSchedule`, `getDeliveryZone`, `triggerAbandonedCartRecovery`, `triggerReengagement`, `processEmailQueue`, `unsubscribeContact`, `getCampaignAnalytics`, `submitSwatchRequest`, `sendEmail`, `exportCustomerAudienceData`, `generateFeed`, `sendMonthlyLoyaltyStatements`, `triggerPostPurchaseSequence`, `runReviewRequestEmails`, `scanAndTriggerWinback`, `getImageUrl`, `subscribeToNewsletter`, `recordPriceSnapshots`, `checkWishlistAlerts`, `getAssemblyFollowUpData`, `subscribe`, `unsubscribe`, `submitQuestion`, `answerQuestion`, `getProductQuestions`, `insertGuestQuestion`, `buildSitemapXml`, `getRobotsTxtContent`, `getSitemapData`.
+
+Triage: cron/admin endpoints (`runGarbageCollection`, `processEmailQueue`, etc.) are legit. cfw-replaced ones (`buildSitemapXml`, `getSitemapData` — cfw has its own sitemap; `getProductQuestions` — cfw has PdpQA via `productQAService`) are deletion candidates after stage3-velo retires (cf-3qt Phase 9). Defer triage until then.
+
+## UNUSED-CAN-DELETE (518) — no caller anywhere
+
+53% of webMethods. **Top files concentrating dead code** (file:method-count):
+
+| Methods | File |
+|---:|---|
+| 18 | `emailTemplates.web.js` |
+| 13 | `tradeProgram.web.js` |
+| 9 | `bundleBuilder.web.js` |
+| 9 | `affiliateProgram.web.js` |
+| 8 | `subscriptionService.web.js` |
+| 8 | `emailAutomation.web.js` |
+| 8 | `errorMonitoring.web.js` |
+| 8 | `pinterestCatalogSync.web.js` |
+| 7 | `wishlistAlerts.web.js`, `dataService.web.js`, `socialStoryScheduler.web.js`, `coreWebVitals.web.js`, `warrantyService.web.js`, `mediaGallery.web.js`, `liveShopping.web.js` |
+
+Permission breakdown of dead methods: 202 Admin / 193 Anyone / 133 SiteMember.
+
+Deletion is safe **only after** confirming via dynamic-import / `wixWebMethods.invoke` grep — those patterns string-key webMethods and would not be caught by static grep. Most cfutons code uses static imports, so the false-positive risk is low; spot-check before each deletion.
+
+## SUSPICIOUS — Permissions.Anyone + public-verb name + no HTTP wrapper
+
+11 truly-dead-and-public-named webMethods are deletion-or-wire candidates:
+
+`submitFabricSampleRequest` (likely supplanted by cf-w1lg's `post_sampleRequests`), `sendSwatchConfirmationEmail` (dead — should fire after swatch request), `trackVideoView`, `trackBundleImpression`, `trackComparison`, `trackAffiliateClick`, `trackEngagement`, `generateBlogRssFeed`, `generateInternalLinks`, `generateRoomPrepChecklist`, `generatePinContent`.
+
+Plus 3 Permissions.Anyone webMethods that are actually internal-only — overly broad permission, should drop to caller's permission level: `cartSessionService.createSession`, `cartSessionService.updateCartItems`, `ups-shipping.trackShipment`.
+
+## Method (audit script)
+
+```
+scripts/cf-dead-routes/audit.py:
+  1. Walk src/backend/**/*.web.js → collect every `export const NAME = webMethod(Permissions.X, ...)`
+  2. Scan src/backend/http-functions.js for `post_NAME` / `get_NAME` exports
+  3. Scan src/backend/events.js + *.events.js for NAME references
+  4. Scan all .js/.ts/.jsx/.tsx in src/ for NAME references (FRONTEND vs INTERNAL classification)
+  5. Cross-rig: scan /Users/hal/gt/carolina-futons-web/src for:
+     - HIGH confidence: `/_functions/<NAME>` URL OR `method: "<...>/<NAME>"` OR `g("<NAME>")` patterns
+     - LOW confidence: bare `\bNAME\b` references (name-collision risk)
+  6. Classify into HTTP-EXPOSED / EVENT-WIRED / FRONTEND / INTERNAL / DEAD
+  7. Cross with cfw to assign GAP-CFW-WANTS / OK-WIRED / WRAPPED-NO-CONSUMER /
+     UNUSED-CAN-DELETE / VELO-INTERNAL / MAYBE-CFW-NAME-COLLISION
+```
+
+Re-runs cleanly from a fresh worktree of cfutons + cfw checked out alongside. Update `CFW_SRC` constant if cfw lives elsewhere.
+
+## Recommended polecat sweeps
+
+1. **🚨 Wire the 23 GAP-CFW-WANTS** (one bead, P0 if member-area features are user-facing in prod): pick Option A (generic dispatcher) for blast-radius efficiency. Estimated 1–2 hour PR including auth-pass-through + tests.
+
+2. **Delete 11 SUSPICIOUS webMethods + tighten 3 INTERNAL-Anyone perms** (one bead, ~30 min).
+
+3. **Triage 6 entirely-dead service files** (per-file decision beads): `tradeProgram`, `affiliateProgram`, `pinterestCatalogSync`, `socialStoryScheduler`, `liveShopping`, `warrantyService`. Keep / supersede / delete?
+
+4. **`emailTemplates.web.js` — 18 dead methods**: confirm whether superseded by `templateRegistry.web.js` (cf-c6g5 era) before action.
+
+5. **Defer WRAPPED-NO-CONSUMER triage** until after cf-3qt Phase 9 (Wix Studio retirement) — many wrappers are intentional Wix-Studio-callable cron/admin endpoints that retire with stage3.
+
+## Source artifacts
+
+- `scripts/cf-dead-routes/audit.py` — runnable detector. Re-run after any `*.web.js`, `http-functions.js`, or cfw `actions/*.ts` change.
+- `docs/velo-dead-routes-2026-05-09.md` — this report.
+- Full per-method classification (992 rows): regenerable; not committed.
+
+Refs cf-hpwy, cf-w1lg, cf-c6g5, cf-3qt Phase 9.

--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Velo dead-route detector — Phase 1.
+
+For each `export const NAME = webMethod(Permissions.X, ...)` in
+src/backend/*.web.js, classify into:
+
+  HTTP-EXPOSED  — http-functions.js imports OR calls NAME (cfw can reach it)
+  EVENT-WIRED   — events.js or *.events.js references NAME
+  FRONTEND      — src/public, src/pages, or any non-.web.js Velo source calls NAME
+  INTERNAL      — only called by another src/backend/*.web.js module
+  DEAD          — no caller anywhere outside the defining file
+
+Plus secondary flag SUSPICIOUS:
+  - Permissions.Anyone, no HTTP wrapper / cfw caller
+  - name starts with a public-verb (submit/track/register/...) → looks
+    publicly callable but isn't reachable from cfw
+"""
+from __future__ import annotations
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path("/tmp/cfutons-velo-dead")
+SRC = ROOT / "src"
+BACKEND = SRC / "backend"
+HTTP_FILE = BACKEND / "http-functions.js"
+EVENTS_FILE = BACKEND / "events.js"
+
+# cfw repo for cross-rig caller check (gap-finder per cf-hpwy)
+CFW_SRC = Path("/Users/hal/gt/carolina-futons-web/src")
+
+# `export const NAME = webMethod(Permissions.X, ...`
+WM_RE = re.compile(
+    r"^export\s+const\s+(\w+)\s*=\s*webMethod\s*\(\s*Permissions\.(\w+)",
+    re.MULTILINE,
+)
+
+PUBLIC_VERB_RE = re.compile(
+    r"^(submit|create|track|register|capture|send|notify|subscribe|"
+    r"unsubscribe|redeem|claim|generate|update|delete)",
+)
+
+
+def all_source_files() -> list[Path]:
+    out: list[Path] = []
+    for p in SRC.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix in (".js", ".jsx", ".ts", ".tsx"):
+            out.append(p)
+    return out
+
+
+def collect_web_methods() -> dict[str, dict]:
+    methods: dict[str, dict] = {}
+    for fp in BACKEND.rglob("*.web.js"):
+        try:
+            text = fp.read_text(errors="ignore")
+        except OSError:
+            continue
+        for m in WM_RE.finditer(text):
+            name, perm = m.group(1), m.group(2)
+            line = text[: m.start()].count("\n") + 1
+            methods[name] = {
+                "file": str(fp.relative_to(ROOT)),
+                "permission": perm,
+                "line": line,
+            }
+    return methods
+
+
+def collect_cfw_files() -> list[Path]:
+    if not CFW_SRC.exists():
+        return []
+    out: list[Path] = []
+    for p in CFW_SRC.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix in (".js", ".jsx", ".ts", ".tsx"):
+            out.append(p)
+    return out
+
+
+def cfw_references(name: str, cfw_files: list[Path]) -> tuple[list[str], list[str]]:
+    """Return (high_confidence, low_confidence) cfw paths.
+
+    High confidence:
+      - `/_functions/<NAME>` literal URL fragment (direct fetch)
+      - `method: "<...>/<NAME>"` or `method: g("<NAME>")` etc. (callVelo pattern)
+    Low confidence:
+      - Bare `\\bNAME\\b` reference anywhere in cfw source (could be a name
+        collision with a cfw-internal symbol).
+    """
+    pat_word = re.compile(rf"\b{re.escape(name)}\b")
+    pat_url = re.compile(rf"/_functions/(?:[A-Za-z0-9_-]+/)?{re.escape(name)}\b")
+    pat_method_str = re.compile(
+        rf"""method\s*:\s*[`'"](?:[A-Za-z0-9_-]+/)?{re.escape(name)}\b"""
+    )
+    pat_method_helper = re.compile(rf"""[gmhl]\s*\(\s*[`'"]{re.escape(name)}\b""")
+    high: list[str] = []
+    low: list[str] = []
+    for fp in cfw_files:
+        try:
+            text = fp.read_text(errors="ignore")
+        except OSError:
+            continue
+        rel = str(fp.relative_to(CFW_SRC.parent))
+        if (
+            pat_url.search(text)
+            or pat_method_str.search(text)
+            or pat_method_helper.search(text)
+        ):
+            high.append(rel)
+        elif pat_word.search(text):
+            low.append(rel)
+    return high, low
+
+
+def classify_method(
+    name: str,
+    info: dict,
+    files: list[Path],
+    cfw_files: list[Path],
+    http_text: str,
+    events_text: str,
+) -> dict:
+    """Return classification for this webMethod."""
+    defining_file = info["file"]
+    pat_call = re.compile(rf"\b{re.escape(name)}\s*\(")  # NAME(... call
+    pat_import = re.compile(rf"\b{re.escape(name)}\b")  # any reference (for imports)
+
+    in_http = bool(
+        pat_call.search(http_text) or pat_import.search(http_text)
+    )
+    in_events = bool(
+        pat_import.search(events_text)
+    )
+    in_public = False
+    in_pages = False
+    in_pdocs_backend = False  # other backend (not defining file, not http-functions, not events)
+    sample_callers: list[str] = []
+
+    for fp in files:
+        rel = str(fp.relative_to(ROOT))
+        if rel == defining_file:
+            continue
+        if rel == "src/backend/http-functions.js":
+            continue  # handled
+        if rel == "src/backend/events.js":
+            continue  # handled
+        try:
+            text = fp.read_text(errors="ignore")
+        except OSError:
+            continue
+        if not pat_import.search(text):
+            continue
+        # any reference counts; don't require call form (could be re-export, type ref)
+        if rel.startswith("src/public/"):
+            in_public = True
+        elif rel.startswith("src/pages/"):
+            in_pages = True
+        elif rel.startswith("src/backend/") and rel.endswith(".web.js"):
+            in_pdocs_backend = True
+        elif rel.startswith("src/backend/"):
+            in_pdocs_backend = True
+        if len(sample_callers) < 5:
+            sample_callers.append(rel)
+
+    buckets: list[str] = []
+    if in_http:
+        buckets.append("HTTP-EXPOSED")
+    if in_events:
+        buckets.append("EVENT-WIRED")
+    if in_public or in_pages:
+        buckets.append("FRONTEND")
+    if in_pdocs_backend:
+        buckets.append("INTERNAL")
+    if not buckets:
+        buckets = ["DEAD"]
+
+    suspicious = (
+        info["permission"] == "Anyone"
+        and "HTTP-EXPOSED" not in buckets
+        and "FRONTEND" not in buckets
+        and PUBLIC_VERB_RE.match(name) is not None
+    )
+
+    cfw_high, cfw_low = cfw_references(name, cfw_files)
+    has_cfw_high = bool(cfw_high)
+    has_cfw_low = bool(cfw_low)
+    has_cfw_any = bool(cfw_high or cfw_low)
+
+    # Gap-finder verdict (cf-hpwy core deliverable)
+    if not in_http and has_cfw_high:
+        gap_verdict = "GAP-CFW-WANTS"  # cfw calls it via /_functions or callVelo, no HTTP wrapper
+    elif in_http and has_cfw_high:
+        gap_verdict = "OK-WIRED"
+    elif in_http and not has_cfw_high:
+        gap_verdict = "WRAPPED-NO-CONSUMER"
+    elif buckets == ["DEAD"] and not has_cfw_any:
+        gap_verdict = "UNUSED-CAN-DELETE"
+    elif has_cfw_low:
+        gap_verdict = "MAYBE-CFW-NAME-COLLISION"  # bare-word match only
+    else:
+        gap_verdict = "VELO-INTERNAL"  # used inside Velo; cfw isn't a consumer
+
+    return {
+        "name": name,
+        "file": defining_file,
+        "line": info["line"],
+        "permission": info["permission"],
+        "bucket": buckets,
+        "suspicious": suspicious,
+        "gap_verdict": gap_verdict,
+        "in_http": in_http,
+        "in_events": in_events,
+        "in_public": in_public,
+        "in_pages": in_pages,
+        "in_other_backend": in_pdocs_backend,
+        "sample_callers": sample_callers,
+        "cfw_high_refs": cfw_high[:6],
+        "cfw_low_refs": cfw_low[:6],
+        "cfw_high_count": len(cfw_high),
+        "cfw_low_count": len(cfw_low),
+    }
+
+
+def main() -> int:
+    files = all_source_files()
+    methods = collect_web_methods()
+    print(f"scanning {len(files)} src files", file=sys.stderr)
+    print(f"webMethods discovered: {len(methods)}", file=sys.stderr)
+
+    http_text = HTTP_FILE.read_text(errors="ignore") if HTTP_FILE.exists() else ""
+    events_text = EVENTS_FILE.read_text(errors="ignore") if EVENTS_FILE.exists() else ""
+    # Also fold any *.events.js into events_text
+    for fp in BACKEND.rglob("*.events.js"):
+        try:
+            events_text += "\n" + fp.read_text(errors="ignore")
+        except OSError:
+            continue
+
+    cfw_files = collect_cfw_files()
+    print(f"cfw src files: {len(cfw_files)}", file=sys.stderr)
+
+    rows = [
+        classify_method(name, info, files, cfw_files, http_text, events_text)
+        for name, info in methods.items()
+    ]
+
+    Path("/tmp/cf-dead-routes/results.json").write_text(json.dumps(rows, indent=2))
+
+    # Single-bucket tally
+    primary = Counter()
+    for r in rows:
+        primary[r["bucket"][0]] += 1
+    print("\nPrimary bucket (first match):", file=sys.stderr)
+    for b, c in primary.most_common():
+        print(f"  {b}: {c}", file=sys.stderr)
+
+    multi = Counter()
+    for r in rows:
+        for b in r["bucket"]:
+            multi[b] += 1
+    print("\nAny-match tally (rows can appear in multiple):", file=sys.stderr)
+    for b, c in multi.most_common():
+        print(f"  {b}: {c}", file=sys.stderr)
+
+    sus = [r for r in rows if r["suspicious"]]
+    print(f"\nSUSPICIOUS (Permissions.Anyone, public-verb name, not HTTP/frontend reachable): {len(sus)}", file=sys.stderr)
+
+    dead = [r for r in rows if r["bucket"] == ["DEAD"]]
+    print(f"DEAD (no caller anywhere): {len(dead)}", file=sys.stderr)
+
+    print("\nGap-verdict tally (cf-hpwy core):", file=sys.stderr)
+    gap = Counter(r["gap_verdict"] for r in rows)
+    for v, c in gap.most_common():
+        print(f"  {v}: {c}", file=sys.stderr)
+    gaps = [r for r in rows if r["gap_verdict"] == "GAP-CFW-WANTS"]
+    if gaps:
+        print(f"\n🚨 GAP-CFW-WANTS — cfw URL/callVelo references but no HTTP wrapper ({len(gaps)}):", file=sys.stderr)
+        for r in gaps:
+            print(f"  {r['name']:35s} {r['file']}:{r['line']}  perm={r['permission']}  cfw_high={r['cfw_high_count']}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Static-analysis sweep matching the cf-w1lg drift-discovery pattern. Walks 992 webMethods across 222 \`*.web.js\` files, 54 HTTP wrappers in \`http-functions.js\`, and 658 cfw consumer files in \`carolina-futons-web/src\`. Classifies every webMethod into actionable buckets.

Repo target: cfutons monorepo (Velo source-of-truth). Zero Vercel impact (cfutons + stage3-velo don't deploy to Vercel).

## Headline — 🚨 23 GAP-CFW-WANTS

cfw calls these via \`callVelo\` or \`/_functions/<name>\` URL but no HTTP wrapper exists in \`http-functions.js\`. **These 404 in production** unless a generic Velo dispatcher is added (none found).

All 23 cluster in **6 files**, all member-area:

| File | Methods |
|---|---|
| \`loyaltyService.web.js\` | 10 |
| \`gamificationCore.web.js\` | 4 |
| \`wishlistService.web.js\` | 3 |
| \`styleQuiz.web.js\` | 3 |
| \`pushNotificationService.web.js\` | 2 |
| \`rewardsStore.web.js\` | 1 |

cfw call sites concentrate in \`src/app/actions/{loyalty,gamification,preferences,style-quiz}.ts\` using \`callVelo({ method: g("name") })\` from \`src/lib/wix/velo-client.ts\`. The helper builds \`/_functions/<MODULE>/<METHOD>\` URLs that don't resolve to any \`post_NAME\` handler.

## Full classification

| Verdict | Count | Meaning |
|---|---:|---|
| 🚨 GAP-CFW-WANTS | **23** | cfw calls via /_functions/* or callVelo, no HTTP wrapper |
| 🔴 UNUSED-CAN-DELETE | 518 | No caller anywhere in cfutons or cfw |
| ⚪ VELO-INTERNAL | 383 | Used by Wix Studio pages / events / other webModules |
| 🟡 WRAPPED-NO-CONSUMER | 35 | HTTP wrapper exists but cfw doesn't call |
| 🟠 MAYBE-CFW-NAME-COLLISION | 28 | Bare-word match only — possible name collision |
| 🟢 OK-WIRED | 5 | Wrapper exists AND cfw calls it |

## Suggested fix paths
- **Option A (preferred)**: generic \`post_dispatch\` handler in http-functions.js that takes \`request.path = [moduleName, methodName]\` and dispatches; closes 23 gaps in one PR with auth-pass-through. ~1–2 hour follow-up PR.
- **Option B**: 23 per-method wrappers (cf-w1lg pattern). ~300 LOC, more verbose.
- **Option C**: rip out the cfw-side calls if the member-area features aren't actually live in prod.

## Detection
- HIGH confidence: \`/_functions/<NAME>\` URL literal OR \`method: "<...>/<NAME>"\` OR \`g("<NAME>")\` helper pattern
- LOW confidence (bare \`\\bNAME\\b\` match): filed under MAYBE-CFW-NAME-COLLISION rather than GAP

False-negative spot-checks (\`getTier\`, \`getTestimonialsByCategory\`, \`trackVideoView\`, \`submitFabricSampleRequest\`) all confirmed zero callers in src/. Detection is sound.

False-positive risk for UNUSED-CAN-DELETE: dynamic imports / \`wixWebMethods.invoke\` patterns aren't caught by static grep. Spot-check before any deletion. Most cfutons code uses static imports so risk is low.

## Test plan
- [x] Doc committed: \`docs/velo-dead-routes-2026-05-09.md\`
- [x] Detector script committed: \`scripts/cf-dead-routes/audit.py\` (re-run after any \`*.web.js\` / http-functions / cfw-actions change)
- [x] Spot-check 4 random UNUSED webMethods → all confirmed zero callers
- [ ] (deferred) Pick fix path A/B/C in a follow-up bead — that's where the actual member-area unblock happens

Refs cf-hpwy, cf-w1lg, cf-c6g5, cf-3qt Phase 9.