### PR TITLE
fix(ratchet): use npm ci to keep auto-ratchet PRs clean

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -53,8 +53,14 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        # `npm ci` is strict (will not mutate package-lock.json); the
+        # repo's main CI uses `npm install --ignore-scripts` because the
+        # @wix/cli postinstall is unwanted there. The ratchet doesn't
+        # need the CLI at all and writing back into the lockfile (e.g.
+        # the `name` field, which is absent from package.json) ends up
+        # in the auto-PR diff. Use `npm ci` to keep ratchet PRs clean.
         if: steps.skip.outputs.skip != 'true'
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Unit tests with coverage (json-summary already enabled)
         if: steps.skip.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

The first cfutons ratchet auto-PR (#1165) carried an unrelated `package-lock.json` `name` field rewrite alongside the actual `vitest.config.js` threshold bump.

## Root cause

`package.json` has no `name` field. `npm install` (which the ratchet workflow was running) writes the workspace directory name into the lockfile's `name`. On the runner that's `carolina-futons`; on past machines the lockfile said `cfutons`. So every ratchet auto-PR will keep flipping that field back and forth.

## Fix

Switch the ratchet workflow's install step to `npm ci --ignore-scripts`:

- `npm ci` is strict — refuses to mutate `package-lock.json`, so future ratchet PRs will only contain the threshold bump.
- `--ignore-scripts` is preserved because the `@wix/cli` postinstall (`wix sync-types`) is interactive and unwanted in CI.

The repo's main `ci.yml` keeps using `npm install --ignore-scripts` (its own concern). This change is scoped to the ratchet workflow.

## Test plan

- [ ] After merge, next ratchet run produces an auto-PR (or auto-pushed branch with manual PR open) whose only diff is `vitest.config.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)