### PR TITLE
fix(cf-yvs4): SECURITY P0 — IDOR defense + lying-status fix

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -2962,6 +2962,16 @@ export async function post_wishlistService(request) {
   try {
     const fn = wishlistServiceModule[method];
     const result = await fn(...args);
+    // cf-yvs4: align wishlist dispatcher to the lying-status fix applied
+    // to _veloDispatch + post_recordSpinGrant + post_submitSurvey. cfw's
+    // velo-client.ts throws VeloRpcError on non-2xx and exposes res.body
+    // — the friendly error string is still readable. Returning 200 +
+    // {success:false} let cfw's `if (!result?.success)` branch silently
+    // succeed (cf-89xn pattern repeat).
+    if (result && typeof result === 'object' && result.success === false) {
+      const status = _veloDispatchSoftFailStatus(result.error);
+      return response({ status, body: JSON.stringify(result), headers: JSON_HEADERS });
+    }
     return ok({ body: JSON.stringify(result), headers: JSON_HEADERS });
   } catch (err) {
     const errorId = (typeof crypto !== 'undefined' && crypto.randomUUID)
@@ -3349,13 +3359,32 @@ function _veloDispatchErrorId() {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// cf-yvs4: map a webMethod soft-failure envelope to the right HTTP status.
+// cfw's velo-client.ts throws VeloRpcError on non-2xx and surfaces res.body
+// in the error — callers can still read the message. Returning 200 for
+// `{success:false}` is the cf-tvbi lying-status pattern cf-89xn already
+// removed from get_deliveryZone; same applies here.
+function _veloDispatchSoftFailStatus(errStr) {
+  const lowered = String(errStr || '').toLowerCase();
+  if (lowered.includes('authentication') || lowered.includes('unauthorized') || lowered.includes('not authenticated')) {
+    return 401;
+  }
+  if (lowered.includes('rate limit') || lowered.includes('rate_limit') || lowered.includes('too many requests')) {
+    return 429;
+  }
+  if (lowered.includes('not found') || lowered.includes('no survey found')) {
+    return 404;
+  }
+  return 400;
+}
+
 async function _veloDispatch(request, registry, scope) {
   const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
   const methodName = (request.path && request.path[0]) || '';
 
   if (!methodName || typeof registry[methodName] !== 'function') {
     return notFound({
-      body: JSON.stringify({ error: 'unknown_method', method: methodName }),
+      body: JSON.stringify({ success: false, error: 'unknown_method', method: methodName }),
       headers: JSON_HEADERS,
     });
   }
@@ -3365,19 +3394,27 @@ async function _veloDispatch(request, registry, scope) {
     body = await request.body.json();
   } catch (err) {
     return badRequest({
-      body: JSON.stringify({ error: 'invalid_json', detail: err && err.message }),
+      body: JSON.stringify({ success: false, error: 'invalid_json', detail: err && err.message }),
       headers: JSON_HEADERS,
     });
   }
   if (!body || !Array.isArray(body.args)) {
     return badRequest({
-      body: JSON.stringify({ error: 'args_must_be_array' }),
+      body: JSON.stringify({ success: false, error: 'args_must_be_array' }),
       headers: JSON_HEADERS,
     });
   }
 
   try {
     const result = await registry[methodName](...body.args);
+    // cf-yvs4: if the webMethod resolves with `{success:false}`, surface the
+    // matching HTTP status rather than 200 (lying-status pattern). cfw's
+    // velo-client throws VeloRpcError on non-2xx and exposes res.body so
+    // callers can still read the error string.
+    if (result && typeof result === 'object' && result.success === false) {
+      const status = _veloDispatchSoftFailStatus(result.error);
+      return response({ status, body: JSON.stringify(result), headers: JSON_HEADERS });
+    }
     return ok({ body: JSON.stringify(result == null ? null : result), headers: JSON_HEADERS });
   } catch (err) {
     const errorId = _veloDispatchErrorId();
@@ -3475,28 +3512,35 @@ export function options_styleQuiz(request) { return response(corsPreflight(reque
  *   500 with errorId on failure.
  */
 export async function post_recordSpinGrant(request) {
-  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
   try {
     let member;
     try {
       member = await currentMember.getMember();
     } catch (err) {
       // getMember() throws when no SiteMember context is available
-      // (cfw forgot to forward the Bearer token). Mirror the
-      // webMethod soft-error envelope so cfw branches on body.success.
+      // (cfw forgot to forward the Bearer token). cf-yvs4: return 401 not
+      // 200 so cfw's velo-client.ts surfaces the failure as a thrown
+      // VeloRpcError rather than the silent lying-status it gets today.
       console.warn('[recordSpinGrant] getMember failed — treating as unauthenticated:', err && err.message);
-      return ok({
+      return response({
+        status: 401,
         body: JSON.stringify({ success: false, error: 'Authentication required' }),
         headers: JSON_HEADERS,
       });
     }
     if (!member || !member._id) {
-      return ok({
+      return response({
+        status: 401,
         body: JSON.stringify({ success: false, error: 'Authentication required' }),
         headers: JSON_HEADERS,
       });
     }
     const result = await grantSpin(member._id);
+    if (result && typeof result === 'object' && result.success === false) {
+      const status = _veloDispatchSoftFailStatus(result.error);
+      return response({ status, body: JSON.stringify(result), headers: JSON_HEADERS });
+    }
     return ok({ body: JSON.stringify(result == null ? { success: true } : result), headers: JSON_HEADERS });
   } catch (err) {
     const errorId = _veloDispatchErrorId();
@@ -3534,7 +3578,7 @@ export function options_recordSpinGrant(request) { return response(corsPreflight
  *   500 with errorId on unexpected throw.
  */
 export async function post_submitSurvey(request) {
-  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
   let body;
   try {
     body = await request.body.json();
@@ -3545,16 +3589,20 @@ export async function post_submitSurvey(request) {
     });
   }
 
-  const score = Number(body && body.score);
-  const orderId = typeof (body && body.orderId) === 'string' ? body.orderId.trim() : '';
-  const comments = typeof (body && body.comments) === 'string' ? body.comments : null;
-
-  if (!Number.isInteger(score) || score < 0 || score > 10) {
+  // cf-yvs4: tighten score type check. `Number(…)` accepts strings ("5"),
+  // booleans (true → 1), null (→ 0), trailing-junk strings — all of which
+  // we don't want from a JSON-typed API. Require a real number coming
+  // through the wire.
+  const rawScore = body && body.score;
+  if (typeof rawScore !== 'number' || !Number.isInteger(rawScore) || rawScore < 0 || rawScore > 10) {
     return badRequest({
       body: JSON.stringify({ success: false, error: 'score must be an integer 0..10' }),
       headers: JSON_HEADERS,
     });
   }
+  const orderId = typeof (body && body.orderId) === 'string' ? body.orderId.trim() : '';
+  const comments = typeof (body && body.comments) === 'string' ? body.comments : null;
+
   if (!orderId) {
     return badRequest({
       body: JSON.stringify({ success: false, error: 'orderId is required' }),
@@ -3562,10 +3610,62 @@ export async function post_submitSurvey(request) {
     });
   }
 
+  // cf-yvs4 IDOR defense-in-depth: do an explicit memberId-scoped Survey
+  // lookup before delegating. submitSurveyResponse already does this
+  // internally (queries `Survey` collection with eq('memberId', memberId)
+  // .eq('orderId', orderId)), so the wrapper-layer check is redundant but
+  // explicit — catches any future regression where the webMethod's IDOR
+  // check is removed or weakened.
+  let member;
   try {
-    // submitSurveyResponse expects { orderId, npsScore, comment } and resolves
-    // the member + Survey row + double-submission guard internally.
-    const result = await submitSurveyResponse({ orderId, npsScore: score, comment: comments });
+    member = await currentMember.getMember();
+  } catch (err) {
+    console.warn('[submitSurvey] getMember failed — treating as unauthenticated:', err && err.message);
+    return response({
+      status: 401,
+      body: JSON.stringify({ success: false, error: 'Authentication required' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  if (!member || !member._id) {
+    return response({
+      status: 401,
+      body: JSON.stringify({ success: false, error: 'Authentication required' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  try {
+    const lookup = await wixData.query('Survey')
+      .eq('memberId', member._id)
+      .eq('orderId', orderId)
+      .limit(1)
+      .find({ suppressAuth: true });
+    if (lookup.items.length === 0) {
+      return response({
+        status: 404,
+        body: JSON.stringify({ success: false, error: 'No survey found for this order' }),
+        headers: JSON_HEADERS,
+      });
+    }
+  } catch (err) {
+    const errorId = _veloDispatchErrorId();
+    console.error(`HTTP function error (post_submitSurvey) errorId=${errorId} ownership lookup failed:`, err);
+    return serverError({
+      body: JSON.stringify({ success: false, error: 'server_error', errorId }),
+      headers: JSON_HEADERS,
+    });
+  }
+
+  try {
+    // submitSurveyResponse expects { orderId, npsScore, comment } and
+    // re-resolves the member + Survey row + double-submission guard. Our
+    // ownership pre-check above just ensures the orderId belongs to the
+    // caller before we delegate.
+    const result = await submitSurveyResponse({ orderId, npsScore: rawScore, comment: comments });
+    if (result && typeof result === 'object' && result.success === false) {
+      const status = _veloDispatchSoftFailStatus(result.error);
+      return response({ status, body: JSON.stringify(result), headers: JSON_HEADERS });
+    }
     return ok({ body: JSON.stringify(result == null ? { success: true } : result), headers: JSON_HEADERS });
   } catch (err) {
     const errorId = _veloDispatchErrorId();

--- a/tests/cfvtx5Dispatchers.test.js
+++ b/tests/cfvtx5Dispatchers.test.js
@@ -78,6 +78,7 @@ import { captureQuizLead } from 'backend/styleQuiz.web';
 import { submitSurveyResponse } from 'backend/surveyService.web';
 import { grantSpin } from 'backend/spinRedemptionService.web';
 import { __setMember } from './__mocks__/wix-members-backend.js';
+import { __seed, __reset as __resetData } from './__mocks__/wix-data.js';
 
 const goodOrigin = 'https://carolina-futons-web.vercel.app';
 
@@ -98,6 +99,7 @@ function flatReq(body) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetData();
   __setMember(null);
 });
 
@@ -123,11 +125,26 @@ describe('cf-vtx5 · post_gamificationCore dispatcher', () => {
     expect(JSON.parse(res.body)).toMatchObject({ error: 'unknown_method', method: 'updateStreakState' });
   });
 
-  it('forwards soft failures verbatim as 200 (no 5xx for {success:false})', async () => {
+  it('cf-yvs4: maps {success:false} envelopes to the matching 4xx status', async () => {
+    // Default soft-fail → 400; "rate_limit" string → 429; "Authentication
+    // required" → 401. cf-89xn lying-status removal applied to all 22
+    // dispatchers per radahn's audit (cf-yvs4).
     vi.mocked(gamificationGetLeaderboard).mockResolvedValue({ success: false, error: 'rate_limit' });
     const res = await post_gamificationCore(dispatcherReq('getLeaderboard'));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(429);
     expect(JSON.parse(res.body)).toEqual({ success: false, error: 'rate_limit' });
+  });
+
+  it('cf-yvs4: defaults soft-fail status to 400 when error string has no recognized marker', async () => {
+    vi.mocked(gamificationGetLeaderboard).mockResolvedValue({ success: false, error: 'something else broke' });
+    const res = await post_gamificationCore(dispatcherReq('getLeaderboard'));
+    expect(res.status).toBe(400);
+  });
+
+  it('cf-yvs4: maps "Authentication required" soft-fail to 401', async () => {
+    vi.mocked(gamificationGetLeaderboard).mockResolvedValue({ success: false, error: 'Authentication required' });
+    const res = await post_gamificationCore(dispatcherReq('getLeaderboard'));
+    expect(res.status).toBe(401);
   });
 
   it('returns 500 with errorId + console-correlated log on unexpected throw', async () => {
@@ -244,10 +261,10 @@ describe('cf-vtx5 · post_recordSpinGrant', () => {
     expect(vi.mocked(grantSpin)).toHaveBeenCalledWith('member-77');
   });
 
-  it('returns 200 + {success:false, "Authentication required"} when no member', async () => {
+  it('cf-yvs4: returns 401 + {success:false, "Authentication required"} when no member', async () => {
     __setMember(null);
     const res = await post_recordSpinGrant(flatReq({}));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
     expect(JSON.parse(res.body)).toMatchObject({ success: false, error: 'Authentication required' });
     expect(vi.mocked(grantSpin)).not.toHaveBeenCalled();
   });
@@ -272,6 +289,12 @@ describe('cf-vtx5 · post_recordSpinGrant', () => {
 // ── post_submitSurvey ─────────────────────────────────────────────────────────
 
 describe('cf-vtx5 · post_submitSurvey', () => {
+  beforeEach(() => {
+    // Default: authenticated member + a Survey row owned by them at order-1.
+    __setMember({ _id: 'member-77', loginEmail: 'm@e.com' });
+    __seed('Survey', [{ _id: 'srv-1', memberId: 'member-77', orderId: 'order-1' }]);
+  });
+
   it('shims cfw shape {score, comments, orderId} → webMethod {orderId, npsScore, comment}', async () => {
     vi.mocked(submitSurveyResponse).mockResolvedValue({ success: true });
     await post_submitSurvey(flatReq({ score: 8, orderId: 'order-1', comments: 'Liked it' }));
@@ -282,21 +305,51 @@ describe('cf-vtx5 · post_submitSurvey', () => {
     });
   });
 
-  it('forwards the webMethod envelope verbatim as 200', async () => {
+  it('forwards the webMethod envelope verbatim as 200 on success', async () => {
     vi.mocked(submitSurveyResponse).mockResolvedValue({ success: true });
     const res = await post_submitSurvey(flatReq({ score: 10, orderId: 'order-1' }));
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ success: true });
   });
 
-  it('forwards soft-failure {success:false, error} as 200 (matches dispatcher contract)', async () => {
-    vi.mocked(submitSurveyResponse).mockResolvedValue({ success: false, error: 'Authentication required' });
+  it('cf-yvs4: maps webMethod soft-failure {success:false} to a matching 4xx', async () => {
+    vi.mocked(submitSurveyResponse).mockResolvedValue({ success: false, error: 'Survey already completed' });
     const res = await post_submitSurvey(flatReq({ score: 5, orderId: 'order-1' }));
-    expect(res.status).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ success: false, error: 'Authentication required' });
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ success: false, error: 'Survey already completed' });
   });
 
-  it('returns 400 when score is not an integer 0..10', async () => {
+  it('cf-yvs4 IDOR: returns 404 when the orderId does not belong to the caller', async () => {
+    // Pre-check pulls a Survey row scoped to the caller's memberId — a
+    // different member's orderId returns no rows → 404.
+    __setMember({ _id: 'attacker-99', loginEmail: 'a@e.com' });
+    const res = await post_submitSurvey(flatReq({ score: 8, orderId: 'order-1' }));
+    expect(res.status).toBe(404);
+    expect(JSON.parse(res.body)).toMatchObject({ success: false, error: expect.stringMatching(/no survey/i) });
+    expect(vi.mocked(submitSurveyResponse)).not.toHaveBeenCalled();
+  });
+
+  it('cf-yvs4: returns 401 when no SiteMember context', async () => {
+    __setMember(null);
+    const res = await post_submitSurvey(flatReq({ score: 5, orderId: 'order-1' }));
+    expect(res.status).toBe(401);
+    expect(JSON.parse(res.body)).toMatchObject({ success: false, error: 'Authentication required' });
+    expect(vi.mocked(submitSurveyResponse)).not.toHaveBeenCalled();
+  });
+
+  it('cf-yvs4: rejects non-number score type (string "5", boolean true, null)', async () => {
+    // Number(…) coerced these to valid integers in the old code; tighten to
+    // typeof === 'number' so JSON-typed inputs are required.
+    const res1 = await post_submitSurvey(flatReq({ score: '5', orderId: 'order-1' }));
+    expect(res1.status).toBe(400);
+    const res2 = await post_submitSurvey(flatReq({ score: true, orderId: 'order-1' }));
+    expect(res2.status).toBe(400);
+    const res3 = await post_submitSurvey(flatReq({ score: null, orderId: 'order-1' }));
+    expect(res3.status).toBe(400);
+    expect(vi.mocked(submitSurveyResponse)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when score is out of range', async () => {
     const res1 = await post_submitSurvey(flatReq({ score: 11, orderId: 'order-1' }));
     expect(res1.status).toBe(400);
     const res2 = await post_submitSurvey(flatReq({ score: 5.5, orderId: 'order-1' }));

--- a/tests/wishlistServiceDispatcher.cfvtx5.test.js
+++ b/tests/wishlistServiceDispatcher.cfvtx5.test.js
@@ -130,13 +130,16 @@ describe('cf-vtx5 · post_wishlistService dispatcher', () => {
     consoleErr.mockRestore();
   });
 
-  it('forwards the webMethod\'s {success:false, error} envelope on logical failure (does NOT 500)', async () => {
-    // When the webMethod resolves with {success:false}, the dispatcher must
-    // pass that through as 200 — the caller branches on the body, not the
-    // status. Reserves 500 for unexpected throws.
+  it('cf-yvs4: maps webMethod soft-failure to a matching 4xx (cf-89xn lying-status pattern removed)', async () => {
+    // PR #1164 originally returned 200 here so cfw could branch on body.
+    // cf-yvs4 (radahn's audit) flipped the contract: cfw treated success:false
+    // as success in some call sites, recreating the cf-89xn deliveryZone
+    // lying-status bug. velo-client.ts throws VeloRpcError on non-2xx and
+    // exposes res.body — the error string is still readable. 5xx still
+    // reserved for unexpected throws.
     vi.mocked(addToWishlist).mockResolvedValue({ success: false, error: 'Not authenticated.' });
     const res = await post_wishlistService(makeRequest('addToWishlist', { args: ['p-1', 'x', 100] }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
     expect(JSON.parse(res.body)).toEqual({ success: false, error: 'Not authenticated.' });
   });
 });


### PR DESCRIPTION
## Summary

**P0 SECURITY** per @radahn's 6-agent post-merge audit on PR #1168. PR #1172 merged the cf-vtx5.fu2 build-break + survey-shim corrections but NOT the cf-yvs4 security additions — those landed on my amended branch tip but were discarded when GitHub re-resolved the merge against the pre-amend commit. This PR applies them to current main.

@melania asked: "does PR #1172 close cf-yvs4?" — **No.** Build break + survey shim closed; IDOR defense + 22-route lying-status NOT yet on main. Verified via `git show origin/main:src/backend/http-functions.js | grep _veloDispatchSoftFailStatus` (zero matches).

## (1) IDOR defense-in-depth on post_submitSurvey

`submitSurveyResponse` webMethod already IDOR-guards via memberId-scoped Survey query. Adds an explicit wrapper-level memberId-scoped lookup before delegating — any future regression where the webMethod's check is removed or weakened still fails closed at the wrapper.

```js
const lookup = await wixData.query('Survey')
  .eq('memberId', member._id)
  .eq('orderId', orderId)
  .limit(1)
  .find({ suppressAuth: true });
if (lookup.items.length === 0) return 404 'No survey found for this order';
```

404 when orderId doesn't belong to caller; 401 when no SiteMember context.

## (2) Lying-status fix across all 22 routes

`_veloDispatch` (4 module dispatchers) + `post_wishlistService` (rennala's #1164 — flipped from her 200 contract) + `post_recordSpinGrant` + `post_submitSurvey` now flip `{success:false}` → 4xx via new helper:

```js
function _veloDispatchSoftFailStatus(errStr) {
  const lowered = String(errStr || '').toLowerCase();
  if (/authentication|unauthorized|not authenticated/.test(lowered)) return 401;
  if (/rate limit|rate_limit|too many requests/.test(lowered))      return 429;
  if (/not found|no survey found/.test(lowered))                    return 404;
  return 400;
}
```

cfw's `velo-client.ts` throws `VeloRpcError` on non-2xx and exposes `res.body` so callers can still read the friendly error string. 5xx reserved for unexpected throws. **Same cf-89xn pattern that fixed `get_deliveryZone` applied to all 22 routes.**

## Fold-ins

- `post_recordSpinGrant` unauth → 401 (was 200 + soft envelope).
- `post_submitSurvey` score type tightened: `typeof === 'number'` (was `Number(…)` which accepted strings, booleans, null).
- `Cache-Control: no-store` on flat-URL wrappers.
- `success:false` key on all 404/400 envelopes for consistency.

## Test contract change

`tests/wishlistServiceDispatcher.cfvtx5.test.js` line 133 now expects **401** instead of 200 for "Not authenticated" soft-fail — overrides @rennala's PR #1164 contract per audit. Pinged rennala for sign-off; she can push back in review.

`tests/cfvtx5Dispatchers.test.js` extended with cf-yvs4 IDOR + 4xx-soft-fail coverage. **143/143 pass locally.**

## Companion PR

`carolina-futons-stage3-velo` PR #26 mirrors all cf-yvs4 fixes. **Both must merge before next Wix CLI publish.**

Closes cf-yvs4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)