### PR TITLE
docs(cf-z68o): cf-vtx5 cluster retro — 22-route 404 outage + admin-merge audit pattern

### DIFF
--- a/docs/cf-vtx5-retro-2026-05-09.md
+++ b/docs/cf-vtx5-retro-2026-05-09.md
@@ -1,0 +1,90 @@
+# cf-vtx5 cluster retro — 2026-05-09
+
+**Bead**: cf-z68o
+**Author**: radahn
+**Cluster scope**: cf-vtx5 (root), cf-yvs4 (audit), cf-hpb2, cf-bkxh, cf-0h9q
+
+## TL;DR
+
+22 cfw→Velo `/_functions/<module>/<method>` routes silently returned 404 in production. Stilgar's e2e thread ("wishlist not persisting", spin-grants not crediting, etc.) all rooted here. Fixed under P0 admin-merge override. Post-merge 6-agent audit surfaced an IDOR in `post_submitSurvey`, the `cf-tvbi` lying-status pattern reintroduced across all 22 routes, and zero test coverage despite a reference test pattern being available from rennala's earlier merge.
+
+The fix shipped fast and resolved the user-visible symptom. The audit found everything we'd hope a pre-merge review would find. Net: emergency-merge protocol worked, but two systemic gaps (test coverage gating, lying-status pattern recurring) should be hardened.
+
+## Timeline
+
+| Time (MT) | Event |
+|---|---|
+| Pre-cluster | cf-jqkg surfaced webMethods missing HTTP wrappers (cfw→Velo gap audit). Did not enumerate the missing 22. |
+| 2026-05-09 ~early | rennala shipped `post_wishlistService` reference dispatcher impl as PR #1164 with companion test (`wishlistServiceDispatcher.cfvtx5.test.js`). |
+| 2026-05-09 mid | godfrey opened PR #1168 — 5 module dispatchers covering 19 sub-paths + 2 explicit gap wrappers (`post_recordSpinGrant`, `post_submitSurvey`). 263 lines added, 0 deletions, 0 tests. |
+| ~T | radahn dispatched 6-agent pre-pass on PR #1168 per Stilgar PR-discipline directive. |
+| ~T+5 min | melania merged PR #1168 under admin override on P0 user-impact urgency, before radahn's audit completed. Stage3-velo mirror PR #24 also merged. |
+| ~T+15 min | code-simplifier returned (1st of 6). 6 alignment findings vs reference impl. |
+| ~T+18 min | pr-test-analyzer + comment-analyzer returned. Both independently flagged `post_submitSurvey` IDOR. Test coverage = 0 of 22. |
+| ~T+22 min | silent-failure-hunter returned. cf-tvbi lying-status pattern reintroduced across all 22 routes. |
+| ~T+24 min | type-design-analyzer returned. Confirmed envelope-shape divergence. |
+| ~T+28 min | code-reviewer returned. Confirmed IDOR with line citations + fix snippet. |
+| ~T+30 min | radahn synthesis: filed cf-yvs4 (P0) consolidating findings, mailed verdict "FIX-FU" to melania. |
+
+## What went well
+
+1. **Fast unblock.** 19 silent 404s in prod ⇒ real user pain (wishlist not persisting, spin-grants not crediting). Admin-merge collapsed merge-window from "wait for full review" to "ship now, audit follows" and the user-facing symptom resolved within the same session.
+
+2. **6-agent audit caught everything.** Independent agents on different lanes converged on the same critical finding (IDOR flagged by 4 of 6 reviewers without coordination). The cf-tvbi lying-status pattern, which we paid to remove from `get_deliveryZone` in cf-89xn earlier the same day, was caught despite being structurally subtle.
+
+3. **Reference impl pattern.** rennala's PR #1164 set the test/dispatch shape. Findings could be expressed as "diverges from reference at X" rather than abstract design critiques.
+
+4. **Followup-bead pattern worked.** melania's "audit becomes post-merge bead" protocol gave a clear handoff target (cf-yvs4 → godfrey). No findings dropped on the floor.
+
+## What went wrong
+
+1. **PR shipped with 0 of 22 tests.** rennala's reference test file (`wishlistServiceDispatcher.cfvtx5.test.js`) had been merged days before — godfrey's PR could have copied it 22 times mechanically. The IDOR would have been caught by a single test asserting "submitting another member's survey returns 403". Cost: a security gap in production until cf-yvs4 ships.
+
+2. **cf-tvbi lying-status pattern recurred within hours.** The cf-89xn followup explicitly carried the recommendation to backport `get_deliveryZone`'s envelope discipline (200 → 503 on `internal_error`) to canonical so the next sync wouldn't reintroduce it. cf-vtx5 reintroduced the same pattern on 22 routes the same day. The recommendation was filed but not yet acted on; the convention exists in code only at one site.
+
+3. **Admin-merge skipped the auth-shape verification.** The IDOR was visible in the JSDoc-vs-implementation diff (the JSDoc claimed an ownership check; the code didn't have one). A pre-merge skim wouldn't have needed deep context to catch it — but the user-impact pressure compressed review time below that threshold.
+
+4. **Bead ID was placeholder ("cf-??") in the assignment nudge.** Minor process friction — radahn had to file the retro bead self-referentially. Cluster retros that show up after the fact are easier to staff if the dispatcher pre-files an empty bead.
+
+## Recommendations
+
+### P0 — would have prevented the IDOR
+
+**Add an automated pre-merge test-coverage gate for new dispatcher routes.** When `src/backend/http-functions.js` gains a new `post_*` or `get_*` export, CI should require a companion `tests/<name>.http.test.js` or `tests/<name>Dispatcher.cfvtx5.test.js` with at minimum:
+- Auth-required path returns 401 when unauthenticated
+- Auth-required path returns 403 when authenticated as a non-owner (covers IDOR by default)
+- Happy path returns 200 with expected envelope
+- Unknown method returns 404 with `success: false` envelope
+- Body parse failure returns 400 with `success: false` envelope
+
+A `package.json` script + simple grep diff against `git diff main -- src/backend/http-functions.js` is enough — no new tooling. The IDOR test is 12 lines and would have failed on godfrey's PR before merge.
+
+### P1 — would have prevented the lying-status recurrence
+
+**Promote `_veloDispatch` to enforce the envelope discriminant.** When the underlying webMethod returns `{ success: false, error }`, the dispatcher must surface a non-2xx status (400 for known errors, 500 for unexpected). This is one if-statement in the shared helper; it removes the pattern from 22 routes at once and prevents the next 22 from inheriting it.
+
+Add a focused unit test on `_veloDispatch` specifically (separate from the per-module tests) so the envelope contract is pinned at the dispatcher layer.
+
+### P2 — small process tweaks
+
+**Pre-file empty followup beads on emergency merges.** When melania admin-merges with intent to audit-after, opening the followup bead at merge time (with placeholder description) gives the auditor a target to commit findings into and saves the dispatch round-trip.
+
+**Codify the "reference impl exists, copy its test" expectation.** A one-line note on PR templates pointing at the most recent reference impl in the same surface area (e.g. for new HTTP dispatchers: "test pattern in `tests/<reference>.cfvtx5.test.js`") nudges the contributor without requiring reviewer enforcement.
+
+## Non-recommendations
+
+- **Don't add review-time SLAs that block emergency merges.** The admin-override path here was correct given prod user-impact. The 30-minute window for the 6-agent audit was an acceptable cost; making the merge wait would have left wishlist/spin/survey broken for users in the meantime.
+
+- **Don't expand the 6-agent suite by default for routine dispatcher PRs.** The audit's value here came from the production-impact stakes. For routine PRs the existing CR pre-pass shape (3-4 agents on diff scope) is right-sized.
+
+## Cluster status as of retro
+
+| Bead | Status | Owner | Note |
+|---|---|---|---|
+| cf-vtx5 | merged via #1168 | godfrey | 19 silent 404s resolved |
+| cf-yvs4 | open P0 | godfrey | IDOR + lying-status + 0/22 tested — this retro's actionables |
+| cf-hpb2 | open P2 | godfrey | referralService rename decision |
+| cf-bkxh | open P2 | godfrey | giftRegistry dispatcher (probe-surfaced) |
+| cf-0h9q | in progress P1 | godfrey | submitCommunityPhoto wrapper |
+
+cf-yvs4 is the urgent thread — IDOR fix-window matters. The other followups are routine sweep work.

--- a/src/backend/communityPhoto.web.js
+++ b/src/backend/communityPhoto.web.js
@@ -105,24 +105,27 @@ export const submitCommunityPhoto = webMethod(
     const invalid = _validateCommunityPhoto(data);
     if (invalid) return { success: false, error: invalid.error };
 
-    // Per-host rate limit — 5 submissions per hour from any single image
-    // host. Coarse but adequate as a UGC abuse damper; finer-grained
-    // by-IP rate-limiting lives one layer up (Wix platform / Cloudflare).
+    // cf-0h9q.fu: per-host rate-limit is a coarse UGC abuse damper, not
+    // the primary defense — moderation is. Tracked: cf-* follow-up to
+    // switch to IP-based or session-based keying once Wix HTTP function
+    // exposes request.ip cleanly to the webMethod surface (today only
+    // the wrapper sees it). Until then host-keying caps a single
+    // attacker domain but lets multiple attackers under different CDNs
+    // each get their own bucket — known limitation.
+    const host = (data.imageUrl.match(/^https:\/\/([^/]+)/) || [])[1] || 'unknown';
     try {
-      const host = (data.imageUrl.match(/^https:\/\/([^/]+)/) || [])[1] || 'unknown';
       const rl = await checkRateLimit('CommunityPhotoRateLimit', host, {
         max: 5,
         windowMs: 60 * 60 * 1000,
       });
       if (!rl.allowed) {
-        // Phrasing chosen to match _veloDispatchSoftFailStatus's
-        // "too many requests" → 429 mapping.
         return { success: false, error: 'Too many requests — please try again later.' };
       }
     } catch (err) {
       // Fail-open on rate-limit infra error — sanity-cap by relying on
-      // moderation. Logged so ops can spot a broken rate-limit store.
-      logError('communityPhoto.submitCommunityPhoto.rateLimit', err);
+      // moderation. Log includes the host so ops can spot whether a
+      // single domain is repeatedly tripping a broken rate-limit store.
+      logError(`communityPhoto.submitCommunityPhoto.rateLimit host=${host}`, err);
     }
 
     const row = {

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -49,6 +49,8 @@ import * as _styleQuizModule from 'backend/styleQuiz.web';
 import { submitSurveyResponse } from 'backend/surveyService.web';
 import { grantSpin } from 'backend/spinRedemptionService.web';
 import { submitCommunityPhoto } from 'backend/communityPhoto.web';
+// cf-bkxh: namespace import for giftRegistry dispatcher.
+import * as _giftRegistryModule from 'backend/giftRegistry.web';
 
 /**
  * Fetch all products from the Stores/Products collection, paginating
@@ -3732,3 +3734,31 @@ export async function post_submitCommunityPhoto(request) {
   }
 }
 export function options_submitCommunityPhoto(request) { return response(corsPreflight(request)); }
+
+// ── /_functions/giftRegistry/<method> dispatcher ─────────────────────────────
+//
+// cf-bkxh (cf-vtx5.fu held-list). cfw's actions/registry.ts uses
+// `r(method) = giftRegistry/${method}` to call 5 webMethods on
+// `backend/giftRegistry.web`. Surfaced during my cf-vtx5 callsite probe
+// but NOT in the original cf-jqkg 22-route list. All 5 cfw method names
+// match backend exports verbatim — no rename needed, just add to the
+// dispatcher allowlist.
+//
+// Method-name reconciliation: backend exports 8 methods (createRegistry,
+// deleteRegistry, getMyRegistries, getPublicRegistry, markItemPurchased,
+// getRegistry, addRegistryItem, removeRegistryItem). The 5 below are
+// what cfw actually calls; the other 3 are intentionally omitted from
+// the allowlist (defense — unknown methods 404 rather than reflectively
+// invoking by name).
+
+const _GIFT_REGISTRY_METHODS = {
+  createRegistry: _giftRegistryModule.createRegistry,
+  deleteRegistry: _giftRegistryModule.deleteRegistry,
+  getMyRegistries: _giftRegistryModule.getMyRegistries,
+  getPublicRegistry: _giftRegistryModule.getPublicRegistry,
+  markItemPurchased: _giftRegistryModule.markItemPurchased,
+};
+export async function post_giftRegistry(request) {
+  return _veloDispatch(request, _GIFT_REGISTRY_METHODS, 'giftRegistry');
+}
+export function options_giftRegistry(request) { return response(corsPreflight(request)); }

--- a/tests/communityPhoto.test.js
+++ b/tests/communityPhoto.test.js
@@ -179,19 +179,31 @@ describe('cf-0h9q · post_submitCommunityPhoto', () => {
     expect(JSON.parse(res.body).error).toBe('invalid_json');
   });
 
-  it('returns 500 + errorId when wixData throws unexpectedly (infra)', async () => {
-    // submitCommunityPhoto's own catch returns success:false (4xx), so to
-    // exercise the wrapper's 5xx path we need the wrapper-level try/catch
-    // to fire. Easiest: make request.body.json reject with a thrown Error
-    // (not SyntaxError). The wrapper's outer catch covers that.
-    const req = {
-      body: { json: async () => { throw new TypeError('something else'); } },
-      headers: { origin: goodOrigin },
-    };
-    const res = await post_submitCommunityPhoto(req);
-    // TypeError on body parse is still treated as invalid_json by the
-    // wrapper (any thrown error in the parse step). Status 400.
-    expect(res.status).toBe(400);
+  it('cf-0h9q.fu: returns 500 + errorId when submitCommunityPhoto throws past its own catch', async () => {
+    // submitCommunityPhoto's own try/catch catches wixData.insert errors
+    // and returns {success:false} (4xx, already covered above). The
+    // wrapper's outer 500 path fires when submitCommunityPhoto itself
+    // throws (not when it gracefully fails). vi.doMock + cache-buster
+    // re-import forces submitCommunityPhoto to throw and asserts the
+    // wrapper's serverError path is reached, including errorId in
+    // console.error log for ops correlation.
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.doMock('backend/communityPhoto.web', () => ({
+      submitCommunityPhoto: vi.fn().mockRejectedValue(new Error('Velo runtime exploded')),
+      _validateCommunityPhoto: vi.fn(() => null),
+    }));
+    const { post_submitCommunityPhoto: wrapper } = await import('../src/backend/http-functions.js?cf-0h9q-throw');
+    const res = await wrapper(flatReq(VALID_BODY));
+    expect(res.status).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({ success: false, error: 'server_error' });
+    expect(typeof body.errorId).toBe('string');
+    expect(body.errorId.length).toBeGreaterThan(0);
+    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain(body.errorId);
+    expect(logged).toContain('post_submitCommunityPhoto');
+    consoleErr.mockRestore();
+    vi.doUnmock('backend/communityPhoto.web');
   });
 
   it('options preflight responds', () => {

--- a/tests/giftRegistryDispatcher.test.js
+++ b/tests/giftRegistryDispatcher.test.js
@@ -1,0 +1,153 @@
+/**
+ * @file giftRegistryDispatcher.test.js
+ * @description cf-bkxh coverage for the giftRegistry dispatcher.
+ * cfw's actions/registry.ts uses `r(method) = giftRegistry/${method}` to
+ * call 5 webMethods on `backend/giftRegistry.web` via callVelo. Same
+ * dispatcher pattern as rennala's #1164 wishlist + cf-yvs4 contract.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('backend/giftRegistry.web', () => ({
+  createRegistry: vi.fn(),
+  deleteRegistry: vi.fn(),
+  getMyRegistries: vi.fn(),
+  getPublicRegistry: vi.fn(),
+  markItemPurchased: vi.fn(),
+  // Methods intentionally NOT in the dispatcher allowlist — must 404.
+  getRegistry: vi.fn(),
+  addRegistryItem: vi.fn(),
+  removeRegistryItem: vi.fn(),
+}));
+
+import {
+  post_giftRegistry,
+  options_giftRegistry,
+} from '../src/backend/http-functions.js';
+import {
+  createRegistry,
+  deleteRegistry,
+  getMyRegistries,
+  getPublicRegistry,
+  markItemPurchased,
+  addRegistryItem,
+} from 'backend/giftRegistry.web';
+
+const goodOrigin = 'https://carolina-futons-web.vercel.app';
+
+const makeRequest = (method, body = { args: [] }) => ({
+  path: method ? [method] : [],
+  body: { json: async () => body },
+  headers: { origin: goodOrigin },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Allowlist routing ─────────────────────────────────────────────────────────
+
+describe('cf-bkxh · post_giftRegistry dispatcher', () => {
+  it('routes getMyRegistries with empty args + returns the bare result', async () => {
+    vi.mocked(getMyRegistries).mockResolvedValue({ success: true, data: { registries: [{ _id: 'r1' }] } });
+    const res = await post_giftRegistry(makeRequest('getMyRegistries'));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true, data: { registries: [{ _id: 'r1' }] } });
+    expect(vi.mocked(getMyRegistries)).toHaveBeenCalledWith();
+  });
+
+  it('routes createRegistry with positional args (cfw passes [{name, ...}])', async () => {
+    vi.mocked(createRegistry).mockResolvedValue({ success: true, data: { _id: 'r2', slug: 'jane-doe-baby' } });
+    await post_giftRegistry(makeRequest('createRegistry', { args: [{ name: 'Jane Doe Baby', occasion: 'baby' }] }));
+    expect(vi.mocked(createRegistry)).toHaveBeenCalledWith({ name: 'Jane Doe Baby', occasion: 'baby' });
+  });
+
+  it('routes deleteRegistry with the registryId arg', async () => {
+    vi.mocked(deleteRegistry).mockResolvedValue({ success: true });
+    await post_giftRegistry(makeRequest('deleteRegistry', { args: ['r-99'] }));
+    expect(vi.mocked(deleteRegistry)).toHaveBeenCalledWith('r-99');
+  });
+
+  it('routes getPublicRegistry by slug (Permissions.Anyone)', async () => {
+    vi.mocked(getPublicRegistry).mockResolvedValue({ success: true, data: { _id: 'r1', items: [] } });
+    await post_giftRegistry(makeRequest('getPublicRegistry', { args: ['jane-doe-baby'] }));
+    expect(vi.mocked(getPublicRegistry)).toHaveBeenCalledWith('jane-doe-baby');
+  });
+
+  it('routes markItemPurchased with itemId + data args (Permissions.Anyone)', async () => {
+    vi.mocked(markItemPurchased).mockResolvedValue({ success: true });
+    await post_giftRegistry(makeRequest('markItemPurchased', { args: ['item-7', { name: 'Aunt Sue' }] }));
+    expect(vi.mocked(markItemPurchased)).toHaveBeenCalledWith('item-7', { name: 'Aunt Sue' });
+  });
+});
+
+// ── Allowlist gating (defense — methods NOT exposed to cfw) ───────────────────
+
+describe('cf-bkxh · post_giftRegistry allowlist gating', () => {
+  it('returns 404 unknown_method for addRegistryItem (in module but NOT in allowlist)', async () => {
+    const res = await post_giftRegistry(makeRequest('addRegistryItem'));
+    expect(res.status).toBe(404);
+    expect(JSON.parse(res.body)).toMatchObject({ success: false, error: 'unknown_method', method: 'addRegistryItem' });
+    expect(vi.mocked(addRegistryItem)).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for getRegistry / removeRegistryItem (not in allowlist)', async () => {
+    const r1 = await post_giftRegistry(makeRequest('getRegistry'));
+    expect(r1.status).toBe(404);
+    const r2 = await post_giftRegistry(makeRequest('removeRegistryItem'));
+    expect(r2.status).toBe(404);
+  });
+
+  it('returns 404 when path is empty', async () => {
+    const res = await post_giftRegistry(makeRequest(null));
+    expect(res.status).toBe(404);
+    expect(JSON.parse(res.body).error).toBe('unknown_method');
+  });
+});
+
+// ── cf-yvs4 contract ──────────────────────────────────────────────────────────
+
+describe('cf-bkxh · cf-yvs4 contract', () => {
+  it('400 invalid_json on body parse failure', async () => {
+    const req = {
+      path: ['getMyRegistries'],
+      body: { json: async () => { throw new SyntaxError('Bad JSON'); } },
+      headers: { origin: goodOrigin },
+    };
+    const res = await post_giftRegistry(req);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('invalid_json');
+  });
+
+  it('400 args_must_be_array when body lacks args[]', async () => {
+    const res = await post_giftRegistry(makeRequest('getMyRegistries', { foo: 'bar' }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('args_must_be_array');
+  });
+
+  it('cf-yvs4: maps webMethod {success:false} to a 4xx via _veloDispatchSoftFailStatus', async () => {
+    vi.mocked(getMyRegistries).mockResolvedValue({ success: false, error: 'Authentication required' });
+    const res = await post_giftRegistry(makeRequest('getMyRegistries'));
+    expect(res.status).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ success: false, error: 'Authentication required' });
+  });
+
+  it('500 server_error + errorId on unexpected throw, logged with same id', async () => {
+    vi.mocked(createRegistry).mockRejectedValue(new Error('Wix Data unavailable'));
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await post_giftRegistry(makeRequest('createRegistry'));
+    expect(res.status).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({ success: false, error: 'server_error' });
+    expect(typeof body.errorId).toBe('string');
+    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain(body.errorId);
+    expect(logged).toContain('post_giftRegistry:createRegistry');
+    consoleErr.mockRestore();
+  });
+
+  it('options preflight responds', () => {
+    const res = options_giftRegistry({ headers: { origin: goodOrigin } });
+    expect(res).toBeDefined();
+    expect(res.status).toBeGreaterThanOrEqual(200);
+  });
+});


### PR DESCRIPTION
Cluster retro covering cf-vtx5 (root), cf-yvs4 (audit), cf-hpb2, cf-bkxh, cf-0h9q. Doc at docs/cf-vtx5-retro-2026-05-09.md.

## TL;DR
22 cfw→Velo /_functions routes silently 404'd in prod. Stilgar's e2e thread (wishlist not persisting, etc.) all rooted here. Fixed under P0 admin-merge override. radahn's 6-agent post-merge audit found IDOR in post_submitSurvey, cf-tvbi lying-status pattern reintroduced across all 22 routes, and 0/22 dispatchers tested despite a reference test pattern being available.

Net: emergency-merge protocol worked, but two systemic gaps (test coverage gating, lying-status pattern recurring) should be hardened.

## Recommendations
- **P0** — pre-merge test-coverage gate when src/backend/http-functions.js gains a new post_*/get_* export. The IDOR would have failed a single 12-line test.
- **P1** — promote _veloDispatch to enforce envelope discriminant. One if-statement removes the cf-tvbi pattern from 22 routes at once and stops the next 22 from inheriting it.
- **P2** — pre-file empty followup beads on emergency merges; codify the reference-impl expectation in PR templates.

Explicit non-recommendations: don't add review-time SLAs that block emergency merges (the admin-override was correct here), don't expand 6-agent suite for routine PRs (stakes drove the value).

Note: this branch builds on top of fix/cf-bkxh-giftregistry-dispatcher's commit (already on origin) which was an unrelated unstaged-change interaction in my worktree. The retro commit itself only touches the new doc.