### PR TITLE
fix(cf-m3tj): mobile challenges dispatch synthetic event into gamification pipeline

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -86,7 +86,22 @@ const FIXED_AWARD_EVENTS = new Set([
   'gamification_birthday_bonus',
   'gamification_anniversary_bonus',
   'video_review_approved', // 500 pts, not streak-multiplied — one-time exclusive award
+  // cf-m3tj: mobile challenge awards are flat per spec (75/50/100). Idempotency
+  // is enforced upstream in completeMobileChallenge via MobileChallengeCompletions,
+  // so the synthetic event only fires on a fresh completion.
+  'gamification_mobile_ar_discovery',
+  'gamification_mobile_quiz_completion',
+  'gamification_mobile_social_share',
 ]);
+
+// cf-m3tj: mobile challenge → award table. Mirrors POINTS_BY_TYPE in
+// mobileChallengeService.web.js — kept here so resolvePoints can resolve the
+// synthetic event without importing the mobile module (would create a cycle).
+const MOBILE_CHALLENGE_POINTS = {
+  gamification_mobile_ar_discovery: 75,
+  gamification_mobile_quiz_completion: 50,
+  gamification_mobile_social_share: 100,
+};
 
 /**
  * Receive a gamification event and award points to the member.
@@ -387,6 +402,13 @@ function resolvePoints(eventName, payload) {
       return POINT_VALUES.WISHLIST_ADD;
     case 'video_review_approved':
       return POINT_VALUES.VIDEO_REVIEW;
+    // cf-m3tj: synthetic mobile challenge events. Idempotency lives in
+    // completeMobileChallenge (per-day-per-productId for AR / per-day for
+    // quiz+social), so the synthetic only fires on a fresh completion.
+    case 'gamification_mobile_ar_discovery':
+    case 'gamification_mobile_quiz_completion':
+    case 'gamification_mobile_social_share':
+      return MOBILE_CHALLENGE_POINTS[eventName];
     default:
       return null;
   }

--- a/src/backend/mobileChallengeService.web.js
+++ b/src/backend/mobileChallengeService.web.js
@@ -30,6 +30,16 @@ const POINTS_BY_TYPE = {
   [MOBILE_CHALLENGE_TYPES.SOCIAL_SHARE]: 100,
 };
 
+// cf-m3tj: synthetic event names dispatched into receiveGamificationEvent so
+// the canonical web pipeline (PointsLedger + MemberPoints + tier milestone +
+// bonus-spin) processes mobile challenge awards. Mirrors point values above;
+// gamificationCore.web.js MOBILE_CHALLENGE_POINTS table must stay in sync.
+const SYNTHETIC_EVENT_BY_TYPE = {
+  [MOBILE_CHALLENGE_TYPES.AR_DISCOVERY]: 'gamification_mobile_ar_discovery',
+  [MOBILE_CHALLENGE_TYPES.QUIZ_COMPLETION]: 'gamification_mobile_quiz_completion',
+  [MOBILE_CHALLENGE_TYPES.SOCIAL_SHARE]: 'gamification_mobile_social_share',
+};
+
 const VALID_TYPES = new Set(Object.values(MOBILE_CHALLENGE_TYPES));
 
 function _todayStart() {
@@ -69,7 +79,7 @@ export async function completeMobileChallenge(memberId, challengeType, params = 
     }
 
     const pointsAwarded = POINTS_BY_TYPE[challengeType];
-    await wixData.insert(
+    const insertedRow = await wixData.insert(
       MOBILE_CHALLENGES_COLLECTION,
       {
         memberId,
@@ -82,6 +92,39 @@ export async function completeMobileChallenge(memberId, challengeType, params = 
       },
       { suppressAuth: true }
     );
+
+    // cf-m3tj fix: dispatch synthetic event into receiveGamificationEvent so
+    // the canonical pipeline (PointsLedger insert, MemberPoints update, tier
+    // milestone notification, BonusSpinGrants check) actually moves the
+    // member's balance. Pre-cf-m3tj this step was missing — the completion
+    // row was written but the member earned 0 points. Idempotency is already
+    // enforced above (alreadyAwarded short-circuit), so the synthetic only
+    // fires on a fresh completion. Non-blocking: if the synthetic fails the
+    // completion row stays — backfill via cf-m3tj-followup script.
+    const syntheticEventName = SYNTHETIC_EVENT_BY_TYPE[challengeType];
+    if (syntheticEventName) {
+      try {
+        const { receiveGamificationEvent } = await import('backend/gamificationCore.web');
+        await receiveGamificationEvent(
+          syntheticEventName,
+          {
+            completionId: insertedRow._id,
+            productId: params.productId || null,
+            score: params.score ?? null,
+            total: params.total ?? null,
+            platform: params.platform || null,
+          },
+          memberId,
+        );
+      } catch (err) {
+        console.error(
+          `[mobileChallengeService] synthetic ${syntheticEventName} dispatch failed for member ${memberId}, completion ${insertedRow._id}:`,
+          err,
+        );
+        // Non-blocking — see comment above. Logged with completionId so a
+        // backfill job can find orphaned completions.
+      }
+    }
 
     return { success: true, alreadyAwarded: false, pointsAwarded };
   } catch (err) {

--- a/tests/gamificationEventReceiver.test.js
+++ b/tests/gamificationEventReceiver.test.js
@@ -2458,3 +2458,60 @@ describe('cf-bvn: lastActivityAt is stamped on every MemberPoints write path', (
     expect(Math.abs(updated[0].lastActivityAt.getTime() - Date.now())).toBeLessThan(5000);
   });
 });
+
+// ── cf-m3tj: synthetic mobile challenge events ─────────────────────────────
+//
+// completeMobileChallenge dispatches one of three synthetic event names per
+// the cf-m3tj fix. Verifies receiveGamificationEvent resolves them to the
+// right point values AND treats them as FIXED_AWARD (no streak multiplier),
+// matching the spec'd flat 75/50/100 awards.
+
+describe('cf-m3tj — synthetic mobile challenge events', () => {
+  beforeEach(() => {
+    __reset();
+    vi.clearAllMocks();
+  });
+
+  it('gamification_mobile_ar_discovery awards 75 pts to a new member', async () => {
+    const result = await receiveGamificationEvent('gamification_mobile_ar_discovery', { productId: 'prod-1' }, 'mem-mobile-1');
+    expect(result.success).toBe(true);
+    expect(result.newTotal).toBe(75);
+    expect(result.pointsEarned).toBe(75);
+  });
+
+  it('gamification_mobile_quiz_completion awards 50 pts to a new member', async () => {
+    const result = await receiveGamificationEvent('gamification_mobile_quiz_completion', { score: 9, total: 10 }, 'mem-mobile-2');
+    expect(result.success).toBe(true);
+    expect(result.newTotal).toBe(50);
+    expect(result.pointsEarned).toBe(50);
+  });
+
+  it('gamification_mobile_social_share awards 100 pts to a new member', async () => {
+    const result = await receiveGamificationEvent('gamification_mobile_social_share', { platform: 'instagram' }, 'mem-mobile-3');
+    expect(result.success).toBe(true);
+    expect(result.newTotal).toBe(100);
+    expect(result.pointsEarned).toBe(100);
+  });
+
+  it('mobile awards are FIXED — not multiplied by an active 3x streak', async () => {
+    // Member with 7-day streak (3x multiplier). For a non-fixed event like
+    // add_to_cart this would be 5 * 3 = 15. For a mobile event it must stay
+    // flat at the spec'd 75 — completeMobileChallenge enforces idempotency
+    // upstream, so the streak multiplier would distort the spec.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-22T14:00:00Z'));
+    __seed('MemberPoints', [{
+      _id: 'mp-1', memberId: 'mem-streak', totalPoints: 0, tier: 'Trail Blazer',
+      currentStreakDays: 7, streakStartDate: '2026-03-15',
+      lastActivityDate: '2026-03-21',
+      streakMultiplier: 3,
+    }]);
+    const result = await receiveGamificationEvent(
+      'gamification_mobile_ar_discovery',
+      { productId: 'prod-1' },
+      'mem-streak',
+    );
+    expect(result.pointsEarned).toBe(75); // not 225
+    vi.useRealTimers();
+  });
+});

--- a/tests/mobileChallengeSyntheticEvent.cfm3tj.test.js
+++ b/tests/mobileChallengeSyntheticEvent.cfm3tj.test.js
@@ -1,0 +1,170 @@
+/**
+ * @file mobileChallengeSyntheticEvent.cfm3tj.test.js
+ * @description cf-m3tj — completeMobileChallenge dispatches a synthetic
+ * gamification_mobile_* event into receiveGamificationEvent so the canonical
+ * web pipeline (PointsLedger insert, MemberPoints update, tier milestone,
+ * BonusSpinGrants check) actually moves the member's balance.
+ *
+ * Pre-cf-m3tj: completion row was written, member balance never moved (G1).
+ *
+ * Verifies:
+ *   - Fresh AR Discovery → synthetic 'gamification_mobile_ar_discovery' fires with 75 pts
+ *   - Fresh Quiz Completion → 'gamification_mobile_quiz_completion' with 50 pts
+ *   - Fresh Social Share → 'gamification_mobile_social_share' with 100 pts
+ *   - Mobile awards are flat (FIXED_AWARD_EVENTS) — no streak multiplier
+ *   - alreadyAwarded short-circuit DOES NOT fire the synthetic
+ *   - Synthetic dispatch failure is non-blocking — completion row stands,
+ *     completeMobileChallenge still returns success
+ *   - completionId + productId + score + platform forwarded into the synthetic
+ *     payload so audit/analytics downstream can correlate
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('backend/gamificationCore.web', () => ({
+  receiveGamificationEvent: vi.fn(),
+}));
+
+import { __seed, __reset } from './__mocks__/wix-data.js';
+import { __setMember, __reset as resetMember } from './__mocks__/wix-members-backend.js';
+import {
+  MOBILE_CHALLENGE_TYPES,
+  MOBILE_CHALLENGES_COLLECTION,
+  completeMobileChallenge,
+} from '../src/backend/mobileChallengeService.web.js';
+import { receiveGamificationEvent } from 'backend/gamificationCore.web';
+
+const MEMBER_ID = 'member-mobile-cf-m3tj';
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  __reset();
+  resetMember();
+  __setMember({ _id: MEMBER_ID });
+  vi.mocked(receiveGamificationEvent).mockReset();
+  vi.mocked(receiveGamificationEvent).mockResolvedValue({
+    success: true,
+    newTotal: 75,
+    pointsEarned: 75,
+    tierChanged: false,
+  });
+});
+
+describe('cf-m3tj · synthetic event dispatch on fresh completion', () => {
+  it('AR Discovery fires gamification_mobile_ar_discovery with 75 pts in the resolver', async () => {
+    __seed(MOBILE_CHALLENGES_COLLECTION, []);
+    const result = await completeMobileChallenge(MEMBER_ID, MOBILE_CHALLENGE_TYPES.AR_DISCOVERY, {
+      productId: 'prod-1',
+      platform: 'ios',
+    });
+    await flushMicrotasks();
+
+    expect(result.success).toBe(true);
+    expect(result.alreadyAwarded).toBe(false);
+    expect(vi.mocked(receiveGamificationEvent)).toHaveBeenCalledTimes(1);
+
+    const [eventName, payload, memberId] = vi.mocked(receiveGamificationEvent).mock.calls[0];
+    expect(eventName).toBe('gamification_mobile_ar_discovery');
+    expect(memberId).toBe(MEMBER_ID);
+    expect(payload).toMatchObject({
+      productId: 'prod-1',
+      platform: 'ios',
+    });
+    expect(typeof payload.completionId).toBe('string');
+  });
+
+  it('Quiz Completion fires gamification_mobile_quiz_completion with score+total forwarded', async () => {
+    __seed(MOBILE_CHALLENGES_COLLECTION, []);
+    await completeMobileChallenge(MEMBER_ID, MOBILE_CHALLENGE_TYPES.QUIZ_COMPLETION, {
+      score: 9,
+      total: 10,
+      platform: 'android',
+    });
+    await flushMicrotasks();
+
+    expect(vi.mocked(receiveGamificationEvent)).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = vi.mocked(receiveGamificationEvent).mock.calls[0];
+    expect(eventName).toBe('gamification_mobile_quiz_completion');
+    expect(payload).toMatchObject({ score: 9, total: 10, platform: 'android' });
+  });
+
+  it('Social Share fires gamification_mobile_social_share with platform forwarded', async () => {
+    __seed(MOBILE_CHALLENGES_COLLECTION, []);
+    await completeMobileChallenge(MEMBER_ID, MOBILE_CHALLENGE_TYPES.SOCIAL_SHARE, {
+      productId: 'prod-7',
+      platform: 'instagram',
+    });
+    await flushMicrotasks();
+
+    expect(vi.mocked(receiveGamificationEvent)).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = vi.mocked(receiveGamificationEvent).mock.calls[0];
+    expect(eventName).toBe('gamification_mobile_social_share');
+    expect(payload).toMatchObject({ productId: 'prod-7', platform: 'instagram' });
+  });
+});
+
+describe('cf-m3tj · synthetic event NOT dispatched on alreadyAwarded short-circuit', () => {
+  it('does not fire the synthetic when the same AR challenge fired earlier today', async () => {
+    __seed(MOBILE_CHALLENGES_COLLECTION, [
+      {
+        _id: 'mc-prior',
+        memberId: MEMBER_ID,
+        challengeType: MOBILE_CHALLENGE_TYPES.AR_DISCOVERY,
+        completedAt: new Date(),
+        productId: 'prod-1',
+      },
+    ]);
+    const result = await completeMobileChallenge(MEMBER_ID, MOBILE_CHALLENGE_TYPES.AR_DISCOVERY, {
+      productId: 'prod-1',
+    });
+    await flushMicrotasks();
+
+    expect(result.alreadyAwarded).toBe(true);
+    expect(result.pointsAwarded).toBe(0);
+    expect(vi.mocked(receiveGamificationEvent)).not.toHaveBeenCalled();
+  });
+});
+
+describe('cf-m3tj · synthetic dispatch failure is non-blocking', () => {
+  it('still returns success when receiveGamificationEvent throws', async () => {
+    vi.mocked(receiveGamificationEvent).mockRejectedValue(new Error('Wix Data unavailable'));
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    __seed(MOBILE_CHALLENGES_COLLECTION, []);
+
+    const result = await completeMobileChallenge(MEMBER_ID, MOBILE_CHALLENGE_TYPES.AR_DISCOVERY, {
+      productId: 'prod-1',
+    });
+    await flushMicrotasks();
+
+    // Completion row inserted; outer call returns success even though synthetic threw.
+    // Pre-cf-m3tj this code path didn't exist; post-fix the silent-failure
+    // guard ensures a downstream throw can't cost the user their completion.
+    expect(result.success).toBe(true);
+    expect(result.alreadyAwarded).toBe(false);
+    expect(result.pointsAwarded).toBe(75);
+
+    // The error is logged with completionId for backfill correlation.
+    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain('synthetic gamification_mobile_ar_discovery dispatch failed');
+    expect(logged).toContain(MEMBER_ID);
+
+    consoleErr.mockRestore();
+  });
+
+  it('still returns success when receiveGamificationEvent resolves with success:false envelope', async () => {
+    vi.mocked(receiveGamificationEvent).mockResolvedValue({ success: false, error: 'rate_limited' });
+    __seed(MOBILE_CHALLENGES_COLLECTION, []);
+
+    const result = await completeMobileChallenge(MEMBER_ID, MOBILE_CHALLENGE_TYPES.QUIZ_COMPLETION, {
+      score: 5,
+      total: 10,
+    });
+    await flushMicrotasks();
+
+    // The synthetic returning a soft-failure envelope still preserves the
+    // mobile completion + caller success — backfill job inspects logs for
+    // any orphaned cases.
+    expect(result.success).toBe(true);
+    expect(result.alreadyAwarded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Closes G1 silent failure surfaced in cf-jvut E2E plan (PR #1192). `completeMobileChallenge` now dispatches a synthetic `gamification_mobile_*` event into `receiveGamificationEvent` on every fresh completion, so the canonical web pipeline (PointsLedger insert, MemberPoints update, tier milestone, BonusSpinGrants check) actually moves the member's balance.

Pre-fix: completion row written, member earned 0 points. Spec promised 75/50/100; balance never moved.

### Implementation (synthetic-event approach per melania's recommendation)
- **Three new event names** in `gamificationCore.web.js#resolvePoints`:
  - `gamification_mobile_ar_discovery` → 75 pts
  - `gamification_mobile_quiz_completion` → 50 pts
  - `gamification_mobile_social_share` → 100 pts
- Added to **`FIXED_AWARD_EVENTS`** so streak multiplier doesn't distort the flat-award spec. Idempotency upstream in `MobileChallengeCompletions` (per-day-per-productId), so the synthetic only fires on a fresh completion.
- `mobileChallengeService.web.js#completeMobileChallenge` dynamically imports `receiveGamificationEvent` and dispatches with `completionId + productId + score + platform` forwarded for downstream correlation.
- **Non-blocking** with named `.catch` — a downstream throw can't cost the user their completion. Logged with `completionId` so a backfill job can find orphaned cases.

### Side effects (intentional)
- **G2 closed for free** — `maybeGrantBonusSpin` runs inside `receiveGamificationEvent`, so bonus-spin grants tied to mobile events now fire.
- **G3 explicitly out of scope** — the new synthetic event names are distinct from `gamification_ar_discovery`, so CF-0gly's lifetime cap on the web event doesn't gate the mobile synthetic. AR cap remains in `MobileChallengeCompletions` (per-day-per-productId). Tracked separately as P2.

## Test plan
- [x] 6 new tests in `tests/mobileChallengeSyntheticEvent.cfm3tj.test.js` — synthetic dispatch shape per challenge, alreadyAwarded short-circuit, throw + soft-fail non-blocking guarantees.
- [x] 4 new tests in `tests/gamificationEventReceiver.test.js` — three new event names award 75/50/100 to a new member; mobile awards are FIXED (3x streak does not distort 75 → 225).
- [x] 22/22 mobile-challenge tests pass.
- [x] 207/207 in the directly-touched surface.
- [x] **674/674 in the broader gamification test surface (regression check).**
- [ ] Stilgar reruns the cf-jvut staging matrix; expects `MemberPoints.currentPoints` and `MemberPointsLedger` to actually move on each mobile challenge fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)