### PR TITLE
feat(cf-hpb2): referralService dispatcher + redeemReferralCode signature refactor

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -51,6 +51,9 @@ import { grantSpin } from 'backend/spinRedemptionService.web';
 import { submitCommunityPhoto } from 'backend/communityPhoto.web';
 // cf-bkxh: namespace import for giftRegistry dispatcher.
 import * as _giftRegistryModule from 'backend/giftRegistry.web';
+// cf-hpb2: namespace import for referralService dispatcher (cfw method
+// names → backend exports requires a 4-entry alias / shim table).
+import * as _referralServiceModule from 'backend/referralService.web';
 
 /**
  * Fetch all products from the Stores/Products collection, paginating
@@ -3865,3 +3868,40 @@ export async function post_giftRegistry(request) {
   return _veloDispatch(request, _GIFT_REGISTRY_METHODS, 'giftRegistry');
 }
 export function options_giftRegistry(request) { return response(corsPreflight(request)); }
+
+// ── /_functions/referralService/<method> dispatcher ──────────────────────────
+//
+// cf-hpb2 — closes the last cf-vtx5.fu held-list item. cfw's
+// actions/referral.ts uses `r(method) = referralService/${method}` for 4
+// methods whose names don't match backend exports verbatim. Stilgar
+// approved combo (b) + (c) per docs/cf-hpb2-referralservice-comparison.md:
+//
+//   (1) getMyReferralCode  → alias for `getReferralLink`        — pure rename
+//   (2) getMyReferralStats → alias for `getReferralStats`       — pure rename
+//   (3) getReferralByCode  → shim wrapping `getReferralLinkOwnerName`
+//                            and reshaping `{success, referrerName}` into
+//                            `{success, referral: {referrerName}}` for
+//                            cfw's PublicReferral type. Stilgar Q1: keep
+//                            PublicReferral thin — just `{referrerName}`.
+//   (4) claimReferral      → alias for `redeemReferralCode`     — backend
+//                            webMethod refactored separately to drop the
+//                            refereeData arg and resolve email from
+//                            currentMember.getMember() (Stilgar Q2:
+//                            server-resolved identity, not user-supplied).
+
+const _REFERRAL_METHODS = {
+  getMyReferralCode: _referralServiceModule.getReferralLink,
+  getMyReferralStats: _referralServiceModule.getReferralStats,
+  getReferralByCode: async (code) => {
+    const r = await _referralServiceModule.getReferralLinkOwnerName(code);
+    if (!r || r.success === false) {
+      return r || { success: false, error: 'Referral not found' };
+    }
+    return { success: true, referral: { referrerName: r.referrerName } };
+  },
+  claimReferral: _referralServiceModule.redeemReferralCode,
+};
+export async function post_referralService(request) {
+  return _veloDispatch(request, _REFERRAL_METHODS, 'referralService');
+}
+export function options_referralService(request) { return response(corsPreflight(request)); }

--- a/src/backend/referralService.web.js
+++ b/src/backend/referralService.web.js
@@ -130,19 +130,29 @@ export const getReferralLink = webMethod(
 
 export const redeemReferralCode = webMethod(
   Permissions.SiteMember,
-  async (code, refereeData = {}) => {
+  async (code) => {
     try {
       const cleanCode = sanitize(code, 20).toUpperCase().replace(/[^A-Z0-9]/g, '');
       if (!cleanCode) {
         return { success: false, error: 'Referral code is required' };
       }
 
-      const { name, email } = refereeData;
-      const cleanEmail = sanitize(email, 254).trim().toLowerCase();
-
+      // cf-hpb2: resolve referee identity from currentMember (auth context),
+      // not request body. User-supplied email lets caller spoof who's
+      // claiming a referral; server-resolved is the security-correct source.
+      // Stilgar's call (Q2 in docs/cf-hpb2-referralservice-comparison.md).
+      const member = await currentMember.getMember();
+      if (!member || !member._id) {
+        return { success: false, error: 'Authentication required' };
+      }
+      const cleanEmail = sanitize(member.loginEmail || '', 254).trim().toLowerCase();
       if (!cleanEmail || !validateEmail(cleanEmail)) {
         return { success: false, error: 'A valid email address is required' };
       }
+      // Best-effort name resolution from member contact details. Falls
+      // back to empty string — Referrals row treats refereeName as optional.
+      const contact = member.contactDetails || {};
+      const name = [contact.firstName, contact.lastName].filter(Boolean).join(' ') || '';
 
       // Find the referral
       const result = await wixData.query(REFERRALS_COLLECTION)

--- a/tests/referralService.test.js
+++ b/tests/referralService.test.js
@@ -112,7 +112,15 @@ describe('getReferralLink', () => {
 // ── redeemReferralCode ──────────────────────────────────────────────
 
 describe('redeemReferralCode', () => {
+  // cf-hpb2: redeemReferralCode no longer takes refereeData. Identity is
+  // resolved server-side via currentMember.getMember() — caller can't
+  // spoof the email. Mock the member here for each test.
   beforeEach(() => {
+    __setMember({
+      _id: 'member-002',
+      loginEmail: 'bob@example.com',
+      contactDetails: { firstName: 'Bob', lastName: 'Smith' },
+    });
     __seed('Referrals', [{
       _id: 'ref-001',
       referrerMemberId: 'member-001',
@@ -128,11 +136,7 @@ describe('redeemReferralCode', () => {
   });
 
   it('redeems a valid referral code', async () => {
-    const result = await redeemReferralCode('ABCD1234', {
-      name: 'Bob',
-      email: 'bob@example.com',
-    });
-
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(true);
     expect(result.referrerName).toBe('Alice');
     expect(result.refereeDiscount).toBe(25);
@@ -140,30 +144,28 @@ describe('redeemReferralCode', () => {
     expect(result.message).toContain('$25');
   });
 
-  it('updates referral status to signed_up', async () => {
+  it('updates referral status to signed_up with server-resolved referee identity', async () => {
     let updated = null;
     __onUpdate((col, item) => {
       if (col === 'Referrals') updated = item;
     });
 
-    await redeemReferralCode('ABCD1234', { name: 'Bob', email: 'bob@example.com' });
+    await redeemReferralCode('ABCD1234');
     expect(updated.status).toBe('signed_up');
-    expect(updated.refereeName).toBe('Bob');
+    expect(updated.refereeName).toBe('Bob Smith');
     expect(updated.refereeEmail).toBe('bob@example.com');
   });
 
   it('normalizes code to uppercase', async () => {
-    const result = await redeemReferralCode('abcd1234', { name: 'Bob', email: 'bob@example.com' });
-    expect(result.success).toBe(true);
+    expect((await redeemReferralCode('abcd1234')).success).toBe(true);
   });
 
   it('strips non-alphanumeric characters from code', async () => {
-    const result = await redeemReferralCode('ABCD-1234', { name: 'Bob', email: 'bob@example.com' });
-    expect(result.success).toBe(true);
+    expect((await redeemReferralCode('ABCD-1234')).success).toBe(true);
   });
 
   it('fails for invalid code', async () => {
-    const result = await redeemReferralCode('XXXX9999', { email: 'test@example.com' });
+    const result = await redeemReferralCode('XXXX9999');
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid');
   });
@@ -186,28 +188,27 @@ describe('redeemReferralCode', () => {
     expect(result.success).toBe(false);
   });
 
-  it('prevents self-referral by email', async () => {
-    const result = await redeemReferralCode('ABCD1234', {
-      name: 'Alice',
-      email: 'alice@example.com',
+  it('cf-hpb2: prevents self-referral when current member matches referrer email', async () => {
+    __setMember({
+      _id: 'member-001',
+      loginEmail: 'alice@example.com',
+      contactDetails: { firstName: 'Alice' },
     });
-
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('own referral');
   });
 
-  it('rejects invalid email format', async () => {
-    const result = await redeemReferralCode('ABCD1234', {
-      name: 'Bob',
-      email: 'not-an-email',
-    });
-
+  it('cf-hpb2: returns 401-ish auth-required when no SiteMember context', async () => {
+    __setMember(null);
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
-    expect(result.error).toContain('email');
+    expect(result.error.toLowerCase()).toContain('authentication');
   });
 
-  it('requires email for redemption', async () => {
-    const result = await redeemReferralCode('ABCD1234', { name: 'Bob' });
+  it('cf-hpb2: rejects member with malformed loginEmail', async () => {
+    __setMember({ _id: 'member-007', loginEmail: 'not-an-email' });
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('email');
   });
@@ -224,23 +225,19 @@ describe('redeemReferralCode', () => {
       refereeCredit: 25,
     }]);
 
-    const result = await redeemReferralCode('ANON5678', { name: 'Bob', email: 'bob@example.com' });
+    const result = await redeemReferralCode('ANON5678');
     expect(result.success).toBe(true);
     expect(result.message).toContain('a friend');
   });
 
-  it('sanitizes referee name', async () => {
+  it('cf-hpb2: tolerates missing contactDetails (refereeName falls back to empty)', async () => {
+    __setMember({ _id: 'member-099', loginEmail: 'no-name@example.com' });
     let updated = null;
-    __onUpdate((col, item) => {
-      if (col === 'Referrals') updated = item;
-    });
-
-    await redeemReferralCode('ABCD1234', {
-      name: '<script>alert(1)</script>Bob',
-      email: 'bob@example.com',
-    });
-
-    expect(updated.refereeName).not.toContain('<script>');
+    __onUpdate((col, item) => { if (col === 'Referrals') updated = item; });
+    const result = await redeemReferralCode('ABCD1234');
+    expect(result.success).toBe(true);
+    expect(updated.refereeName).toBe('');
+    expect(updated.refereeEmail).toBe('no-name@example.com');
   });
 });
 

--- a/tests/referralServiceCoverage.test.js
+++ b/tests/referralServiceCoverage.test.js
@@ -112,31 +112,43 @@ describe('referralService — getReferralLink', () => {
 // ── redeemReferralCode ──────────────────────────────────────────────
 
 describe('referralService — redeemReferralCode', () => {
+  // cf-hpb2: signature changed — refereeData arg dropped, identity from currentMember.
+  beforeEach(() => {
+    __setMember({
+      _id: 'member-referee',
+      loginEmail: 'test@example.com',
+      contactDetails: { firstName: 'Test', lastName: 'User' },
+    });
+  });
+
   it('rejects empty code', async () => {
-    const result = await redeemReferralCode('', { email: 'test@example.com' });
+    const result = await redeemReferralCode('');
     expect(result.success).toBe(false);
     expect(result.error).toContain('required');
   });
 
-  it('rejects missing email', async () => {
-    const result = await redeemReferralCode('ABCD1234', { name: 'Test' });
+  it('cf-hpb2: rejects when no SiteMember context', async () => {
+    __setMember(null);
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
-    expect(result.error).toContain('email');
+    expect(result.error.toLowerCase()).toContain('authentication');
   });
 
-  it('rejects invalid email format', async () => {
-    const result = await redeemReferralCode('ABCD1234', { email: 'notanemail' });
+  it('cf-hpb2: rejects member with malformed loginEmail', async () => {
+    __setMember({ _id: 'member-x', loginEmail: 'notanemail' });
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('email');
   });
 
   it('rejects expired/invalid referral code', async () => {
-    const result = await redeemReferralCode('NOTACODE', { email: 'test@example.com' });
+    const result = await redeemReferralCode('NOTACODE');
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid or expired');
   });
 
-  it('prevents self-referral', async () => {
+  it('prevents self-referral (current member is the referrer)', async () => {
+    __setMember({ _id: 'member-1', loginEmail: 'self@example.com' });
     __seed('Referrals', [{
       _id: 'ref-1',
       referrerMemberId: 'member-1',
@@ -144,12 +156,13 @@ describe('referralService — redeemReferralCode', () => {
       referralCode: 'SELF1234',
       status: 'pending',
     }]);
-    const result = await redeemReferralCode('SELF1234', { email: 'self@example.com' });
+    const result = await redeemReferralCode('SELF1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('own referral');
   });
 
   it('prevents self-referral case-insensitive', async () => {
+    __setMember({ _id: 'member-1', loginEmail: 'SELF@EXAMPLE.COM' });
     __seed('Referrals', [{
       _id: 'ref-1',
       referrerMemberId: 'member-1',
@@ -157,12 +170,17 @@ describe('referralService — redeemReferralCode', () => {
       referralCode: 'CASE1234',
       status: 'pending',
     }]);
-    const result = await redeemReferralCode('CASE1234', { email: 'SELF@EXAMPLE.COM' });
+    const result = await redeemReferralCode('CASE1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('own referral');
   });
 
-  it('succeeds with valid code and email', async () => {
+  it('succeeds for an authenticated member with a valid code', async () => {
+    __setMember({
+      _id: 'member-bob',
+      loginEmail: 'bob@example.com',
+      contactDetails: { firstName: 'Bob' },
+    });
     __seed('Referrals', [{
       _id: 'ref-2',
       referrerMemberId: 'member-1',
@@ -171,7 +189,7 @@ describe('referralService — redeemReferralCode', () => {
       referralCode: 'GOOD1234',
       status: 'pending',
     }]);
-    const result = await redeemReferralCode('GOOD1234', { name: 'Bob', email: 'bob@example.com' });
+    const result = await redeemReferralCode('GOOD1234');
     expect(result.success).toBe(true);
     expect(result.referrerName).toBe('Alice');
     expect(result.refereeDiscount).toBe(25);
@@ -179,7 +197,12 @@ describe('referralService — redeemReferralCode', () => {
     expect(result.message).toContain('$25');
   });
 
-  it('updates referral status to signed_up', async () => {
+  it('updates referral status to signed_up with server-resolved referee identity', async () => {
+    __setMember({
+      _id: 'member-charlie',
+      loginEmail: 'charlie@test.com',
+      contactDetails: { firstName: 'Charlie' },
+    });
     __seed('Referrals', [{
       _id: 'ref-3',
       referrerMemberId: 'member-1',
@@ -191,7 +214,7 @@ describe('referralService — redeemReferralCode', () => {
     __onUpdate((collection, item) => {
       if (collection === 'Referrals') updated = item;
     });
-    await redeemReferralCode('UPDT1234', { name: 'Charlie', email: 'charlie@test.com' });
+    await redeemReferralCode('UPDT1234');
     expect(updated.status).toBe('signed_up');
     expect(updated.refereeEmail).toBe('charlie@test.com');
     expect(updated.refereeName).toBe('Charlie');
@@ -205,8 +228,7 @@ describe('referralService — redeemReferralCode', () => {
       referralCode: 'ABCD5678',
       status: 'pending',
     }]);
-    const result = await redeemReferralCode('abcd-5678', { email: 'test@example.com' });
-    expect(result.success).toBe(true);
+    expect((await redeemReferralCode('abcd-5678')).success).toBe(true);
   });
 
   it('handles missing referrerName gracefully', async () => {
@@ -217,7 +239,7 @@ describe('referralService — redeemReferralCode', () => {
       referralCode: 'NONAME12',
       status: 'pending',
     }]);
-    const result = await redeemReferralCode('NONAME12', { email: 'test@example.com' });
+    const result = await redeemReferralCode('NONAME12');
     expect(result.success).toBe(true);
     expect(result.message).toContain('a friend');
   });

--- a/tests/referralServiceDeep.test.js
+++ b/tests/referralServiceDeep.test.js
@@ -66,6 +66,9 @@ vi.mock('wix-data', () => ({
 }));
 
 let _mockMember = { _id: 'member-abc', loginEmail: 'user@example.com', name: 'Test User' };
+// cf-hpb2: helper to keep tests readable when redeemReferralCode now reads
+// identity from currentMember.getMember() instead of a refereeData arg.
+function __setMember(m) { _mockMember = m; }
 vi.mock('wix-members-backend', () => ({
   currentMember: {
     getMember: async () => _mockMember,
@@ -158,11 +161,16 @@ describe('getReferralLink', () => {
 // redeemReferralCode
 // ═════════════════════════════════════════════════════════════════════
 describe('redeemReferralCode', () => {
-  it('redeems a valid referral code', async () => {
+  // cf-hpb2: signature changed — refereeData arg dropped, identity from currentMember.
+  beforeEach(() => {
+    __setMember({ _id: 'member-bob', loginEmail: 'bob@example.com', contactDetails: { firstName: 'Bob' } });
+  });
+
+  it('redeems a valid referral code (referee identity from currentMember)', async () => {
     __seed('Referrals', [
       { _id: 'r1', referralCode: 'ABCD1234', status: 'pending', referrerName: 'Jane', referrerEmail: 'jane@example.com', referrerMemberId: 'other' },
     ]);
-    const result = await redeemReferralCode('ABCD1234', { name: 'Bob', email: 'bob@example.com' });
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(true);
     expect(result.refereeDiscount).toBe(25);
     expect(result.referrerName).toBe('Jane');
@@ -172,38 +180,40 @@ describe('redeemReferralCode', () => {
   });
 
   it('rejects empty code', async () => {
-    const result = await redeemReferralCode('', { email: 'a@b.com' });
-    expect(result.success).toBe(false);
+    expect((await redeemReferralCode('')).success).toBe(false);
   });
 
   it('rejects null code', async () => {
-    const result = await redeemReferralCode(null, { email: 'a@b.com' });
-    expect(result.success).toBe(false);
+    expect((await redeemReferralCode(null)).success).toBe(false);
   });
 
-  it('rejects missing email', async () => {
-    const result = await redeemReferralCode('ABCD1234', { name: 'Bob' });
+  it('cf-hpb2: rejects when no SiteMember context', async () => {
+    __setMember(null);
+    const result = await redeemReferralCode('ABCD1234');
+    expect(result.success).toBe(false);
+    expect(result.error.toLowerCase()).toContain('authentication');
+  });
+
+  it('cf-hpb2: rejects member with malformed loginEmail', async () => {
+    __setMember({ _id: 'member-x', loginEmail: 'not-an-email' });
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('email');
   });
 
-  it('rejects invalid email', async () => {
-    const result = await redeemReferralCode('ABCD1234', { email: 'not-an-email' });
-    expect(result.success).toBe(false);
-  });
-
   it('rejects non-existent code', async () => {
     __seed('Referrals', []);
-    const result = await redeemReferralCode('ZZZZZZZZ', { email: 'a@b.com' });
+    const result = await redeemReferralCode('ZZZZZZZZ');
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid or expired');
   });
 
-  it('prevents self-referral', async () => {
+  it('prevents self-referral when current member matches referrer email', async () => {
+    __setMember({ _id: 'member-abc', loginEmail: 'user@example.com' });
     __seed('Referrals', [
       { _id: 'r1', referralCode: 'SELFREF', status: 'pending', referrerEmail: 'user@example.com', referrerMemberId: 'member-abc' },
     ]);
-    const result = await redeemReferralCode('SELFREF', { email: 'user@example.com' });
+    const result = await redeemReferralCode('SELFREF');
     expect(result.success).toBe(false);
     expect(result.error).toContain('own referral');
   });
@@ -212,24 +222,22 @@ describe('redeemReferralCode', () => {
     __seed('Referrals', [
       { _id: 'r1', referralCode: 'ABCD1234', status: 'pending', referrerName: 'X', referrerEmail: 'other@e.com', referrerMemberId: 'other' },
     ]);
-    const result = await redeemReferralCode('abcd1234', { email: 'a@b.com' });
-    expect(result.success).toBe(true);
+    expect((await redeemReferralCode('abcd1234')).success).toBe(true);
   });
 
   it('strips non-alphanumeric chars from code', async () => {
     __seed('Referrals', [
       { _id: 'r1', referralCode: 'ABCD1234', status: 'pending', referrerName: 'X', referrerEmail: 'other@e.com', referrerMemberId: 'other' },
     ]);
-    const result = await redeemReferralCode('ABCD-1234!', { email: 'a@b.com' });
-    expect(result.success).toBe(true);
+    expect((await redeemReferralCode('ABCD-1234!')).success).toBe(true);
   });
 
-  it('lowercases email for matching', async () => {
+  it('lowercases email for matching (self-referral via loginEmail casing)', async () => {
+    __setMember({ _id: 'member-x', loginEmail: 'OWNER@Example.com' });
     __seed('Referrals', [
       { _id: 'r1', referralCode: 'ABCD1234', status: 'pending', referrerEmail: 'Owner@Example.com', referrerMemberId: 'other' },
     ]);
-    // Self-referral check uses lowercase comparison
-    const result = await redeemReferralCode('ABCD1234', { email: 'owner@example.com' });
+    const result = await redeemReferralCode('ABCD1234');
     expect(result.success).toBe(false);
     expect(result.error).toContain('own referral');
   });

--- a/tests/referralServiceDispatcher.test.js
+++ b/tests/referralServiceDispatcher.test.js
@@ -1,0 +1,198 @@
+/**
+ * @file referralServiceDispatcher.test.js
+ * @description cf-hpb2 coverage for the referralService dispatcher.
+ * cfw's actions/referral.ts uses `r(method) = referralService/${method}`
+ * to call 4 webMethods whose names don't match backend exports verbatim
+ * (Stilgar combo b+c — see docs/cf-hpb2-referralservice-comparison.md).
+ *
+ * Verifies (cf-yvs4 / cf-mgnh contract):
+ *   - getMyReferralCode / getMyReferralStats — pure rename aliases
+ *   - getReferralByCode — shape shim wrapping {referrerName} → {referral: {referrerName}}
+ *   - claimReferral — alias for redeemReferralCode (post Stilgar Q2 refactor)
+ *   - allowlist 404 for unknown methods
+ *   - cf-yvs4 4xx mapping on {success:false} envelopes
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('backend/referralService.web', () => ({
+  // cfw-aliased
+  getReferralLink: vi.fn(),
+  getReferralStats: vi.fn(),
+  getReferralLinkOwnerName: vi.fn(),
+  redeemReferralCode: vi.fn(),
+  // NOT exposed via dispatcher — must 404 from cfw
+  completeReferral: vi.fn(),
+  getMyReferrals: vi.fn(),
+  getMyCredits: vi.fn(),
+  applyCredit: vi.fn(),
+  getReferralLinkOwnerName2: vi.fn(),
+  getPostPurchaseRewardSummary: vi.fn(),
+  _getReferralLinkForMember: vi.fn(),
+  _processReferralOnOrderCreated: vi.fn(),
+}));
+
+import {
+  post_referralService,
+  options_referralService,
+} from '../src/backend/http-functions.js';
+import {
+  getReferralLink,
+  getReferralStats,
+  getReferralLinkOwnerName,
+  redeemReferralCode,
+  completeReferral,
+  applyCredit,
+} from 'backend/referralService.web';
+
+const goodOrigin = 'https://carolina-futons-web.vercel.app';
+const makeRequest = (method, body = { args: [] }) => ({
+  path: method ? [method] : [],
+  body: { json: async () => body },
+  headers: { origin: goodOrigin },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Pure-rename aliases ───────────────────────────────────────────────────────
+
+describe('cf-hpb2 · pure-rename aliases', () => {
+  it('routes getMyReferralCode → getReferralLink', async () => {
+    vi.mocked(getReferralLink).mockResolvedValue({ success: true, code: 'ABCD1234', link: 'https://…' });
+    const res = await post_referralService(makeRequest('getMyReferralCode'));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true, code: 'ABCD1234', link: 'https://…' });
+    expect(vi.mocked(getReferralLink)).toHaveBeenCalledWith();
+  });
+
+  it('routes getMyReferralStats → getReferralStats', async () => {
+    vi.mocked(getReferralStats).mockResolvedValue({ success: true, stats: { pending: 2, signedUp: 1 } });
+    const res = await post_referralService(makeRequest('getMyReferralStats'));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true, stats: { pending: 2, signedUp: 1 } });
+  });
+});
+
+// ── getReferralByCode shape shim (Stilgar Q1: keep PublicReferral thin) ──────
+
+describe('cf-hpb2 · getReferralByCode shape shim', () => {
+  it('reshapes {success, referrerName} → {success, referral: {referrerName}}', async () => {
+    vi.mocked(getReferralLinkOwnerName).mockResolvedValue({ success: true, referrerName: 'Alice' });
+    const res = await post_referralService(makeRequest('getReferralByCode', { args: ['ABCD1234'] }));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true, referral: { referrerName: 'Alice' } });
+    expect(vi.mocked(getReferralLinkOwnerName)).toHaveBeenCalledWith('ABCD1234');
+  });
+
+  it('forwards {success: false} verbatim (no reshape on the failure path)', async () => {
+    vi.mocked(getReferralLinkOwnerName).mockResolvedValue({ success: false });
+    const res = await post_referralService(makeRequest('getReferralByCode', { args: ['BADCODE'] }));
+    // cf-mgnh: {success:false} with NO error string falls through to the
+    // business-logic default (null → 200) so cfw branches on body.success
+    // without a VeloRpcError throw on a routine "not found" outcome.
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ success: false });
+  });
+
+  it('synthesizes a sensible error envelope when backend returns null/undefined', async () => {
+    vi.mocked(getReferralLinkOwnerName).mockResolvedValue(null);
+    const res = await post_referralService(makeRequest('getReferralByCode', { args: ['NULLCASE'] }));
+    expect(JSON.parse(res.body)).toMatchObject({ success: false, error: expect.stringMatching(/not found/i) });
+  });
+});
+
+// ── claimReferral alias (post Stilgar Q2: identity from currentMember) ───────
+
+describe('cf-hpb2 · claimReferral alias', () => {
+  it('routes claimReferral → redeemReferralCode with the code arg only', async () => {
+    vi.mocked(redeemReferralCode).mockResolvedValue({ success: true, refereeDiscount: 25 });
+    const res = await post_referralService(makeRequest('claimReferral', { args: ['ABCD1234'] }));
+    expect(res.status).toBe(200);
+    expect(vi.mocked(redeemReferralCode)).toHaveBeenCalledWith('ABCD1234');
+  });
+});
+
+// ── Allowlist gating (defense — methods NOT exposed to cfw) ───────────────────
+
+describe('cf-hpb2 · allowlist gating', () => {
+  it('404 for completeReferral (backend export, but NOT exposed to cfw)', async () => {
+    const res = await post_referralService(makeRequest('completeReferral'));
+    expect(res.status).toBe(404);
+    expect(JSON.parse(res.body)).toMatchObject({ success: false, error: 'unknown_method', method: 'completeReferral' });
+    expect(vi.mocked(completeReferral)).not.toHaveBeenCalled();
+  });
+
+  it('404 for applyCredit / getReferralLink (backend names not in cfw alias map)', async () => {
+    expect((await post_referralService(makeRequest('applyCredit'))).status).toBe(404);
+    expect((await post_referralService(makeRequest('getReferralLink'))).status).toBe(404);
+    expect(vi.mocked(applyCredit)).not.toHaveBeenCalled();
+  });
+
+  it('404 when path is empty', async () => {
+    const res = await post_referralService(makeRequest(null));
+    expect(res.status).toBe(404);
+    expect(JSON.parse(res.body).error).toBe('unknown_method');
+  });
+});
+
+// ── cf-yvs4 contract ──────────────────────────────────────────────────────────
+
+describe('cf-hpb2 · cf-yvs4 contract', () => {
+  it('400 invalid_json on body parse failure', async () => {
+    const req = {
+      path: ['getMyReferralCode'],
+      body: { json: async () => { throw new SyntaxError('Bad JSON'); } },
+      headers: { origin: goodOrigin },
+    };
+    const res = await post_referralService(req);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('invalid_json');
+  });
+
+  it('400 args_must_be_array when body lacks args[]', async () => {
+    const res = await post_referralService(makeRequest('getMyReferralCode', { foo: 'bar' }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('args_must_be_array');
+  });
+
+  it('cf-yvs4: maps Authentication required {success:false} to 401', async () => {
+    vi.mocked(getReferralLink).mockResolvedValue({ success: false, error: 'Authentication required' });
+    const res = await post_referralService(makeRequest('getMyReferralCode'));
+    expect(res.status).toBe(401);
+  });
+
+  it('cf-yvs4: maps "Invalid or expired" soft-fail to 400', async () => {
+    vi.mocked(redeemReferralCode).mockResolvedValue({ success: false, error: 'Invalid or expired referral code' });
+    const res = await post_referralService(makeRequest('claimReferral', { args: ['BAD'] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('cf-mgnh: business-logic outcome ("own referral") falls through to 200', async () => {
+    vi.mocked(redeemReferralCode).mockResolvedValue({ success: false, error: 'You cannot use your own referral code' });
+    const res = await post_referralService(makeRequest('claimReferral', { args: ['SELF'] }));
+    // 'You cannot use your own…' doesn't match any 4xx bucket → null → 200
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ success: false });
+  });
+
+  it('500 server_error + errorId on unexpected throw', async () => {
+    vi.mocked(getReferralStats).mockRejectedValue(new Error('Wix Data unavailable'));
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await post_referralService(makeRequest('getMyReferralStats'));
+    expect(res.status).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({ success: false, error: 'server_error' });
+    expect(typeof body.errorId).toBe('string');
+    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain(body.errorId);
+    expect(logged).toContain('post_referralService:getMyReferralStats');
+    consoleErr.mockRestore();
+  });
+
+  it('options preflight responds', () => {
+    const res = options_referralService({ headers: { origin: goodOrigin } });
+    expect(res).toBeDefined();
+    expect(res.status).toBeGreaterThanOrEqual(200);
+  });
+});


### PR DESCRIPTION
## Summary

Closes cf-vtx5.fu held-list. Stilgar approved combo (b)+(c) per `docs/cf-hpb2-referralservice-comparison.md` (PR #1182).

## (b) backend signature refactor

`referralService.web.js#redeemReferralCode` was `(code, refereeData = {name, email})` requiring `email` in the body. Now `(code)` only — identity from `currentMember.getMember()`. Stilgar Q2: server-resolved is the security-correct source (caller can't spoof email).

Q3 verified: zero production callers outside tests. `dataService.web.js` has a separately-named `redeemReferralCode(code)` — unrelated, unaffected.

## (c) dispatcher in http-functions.js

| cfw method | backend method | shim |
|---|---|---|
| `getMyReferralCode` | `getReferralLink` | pure rename |
| `getMyReferralStats` | `getReferralStats` | pure rename |
| `getReferralByCode` | `getReferralLinkOwnerName` | reshape `{referrerName}` → `{referral: {referrerName}}` (Stilgar Q1: keep PublicReferral thin) |
| `claimReferral` | `redeemReferralCode` (refactored above) | alias |

**Defense:** 9 other backend exports (`completeReferral`, `getMyReferrals`, `getMyCredits`, `applyCredit`, `getReferralLinkOwnerName` direct, `getPostPurchaseRewardSummary`, `_*` helpers) are NOT in the allowlist — unknown_method 404 from cfw.

## Tests

- `tests/referralServiceDispatcher.test.js` — **NEW**, 16 cases (allowlist routing, gating, cf-yvs4/cf-mgnh contract).
- `tests/referralService.test.js` — 11 cases rewritten for new signature.
- `tests/referralServiceCoverage.test.js` — 11 cases rewritten.
- `tests/referralServiceDeep.test.js` — 10 cases rewritten + local `__setMember` helper.

**163/163 pass across all 4 referral test files.**

## Companion PR

`carolina-futons-stage3-velo` — mirrors the dispatcher add + signature change. Both must merge before next Wix CLI publish.

Closes cf-hpb2 — last cf-vtx5.fu held-list item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)