### PR TITLE
fix(cf-id8p): drop duplicate loyaltyService import in http-functions.js

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -27,7 +27,6 @@ import { getDeliveryZone as _getDeliveryZone } from 'backend/deliveryZoneService
 import { CLUSTERS, SITE_URL } from 'backend/utils/topicClusterData';
 import { listBundles, getBundleBySlug, addBundleToCart } from 'backend/bundleDeals.web';
 import { receiveGamificationEvent, getActiveChallenges as _getActiveChallengesWebMethod, recordChallengeProgress as _recordChallengeProgressWebMethod } from 'backend/gamificationEventReceiver.web';
-import { getLeaderboard as _getLeaderboardWebMethod } from 'backend/loyaltyService.web';
 export { post_getLeaderboard } from 'backend/leaderboard-http';
 import { validateIncomingEvent, logEventTrace } from 'backend/utils/eventBus';
 import { runGarbageCollection } from 'backend/cmsGarbageCollector.web';
@@ -2351,7 +2350,7 @@ export async function get_leaderboard(request) {
       _leaderboardRateLimit.set(memberId, { count: 1, windowStart: now });
     }
 
-    const result = await _getLeaderboardWebMethod({ limit: rawLimit, period });
+    const result = await _loyaltyServiceModule.getLeaderboard({ limit: rawLimit, period });
     return ok({ body: json(result), headers: JSON_HEADERS });
   } catch (err) {
     console.error('HTTP function error (leaderboard):', err);


### PR DESCRIPTION
## Summary
- One-line cleanup: drop the named-import \`import { getLeaderboard as _getLeaderboardWebMethod }\` from \`backend/loyaltyService.web\` (already imported as \`* as _loyaltyServiceModule\` at line 43)
- Update the single call site to \`_loyaltyServiceModule.getLeaderboard\`

## Why this is urgent
The duplicate-import CI gate is currently failing on **every PR opened against main** because http-functions.js had two imports from the same path. Saw it on PR #1198 (#1198 is doc-only and shouldn't be failing CI).

## Verification
- \`node scripts/check-duplicate-imports.mjs\` → clean post-fix (1761 files, 0 duplicates)
- \`npx vitest run tests/httpFunctionsCoverage.test.js\` → 101/101 pass

## Refs
The CF-id8p gate enforces that no JS/TS file imports the same module twice — known incident CF-2fs8 caused by a bad merge. This fix is the standard remediation pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)