### PR TITLE
fix(cf-fgsw): tag pre-existing vi.doMock() — unblocks all cfutons CI

### DIFF
--- a/tests/communityPhoto.test.js
+++ b/tests/communityPhoto.test.js
@@ -188,7 +188,7 @@ describe('cf-0h9q · post_submitCommunityPhoto', () => {
     // wrapper's serverError path is reached, including errorId in
     // console.error log for ops correlation.
     const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.doMock('backend/communityPhoto.web', () => ({
+    vi.doMock('backend/communityPhoto.web', () => ({ // vi-domock-legacy
       submitCommunityPhoto: vi.fn().mockRejectedValue(new Error('Velo runtime exploded')),
       _validateCommunityPhoto: vi.fn(() => null),
     }));


### PR DESCRIPTION
## Summary

- Adds `// vi-domock-legacy` to `tests/communityPhoto.test.js:191`
- The `noDoMockInTestBody` invariant (CF-fgsw) enforces that new tests don't use `vi.doMock()` inside test bodies — this pre-existing call predates the invariant
- **Unblocks every open cfutons PR**: test(20)/test(22) were failing on this single assertion (`1 failed | 40292 passed`)

## Test plan
- [ ] `noDoMockInTestBody.test.js` passes (invariant green)
- [ ] test(20)/test(22) green on this PR's CI run
- [ ] No other untagged `vi.doMock()` calls (grep confirmed 0 remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)