### PR TITLE
docs(cf-kull): stage3-velo ↔ cfutons monorepo parity audit

### DIFF
--- a/docs/stage3-velo-parity-2026-05-09.md
+++ b/docs/stage3-velo-parity-2026-05-09.md
@@ -1,0 +1,156 @@
+# stage3-velo ↔ cfutons monorepo Parity Audit — 2026-05-09 (cf-kull)
+
+**Scope**: full-grep parity sweep of `src/backend/`, `src/pages/`, `src/public/` between the cfutons monorepo (Velo source-of-truth) and `carolina-futons-stage3-velo` (Wix CLI deploy target). Per Stilgar 2026-05-05: *"STAGE3 REPO: was latest production code pre-migration — verify nothing missed."*
+
+cf-w1lg only closed the 5 missing `/_functions/*` endpoints. This audit answers the bigger question: **what else has drifted?**
+
+## Headline
+
+| Subtree | Common | Identical | Differ | Only cfutons | Only stage3 |
+|---|---:|---:|---:|---:|---:|
+| `src/backend` | 222 | 166 | 56 | **36** | 1 |
+| `src/pages` | 54 | 41 | 13 | **12** | 0 |
+| `src/public` | 257 | 224 | 33 | **31** | 0 |
+| **Total** | **533** | **431** | **102** | **79** | **1** |
+
+The **79 only-in-cfutons files** are the cf-w1lg pattern at scale: code committed to the monorepo that never made it into the deploy target, so any consumer (cfw HTTP call, Wix Studio editor page reference, internal Velo import) hits a 404 / undefined-export. The **102 differ files** are stage3-velo running an older cut of the monorepo logic.
+
+The **1 only-in-stage3 file** (`src/backend/blogRssFeed.web.js`) is the inverse pattern — cfutons just deleted it in PR #1186 (cf-66ne chunk 3). stage3-velo will catch up at next Wix CLI publish.
+
+## HTTP endpoint diff (`http-functions.js`)
+
+The most cfw-impacting layer. cfw → Velo calls land here:
+
+| | cfutons | stage3-velo |
+|---|---:|---:|
+| Total `*_NAME` endpoints | 81 | 81 |
+| Common | 79 | 79 |
+| Only this side | **2** | **2** |
+
+**Only in cfutons** (deploy target lacks them; cfw cannot reach):
+- `get_runReviewRequestEmailsCron` — review-request email cron trigger
+- `get_scanAndTriggerWinbackCron` — winback campaign cron trigger
+
+Both are admin-cron endpoints. If cfutons monorepo expects them callable from a scheduler hitting the live Wix site, those calls 404 today. Verify scheduler config; if the scheduler is internal (Wix Velo cron events), the endpoints don't need to be HTTP-reachable and the gap is moot.
+
+**Only in stage3-velo** (cfutons monorepo lacks them; would be undone on next Wix CLI sync from cfutons):
+- `options_referralService`
+- `post_referralService`
+
+These are the cf-vtx5 referralService dispatcher. The fix landed in stage3-velo first (under prod-fire pressure). Needs back-port to cfutons OR the cfutons-side will overwrite stage3-velo at next publish. Recommended: back-port immediately.
+
+## Backend — 36 files in cfutons, missing from stage3-velo
+
+Grouped by likely impact:
+
+### High impact — has webMethods + plausible cfw / Wix Studio caller (verify each)
+- `cartSessionService.web.js` — guest-cart entry point per `eventBus.js` documentation
+- `chatbotService.web.js` — chatbot backend
+- `completeTheLookService.web.js` — PDP cross-sell helper
+- `customerRoomPhotos.web.js` — UGC backend
+- `deepLinkService.web.js` — mobile deep linking
+- `deliveryNotifications.web.js` — fulfillment notification flow
+- `emailQueueService.web.js` — email queue helper
+- `fabricSampleService.web.js` — already-broken frontend per cf-kg1x reconcile bead
+- `furnitureCareGuideService.web.js` — care-guide content service
+- `gamificationChipService.web.js` — gamification PDP chips
+- `marketingSequences.web.js` — marketing email sequencer
+- `memberPointsLedgerService.web.js` — loyalty points ledger
+- `mobileChallengeService.web.js` — mobile-challenge gamification
+- `priceAlertService.web.js` — price-drop alerts
+- `rewardEngine.web.js` — loyalty rewards engine
+- `sommelierService.web.js` — futon-sommelier quiz backend
+- `swatchKitService.web.js` — fabric swatch-kit logic
+- `tradeInService.web.js` — trade-in program
+- `trailChallengeService.web.js` — trail/challenge service
+- `trailPerkService.web.js` — trail perks
+- `unsubscribeService.web.js` — unsubscribe-token verification
+- `videoReviewService.web.js` — video reviews backend
+- `whiteGloveScheduling.web.js` — white-glove delivery scheduling
+
+### Medium impact — tooling / internal services (verify whether anything imports them)
+- `abTestResults.web.js` — admin A/B-test results
+- `buyingGuideOgCards.web.js` — OG-card generator for buying guides
+- `challengeService.web.js` — generic challenge service
+- `conversionFunnel.web.js` — funnel analytics
+- `lifecycleCron.web.js` — lifecycle email cron
+- `lifecycleEmailSender.web.js` — lifecycle email sender
+- `lifecycleEmailTemplates.js` — lifecycle email template registry
+- `seoAutoMeta.web.js` — auto meta-tag generator
+- `siteContentSeed.web.js` — site-content seeding helper (likely cf-4mol / cfw-66o adjacent)
+- `sitemapEnhancer.web.js` — sitemap enhancer
+
+### Low impact — utilities (no HTTP, no caller from outside)
+- `utils/chatbotContext.js`
+- `utils/crossRigSyncUtils.js`
+- `utils/queryAll.js`
+
+## Pages — 12 only in cfutons (no live Wix Studio editor surface for these)
+
+Wix Studio publishes pages from stage3-velo. These 12 page modules exist as cfutons code but no live page on the published Wix site can use them:
+
+`Admin A-B Tests.js`, `Admin Delivery Calendar.js`, `Admin Virtual Consultation.js`, `Consultation.js`, `Leaderboard.js`, `Reviews.js`, `Survey.js`, `Swatch Kit.js`, `Trade In.js`, `Virtual Consultation.js`, `Warranty Registration.js`, `White Glove Delivery.js`.
+
+Note: cfw replicates several of these as Next.js routes (`/reviews`, `/survey`, `/white-glove-delivery`) so the cfw-side experience is fine. The Wix Studio side is the gap.
+
+## Public — 31 only in cfutons
+
+Wix Studio frontend modules that exist as cfutons code but aren't deployable today:
+
+`BNPLCalculatorWidget.js`, `BNPLWidget.js`, `BundleBuilder.js`, `CategoryPage.js`, `CollectionPage.js`, `CompleteTheLookWidget.js`, `FabricSampleRequest.js`, `FurnitureCareGuideWidget.js`, `HeroPorchWix.js`, `HeroV3Wix.js`, `LoyaltyBadgeWidget.js`, `LoyaltyPerksWidget.js`, `LoyaltyTierBanner.js`, `NpsSurveyWidget.js`, `ProductUGCGallery.js`, `RatingsRollup.js`, `ReviewsCarousel.js`, `SaleLightbox.js`, `ShareYourRoom.js`, `SommelierWidget.js`, `SwatchKitWidget.js`, `TradeInWidget.js`, `TrailProgressDisplay.js`, `TrailProgressWidget.js`, `VideoReviewGrid.js`, `WarrantyInfoWidget.js`, `WarrantyWidget.js`, `YouMightAlsoLike.js`, `funnelTracker.js`, `loyaltyTiers.ts`, `ugcTaxonomy.js`.
+
+Many of these are paired with the corresponding "only-in-cfutons" backend modules above (e.g., `FabricSampleRequest.js` ↔ `fabricSampleService.web.js`). The frontend ↔ backend mismatch means the entire feature is non-deployable until both sides land in stage3-velo.
+
+## Top divergent files (largest content gap on the same path)
+
+Stage3-velo is running an older cut of these:
+
+| Δ bytes | Δ lines | Path |
+|---:|---:|---|
+| +12,519 | +303 | `src/backend/gamificationNotifs.web.js` |
+| +11,973 | +292 | `src/backend/socialStoryScheduler.web.js` |
+| +11,945 | +254 | `src/backend/http-functions.js` |
+| +11,583 | +328 | `src/backend/reviewsService.web.js` |
+| +11,067 | +224 | `src/backend/gamificationCore.web.js` |
+| +9,445  | +274 | `src/backend/leaderboardService.web.js` |
+| +8,789  | +247 | `src/backend/bundleBuilder.web.js` |
+| +6,676  | +197 | `src/backend/styleQuizService.web.js` |
+| +5,714  | +153 | `src/backend/smsService.web.js` |
+| +5,518  | +157 | `src/backend/productRecommendations.web.js` |
+
+Positive deltas mean cfutons is bigger; the same-named file in stage3-velo is older / smaller. These are exactly where new features have been merged to monorepo without the mirror landing in stage3-velo.
+
+## Recommendations
+
+### Immediate (P1)
+1. **Back-port stage3-velo's referralService dispatcher to cfutons** (the `options_referralService` + `post_referralService` exports in stage3-velo's `http-functions.js`). cfutons-side will overwrite at next Wix CLI publish unless this lands first. Owner: whoever shipped cf-vtx5 referralService.
+
+### Convergence sweep (P2 — file as cf-kull.fu sequence)
+2. **23 high-impact backend files** to mirror into stage3-velo (the "High impact" list above). Pair this with the corresponding `src/public/*Widget.js` and `src/pages/*` files where dependencies exist.
+3. **Stilgar / Wix CLI publish cycle**: every time a backend or page merges to cfutons, the deploy-to-stage3-velo step should be a CI gate (proposed in cf-w1lg long-term follow-up). Right now, each merge has to manually mirror, and most don't.
+
+### Verify-then-decide (P3)
+4. **Confirm the 2 only-in-cfutons HTTP cron endpoints** (`get_runReviewRequestEmailsCron`, `get_scanAndTriggerWinbackCron`) are not actually scheduled to hit the live site. If they are, mirror to stage3-velo. If they're internal Velo cron, no action.
+5. **102 differ files**: not all need same-day reconciliation. Top 10 by size delta (per table above) are the real risk; the rest are mostly minor (whitespace, version bumps, JSDoc edits). Spot-check the top 10; bulk-reconcile the rest at next major Wix CLI publish.
+6. **12 admin / scheduling page modules** (`Admin *.js`, `Consultation.js`, etc.) — confirm whether any are intended to be live on the Wix Studio site. If not, no action; if yes, port.
+
+## Method (re-runnable)
+
+```
+scripts/cf-kull/audit.py:
+  1. Walk cfutons/src/{backend,pages,public} and stage3-velo/src/{backend,pages,public}
+  2. Build {relative_path → absolute_path} maps
+  3. Set difference: only-in-cfutons, only-in-stage3, common
+  4. For each common: byte-equal check + size/line delta
+  5. Special-case http-functions.js: extract `*_NAME` endpoint exports both sides, diff
+```
+
+Re-run after every sync window to track convergence progress. Output: `/tmp/cf-kull-results.json` (full per-file detail) + this Markdown summary.
+
+## Source artifacts
+
+- `scripts/cf-kull/audit.py` — re-runnable detector
+- `docs/stage3-velo-parity-2026-05-09.md` — this report
+- Full per-file detail: not committed (regenerable from audit script)
+
+Refs cf-kull, cf-w1lg, cf-vtx5, cf-66ne.

--- a/scripts/cf-kull/audit.py
+++ b/scripts/cf-kull/audit.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""cf-kull — stage3-velo ↔ cfutons monorepo parity audit.
+
+For each src/ subtree (backend, pages, public), enumerate files in both
+repos and report:
+  - ONLY-IN-CFUTONS: file present in cfutons monorepo, missing in stage3-velo
+    → cfw → Velo callers will 404 if they hit it (cf-w1lg pattern)
+  - ONLY-IN-STAGE3:  file present in stage3-velo, missing in cfutons
+    → drift in the other direction (Velo edits never made it back)
+  - DIFFERS:         same path in both repos but file content differs
+    → live divergence; stage3-velo and monorepo are out of sync
+
+Per-file diff is reported as (size_delta, line_delta, sha) so reviewers can
+prioritize substantial differences over whitespace/import-order changes.
+"""
+from __future__ import annotations
+import hashlib
+import json
+import re
+from pathlib import Path
+
+CFUTONS = Path("/tmp/cfutons-kull")
+STAGE3 = Path("/Users/hal/gt/cfutons/carolina-futons-stage3-velo")
+
+SUBTREES = ["src/backend", "src/pages", "src/public"]
+
+
+def collect(root: Path, subtree: str) -> dict[str, Path]:
+    """Walk subtree, return {relative_path → absolute_path} for .js / .jsx / .ts / .tsx files."""
+    out: dict[str, Path] = {}
+    base = root / subtree
+    if not base.exists():
+        return out
+    for p in base.rglob("*"):
+        if p.is_file() and p.suffix in (".js", ".jsx", ".ts", ".tsx", ".json"):
+            rel = str(p.relative_to(root))
+            out[rel] = p
+    return out
+
+
+def sha(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()[:12]
+
+
+def diff_summary(a: Path, b: Path) -> dict:
+    a_text = a.read_text(errors="ignore")
+    b_text = b.read_text(errors="ignore")
+    return {
+        "size_delta": len(a_text) - len(b_text),
+        "line_delta": a_text.count("\n") - b_text.count("\n"),
+        "cfutons_sha": sha(a),
+        "stage3_sha": sha(b),
+        "cfutons_lines": a_text.count("\n") + 1,
+        "stage3_lines": b_text.count("\n") + 1,
+    }
+
+
+def is_http_function(path: str) -> bool:
+    return path.endswith("http-functions.js")
+
+
+def extract_http_exports(p: Path) -> set[str]:
+    text = p.read_text(errors="ignore")
+    pat = re.compile(r"^\s*export\s+(?:async\s+)?function\s+(post|get|put|delete|patch|options|use)_(\w+)", re.MULTILINE)
+    pat_reexport = re.compile(r"^\s*export\s*\{\s*([^}]+)\s*\}\s*from", re.MULTILINE)
+    out: set[str] = set()
+    for m in pat.finditer(text):
+        out.add(f"{m.group(1)}_{m.group(2)}")
+    for m in pat_reexport.finditer(text):
+        for n in m.group(1).split(","):
+            n = n.strip().split(" as ")[0]
+            if re.match(r"^(post|get|put|delete|patch|options|use)_\w+", n):
+                out.add(n)
+    return out
+
+
+def main():
+    report: dict = {}
+    for subtree in SUBTREES:
+        cf = collect(CFUTONS, subtree)
+        s3 = collect(STAGE3, subtree)
+
+        only_cfutons = sorted(set(cf) - set(s3))
+        only_stage3 = sorted(set(s3) - set(cf))
+        common = sorted(set(cf) & set(s3))
+
+        differs = []
+        same = 0
+        for path in common:
+            if cf[path].read_bytes() == s3[path].read_bytes():
+                same += 1
+            else:
+                d = diff_summary(cf[path], s3[path])
+                d["path"] = path
+                differs.append(d)
+
+        # Sort differs by absolute size_delta descending
+        differs.sort(key=lambda d: -abs(d["size_delta"]))
+
+        report[subtree] = {
+            "only_in_cfutons": only_cfutons,
+            "only_in_stage3": only_stage3,
+            "differs": differs,
+            "identical_count": same,
+            "common_count": len(common),
+        }
+
+    # Special-case: http-functions.js endpoint diff
+    cf_http = CFUTONS / "src/backend/http-functions.js"
+    s3_http = STAGE3 / "src/backend/http-functions.js"
+    if cf_http.exists() and s3_http.exists():
+        cf_endpoints = extract_http_exports(cf_http)
+        s3_endpoints = extract_http_exports(s3_http)
+        report["http_endpoints"] = {
+            "only_in_cfutons": sorted(cf_endpoints - s3_endpoints),
+            "only_in_stage3": sorted(s3_endpoints - cf_endpoints),
+            "common_count": len(cf_endpoints & s3_endpoints),
+            "cfutons_total": len(cf_endpoints),
+            "stage3_total": len(s3_endpoints),
+        }
+
+    Path("/tmp/cf-kull-results.json").write_text(json.dumps(report, indent=2, default=str))
+
+    print("Subtree summary:")
+    for sub, r in report.items():
+        if sub == "http_endpoints":
+            print(f"\n  HTTP endpoints in http-functions.js:")
+            print(f"    cfutons: {r['cfutons_total']}, stage3-velo: {r['stage3_total']}, common: {r['common_count']}")
+            print(f"    only-cfutons: {len(r['only_in_cfutons'])} → {r['only_in_cfutons'][:6]}{'...' if len(r['only_in_cfutons'])>6 else ''}")
+            print(f"    only-stage3: {len(r['only_in_stage3'])} → {r['only_in_stage3'][:6]}{'...' if len(r['only_in_stage3'])>6 else ''}")
+            continue
+        print(f"\n  {sub}:")
+        print(f"    common files: {r['common_count']} ({r['identical_count']} identical, {len(r['differs'])} differ)")
+        print(f"    only in cfutons: {len(r['only_in_cfutons'])}")
+        print(f"    only in stage3-velo: {len(r['only_in_stage3'])}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Per Stilgar 2026-05-05: *"STAGE3 REPO: was latest production code pre-migration — verify nothing missed."* cf-w1lg only closed 5 missing \`/_functions\` endpoints. This audit answers the bigger question: what else has drifted between the cfutons monorepo (Velo source-of-truth) and \`carolina-futons-stage3-velo\` (Wix CLI deploy target)?

## Headline

| Subtree | Common | Identical | Differ | Only cfutons | Only stage3 |
|---|---:|---:|---:|---:|---:|
| \`src/backend\` | 222 | 166 | 56 | **36** | 1 |
| \`src/pages\` | 54 | 41 | 13 | **12** | 0 |
| \`src/public\` | 257 | 224 | 33 | **31** | 0 |
| **Total** | **533** | **431** | **102** | **79** | **1** |

**79 only-in-cfutons files** = cf-w1lg pattern at scale. Code merged to monorepo that never reached the deploy target → consumers 404.

**102 differ files** = stage3-velo running an older cut of monorepo logic.

**1 only-in-stage3** = \`blogRssFeed.web.js\` (cfutons just deleted in PR #1186; will sync at next Wix CLI publish).

## HTTP endpoint diff (\`http-functions.js\`)
- 79 common, 81 each total
- **cfutons-only**: \`get_runReviewRequestEmailsCron\`, \`get_scanAndTriggerWinbackCron\` (admin cron triggers)
- **stage3-only**: \`options_referralService\`, \`post_referralService\` (cf-vtx5 dispatcher landed in stage3 first under prod-fire pressure → **needs back-port to cfutons before next CLI publish overwrites**)

## P1 immediate
Back-port the stage3-velo \`referralService\` dispatcher to cfutons. Without this, the next monorepo→stage3 publish undoes the cf-vtx5 fix.

## P2 convergence sweep
~23 high-impact backend files to mirror into stage3-velo (cartSession, chatbot, completeTheLook, customerRoomPhotos, fabricSample, furnitureCareGuide, gamificationChip, marketingSequences, memberPointsLedger, mobileChallenge, priceAlert, rewardEngine, sommelier, swatchKit, tradeIn, trailChallenge, trailPerk, unsubscribe, videoReview, whiteGloveScheduling, etc.). Pair with their \`src/public/*Widget.js\` + \`src/pages/*\` counterparts.

## P3 follow-ups
- Verify the 2 cfutons-only HTTP cron endpoints aren't externally scheduled.
- Spot-check top-10 differ files (largest gap: +12,519 bytes / +303 lines on \`gamificationNotifs.web.js\`).
- Decide-and-do on 12 only-cfutons admin/scheduling page modules.

## Method
\`scripts/cf-kull/audit.py\` walks both trees, builds path→file maps, set-diffs each subtree, byte-equal checks the common set, and special-cases \`http-functions.js\` to extract \`*_NAME\` endpoint exports both sides. Re-runnable against any sync window.

## Test plan
- [x] Doc committed: \`docs/stage3-velo-parity-2026-05-09.md\`
- [x] Detector script committed: \`scripts/cf-kull/audit.py\` (re-runnable; any sync window)
- [x] HTTP endpoint diff verified against current monorepo + stage3-velo
- [ ] (deferred — separate beads) referralService back-port; convergence sweep; cron-endpoint audit

Refs cf-kull, cf-w1lg, cf-vtx5, cf-66ne.