### PR TITLE
fix(cf-hafn): contact_form_auto_reply — close customer-side silent confirmation gap

### DIFF
--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -175,6 +175,24 @@ export const sendEmail = webMethod(
         status: 'new',
       });
 
+      // cf-hafn (cf-icww F6): customer-side auto-reply so the submitter sees
+      // an inbox acknowledgement matching their submission. Pre-cf-hafn the
+      // contact form was a silent confirmation gap — customers re-submitted
+      // because they had no email proof. Non-blocking: owner notification +
+      // CMS row already happened, so a customer-side failure must NOT flip
+      // the overall result. Uses contacts.appendOrCreateContact directly
+      // (same pattern as cartRecovery / giftCards / swatchRequest); when
+      // cf-xdji's resolveContactId helper lands, refactor in a follow-up
+      // sweep.
+      _sendCustomerContactAutoReply({
+        email: cleanEmail,
+        name: cleanName,
+        subject: cleanSubject,
+        message: cleanMessage,
+      }).catch((err) => {
+        console.warn('[emailService] customer auto-reply failed (non-blocking):', err?.message ?? err);
+      });
+
       logAuditEvent('ContactSubmissions', 'send_email', cleanEmail, { subject: cleanSubject });
       return { success: true };
     } catch (err) {
@@ -183,6 +201,48 @@ export const sendEmail = webMethod(
     }
   }
 );
+
+/**
+ * Internal customer-side auto-reply (cf-hafn). Resolves a Wix CRM contact
+ * for the submitter via contacts.appendOrCreateContact (idempotent — Wix
+ * dedupes by email), then fires the `contact_form_auto_reply` triggered
+ * email so the submitter sees an inbox confirmation matching their
+ * submission. Wrapped in try/catch so a missing contactId silently degrades
+ * (warn logged) and a transient CRM/Triggered-Emails failure can't fail
+ * the parent sendEmail call.
+ *
+ * Variables passed to the template (registered in
+ * emailTemplates.web.js#TEMPLATE_REGISTRY.contact_form_auto_reply):
+ *   customerName  — sanitised name
+ *   subject       — original subject (or empty string)
+ *   message       — original message body
+ *   replyEta      — static copy explaining when a human replies
+ *   supportPhone  — fallback phone number
+ *
+ * @param {{email: string, name: string, subject: string, message: string}} args
+ * @returns {Promise<void>}
+ */
+async function _sendCustomerContactAutoReply({ email, name, subject, message }) {
+  const contactResult = await contacts.appendOrCreateContact({
+    name: name ? { first: name } : undefined,
+    emails: [{ email }],
+  });
+  const customerContactId = contactResult?.contactId || contactResult?._id;
+  if (!customerContactId) {
+    console.warn('[emailService] customer auto-reply skipped — appendOrCreateContact returned empty', { email });
+    return;
+  }
+  await triggeredEmails.emailContact('contact_form_auto_reply', customerContactId, {
+    variables: {
+      customerName: name,
+      subject: subject || '',
+      message: message || '',
+      replyEta: 'within 1 business day',
+      supportPhone: '(828) 252-9449',
+      email,
+    },
+  });
+}
 
 /**
  * Submit a fabric swatch request. Stores in ContactSubmissions CMS and

--- a/src/backend/emailTemplates.web.js
+++ b/src/backend/emailTemplates.web.js
@@ -192,6 +192,24 @@ const TEMPLATE_REGISTRY = {
     category: 'transactional',
   },
 
+  // Contact form auto-reply (cf-hafn / cf-icww F6)
+  // Customer-side acknowledgement after submitting the contact form. Owner
+  // notification is the existing `contact_form_submission` template (in the
+  // Wix CRM Triggered Emails dashboard, not registered here as the dashboard
+  // is the source of truth for that one). This auto-reply closes the
+  // silent-confirmation gap surfaced in cf-icww F6 — submitters were getting
+  // a UI "thanks" but no inbox confirmation, leading to repeat submissions.
+  contact_form_auto_reply: {
+    id: 'contact_form_auto_reply',
+    name: 'Contact Form — Customer Auto-Reply',
+    sequence: 'contact',
+    step: 1,
+    subjectLine: 'We got your message — Carolina Futons',
+    previewText: 'A real human will reply within 1 business day. Here\'s what you sent.',
+    variables: ['customerName', 'subject', 'message', 'replyEta', 'supportPhone', 'email'],
+    category: 'transactional',
+  },
+
   // Promotional
   promotional_sale: {
     id: 'promotional_sale',

--- a/tests/cartRecoveryFlow.integration.test.js
+++ b/tests/cartRecoveryFlow.integration.test.js
@@ -600,8 +600,10 @@ describe('Email Service Integration', () => {
 
     expect(result.success).toBe(true);
     const emailLog = __getEmailLog();
-    expect(emailLog).toHaveLength(1);
-    expect(emailLog[0].templateId).toBe('contact_form_submission');
+    // cf-hafn: sendEmail also fires a customer-side auto-reply now; scope
+    // this assertion to the owner notification specifically.
+    const ownerLog = emailLog.find((e) => e.templateId === 'contact_form_submission');
+    expect(ownerLog).toBeDefined();
   });
 });
 

--- a/tests/contactFormAutoReply.cfhafn.test.js
+++ b/tests/contactFormAutoReply.cfhafn.test.js
@@ -1,0 +1,154 @@
+/**
+ * @file contactFormAutoReply.cfhafn.test.js
+ * @description cf-hafn (cf-icww F6) — sendEmail fires a customer-side auto-reply
+ * via the `contact_form_auto_reply` triggered email after the owner notification.
+ * Closes the silent-confirmation gap surfaced in the cf-icww email audit.
+ *
+ * Verifies:
+ *   - Template registered in emailTemplates.web.js#TEMPLATE_REGISTRY
+ *   - Successful sendEmail dispatches BOTH the owner notification AND the
+ *     customer auto-reply
+ *   - Auto-reply uses the resolved customer contactId, the customer's name,
+ *     the submitted subject + message, and the static replyEta + supportPhone
+ *   - Auto-reply is non-blocking — a failure in the customer-side path does
+ *     NOT flip the overall result to failure
+ *   - Empty contactId from appendOrCreateContact short-circuits without raising
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { __seed, __reset as resetData } from './__mocks__/wix-data.js';
+import { __setSecrets, __reset as resetSecrets } from './__mocks__/wix-secrets-backend.js';
+import {
+  __getEmailLog,
+  __reset as resetCrm,
+  __seedContacts,
+} from './__mocks__/wix-crm-backend.js';
+
+import { sendEmail } from '../src/backend/emailService.web.js';
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  resetData();
+  resetSecrets();
+  resetCrm();
+  __setSecrets({ SITE_OWNER_CONTACT_ID: 'owner-contact-123' });
+});
+
+const validSubmission = () => ({
+  name: 'Asheville Andy',
+  email: 'andy@example.com',
+  phone: '828-555-0100',
+  subject: 'Eureka availability',
+  message: 'Do you have the Eureka in slate blue?',
+});
+
+describe('cf-hafn · contact_form_auto_reply template registration', () => {
+  it('exposes contact_form_auto_reply in the template registry with the right variables', async () => {
+    // The internal-only test export lets us pin the template shape so a
+    // future maintainer doesn't drop the registration silently.
+    const { getTemplate } = await import('../src/backend/emailTemplates.web.js');
+    const meta = await getTemplate('contact_form_auto_reply');
+    expect(meta).toBeTruthy();
+    expect(meta.id).toBe('contact_form_auto_reply');
+    expect(meta.category).toBe('transactional');
+    expect(meta.variables).toEqual(
+      expect.arrayContaining(['customerName', 'subject', 'message', 'replyEta', 'supportPhone', 'email']),
+    );
+  });
+});
+
+describe('cf-hafn · sendEmail customer auto-reply', () => {
+  it('dispatches both owner notification AND customer auto-reply on success', async () => {
+    const result = await sendEmail(validSubmission());
+    await flushMicrotasks();
+
+    expect(result.success).toBe(true);
+    const log = __getEmailLog();
+
+    const ownerEmail = log.find((e) => e.templateId === 'contact_form_submission');
+    const customerEmail = log.find((e) => e.templateId === 'contact_form_auto_reply');
+
+    expect(ownerEmail).toBeDefined();
+    expect(ownerEmail.contactId).toBe('owner-contact-123');
+
+    expect(customerEmail).toBeDefined();
+    // appendOrCreateContact mock generates a contact-* id when no prior contact
+    expect(typeof customerEmail.contactId).toBe('string');
+    expect(customerEmail.contactId).toMatch(/^contact-/);
+  });
+
+  it('passes customerName, subject, message, replyEta, and supportPhone to the auto-reply template', async () => {
+    await sendEmail(validSubmission());
+    await flushMicrotasks();
+
+    const customerEmail = __getEmailLog().find((e) => e.templateId === 'contact_form_auto_reply');
+    expect(customerEmail.options.variables).toMatchObject({
+      customerName: 'Asheville Andy',
+      subject: 'Eureka availability',
+      message: 'Do you have the Eureka in slate blue?',
+      replyEta: 'within 1 business day',
+      supportPhone: '(828) 252-9449',
+      email: 'andy@example.com',
+    });
+  });
+
+  it('reuses an existing CRM contact when one already exists for the email', async () => {
+    __seedContacts([
+      { _id: 'contact-existing-9', primaryInfo: { email: 'andy@example.com' } },
+    ]);
+    await sendEmail(validSubmission());
+    await flushMicrotasks();
+
+    const customerEmail = __getEmailLog().find((e) => e.templateId === 'contact_form_auto_reply');
+    // appendOrCreateContact dedupes by email; mock returns the existing _id.
+    expect(customerEmail.contactId).toBe('contact-existing-9');
+  });
+});
+
+describe('cf-hafn · auto-reply is non-blocking', () => {
+  it('still returns success when the auto-reply triggered email fails', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Fail the SECOND emailContact call (the auto-reply) but let the first
+    // (owner notification) succeed. Without skip-count support in the mock,
+    // simulate via spying on the imported triggeredEmails.
+    const crm = await import('wix-crm-backend');
+    const original = crm.triggeredEmails.emailContact;
+    let callCount = 0;
+    vi.spyOn(crm.triggeredEmails, 'emailContact').mockImplementation(async (...args) => {
+      callCount += 1;
+      if (callCount === 2) throw new Error('Triggered Emails service unavailable');
+      return original.apply(crm.triggeredEmails, args);
+    });
+
+    const result = await sendEmail(validSubmission());
+    await flushMicrotasks();
+
+    expect(result.success).toBe(true); // owner email + CMS row already happened
+    expect(__getEmailLog().some((e) => e.templateId === 'contact_form_submission')).toBe(true);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('customer auto-reply failed'),
+      expect.any(String),
+    );
+    consoleWarn.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('skips auto-reply when appendOrCreateContact returns empty', async () => {
+    const crm = await import('wix-crm-backend');
+    vi.spyOn(crm.contacts, 'appendOrCreateContact').mockResolvedValue({});
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await sendEmail(validSubmission());
+    await flushMicrotasks();
+
+    expect(result.success).toBe(true);
+    expect(__getEmailLog().some((e) => e.templateId === 'contact_form_auto_reply')).toBe(false);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('customer auto-reply skipped'),
+      expect.any(Object),
+    );
+    consoleWarn.mockRestore();
+    vi.restoreAllMocks();
+  });
+});

--- a/tests/emailService.test.js
+++ b/tests/emailService.test.js
@@ -26,13 +26,16 @@ describe('sendEmail', () => {
 
     expect(result).toEqual({ success: true });
 
+    // cf-hafn: sendEmail also fires a customer-side auto-reply (separate
+    // template). This assertion scopes to the owner notification specifically;
+    // contactFormAutoReply.cfhafn.test.js covers the auto-reply leg.
     const emails = __getEmailLog();
-    expect(emails).toHaveLength(1);
-    expect(emails[0].templateId).toBe('contact_form_submission');
-    expect(emails[0].contactId).toBe('owner-contact-123');
-    expect(emails[0].options.variables.customerName).toBe('John Doe');
-    expect(emails[0].options.variables.customerEmail).toBe('john@example.com');
-    expect(emails[0].options.variables.subject).toBe('Question about futons');
+    const ownerEmail = emails.find((e) => e.templateId === 'contact_form_submission');
+    expect(ownerEmail).toBeDefined();
+    expect(ownerEmail.contactId).toBe('owner-contact-123');
+    expect(ownerEmail.options.variables.customerName).toBe('John Doe');
+    expect(ownerEmail.options.variables.customerEmail).toBe('john@example.com');
+    expect(ownerEmail.options.variables.subject).toBe('Question about futons');
   });
 
   it('persists submission to ContactSubmissions CMS', async () => {

--- a/tests/emailTemplatesDeepen.test.js
+++ b/tests/emailTemplatesDeepen.test.js
@@ -130,7 +130,7 @@ describe('getTemplateIndex', () => {
   it('returns correct structure with all known sequences', async () => {
     const index = await getTemplateIndex();
     const keys = Object.keys(index).sort();
-    expect(keys).toEqual(['cart_recovery', 'post_purchase', 'promotional', 'reengagement', 'transactional', 'welcome']);
+    expect(keys).toEqual(['cart_recovery', 'contact', 'post_purchase', 'promotional', 'reengagement', 'transactional', 'welcome']);
   });
 });
 

--- a/tests/httpFunctionsCoverage.test.js
+++ b/tests/httpFunctionsCoverage.test.js
@@ -1004,9 +1004,10 @@ describe('post_contactSubmissions', () => {
     expect(result.status).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ success: true });
     expect(result.headers['Access-Control-Allow-Origin']).toBe(goodOrigin);
+    // cf-hafn: customer-side auto-reply also lands in the log; scope to owner.
     const log = crmEmailLog();
-    expect(log).toHaveLength(1);
-    expect(log[0].contactId).toBe('owner-1');
+    const ownerLog = log.filter((e) => e.contactId === 'owner-1');
+    expect(ownerLog).toHaveLength(1);
   });
 
   it('prepends [Size: <sizeOfInterest>] to the subject so the store sees it', async () => {
@@ -1022,9 +1023,11 @@ describe('post_contactSubmissions', () => {
       }),
     );
     expect(result.status).toBe(200);
+    // cf-hafn: customer-side auto-reply also lands in the log; scope to owner.
     const log = crmEmailLog();
-    expect(log).toHaveLength(1);
-    expect(log[0].options.variables.subject).toBe('[Size: queen] Frame question');
+    const ownerLog = log.filter((e) => e.contactId === 'owner-1');
+    expect(ownerLog).toHaveLength(1);
+    expect(ownerLog[0].options.variables.subject).toBe('[Size: queen] Frame question');
   });
 
   it('omits the size prefix when sizeOfInterest is absent', async () => {


### PR DESCRIPTION
## Summary
Closes the F6 silent-failure surfaced in the cf-icww email audit. Contact form previously sent owner an email but no inbox acknowledgement to the submitter, leading customers to re-submit because they had no email proof.

### Implementation
- **`emailTemplates.web.js`** — register `contact_form_auto_reply` template in `TEMPLATE_REGISTRY` (sequence: `contact`, category: `transactional`). Variables: `customerName, subject, message, replyEta, supportPhone, email`.
- **`emailService.web.js`** — internal `_sendCustomerContactAutoReply` helper fires after owner notification + CMS insert. Resolves CRM contactId via `contacts.appendOrCreateContact` (idempotent — Wix dedupes by email; same pattern as cartRecovery / giftCards / swatchRequest until cf-xdji's `resolveContactId` helper lands). Triggers `contact_form_auto_reply`. Fire-and-forget with named `.catch` — customer-side failure cannot flip overall `sendEmail` result. PR #1204's draft-spec doc is the template content reference for Stilgar's CRM dashboard registration.

### Tests
- New `tests/contactFormAutoReply.cfhafn.test.js` (6 tests): registry presence, both-emails-dispatched, variable binding, existing-contact reuse, non-blocking on triggered-email failure, empty-contactId short-circuit.
- `tests/emailService.test.js` — relaxed length assertion to filter for the owner email by templateId (auto-reply now lands in the log too).
- `tests/emailTemplatesDeepen.test.js` — added `'contact'` to the known-sequences invariant.
- **288/288 in the directly-touched test surface** (regression check).

### Acceptance per bead
- [x] (1) Template registered in `emailTemplates.web.js`
- [x] (2) `triggeredEmails.emailContact` called in contact form submit
- [x] (3) Tests
- [ ] Stilgar registers `contact_form_auto_reply` in the Wix CRM Triggered Emails dashboard with the 6 variables (template body copy in PR #1204's draft doc)
- [ ] Staging-verify: submit as brand-new email → both owner + customer inbox arrivals

🤖 Generated with [Claude Code](https://claude.com/claude-code)