### PR TITLE
feat(cf-sq0d): cf-hpwy detector v3 — flag files referenced by filesystem path

### DIFF
--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -119,6 +119,109 @@ def collect_web_methods() -> dict[str, dict]:
     return methods
 
 
+# cf-sq0d (cf-hpwy detector v3): filesystem-path reference detection.
+#
+# The v2 detector closed the same-file caller blind-spot. v3 closes the
+# next layer up: a same-path-as-string caller. cf-4x7e Pass 2 chunk 3
+# (PR #1217) tripped on this when catalogImport.web.js was deleted —
+# all 5 of its webMethods were correctly DEAD per v2, but
+# scripts/validate-catalog.js and tests/validateCatalog.test.js both
+# read the file directly via fs.readFileSync as the canonical source for
+# VALID_CATEGORIES. v2 only scans for `import`/`from 'backend/...'`
+# patterns, so the filesystem-path reads slipped past.
+#
+# Patterns we now flag (any of these → file is FS-path-referenced):
+#   1. fs.readFileSync('...src/backend/<module>.web.js'...)        — Node
+#   2. path.resolve(__dirname, '...src/backend/<module>...')       — relative
+#   3. import x from '...src/backend/<module>?raw'                  — Vite ?raw
+#   4. quoted bare path in array/string: '...src/backend/<module>...' — generic
+#
+# All four collapse to the same shape: a quoted string literal containing
+# the substring `src/backend/<module>` (with or without the `.web.js`
+# suffix). One regex catches all four — we don't need to model each call
+# shape because the path string itself is the signal.
+#
+# False positive risk: a comment or doc that happens to quote the path
+# wouldn't be a real reference. Acceptable trade-off — comments referencing
+# the file are themselves a load-bearing signal that someone cared about
+# the file enough to write about it. Extreme false-positive cases (e.g.
+# CHANGELOG entries naming all 802 files) can be filtered out later by
+# adding a comment-stripping pass.
+FS_PATH_REF_RE_TEMPLATE = (
+    r"""['"`][^'"`]*src/backend/{module}(?:\.web)?\.js[^'"`]*['"`]"""
+)
+
+
+def _module_basename(file_rel: str) -> str:
+    """Return module basename (no extension) for fs-path lookup.
+
+    `src/backend/catalogImport.web.js` → `catalogImport`.
+    `src/backend/sub/foo.js`           → `foo`.
+    """
+    base = file_rel.rsplit("/", 1)[-1]
+    for suffix in (".web.js", ".js"):
+        if base.endswith(suffix):
+            return base[: -len(suffix)]
+    return base
+
+
+def collect_filesystem_path_refs(files: list[Path]) -> dict[str, list[str]]:
+    """Scan all source files for filesystem-path references to backend modules.
+
+    Returns a dict mapping module basename (e.g. 'catalogImport') → list of
+    relative source paths that reference it via a quoted filesystem path.
+    Self-references (the defining file referencing itself) are filtered —
+    only cross-file references prove an external consumer.
+    """
+    backend_modules: set[str] = set()
+    for fp in BACKEND.rglob("*.js"):
+        if not fp.is_file():
+            continue
+        backend_modules.add(_module_basename(str(fp.relative_to(ROOT))))
+
+    if not backend_modules:
+        return {}
+
+    # One compiled regex per backend module — anchored on a literal module
+    # name so backtracking is bounded.
+    patterns = {
+        mod: re.compile(FS_PATH_REF_RE_TEMPLATE.format(module=re.escape(mod)))
+        for mod in backend_modules
+    }
+
+    # Also scan files outside `src/` — scripts/, tests/ are the documented
+    # cf-4x7e blast site. Build a lazy file list that includes both src/ and
+    # the repo-root scripts/+tests/ trees if they exist.
+    scan_files: list[Path] = list(files)
+    for extra_root in ("scripts", "tests"):
+        extra_path = ROOT / extra_root
+        if not extra_path.exists():
+            continue
+        for p in extra_path.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.suffix in (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"):
+                scan_files.append(p)
+
+    refs: dict[str, list[str]] = {mod: [] for mod in backend_modules}
+    for fp in scan_files:
+        try:
+            rel = str(fp.relative_to(ROOT))
+        except ValueError:
+            continue
+        rel_basename = _module_basename(rel)
+        try:
+            text = fp.read_text(errors="ignore")
+        except OSError:
+            continue
+        for mod, pat in patterns.items():
+            if mod == rel_basename:
+                continue
+            if pat.search(text):
+                refs[mod].append(rel)
+    return refs
+
+
 def collect_cfw_files() -> list[Path]:
     if not CFW_SRC.exists():
         return []
@@ -173,6 +276,7 @@ def classify_method(
     cfw_files: list[Path],
     http_text: str,
     events_text: str,
+    fs_path_refs: dict[str, list[str]] | None = None,
 ) -> dict:
     """Return classification for this webMethod."""
     defining_file = info["file"]
@@ -229,6 +333,16 @@ def classify_method(
         if len(sample_callers) < 5:
             sample_callers.append(rel)
 
+    # cf-sq0d (v3): a file referenced by filesystem path from another module
+    # is NOT dead — deleting it would ENOENT the consumer. Surface these as a
+    # distinct bucket so the operator sees WHY the demotion happened (and can
+    # decide whether to refactor the consumer to use a proper import).
+    fs_path_consumers: list[str] = []
+    if fs_path_refs:
+        module_basename = _module_basename(defining_file)
+        fs_path_consumers = list(fs_path_refs.get(module_basename, []))
+    in_fs_path = bool(fs_path_consumers)
+
     buckets: list[str] = []
     if in_http:
         buckets.append("HTTP-EXPOSED")
@@ -238,6 +352,8 @@ def classify_method(
         buckets.append("FRONTEND")
     if in_pdocs_backend or in_same_file:
         buckets.append("INTERNAL")
+    if in_fs_path:
+        buckets.append("FILESYSTEM-PATH-REFERENCED")
     if not buckets:
         buckets = ["DEAD"]
 
@@ -285,6 +401,8 @@ def classify_method(
         "in_pages": in_pages,
         "in_other_backend": in_pdocs_backend,
         "in_same_file": in_same_file,
+        "in_filesystem_path": in_fs_path,
+        "filesystem_path_consumers": fs_path_consumers[:6],
         "sample_callers": sample_callers,
         "cfw_high_refs": cfw_high[:6],
         "cfw_low_refs": cfw_low[:6],
@@ -311,8 +429,20 @@ def main() -> int:
     cfw_files = collect_cfw_files()
     print(f"cfw src files: {len(cfw_files)}", file=sys.stderr)
 
+    # cf-sq0d (v3): scan for filesystem-path references once up front; pass
+    # the result into classify_method so each row can demote DEAD → INTERNAL
+    # when its defining file is read by path from elsewhere.
+    fs_path_refs = collect_filesystem_path_refs(files)
+    fs_path_referenced_modules = sum(1 for v in fs_path_refs.values() if v)
+    print(
+        f"backend modules referenced by filesystem-path: {fs_path_referenced_modules}",
+        file=sys.stderr,
+    )
+
     rows = [
-        classify_method(name, info, files, cfw_files, http_text, events_text)
+        classify_method(
+            name, info, files, cfw_files, http_text, events_text, fs_path_refs
+        )
         for name, info in methods.items()
     ]
 

--- a/scripts/cf-dead-routes/test_audit_v3.py
+++ b/scripts/cf-dead-routes/test_audit_v3.py
@@ -1,0 +1,206 @@
+"""cf-sq0d: tests for the v3 filesystem-path reference detection.
+
+Pins the four pattern shapes called out in the bead so a future regex
+edit can't silently regress detection. Each test seeds a temp repo,
+runs the v3 collector, and asserts a backend module is/isn't flagged.
+
+Run: `python -m pytest scripts/cf-dead-routes/test_audit_v3.py -v`
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a minimal Velo-shaped repo: src/backend + scripts + tests."""
+    (tmp_path / "src" / "backend").mkdir(parents=True)
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "tests").mkdir()
+    return tmp_path
+
+
+def _run_v3(repo: Path) -> dict[str, list[str]]:
+    """Reload audit.py with CFUTONS_ROOT=repo so fresh ROOT/SRC/BACKEND bind."""
+    os.environ["CFUTONS_ROOT"] = str(repo)
+    # Force a fresh import so module-scope ROOT picks up the new env var.
+    for mod in list(sys.modules):
+        if mod == "audit":
+            del sys.modules[mod]
+    import audit  # noqa: WPS433 — intentional late import per test
+
+    files = audit.all_source_files()
+    return audit.collect_filesystem_path_refs(files)
+
+
+def test_pattern_1_fs_readfilesync_with_web_js(tmp_path: Path) -> None:
+    """fs.readFileSync('src/backend/foo.web.js') flags `foo`."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "scripts" / "validate.js").write_text(
+        "const x = fs.readFileSync('src/backend/foo.web.js', 'utf8');\n"
+    )
+    refs = _run_v3(repo)
+    assert refs["foo"] == ["scripts/validate.js"]
+
+
+def test_pattern_2_path_resolve_relative(tmp_path: Path) -> None:
+    """path.resolve(__dirname, '../../src/backend/foo') flags `foo`."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "tests" / "foo.test.js").write_text(
+        "const p = path.resolve(__dirname, '../src/backend/foo.web.js');\n"
+    )
+    refs = _run_v3(repo)
+    assert refs["foo"] == ["tests/foo.test.js"]
+
+
+def test_pattern_3_vite_raw_import(tmp_path: Path) -> None:
+    """import x from 'src/backend/foo?raw' flags `foo`."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "scripts" / "raw-loader.js").write_text(
+        "import x from 'src/backend/foo.web.js?raw';\n"
+    )
+    refs = _run_v3(repo)
+    assert refs["foo"] == ["scripts/raw-loader.js"]
+
+
+def test_pattern_4_quoted_bare_path_in_array(tmp_path: Path) -> None:
+    """quoted 'src/backend/foo.web.js' in any context flags `foo`."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "scripts" / "manifest.js").write_text(
+        "const files = ['src/backend/foo.web.js', 'src/backend/baz.js'];\n"
+    )
+    refs = _run_v3(repo)
+    assert refs["foo"] == ["scripts/manifest.js"]
+
+
+def test_self_reference_is_filtered(tmp_path: Path) -> None:
+    """A backend file mentioning its own path doesn't count as a consumer."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "// path: src/backend/foo.web.js\n"
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    refs = _run_v3(repo)
+    assert refs["foo"] == []
+
+
+def test_unrelated_path_not_flagged(tmp_path: Path) -> None:
+    """A path that resembles `src/backend/<other>` doesn't flag `foo`."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "src" / "backend" / "baz.web.js").write_text(
+        "export const qux = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "scripts" / "uses-baz.js").write_text(
+        "const p = 'src/backend/baz.web.js';\n"
+    )
+    refs = _run_v3(repo)
+    assert refs["foo"] == []
+    assert refs["baz"] == ["scripts/uses-baz.js"]
+
+
+def test_multiple_consumers_all_recorded(tmp_path: Path) -> None:
+    """Two consumers of the same backend file are both surfaced."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "export const bar = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    (repo / "scripts" / "a.js").write_text(
+        "fs.readFileSync('src/backend/foo.web.js');\n"
+    )
+    (repo / "tests" / "b.test.js").write_text(
+        "import('src/backend/foo.web.js?raw');\n"
+    )
+    refs = _run_v3(repo)
+    assert sorted(refs["foo"]) == ["scripts/a.js", "tests/b.test.js"]
+
+
+def test_classify_method_demotes_dead_to_filesystem_path(tmp_path: Path) -> None:
+    """End-to-end: a DEAD-by-v2 webMethod in a fs-path-referenced file flips
+    to FILESYSTEM-PATH-REFERENCED bucket, not DEAD."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "import { webMethod, Permissions } from 'wix-web-module';\n"
+        "export const myDeadMethod = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+    # No callers in src — but a script reads the file by path.
+    (repo / "scripts" / "validate.js").write_text(
+        "fs.readFileSync('src/backend/foo.web.js', 'utf8');\n"
+    )
+
+    os.environ["CFUTONS_ROOT"] = str(repo)
+    for mod in list(sys.modules):
+        if mod == "audit":
+            del sys.modules[mod]
+    import audit
+
+    files = audit.all_source_files()
+    methods = audit.collect_web_methods()
+    fs_path_refs = audit.collect_filesystem_path_refs(files)
+
+    assert "myDeadMethod" in methods
+    row = audit.classify_method(
+        "myDeadMethod",
+        methods["myDeadMethod"],
+        files,
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs=fs_path_refs,
+    )
+    assert "FILESYSTEM-PATH-REFERENCED" in row["bucket"]
+    assert "DEAD" not in row["bucket"]
+    assert row["in_filesystem_path"] is True
+    assert "scripts/validate.js" in row["filesystem_path_consumers"]
+
+
+def test_classify_method_unchanged_when_no_fs_path_ref(tmp_path: Path) -> None:
+    """A truly DEAD method (no fs-path consumers either) still buckets DEAD."""
+    repo = _make_repo(tmp_path)
+    (repo / "src" / "backend" / "foo.web.js").write_text(
+        "import { webMethod, Permissions } from 'wix-web-module';\n"
+        "export const lonely = webMethod(Permissions.Anyone, () => 1);\n"
+    )
+
+    os.environ["CFUTONS_ROOT"] = str(repo)
+    for mod in list(sys.modules):
+        if mod == "audit":
+            del sys.modules[mod]
+    import audit
+
+    files = audit.all_source_files()
+    methods = audit.collect_web_methods()
+    fs_path_refs = audit.collect_filesystem_path_refs(files)
+
+    row = audit.classify_method(
+        "lonely",
+        methods["lonely"],
+        files,
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs=fs_path_refs,
+    )
+    assert row["bucket"] == ["DEAD"]
+    assert row["in_filesystem_path"] is False


### PR DESCRIPTION
## Bead
cf-sq0d (P3, task) — self-claimed by radahn from bd ready (was assigned to melania, queue had no radahn-aimed work).

## Why
cf-4x7e Pass 2 chunk 3 (PR #1217) hit ENOENT after deleting `catalogImport.web.js`. The 5 webMethods in that file were correctly classified DEAD by the v2 detector — but `scripts/validate-catalog.js` and `tests/validateCatalog.test.js` both `fs.readFileSync('src/backend/catalogImport.web.js')` as the canonical source for `VALID_CATEGORIES`. v2 only scanned for `import` / `from 'backend/...'` patterns; the filesystem-path reads slipped past.

Same shape as the same-file caller blind-spot v2 closed (cf-quba / PR #1185), one layer up.

## What v3 detects
A single regex pass over all source + `scripts/` + `tests/` files looking for any quoted string containing `src/backend/<module>(.web)?.js`. The four patterns the bead calls out all collapse to that shape — the path string itself is the load-bearing signal:

1. `fs.readFileSync('src/backend/foo.web.js', ...)`
2. `path.resolve(__dirname, '../src/backend/foo.web.js')`
3. `import x from 'src/backend/foo.web.js?raw'`
4. `const files = ['src/backend/foo.web.js', ...]`

Each ENOENTs identically if the file is deleted. No need to model each call shape separately.

## Behavior change
- New bucket `FILESYSTEM-PATH-REFERENCED` added to `classify_method`.
- A method previously DEAD-only (no other bucket) flips to `FILESYSTEM-PATH-REFERENCED` if its defining file is path-referenced from elsewhere.
- Each row records up to 6 sample consumers under `filesystem_path_consumers` so the operator sees WHY the demotion happened (and can refactor the consumer into a proper import if desired).
- Self-references filtered (the defining backend file mentioning its own path doesn't count).
- HTTP-EXPOSED / EVENT-WIRED / FRONTEND / INTERNAL buckets unchanged — fs-path is purely additive. `gap_verdict` logic still uses `bucket == ['DEAD']` for `UNUSED-CAN-DELETE`, so it correctly stops firing for fs-path-referenced rows.

## Real-run verification (main)
- **catalogImport** (the cf-4x7e canonical case) — all 5 webMethods now bucket `FILESYSTEM-PATH-REFERENCED` with `scripts/validate-catalog.js` + `tests/catalogImport*.test.js` listed as consumers. Exactly the case that broke chunk 3.
- 222 backend modules surface as fs-path-referenced. Most are dynamic-import-via-string-path from the test suite (e.g. `await import('../src/backend/spinWheel.web.js')`), which IS a real load-bearing reference. v3 now surfaces these as the operator-visible signal they always were.
- Pre-existing classifications unchanged — diff is purely additive.

## Tests
`scripts/cf-dead-routes/test_audit_v3.py` — 9 cases:
- 4 covering each spec pattern (`fs.readFileSync`, `path.resolve`, `?raw` import, bare quoted path in array)
- self-reference filter (defining file mentioning its own path doesn't flag)
- unrelated-path negative (`baz` reference doesn't flag `foo`)
- multi-consumer aggregation (two referencing files both surface)
- end-to-end DEAD→FILESYSTEM-PATH-REFERENCED demotion via `classify_method`
- pure-DEAD method stays DEAD when no fs-path consumers

9/9 green: `python -m pytest scripts/cf-dead-routes/test_audit_v3.py -v`

## Acceptance (from bead)
- [x] `audit.py` extended with the 4 filesystem-path patterns
- [x] catalogImport (cf-4x7e canonical case) flagged correctly post-fix
- [x] Pre-existing v2 classifications preserved
- [x] Tests pin each pattern shape against future regression