### PR TITLE
feat(cf-3qt.8): Wix CMS snapshot script + runbook (acceptance item 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ overseer.json
 daemon.json
 dolt-server.port
 _mayor_backup/
+/snapshots/

--- a/docs/cf-3qt.8/wix-snapshot-runbook.md
+++ b/docs/cf-3qt.8/wix-snapshot-runbook.md
@@ -1,0 +1,136 @@
+# cf-3qt.8 — Wix CMS Snapshot Runbook
+
+**Bead:** cf-3qt.8 (acceptance item 1 — "DB snapshot both sites")
+**Owner:** millicent (CI/devops) + Stilgar (runs the script with live creds) + melania (gate-keeps)
+**Last updated:** 2026-05-10
+
+The cf-3qt migration keeps Wix as the data backend (Wix Studio retires as the rendering layer; the full Wix exit is the deferred `cf-xe2` epic). "Both sites" therefore reduces to one backend — Wix — captured as a point-in-time JSON export. This runbook describes when to run the snapshot, what's in / what's out, and how to use the output during and after the cutover.
+
+---
+
+## What gets captured
+
+`scripts/cutover/snapshot-wix-data.mjs` walks a hard-coded list of load-bearing CMS collections (see `--manifest` for the live list) and writes one JSON file per collection plus a `MANIFEST.md` summary into the output directory:
+
+```
+snapshots/<YYYYMMDD-HHMMSS>/
+├── MANIFEST.md                     # human-readable summary table
+├── SiteContent.json                # Brenda's edits (Path B)
+├── ContactSubmissions.json         # form funnel
+├── AbandonedCarts.json             # recovery flow
+├── EmailQueue.json                 # in-flight transactional emails
+├── Fulfillments.json               # shipping ledger
+├── GiftCards.json                  # monetary state
+├── ReferralCodes.json              # monetary state
+├── InventoryLevels.json            # commerce-critical
+├── … (37 collections total)
+```
+
+Each JSON file has the shape:
+
+```json
+{
+  "collectionId": "SiteContent",
+  "capturedAtIso": "2026-05-10T03:00:00.000Z",
+  "items": [ { "_id": "...", "key": "...", "value": "..." }, ... ]
+}
+```
+
+`_id` is preserved, so a single-row restore is a `wixData.update(collectionId, row)` from a Velo backend webMethod.
+
+---
+
+## What is **not** captured
+
+- **Wix Stores Orders** — captured separately by `capture-order-baseline.mjs` (cf-3qt.8 item 5). Don't double-pull; orders churn fast and the baseline file already encodes the load-bearing aggregate.
+- **Wix Members PII** — opted out for consent + retention reasons. If a member-row export is needed for an incident postmortem, file a sibling bead and capture under a separate retention policy.
+- **Wix Media Manager binaries** — only the URLs that show up inside CMS rows are captured. The actual asset bytes live in Wix's media CDN; restoring an image needs to come from there (Wix's own dashboard backup is the right tool for media assets).
+
+---
+
+## When to run
+
+**Within the 24h pre-cutover window, after the order-baseline pull but before the DNS TTL drop.** Running before the TTL drop keeps the snapshot reflective of normal traffic patterns; running after the order-baseline pull means the same API key + scope + headers can be reused without re-authenticating.
+
+If the cutover slips by more than 24 hours, **re-run** the script. A snapshot older than the cutover by > 48 hours has higher drift and reduces postmortem value.
+
+---
+
+## How to run
+
+```sh
+# Required: Wix REST API key + site ID. Stilgar has these in the
+# password manager; the API key needs the same scope as
+# capture-order-baseline.mjs plus `Wix Data Read` on every collection
+# in the manifest. Easiest is a short-lived "snapshot" key with all-
+# read scope, revoked after the cutover.
+export WIX_API_KEY=…
+export WIX_SITE_ID=…
+
+# Optional: override the output dir or per-collection cap.
+# export SNAPSHOT_OUT_DIR=/Users/hal/cutover-snapshot/2026-05-10/
+# export SNAPSHOT_LIMIT_PER_COLLECTION=100000
+
+node scripts/cutover/snapshot-wix-data.mjs
+```
+
+The script emits one progress line per collection and exits with:
+
+| Exit | Meaning |
+| ---: | --- |
+| 0 | Snapshot complete; `MANIFEST.md` written |
+| 1 | `WIX_API_KEY` or `WIX_SITE_ID` missing |
+| 2 | Auth/scope failure (401/403) on a collection. Partial snapshot left in place under the output dir; re-issue the API key with broader scope and re-run with a fresh `SNAPSHOT_OUT_DIR` to avoid the "directory non-empty" guard |
+| 3 | Output directory exists and is non-empty (refuse to overwrite) |
+
+A 404 on a single collection (it doesn't exist on this site yet) is **not** an exit-3 condition — it's logged as a `(missing)` line in `MANIFEST.md` and the snapshot continues.
+
+### Preview the manifest without running
+
+```sh
+node scripts/cutover/snapshot-wix-data.mjs --manifest
+```
+
+Prints the JSON array of collection IDs and exits 0.
+
+---
+
+## How to use during the cutover
+
+1. **Confirm completeness.** Open `MANIFEST.md` immediately after capture. Every load-bearing collection (the funnel + ledger groups) should show `✓` with a non-zero count. The loyalty/engagement collections may legitimately show 0 rows on a low-traffic site — that's fine. Anything `✗` is a real problem; investigate before the cutover proceeds.
+2. **Move off-laptop.** Copy the entire output directory to a dedicated cloud drive or attach to the team password manager. The cutover-night on-call should have it accessible without depending on the operator's laptop.
+3. **Diff at t+24h.** Re-run the snapshot 24 hours post-cutover into a fresh directory. A pairwise diff (`diff -ru pre/ post/`) flags any unexpected collection-level write during the cutover window. Expected diffs: `ContactSubmissions`, `AbandonedCarts`, `EmailQueue`, `InventoryLog`, `ProductAnalytics` (these churn). Unexpected diffs: `SiteContent`, `Promotions`, `AssemblyGuides`, `Landings`, `ComparisonFeatures` (these are Brenda-edited and should be quiet during the cutover).
+4. **Surgical restore path.** Each row in each JSON file has its `_id`. To restore a specific row:
+   ```js
+   // Velo backend webMethod (admin permission)
+   import wixData from 'wix-data';
+   const snapshotRow = /* from JSON */;
+   await wixData.update('SiteContent', snapshotRow, { suppressAuth: true });
+   ```
+   Bulk restore from a JSON file is a `for` loop around the same call. There is no single-shot "restore the whole snapshot" command — and there shouldn't be, since the snapshot is a read-only forensic artifact, not a backup-and-restore product.
+
+---
+
+## Sanity checks before relying on the snapshot
+
+The `MANIFEST.md` file is the audit surface. Before considering the snapshot good, scan for:
+
+1. **All mandatory collections show `✓`.** The mandatory subset is enforced by `tests/snapshotWixData.cf3qt8.test.js`: `SiteContent`, `ContactSubmissions`, `AbandonedCarts`, `EmailQueue`, `Fulfillments`, `GiftCards`, `ReferralCodes`, `InventoryLevels`. Any of these showing `✗` is a stop-the-cutover signal.
+2. **Total rows count is in the right order of magnitude.** Carolina Futons today has ~hundreds of rows in `ContactSubmissions`, low thousands in `AbandonedCarts` + `EmailQueue` + `InventoryLog`. Order of magnitude < 100 across the whole snapshot is suspicious — usually a wrong site ID.
+3. **`SiteContent.json` row count matches the page count Brenda has edited.** If `SiteContent` is `✓` with 0 rows, the collection exists but is empty (cf-4mol initial state) — that's fine and expected pre-launch. If the page is supposed to render Brenda's edits but `SiteContent` is empty, something else is wrong.
+
+---
+
+## Future work
+
+- Optional `--diff PATH_TO_PRIOR_SNAPSHOT` flag that reads a previous snapshot directory + the live API and emits the post-cutover comparison automatically. Out of scope for cf-3qt.8 — a useful follow-up after the first cutover surfaces what diff queries the on-call actually wants.
+- Optional integration with the cf-3qt.8 24-hour monitor: snapshot at t+0, t+1h, t+6h, t+24h, surface the diff in the same dashboard the order-rate baseline feeds. Filed as a separate bead if the cutover proves the manual flow is too slow.
+
+---
+
+## Reference
+
+- Parent: cf-3qt.8 (DNS cutover) acceptance item 1
+- Sibling runbook: `docs/cf-3qt.8/order-baseline-runbook.md` (item 5)
+- API: Wix Data v2 items/query <https://www.wixapis.com/wix-data/v2/items/query>
+- Pattern reference: `scripts/cutover/capture-order-baseline.mjs` (same auth headers, same env-var contract, same JSON-and-Markdown output style)

--- a/scripts/cutover/snapshot-wix-data.mjs
+++ b/scripts/cutover/snapshot-wix-data.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * @file snapshot-wix-data.mjs
+ * @description cf-3qt.8 acceptance item 1 — capture a JSON snapshot of every
+ * load-bearing Wix CMS collection before the DNS cutover, so that a
+ * post-cutover forensic comparison or worst-case restore is possible.
+ *
+ * cf-3qt keeps Wix as the data backend (the migration retires Wix Studio
+ * as the rendering layer; the full Wix exit is the deferred cf-xe2 epic).
+ * "DB snapshot both sites" therefore reduces to ONE backend — Wix —
+ * captured as a point-in-time JSON export of the collections both
+ * STAGING_SITE and the Vercel cfw frontend share.
+ *
+ * The snapshot is a redundancy on top of Wix's own dashboard backups, not
+ * a replacement. Its primary uses:
+ *   1. Audit trail: pinpoint what data looked like at the moment of the
+ *      cutover for any incident postmortem.
+ *   2. Selective restore: if a specific row is corrupted post-cutover, the
+ *      snapshot is the source of truth for the prior value.
+ *   3. Drift detection: re-run at t+24h and diff to confirm no unexpected
+ *      writes happened during the cutover window.
+ *
+ * Not in scope here: Wix Stores Orders (covered by the order-baseline
+ * pull, cf-3qt.8 item 5) and Wix Members PII (separate consent + retention
+ * concerns; if Stilgar wants member snapshots, file a sibling bead).
+ *
+ * Run before the cutover (recommend immediately after the order-baseline
+ * pull — same credentials):
+ *
+ *   WIX_API_KEY=… WIX_SITE_ID=… node scripts/cutover/snapshot-wix-data.mjs
+ *
+ * Optional env:
+ *   SNAPSHOT_OUT_DIR — output directory (default snapshots/<YYYYMMDD-HHMMSS>/
+ *                      relative to the repo root)
+ *   SNAPSHOT_LIMIT_PER_COLLECTION — soft cap per collection (default 50000)
+ *
+ * Exit codes:
+ *   0 — snapshot complete
+ *   1 — WIX_API_KEY/WIX_SITE_ID missing
+ *   2 — Wix API rejected the query (auth / scope / outage). Partial
+ *       snapshot left in place under the output dir.
+ *   3 — output directory exists and is non-empty (refuse to overwrite)
+ */
+
+import { writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+const QUERY_API = 'https://www.wixapis.com/wix-data/v2/items/query';
+const PAGE_SIZE = 100;
+
+// Load-bearing collection inventory — derived from
+// scripts/provisionCmsCollections.js + a few Wix-managed collections that
+// are not in the manifest because backend code creates them on first use
+// (see Step 4 of MASTER-HOOKUP.md). Order matters: largest/highest-write
+// collections last so the snapshot finishes the small reference data
+// even if the API throttles us out at the tail.
+//
+// Exposed for tests + for ops to easily preview the manifest with
+// `node scripts/cutover/snapshot-wix-data.mjs --manifest`.
+export const SNAPSHOT_COLLECTIONS = [
+  // ── Brenda-edited content (Path B + Path A both write here) ───────────
+  'SiteContent',
+  'Promotions',
+  'AssemblyGuides',
+  'FabricSwatches',
+  'ProductBundles',
+  'Videos',
+  'Landings',
+  'PressMentions',
+  'PressKitAssets',
+  'ComparisonFeatures',
+  'SustainabilityStory',
+  'SustainabilityCertification',
+  'SustainabilityMaterial',
+
+  // ── customer-funnel state ─────────────────────────────────────────────
+  'ContactSubmissions',
+  'AbandonedCarts',
+  'BackInStockSignups',
+  'Unsubscribes',
+  'NewsletterSubscribers',
+
+  // ── operational ledger ────────────────────────────────────────────────
+  'Fulfillments',
+  'EmailQueue',
+  'FailedEvents',
+  'InventoryLevels',
+  'InventoryLog',
+  'DeliverySchedule',
+  'ReviewRequests',
+
+  // ── loyalty / referral / engagement ───────────────────────────────────
+  'GiftCards',
+  'ReferralCodes',
+  'SpinGrants',
+  'MobileChallengeCompletions',
+  'CrossRigSyncLog',
+  'CustomerEngagement',
+  'PointsLedger',
+  'BonusSpinGrants',
+  'RecentlyViewed',
+  'MemberPreferences',
+  'PushTokens',
+  'PremiumMemberships',
+  'ProductAnalytics',
+];
+
+// Exposed for tests so the manifest validator + summary writer can be
+// exercised against fixtures without the network round-trip.
+export const _internals = {
+  buildManifestSummary,
+  formatCollectionLine,
+};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function buildHeaders(apiKey, siteId) {
+  return {
+    Authorization: apiKey,
+    'wix-site-id': siteId,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function fetchAllItems({ headers, collectionId, limitPerCollection }) {
+  const items = [];
+  let offset = 0;
+  // Cap pagination by the per-collection ceiling, rounded up to the
+  // nearest PAGE_SIZE so the last page completes cleanly.
+  const maxPages = Math.ceil(limitPerCollection / PAGE_SIZE);
+  for (let page = 0; page < maxPages; page++) {
+    const body = JSON.stringify({
+      dataCollectionId: collectionId,
+      query: {
+        paging: { limit: PAGE_SIZE, offset },
+      },
+    });
+    const res = await fetch(QUERY_API, { method: 'POST', headers, body });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '(unreadable)');
+      const err = new Error(`${collectionId} query → ${res.status}: ${text.slice(0, 200)}`);
+      err.status = res.status;
+      err.collection = collectionId;
+      throw err;
+    }
+    const data = await res.json();
+    const pageItems = data.dataItems || data.items || [];
+    items.push(...pageItems);
+    if (pageItems.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return items;
+}
+
+function formatCollectionLine({ id, status, count, error }) {
+  if (status === 'ok') return `  ✓ ${id.padEnd(28)} ${String(count).padStart(6)} rows`;
+  if (status === 'missing') return `  ○ ${id.padEnd(28)} (collection not found — skipped)`;
+  if (status === 'error') return `  ✗ ${id.padEnd(28)} ERROR: ${error || ''}`.trim();
+  return `  ? ${id} (unknown status)`;
+}
+
+function buildManifestSummary({ outDir, capturedAtIso, results, totalRows }) {
+  const lines = [];
+  lines.push(`# cf-3qt.8 — Wix CMS Snapshot`);
+  lines.push('');
+  lines.push(`**Captured:** ${capturedAtIso}`);
+  lines.push(`**Output:** \`${outDir}\``);
+  lines.push(`**Collections requested:** ${results.length}`);
+  lines.push(`**Total rows captured:** ${totalRows}`);
+  lines.push('');
+  lines.push('## Per-collection result');
+  lines.push('');
+  lines.push('```');
+  for (const r of results) lines.push(formatCollectionLine(r));
+  lines.push('```');
+  lines.push('');
+  lines.push('## What is NOT in this snapshot');
+  lines.push('');
+  lines.push('- **Wix Stores Orders** — captured separately by `capture-order-baseline.mjs` (cf-3qt.8 item 5). Don\'t double-pull; orders churn fast and the baseline file already encodes the load-bearing aggregate.');
+  lines.push('- **Wix Members PII** — opted out for consent + retention reasons. If a member-row export is needed for an incident postmortem, file a sibling bead and capture under a separate retention policy.');
+  lines.push('- **Wix Media Manager binaries** — only the URLs that show up inside CMS rows are captured. The actual asset bytes live in Wix\'s media CDN; restoring an image needs to come from there.');
+  lines.push('');
+  lines.push('## How to use during the cutover');
+  lines.push('');
+  lines.push('1. Confirm the snapshot completed (`✓` for every load-bearing collection — the loyalty/engagement ones are nice-to-have, the funnel/ledger ones are mandatory).');
+  lines.push('2. Keep the output directory off-laptop for the cutover window — copy to a dedicated cloud drive or the team password manager attachments.');
+  lines.push('3. Re-run at t+24h post-cutover with `SNAPSHOT_OUT_DIR=…` pointing at a fresh directory; diff selected files to confirm no unexpected writes happened during the migration window.');
+  lines.push('4. If a specific row needs to be restored, the JSON has every field including `_id` so a `wixData.update(collection, row)` from a Velo backend webMethod is the surgical path.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+function die(code, msg) {
+  console.error(`snapshot-wix-data: ${msg}`);
+  process.exit(code);
+}
+
+async function main() {
+  if (process.argv.includes('--manifest')) {
+    console.log(JSON.stringify(SNAPSHOT_COLLECTIONS, null, 2));
+    process.exit(0);
+  }
+
+  const apiKey = process.env.WIX_API_KEY;
+  const siteId = process.env.WIX_SITE_ID;
+  if (!apiKey || !siteId) {
+    die(1, 'WIX_API_KEY and WIX_SITE_ID env vars are required.');
+  }
+  const limitPerCollection = Number(process.env.SNAPSHOT_LIMIT_PER_COLLECTION || 50_000);
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '').replace('T', '-').slice(0, 15);
+  const outDir = process.env.SNAPSHOT_OUT_DIR
+    ? resolve(process.env.SNAPSHOT_OUT_DIR)
+    : resolve(REPO_ROOT, 'snapshots', stamp);
+
+  if (existsSync(outDir) && readdirSync(outDir).length > 0) {
+    die(3, `output directory ${outDir} already exists and is non-empty — refusing to overwrite.`);
+  }
+  mkdirSync(outDir, { recursive: true });
+
+  const headers = buildHeaders(apiKey, siteId);
+  const capturedAtIso = new Date().toISOString();
+  console.log(`[snapshot-wix-data] writing to ${outDir}`);
+  console.log(`[snapshot-wix-data] ${SNAPSHOT_COLLECTIONS.length} collections, limit ${limitPerCollection}/each`);
+
+  const results = [];
+  let totalRows = 0;
+
+  for (const id of SNAPSHOT_COLLECTIONS) {
+    process.stdout.write(`[snapshot-wix-data] ${id}…`);
+    try {
+      const items = await fetchAllItems({ headers, collectionId: id, limitPerCollection });
+      const path = resolve(outDir, `${id}.json`);
+      writeFileSync(path, JSON.stringify({ collectionId: id, capturedAtIso, items }, null, 2) + '\n');
+      results.push({ id, status: 'ok', count: items.length });
+      totalRows += items.length;
+      console.log(` ${items.length}`);
+    } catch (err) {
+      // 404 means the collection doesn't exist on this site — common for
+      // new collections that haven't been provisioned. Treat as a soft
+      // miss; press on rather than abort the whole snapshot.
+      if (err.status === 404) {
+        results.push({ id, status: 'missing' });
+        console.log(' (missing)');
+        continue;
+      }
+      results.push({ id, status: 'error', error: err.message });
+      console.log(` ERROR: ${err.message.slice(0, 80)}`);
+      // Hard auth/scope failure — bail out so the operator can fix the
+      // key rather than fill the output dir with empty error stubs.
+      if (err.status === 401 || err.status === 403) {
+        const summary = buildManifestSummary({ outDir, capturedAtIso, results, totalRows });
+        writeFileSync(resolve(outDir, 'MANIFEST.md'), summary + '\n');
+        die(2, `auth rejection on ${id} (${err.status}). Partial snapshot at ${outDir}.`);
+      }
+    }
+  }
+
+  const summary = buildManifestSummary({ outDir, capturedAtIso, results, totalRows });
+  writeFileSync(resolve(outDir, 'MANIFEST.md'), summary + '\n');
+  console.log(`[snapshot-wix-data] done. ${totalRows} total rows. summary at ${resolve(outDir, 'MANIFEST.md')}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(`[snapshot-wix-data] unhandled error: ${err.stack || err.message}`);
+    process.exit(2);
+  });
+}

--- a/tests/snapshotWixData.cf3qt8.test.js
+++ b/tests/snapshotWixData.cf3qt8.test.js
@@ -1,0 +1,129 @@
+/**
+ * @file snapshotWixData.cf3qt8.test.js
+ * @description Unit tests for scripts/cutover/snapshot-wix-data.mjs —
+ * specifically the manifest-summary writer and per-collection-line
+ * formatter. The network call is exercised on cutover-prep night with
+ * real WIX_API_KEY/WIX_SITE_ID; not in scope here.
+ *
+ * cf-3qt.8 acceptance item 1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SNAPSHOT_COLLECTIONS,
+  _internals,
+} from '../scripts/cutover/snapshot-wix-data.mjs';
+
+const { buildManifestSummary, formatCollectionLine } = _internals;
+
+describe('SNAPSHOT_COLLECTIONS manifest', () => {
+  it('lists at least the load-bearing collections', () => {
+    // Anchor against a small must-have subset; the full list is allowed
+    // to grow but must never lose any of these mandatory entries.
+    const mandatory = [
+      'SiteContent',           // Brenda's edits (Path B)
+      'ContactSubmissions',    // form funnel
+      'AbandonedCarts',        // recovery flow
+      'EmailQueue',            // in-flight transactional emails
+      'Fulfillments',          // shipping ledger
+      'GiftCards',             // monetary state
+      'ReferralCodes',         // monetary state
+      'InventoryLevels',       // commerce-critical
+    ];
+    for (const id of mandatory) {
+      expect(SNAPSHOT_COLLECTIONS).toContain(id);
+    }
+  });
+
+  it('has no duplicates', () => {
+    expect(SNAPSHOT_COLLECTIONS.length).toBe(new Set(SNAPSHOT_COLLECTIONS).size);
+  });
+
+  it('each entry is a non-empty string with no whitespace', () => {
+    for (const id of SNAPSHOT_COLLECTIONS) {
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+      expect(id).not.toMatch(/\s/);
+    }
+  });
+});
+
+describe('formatCollectionLine', () => {
+  it('renders a successful row with right-padded count', () => {
+    const out = formatCollectionLine({ id: 'SiteContent', status: 'ok', count: 42 });
+    expect(out).toMatch(/✓\s+SiteContent\s+\s+42 rows/);
+  });
+
+  it('renders a missing-collection row', () => {
+    const out = formatCollectionLine({ id: 'NotProvisioned', status: 'missing' });
+    expect(out).toContain('○');
+    expect(out).toContain('NotProvisioned');
+    expect(out).toMatch(/collection not found/i);
+  });
+
+  it('renders an error row with the error message', () => {
+    const out = formatCollectionLine({ id: 'X', status: 'error', error: 'rate-limited' });
+    expect(out).toContain('✗');
+    expect(out).toContain('X');
+    expect(out).toContain('rate-limited');
+  });
+
+  it('renders an unknown-status row defensively', () => {
+    const out = formatCollectionLine({ id: 'X', status: 'weird' });
+    expect(out).toContain('?');
+    expect(out).toContain('X');
+  });
+});
+
+describe('buildManifestSummary', () => {
+  const SAMPLE = [
+    { id: 'SiteContent', status: 'ok', count: 12 },
+    { id: 'ContactSubmissions', status: 'ok', count: 88 },
+    { id: 'NotProvisioned', status: 'missing' },
+    { id: 'BadAuth', status: 'error', error: 'forbidden' },
+  ];
+
+  it('contains the cutover header and all four entries', () => {
+    const md = buildManifestSummary({
+      outDir: '/tmp/snap',
+      capturedAtIso: '2026-05-10T03:00:00.000Z',
+      results: SAMPLE,
+      totalRows: 100,
+    });
+    expect(md).toContain('# cf-3qt.8 — Wix CMS Snapshot');
+    expect(md).toContain('**Captured:** 2026-05-10T03:00:00.000Z');
+    expect(md).toContain('**Output:** `/tmp/snap`');
+    expect(md).toContain('**Collections requested:** 4');
+    expect(md).toContain('**Total rows captured:** 100');
+    expect(md).toContain('SiteContent');
+    expect(md).toContain('ContactSubmissions');
+    expect(md).toContain('NotProvisioned');
+    expect(md).toContain('BadAuth');
+  });
+
+  it('has the not-in-snapshot caveat block', () => {
+    const md = buildManifestSummary({
+      outDir: '/tmp/snap',
+      capturedAtIso: '2026-05-10T03:00:00.000Z',
+      results: SAMPLE,
+      totalRows: 100,
+    });
+    expect(md).toContain('## What is NOT in this snapshot');
+    expect(md).toContain('Wix Stores Orders');
+    expect(md).toContain('cf-3qt.8 item 5');
+    expect(md).toContain('Wix Members PII');
+    expect(md).toContain('Wix Media Manager');
+  });
+
+  it('has the cutover-usage block with the t+24h diff suggestion', () => {
+    const md = buildManifestSummary({
+      outDir: '/tmp/snap',
+      capturedAtIso: '2026-05-10T03:00:00.000Z',
+      results: SAMPLE,
+      totalRows: 100,
+    });
+    expect(md).toContain('## How to use during the cutover');
+    expect(md).toMatch(/t\+24h post-cutover/);
+    expect(md).toMatch(/wixData\.update\(collection, row\)/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-3qt.8 acceptance item 1: "DB snapshot both sites" before the cutover. Since cf-3qt keeps Wix as the data backend, "both sites" reduces to one backend captured as a point-in-time JSON export of the load-bearing CMS collections.

Sibling to PR #1222 (item 5 — order-rate baseline). Same auth pattern, same env-var contract, same JSON-and-Markdown output style — Stilgar runs both with the same key on the same night.

## What ships

**`scripts/cutover/snapshot-wix-data.mjs`** — walks 37 load-bearing collection IDs (Brenda-edited content + customer funnel + operational ledger + loyalty/engagement), paginates each via Wix Data v2 `items/query`, writes one JSON file per collection plus a `MANIFEST.md` summary into `snapshots/<YYYYMMDD-HHMMSS>/`. Per-row `_id` is preserved so a surgical restore is one `wixData.update(collection, row)` call. Distinct exit codes (0 ok / 1 missing env / 2 auth-rejection / 3 dir non-empty). `--manifest` mode previews the collection list without touching Wix. Soft-miss on 404 (collection not provisioned), hard fail on 401/403 with a partial-snapshot manifest left in place.

**`tests/snapshotWixData.cf3qt8.test.js`** — 10 vitest cases: mandatory-collection coverage assertion, no-dup / non-empty / no-whitespace invariants, `formatCollectionLine` renders ok/missing/error/unknown, `buildManifestSummary` contains the cutover header + all entries + the not-in-snapshot caveats + the t+24h diff suggestion + the `wixData.update` restore-path example.

**`docs/cf-3qt.8/wix-snapshot-runbook.md`** — when to run (24h+ pre-cutover, after order-baseline, before TTL drop), how to invoke, exit-code table, what's NOT captured (Orders/Members PII/Media binaries — with reasons), how to use during the cutover (4-step), pre-cutover sanity-check list, future-work notes.

**`.gitignore`** — `/snapshots/` (generated artifacts don't go in the repo; they live on the cutover-night cloud drive or password-manager attachment per the runbook).

## Test plan

- [x] `npx vitest run tests/snapshotWixData.cf3qt8.test.js` — 10/10
- [x] `node scripts/cutover/snapshot-wix-data.mjs --manifest` — prints the JSON list and exits 0
- [x] `node scripts/cutover/snapshot-wix-data.mjs` (no env) — exits 1 with `WIX_API_KEY and WIX_SITE_ID env vars are required.`
- [x] eslint clean
- [x] `check-http-endpoint-test-coverage` gate still OK (61/63, baseline unchanged)
- [ ] **Live verification (Stilgar/melania):** run with real `WIX_API_KEY` + `WIX_SITE_ID`, confirm the output dir is created, every mandatory collection (`SiteContent`, `ContactSubmissions`, `AbandonedCarts`, `EmailQueue`, `Fulfillments`, `GiftCards`, `ReferralCodes`, `InventoryLevels`) shows `✓` in `MANIFEST.md`.

## Caveat

Same as PR #1222: I don't have `WIX_API_KEY` locally so the REST round-trip isn't exercised. Pattern matches `capture-order-baseline.mjs` and `assign-skus.mjs` (both production-proven); runbook spells out the exit-code interpretation Stilgar will see if scope is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)