### PR TITLE
feat(cf-3qt.8): DNS TTL drop runbook + verify helper (acceptance item 2)

### DIFF
--- a/docs/cf-3qt.8/dns-ttl-drop-runbook.md
+++ b/docs/cf-3qt.8/dns-ttl-drop-runbook.md
@@ -1,0 +1,111 @@
+# cf-3qt.8 — DNS TTL Drop Runbook
+
+**Bead:** cf-3qt.8 (acceptance item 2 — "Lower DNS TTL to 60s (48h prior)")
+**Owner:** Stilgar (executes in Wix DNS dashboard) + millicent (verification helper) + melania (gate-keeps timing)
+**Last updated:** 2026-05-10
+
+The cf-3qt.8 cutover commits to a **rollback-inside-15-minutes** SLO. That commitment depends entirely on the TTL of the `carolinafutons.com` records being short enough that resolvers re-fetch within the rollback window. Today the records carry a default `~3600` (1-hour) TTL — too long. This runbook captures the procedure for dropping all of them to **60 seconds** at least 48 hours before the cutover, plus the post-cutover restoration to a normal TTL once the migration has stabilized.
+
+---
+
+## Why 60s, why 48h
+
+- **Why 60s:** the rollback SLO is 15 minutes from "decision to rollback" to "carolinafutons.com resolves to Wix again." With a 60s TTL, a globally-cached record expires within one minute; the long tail of intermediate caches (some ISPs ignore TTL and cap at their own minimum, often 5–10 min) settles by the 15-minute mark. With a 3600s TTL, the same propagation takes up to an hour — the SLO is unreachable.
+- **Why 48h:** A TTL drop only takes effect after the *previous* TTL window has expired. If we drop TTL → 60 from 3600 at T-12h, resolvers that fetched the record at T-11h still hold the old 3600s entry until T+49min. 48 hours is a comfortable safety margin (12× the 3600s window, accounts for resolvers that round up TTL).
+
+If the cutover slips by more than 48h after the TTL drop, no action needed — the short TTL just means more re-fetches, no operational risk. If the cutover slips by more than **two weeks**, restore TTL to the normal value and re-drop 48h before the new cutover date (long-running 60s TTL makes the records sensitive to single-DNS-server outages).
+
+---
+
+## Pre-flight inventory
+
+The records to lower are the four authoritative entries for `carolinafutons.com` per `dns-staging.md` (cf-3qt.8.2). Wix is the DNS provider today (nameservers `ns2.wixdns.net`, `ns3.wixdns.net`), so the procedure happens in the Wix Dashboard, not at an external registrar.
+
+| # | Type | Name | Current value | Current TTL | Target TTL |
+| ---: | --- | --- | --- | ---: | ---: |
+| 1 | A | `@` | `185.230.63.186` | `~3600` | **60** |
+| 2 | A | `@` | `185.230.63.107` | `~3600` | **60** |
+| 3 | A | `@` | `185.230.63.171` | `~3600` | **60** |
+| 4 | CNAME | `www` | `cdn1.wixdns.net.` | `~3600` | **60** |
+
+**Do NOT touch:**
+- **MX `@` → `mx30.mailspamprotection.com.` (priority 30)** — mail routing. A TTL drop here is harmless but unnecessary; keep the surface of changes minimal so the email-risk assessment in `dns-staging.md` stays valid.
+- **NS records (`ns2.wixdns.net.` / `ns3.wixdns.net.`)** — registrar-level, not edited from the DNS dashboard. Untouched.
+- **No TXT / SPF / DMARC / DKIM records exist** today (per cf-3qt.8.2). Nothing to lower.
+
+---
+
+## Procedure (Wix DNS dashboard)
+
+**Estimated time: 5 minutes. Stilgar executes; melania pairs.**
+
+1. Log into the Wix Dashboard at <https://manage.wix.com>.
+2. Open `carolinafutons.com` site → **Settings** → **Domains**.
+3. Click `carolinafutons.com` → **Advanced** → **Edit DNS**.
+4. For each of the 4 records above:
+   1. Click the row → **Edit**.
+   2. Change the TTL field from `1 Hour` (or whatever the current value reads) to `1 Minute`. Wix's UI presents preset choices — `1 Minute` corresponds to 60 seconds.
+   3. Click **Save**.
+5. Confirm all 4 rows now show `1 Minute` in the TTL column.
+6. Record the timestamp of the last save in `docs/cf-3qt.8/ttl-drop-log.md` (create the file if it doesn't exist; one line per drop):
+   ```
+   2026-05-12T14:00 MT — TTL → 60s on @, @, @, www. Done by Stilgar (verified: melania).
+   ```
+   This timestamp is the start of the 48-hour window. The earliest the cutover may proceed is T+48h.
+
+---
+
+## Verification
+
+`scripts/cutover/verify-dns-ttl.sh` polls public resolvers and exits non-zero if any of the 4 records still report a TTL > 120s (60s with a small grace for clock skew). Run it:
+
+- Immediately after the dashboard save (expect: still some resolvers report old TTL — this is the propagation tail)
+- 1 hour later (expect: most major resolvers updated)
+- At T+24h (expect: every checked resolver reports ≤ 120s — anything else is investigated before cutover)
+- Right before the cutover (final go/no-go signal)
+
+```sh
+bash scripts/cutover/verify-dns-ttl.sh
+# → exits 0 if all 4 records show TTL ≤ 120s on every checked resolver
+# → exits 1 with a per-resolver/record table if any still show stale TTL
+```
+
+The script is plain `dig`-based — works without any Wix or Vercel auth.
+
+---
+
+## Post-cutover restoration
+
+Once the cutover has been stable for **30 days** (or the rollback window is officially closed by Stilgar, whichever comes first), restore the TTL to a normal value:
+
+| Record | Restore TTL |
+| --- | ---: |
+| A `@` (3 records, now pointing at Vercel `76.76.21.21`) | `3600` (1 hour) |
+| CNAME `www` (now `cname.vercel-dns.com.`) | `3600` (1 hour) |
+
+Same procedure as the drop: Wix Dashboard → Domains → Edit DNS → set TTL `1 Hour`. Append the timestamp to `ttl-drop-log.md` so the historical record is intact.
+
+Why restore: a permanent 60s TTL doubles or triples the DNS query load (every minute vs every hour), and a single brief Wix-DNS-server outage during a 60s window means lots of users see immediate resolution failures. 1 hour is the standard balance.
+
+---
+
+## Failure modes
+
+| Mode | Detection | Response |
+| --- | --- | --- |
+| Wix UI saves silently fail | Verification script at T+1h still shows 3600s | Re-open the record in the dashboard, re-save. If still fails, contact Wix support — their dashboard occasionally drops writes during deploys. |
+| One record was missed | Verification script reports TTL > 120s on a specific record | Edit that single record, re-save, re-verify. Common cause: the third A record at the bottom of the list scrolled off. |
+| Cutover triggered without 48h elapsed | Pre-cutover gate (melania) | **Block the cutover.** Resolver caches still hold the old TTL; rollback would not finish in 15 min. Reschedule the cutover for T+48h after the actual TTL drop. |
+| Resolvers report TTL > 60s but ≤ 120s | Verification script | **Acceptable.** Some resolvers (Google's `8.8.8.8`, Cloudflare's `1.1.1.1`) clamp TTL to a minimum (often 30–60s) and present a slightly higher value in `dig` output. The 120s grace in the script accommodates this without false failures. |
+
+---
+
+## Reference
+
+- Parent: cf-3qt.8 (DNS cutover) acceptance item 2
+- DNS record inventory: `dns-staging.md` (cf-3qt.8.2)
+- Sibling runbooks:
+  - `docs/cf-3qt.8/order-baseline-runbook.md` (item 5)
+  - `docs/cf-3qt.8/wix-snapshot-runbook.md` (item 1)
+  - `docs/ops/rollback-runbook.md` (item 4 — the rollback procedure that depends on this TTL drop)
+- Wix DNS dashboard: <https://manage.wix.com> → Settings → Domains → Advanced → Edit DNS

--- a/scripts/cutover/verify-dns-ttl.sh
+++ b/scripts/cutover/verify-dns-ttl.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# verify-dns-ttl.sh — confirm that carolinafutons.com DNS records carry a
+# short TTL (≤ 120s by default) across multiple public resolvers, ahead of
+# the cf-3qt.8 cutover.
+#
+# Usage:
+#   bash scripts/cutover/verify-dns-ttl.sh                      # default 120s grace
+#   TTL_GRACE_SECONDS=60 bash scripts/cutover/verify-dns-ttl.sh # strict 60s
+#
+# Exit codes:
+#   0 — every checked (resolver, record) pair reports TTL ≤ TTL_GRACE_SECONDS
+#   1 — at least one pair reports TTL > grace; per-pair table written to stderr
+#   2 — `dig` not available on PATH; cannot verify
+#
+# Reads no secrets, makes no network calls except DNS.
+
+set -euo pipefail
+
+DOMAIN="${TTL_VERIFY_DOMAIN:-carolinafutons.com}"
+GRACE="${TTL_GRACE_SECONDS:-120}"
+
+# Records to probe — the 4 entries from dns-staging.md (cf-3qt.8.2). The
+# query name plus the record type is enough — `dig` returns the TTL of
+# each authoritative answer.
+RECORD_TYPES=(A CNAME)
+QUERY_NAMES=("${DOMAIN}" "www.${DOMAIN}")
+
+# Public resolvers to probe — geographically + administratively distinct
+# so we catch single-resolver caching anomalies.
+RESOLVERS=(
+  "8.8.8.8"      # Google
+  "8.8.4.4"      # Google secondary
+  "1.1.1.1"      # Cloudflare
+  "1.0.0.1"      # Cloudflare secondary
+  "9.9.9.9"      # Quad9
+)
+
+if ! command -v dig >/dev/null 2>&1; then
+  echo "verify-dns-ttl: dig not found on PATH — install bind-utils / dnsutils." >&2
+  exit 2
+fi
+
+echo "verify-dns-ttl: domain=${DOMAIN} grace=${GRACE}s"
+echo
+
+failures=0
+total=0
+table=$(printf "resolver\tname\ttype\tttl\tstatus")
+
+for resolver in "${RESOLVERS[@]}"; do
+  for name in "${QUERY_NAMES[@]}"; do
+    for rtype in "${RECORD_TYPES[@]}"; do
+      total=$((total + 1))
+      # +noall +answer prints just the answer-section rows; awk pulls the
+      # TTL column (field 2 in 'NAME TTL CLASS TYPE VALUE'). +tries=2
+      # +time=3 keeps slow resolvers from hanging the script.
+      # `set -e` plus a pipeline that returns nothing (e.g. CNAME query at
+      # apex) would otherwise exit the whole script — guard with `|| true`
+      # and let the empty-string check below skip it cleanly.
+      ttl=$(dig +noall +answer +tries=2 +time=3 "@${resolver}" "${name}" "${rtype}" 2>/dev/null \
+        | awk 'NR==1 { print $2 }' || true)
+      if [ -z "${ttl}" ]; then
+        # No answer of this type — common for CNAME at apex, or if the
+        # record genuinely doesn't exist. Skip; not a failure.
+        continue
+      fi
+      if ! [[ "${ttl}" =~ ^[0-9]+$ ]]; then
+        # `dig` printed an error line (e.g. "connection timed out") where
+        # the answer would normally be. Surface as a network blip without
+        # treating it as a TTL failure.
+        table="${table}
+${resolver}	${name}	${rtype}	-	timeout"
+        continue
+      fi
+      if [ "${ttl}" -le "${GRACE}" ]; then
+        status="ok"
+      else
+        status="STALE"
+        failures=$((failures + 1))
+      fi
+      table="${table}
+${resolver}	${name}	${rtype}	${ttl}	${status}"
+    done
+  done
+done
+
+# Pretty-print as columns.
+echo "${table}" | column -t -s $'\t'
+echo
+
+if [ "${failures}" -gt 0 ]; then
+  echo "verify-dns-ttl: ${failures}/${total} pairs report TTL > ${GRACE}s — investigate before cutover." >&2
+  exit 1
+fi
+
+echo "verify-dns-ttl: OK — every checked pair reports TTL ≤ ${GRACE}s."
+exit 0


### PR DESCRIPTION
## Summary

cf-3qt.8 acceptance item 2 — "Lower DNS TTL to 60s (48h prior)". The rollback-inside-15-minutes SLO depends on resolvers re-fetching within the rollback window. Records today are at ~3600s (1 hour) per `dns-staging.md` (cf-3qt.8.2); this PR ships the drop procedure and a `dig`-based verifier that becomes the cutover go/no-go gate.

Sibling to PRs #1222 (item 5) and #1226 (item 1).

## What ships

**`docs/cf-3qt.8/dns-ttl-drop-runbook.md`** — Stilgar-facing procedure for dropping the 4 cutover-relevant records (3× A on `@` + 1× CNAME on `www`) from ~3600 → 60 seconds via the Wix Dashboard (Wix is the DNS provider — no external registrar trip). MX/NS records explicitly out of scope so the mail-risk assessment stays contained. Covers:

- why 60s, why 48h pre-cutover (TTL drop only takes effect after the previous TTL window has expired; 48h = 12× the 3600s window — comfortable safety margin)
- pre-flight inventory (record × current value × target TTL)
- 5-min Wix-dashboard procedure with timestamp-log requirement
- verification cadence (T+0, T+1h, T+24h, pre-cutover)
- post-cutover restoration to 3600s after 30 days
- failure modes table (silent UI save fail, missed record, cutover before 48h elapsed, clamping-resolver false-failures)

**`scripts/cutover/verify-dns-ttl.sh`** — plain bash + `dig`. Probes 5 public resolvers (Google × 2, Cloudflare × 2, Quad9) for `A` + `CNAME` on apex + `www`, prints a per-(resolver, record) status table, exits 0 when every pair reports TTL ≤ `TTL_GRACE_SECONDS` (default 120s — covers the 60s target plus clamping grace) and 1 when any are still stale. Skips records that don't exist (CNAME at apex) and surfaces resolver timeouts as `timeout` rows without conflating them with TTL failures.

## Live verification (today's pre-drop state)

```
verify-dns-ttl: domain=carolinafutons.com grace=120s
resolver  name                    type   ttl   status
8.8.8.8   carolinafutons.com      A      3600  STALE
8.8.8.8   www.carolinafutons.com  A      3532  STALE
…
1.0.0.1   carolinafutons.com      A      3600  STALE
9.9.9.9   www.carolinafutons.com  CNAME  3558  STALE
verify-dns-ttl: 12/20 pairs report TTL > 120s — investigate before cutover.
```

Exits 1, as expected — the records are still on the pre-drop TTL. After Stilgar runs the runbook procedure, the same script becomes the go/no-go gate.

## Test plan

- [x] `bash -n scripts/cutover/verify-dns-ttl.sh` — clean
- [x] Live run today (pre-drop) → exit 1 with the 12 STALE rows above (correct behavior)
- [x] Skips apex CNAME (4 rows skipped, not failures)
- [x] Surfaces 1.1.1.1 unreachable as `timeout` rows (not STALE-conflated)
- [ ] **Post-drop verification (Stilgar/melania):** after Wix-dashboard TTL drop → run script → exit 0 with all 16 valid pairs ≤ 120s

## Items shipped in this session for cf-3qt.8

- ✅ Item 1 — Wix CMS snapshot (#1226 merged)
- 🆕 Item 2 — DNS TTL drop runbook + verifier (this PR)
- ✓ Item 3 — Synthetic monitoring (already shipped via cf-3qt.8.3 / `monitoring-setup.md`)
- ✓ Item 4 — Rollback playbook (already shipped via cf-3qt.8.4 / `rollback-runbook.md`)
- ✅ Item 5 — Order-rate baseline (#1222 merged)
- ⏳ Item 6 — Vercel Hobby → Pro upgrade (Stilgar dashboard work, owner-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)