### PR TITLE
chore(cf-4x7e): Pass 2 chunk 8 — surgical SUPERSEDE on blogService.web.js (last SUPERSEDE)

### DIFF
--- a/src/backend/blogService.web.js
+++ b/src/backend/blogService.web.js
@@ -1,14 +1,24 @@
 /**
- * Blog Service — web module wrapper for blogContent (static) and Wix Blog CMS (live).
+ * Blog Service — web module wrapper for the live Wix Blog CMS.
  * Exposes blog functions to public/page files via Wix web module convention.
+ *
+ * cf-4x7e Pass 2 chunk 8 retired the static-data wrappers
+ * (fetchBlogPost, fetchBlogSlugs, fetchBlogFaqs, getPostBySlug) — none
+ * had callers in cfutons or stage3-velo. The live methods kept here
+ * are wired by:
+ *   - getPublishedBlogPosts: src/pages/Blog.js (cfutons + stage3)
+ *   - getRecentPosts:        src/public/HomeBlogTeasers.js (cfutons + stage3)
+ *   - fetchAllBlogPosts:     stage3 src/public/HomeBlogTeasers.js
+ *   - getCategories:         stage3 src/pages/Blog.js
  *
  * @requires wix-web-module
  * @requires wix-blog-backend
- * @requires backend/blogContent
+ * @requires backend/blogContent — for fetchAllBlogPosts (the only static
+ *           wrapper still alive)
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { posts as blogPosts } from 'wix-blog-backend';
-import { getAllBlogPosts, getBlogPost, getBlogSlugs, getBlogFaqs } from 'backend/blogContent';
+import { getAllBlogPosts } from 'backend/blogContent';
 
 const DEFAULT_PER_PAGE = 9;
 const FALLBACK_AUTHOR = 'Carolina Futons Team';
@@ -105,30 +115,6 @@ export const getRecentPosts = webMethod(
 );
 
 /**
- * Fetch a single published post from the Wix Blog CMS by its slug.
- * Returns a normalized post object, or null if not found or on error.
- *
- * @function getPostBySlug
- * @param {string} slug Post slug (from URL path)
- * @returns {Promise<Object|null>} Normalized post or null
- * @permission Anyone
- */
-export const getPostBySlug = webMethod(
-  Permissions.Anyone,
-  async (slug) => {
-    if (!slug || typeof slug !== 'string') return null;
-    try {
-      const response = await blogPosts.getPost(slug.trim());
-      return response.post ? normalizePost(response.post) : null;
-    } catch (err) {
-      if (err?.code === 404 || err?.message?.includes('not found')) return null;
-      console.error('[blogService] getPostBySlug failed:', err?.message);
-      return null;
-    }
-  }
-);
-
-/**
  * Return the sorted list of unique category labels found in recent posts.
  * Fetches up to 50 posts to collect categories; fails open → returns [].
  *
@@ -157,12 +143,6 @@ export const getCategories = webMethod(
   }
 );
 
-// ── Static data wrappers (legacy — used by Blog Post page and RSS) ────
+// ── Static data wrapper kept for stage3-velo's HomeBlogTeasers ────────
 
 export const fetchAllBlogPosts = webMethod(Permissions.Anyone, () => getAllBlogPosts());
-
-export const fetchBlogPost = webMethod(Permissions.Anyone, (slug) => getBlogPost(slug));
-
-export const fetchBlogSlugs = webMethod(Permissions.Anyone, () => getBlogSlugs());
-
-export const fetchBlogFaqs = webMethod(Permissions.Anyone, (slug) => getBlogFaqs(slug));

--- a/tests/blogServiceCms.test.js
+++ b/tests/blogServiceCms.test.js
@@ -3,7 +3,7 @@
  * TDD tests for CMS-driven blog web methods:
  *   - getPublishedBlogPosts (paginated listing)
  *   - getRecentPosts (flat recent-N fetch)
- *   - getPostBySlug (single-post lookup)
+ * 
  *   - getCategories (category extraction)
  *
  * Uses wix-blog-backend mock; covers happy path, empty state, slug routing, and error paths.
@@ -20,7 +20,6 @@ import {
 import {
   getPublishedBlogPosts,
   getRecentPosts,
-  getPostBySlug,
   getCategories,
 } from '../src/backend/blogService.web.js';
 
@@ -292,65 +291,6 @@ describe('getRecentPosts — post fetch', () => {
   });
 });
 
-// ── getPostBySlug — slug routing ──────────────────────────────────────
-
-describe('getPostBySlug — slug routing', () => {
-  it('returns normalized post when slug matches', async () => {
-    __setPosts([makePost(1, { slug: 'how-to-care-for-your-futon' })]);
-    const result = await getPostBySlug('how-to-care-for-your-futon');
-    expect(result).not.toBeNull();
-    expect(result.slug).toBe('how-to-care-for-your-futon');
-  });
-
-  it('returns normalized post shape', async () => {
-    __setPosts([makePost(1, { slug: 'test-slug' })]);
-    const result = await getPostBySlug('test-slug');
-    expect(result).toHaveProperty('_id');
-    expect(result).toHaveProperty('title');
-    expect(result).toHaveProperty('slug');
-    expect(result).toHaveProperty('excerpt');
-    expect(result).toHaveProperty('coverImageUrl');
-    expect(result).toHaveProperty('category');
-    expect(result).toHaveProperty('authorName');
-  });
-
-  it('returns null when slug does not match any post', async () => {
-    __setPosts([makePost(1, { slug: 'some-other-post' })]);
-    const result = await getPostBySlug('nonexistent-slug');
-    expect(result).toBeNull();
-  });
-
-  it('returns null for null slug', async () => {
-    const result = await getPostBySlug(null);
-    expect(result).toBeNull();
-  });
-
-  it('returns null for empty string slug', async () => {
-    const result = await getPostBySlug('');
-    expect(result).toBeNull();
-  });
-
-  it('returns null on CMS error (fails open)', async () => {
-    __setPosts([makePost(1)]);
-    __setGetError(new Error('CMS down'));
-    const result = await getPostBySlug('post-1');
-    expect(result).toBeNull();
-  });
-
-  it('does not throw on error', async () => {
-    __setGetError(new Error('Network error'));
-    await expect(getPostBySlug('any-slug')).resolves.toBeNull();
-  });
-
-  it('trims whitespace from slug', async () => {
-    __setPosts([makePost(1, { slug: 'trimmed-slug' })]);
-    const result = await getPostBySlug('  trimmed-slug  ');
-    expect(result).not.toBeNull();
-    expect(result.slug).toBe('trimmed-slug');
-  });
-});
-
-// ── getCategories ─────────────────────────────────────────────────────
 
 describe('getCategories — category extraction', () => {
   it('returns sorted array of unique category labels', async () => {


### PR DESCRIPTION
## Summary
**Final SUPERSEDE-phase chunk** per the cf-4x7e Pass 1 decision matrix. \`blogService.web.js\` had 8 webMethods; per-rig sweep confirmed cfutons + stage3-velo together use 4. Trim down to those 4; retire the unused-anywhere set.

## Pre-deletion checklist (per dropped method)
- ✅ no module-level imports anywhere in \`src/\`
- ✅ no cfw URL/callVelo reference
- ✅ no \`wixWebMethods.invoke\` dynamic dispatch
- ✅ no stage3-velo external caller
- ✅ no \`scripts/\` filesystem-path read of \`blogService.web.js\`
- ✅ no same-file caller

## Detector blind-spot caught
Pass 1 flagged \`getPostBySlug\` as cfw_low=4 (bare-name match in cfw, possible name collision). Verified: cfw has its own \`getPostBySlug\` at \`src/lib/wix/blog.ts:148\` — a pure cfw-side TypeScript function, NOT a callVelo to Velo's blogService. The 4 cfw refs are all to that local function. **False positive** — same name-collision-across-files pattern as `addBundleToCart` (chunk 5) and `submitReview` (chunk 7); logged for cf-sq0d v3 work.

## Cross-rig consideration (a new pattern this chunk surfaced)
Pass 1 expected 3 alive / 5 dead. Per-rig sweep showed:

| Method | cfutons callers | stage3 callers |
|---|---|---|
| \`getPublishedBlogPosts\` | Blog.js | Blog.js |
| \`getRecentPosts\` | HomeBlogTeasers.js | HomeBlogTeasers.js |
| \`getCategories\` | (none) | Blog.js |
| \`fetchAllBlogPosts\` | (none) | HomeBlogTeasers.js |

Deleting \`getCategories\` or \`fetchAllBlogPosts\` from cfutons would break stage3-velo at the next monorepo→stage3 publish (the cf-w1lg pattern in reverse). **Kept both.**

## Kept (4 alive methods)
- \`getPublishedBlogPosts\`
- \`getRecentPosts\`
- \`getCategories\`
- \`fetchAllBlogPosts\`

## Deleted (4 methods)
- \`getPostBySlug\` — no callers; cfw has its own (name-collision FP)
- \`fetchBlogPost\`, \`fetchBlogSlugs\`, \`fetchBlogFaqs\` — no callers anywhere

Plus dropped 3 imports from \`backend/blogContent\` (no longer needed).

## Test changes
- \`tests/blogServiceCms.test.js\` — drop \`getPostBySlug\` describe block (−59 LOC); drop the import; update docstring
- \`tests/blogHandlers.test.js\`, \`blogRssAndPaginationHardening.test.js\`, \`homeBlogTeasers.test.js\` — unchanged

## Diff
Net: **−80 LOC** across 2 files (95 deletions, 15 insertions for JSDoc / import edits)

## Test plan
- [x] Pre-deletion checklist (6 checks) re-verified
- [x] Cross-rig stage3-velo caller sweep on the 4 dropped methods — zero external callers
- [x] Zero remaining grep refs to any of the 4 dropped methods in \`src/\`
- [x] Targeted vitest on 4 affected test files: 154/154 pass
- [x] Full vitest: **39,273 / 39,332 pass** (59 todo, 0 failed)

## Cumulative cf-4x7e Pass 2 — COMPLETE
| Chunk | PR | Methods | LOC |
|---|---|---:|---:|
| 1 | #1211 | 11 | −2,285 |
| 2 | #1213 | 13 | −2,174 |
| 3 | #1217 | 6 | −1,074 |
| 4 | #1219 | 17 | −5,596 |
| 5 (cf-dtu6) | #1221 | 5 | −1,383 |
| 6 (bundleBuilder) | #1225 | 10 | −2,188 |
| 7 (dataService) | #1227 | 7 | −1,137 |
| **8 (this, blogService)** | — | **4** | **−80** |
| **Total** | | **73** | **−15,917** |

**DELETE-NOW-SAFE complete; SUPERSEDE complete.**

Next phase per Pass 1 sequence: KEEP-PARTIAL bucket (8 files / 54 methods — surgical removal of dead subsets while preserving alive endpoints). KEEP-BLOCKED (3 files / 33 methods) waits for cf-c6g5 + CF+ rollout.

Refs cf-4x7e, cf-66ne, cf-hpwy, cf-sq0d.