### PR TITLE
feat(cf-xdji): resolveContactId helper — single source of truth for CRM upsert

### DIFF
--- a/src/backend/contacts/contactResolver.web.js
+++ b/src/backend/contacts/contactResolver.web.js
@@ -1,0 +1,115 @@
+/**
+ * @module contactResolver.web
+ * @description Resolve a Wix CRM contactId for an email address — creating the
+ * contact if it doesn't exist, or returning the existing contactId if it does.
+ * Wraps `contacts.appendOrCreateContact` from `wix-crm-backend` (which already
+ * dedupes by email server-side) so backend code can write `recipientContactId`
+ * onto EmailQueue rows / triggered-email sends without each call site
+ * re-implementing the same upsert.
+ *
+ * cf-xdji (P1) — closes the F1 (welcome series for anonymous + member-self-
+ * trigger paths) and F7 (swatch confirmation for new visitors) silent
+ * failures surfaced in the cf-icww email audit. Pre-cf-xdji, those paths
+ * passed `recipientContactId: ''` because they had no member identity to
+ * draw from; emailQueueService's send step then failed with "No contact ID
+ * for recipient" and the welcome / swatch email never delivered.
+ *
+ * Permission: Anyone — the helper accepts an arbitrary email and returns a
+ * contactId. Callers (subscribeToNewsletter, captureExitIntentEmail,
+ * submitSwatchRequest, sendEmail/_sendCustomerContactAutoReply) are already
+ * Permissions.Anyone webMethods that rate-limit and validate the email
+ * upstream. The helper itself is purely a CRM upsert — no PII beyond what
+ * the caller already has.
+ *
+ * Existing patterns this consolidates (refactor in a follow-up sweep):
+ *   - cartRecovery.web.js:210         — same shape, inline
+ *   - giftCards.web.js:274/297        — same shape, inline (purchaser/recipient)
+ *   - swatchRequest.web.js:115        — same shape, returns result.contactId
+ *   - emailService.web.js (cf-hafn)   — _sendCustomerContactAutoReply inline
+ */
+
+import { Permissions, webMethod } from 'wix-web-module';
+import { contacts } from 'wix-crm-backend';
+import { sanitize, validateEmail } from 'backend/utils/sanitize';
+
+/**
+ * Resolve (or create) a Wix CRM contact for an email address.
+ *
+ * Wix's `appendOrCreateContact` is idempotent: it queries by primary email
+ * and returns the existing contact when one matches, otherwise creates a
+ * new one. This helper sanitises + validates the email upstream and surfaces
+ * a stable `contactId` so callers can pass it as `recipientContactId` on
+ * EmailQueue rows / triggered-email sends without each call site
+ * re-implementing the same upsert.
+ *
+ * @function resolveContactId
+ * @param {string} email - Email address to upsert.
+ * @param {string} [firstName] - Optional first name to seed on a new contact.
+ *   Wix preserves an existing contact's name if one is already set; this
+ *   value is only used when the contact is created.
+ * @returns {Promise<string | null>}
+ *   - The contactId on success (whether newly created or existing match).
+ *   - `null` on validation failure or upstream throw — caller decides whether
+ *     to fail closed (skip the email) or fail open (queue without contactId
+ *     and let the existing send-side guard reject). All known callers fail
+ *     closed.
+ *
+ * @example
+ *   const contactId = await resolveContactId('shopper@example.com', 'Asha');
+ *   if (!contactId) return; // upstream failed; do not queue
+ *   await enqueueEmail({ recipientContactId: contactId, ... });
+ */
+export const resolveContactId = webMethod(
+  Permissions.Anyone,
+  async (email, firstName) => _resolveContactIdInternal(email, firstName),
+);
+
+/**
+ * Internal implementation — exported for backend-to-backend callers that
+ * want to bypass the webMethod wrapper. Same contract as the webMethod;
+ * existing call sites in cartRecovery / giftCards / swatchRequest /
+ * sendEmail can refactor to import this directly without touching
+ * Permissions.
+ *
+ * @param {string} email
+ * @param {string} [firstName]
+ * @returns {Promise<string | null>}
+ */
+export async function _resolveContactIdInternal(email, firstName) {
+  // Validation: same shape as the upstream webMethod callers (subscribeToNewsletter
+  // etc) already use, but defensively re-checked here so a bypassed caller
+  // can't sneak past the validation boundary.
+  if (!email || typeof email !== 'string') return null;
+  const cleanEmail = sanitize(email, 254).toLowerCase().trim();
+  if (!validateEmail(cleanEmail)) return null;
+
+  const cleanFirstName = firstName ? sanitize(String(firstName), 200).trim() : '';
+
+  const payload = {
+    emails: [{ email: cleanEmail }],
+  };
+  if (cleanFirstName) {
+    payload.name = { first: cleanFirstName };
+  }
+
+  let result;
+  try {
+    result = await contacts.appendOrCreateContact(payload);
+  } catch (err) {
+    // CRM upstream failure — caller decides whether to retry. Logged with
+    // the email so support can correlate; never log full PII beyond what
+    // the caller already has access to (the email).
+    console.error('[contactResolver] appendOrCreateContact failed for', cleanEmail, '— error:', err?.message ?? err);
+    return null;
+  }
+
+  // Wix's response shape varies by SDK version: some return `{contactId,
+  // identityType}`, others return `{contact: {_id, ...}}`. Defensive
+  // resolution covers both.
+  const contactId = result?.contactId || result?.contact?._id || result?._id;
+  if (!contactId) {
+    console.warn('[contactResolver] appendOrCreateContact returned no contactId for', cleanEmail);
+    return null;
+  }
+  return contactId;
+}

--- a/tests/contactResolver.cfxdji.test.js
+++ b/tests/contactResolver.cfxdji.test.js
@@ -1,0 +1,153 @@
+/**
+ * @file contactResolver.cfxdji.test.js
+ * @description cf-xdji — resolveContactId(email, firstName?) helper that
+ * wraps contacts.appendOrCreateContact. Closes the F1 (welcome series for
+ * anonymous + member-self-trigger) and F7 (swatch confirmation for new
+ * visitors) silent failures from the cf-icww email audit by giving every
+ * EmailQueue producer a single source of truth for upserting CRM contacts.
+ *
+ * Verifies:
+ *   - New email → calls appendOrCreateContact with { emails, name? } and
+ *     returns { contactId, created: true }
+ *   - Existing email (identityType: 'CONTACT') → returns { contactId,
+ *     created: false } and reuses the existing contact's id
+ *   - Missing/invalid email → null (no Wix call)
+ *   - firstName sanitised + trimmed; whitespace-only firstName omitted
+ *   - Wix throws → null (logged with the email; never throws upstream)
+ *   - Wix returns no contactId → null + warn logged
+ *   - Both webMethod export AND _resolveContactIdInternal export work
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  __seedContacts,
+  __reset as resetCrm,
+  contacts,
+} from './__mocks__/wix-crm-backend.js';
+
+import {
+  resolveContactId,
+  _resolveContactIdInternal,
+} from '../src/backend/contacts/contactResolver.web.js';
+
+beforeEach(() => {
+  resetCrm();
+  vi.restoreAllMocks();
+});
+
+describe('cf-xdji · resolveContactId — happy path', () => {
+  it('creates a new contact and returns the contactId for a fresh email', async () => {
+    const contactId = await resolveContactId('new-shopper@example.com');
+    expect(typeof contactId).toBe('string');
+    expect(contactId).toMatch(/^contact-/); // mock-generated id shape
+  });
+
+  it('returns the existing contactId when a contact already exists for the email', async () => {
+    __seedContacts([
+      { _id: 'contact-existing-9', primaryInfo: { email: 'existing@example.com' } },
+    ]);
+    const contactId = await resolveContactId('existing@example.com');
+    expect(contactId).toBe('contact-existing-9');
+  });
+
+  it('lowercases + trims the email before passing to appendOrCreateContact', async () => {
+    const spy = vi.spyOn(contacts, 'appendOrCreateContact');
+    await resolveContactId('  Shopper@Example.COM  ');
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emails: [{ email: 'shopper@example.com' }],
+      }),
+    );
+  });
+
+  it('forwards firstName when provided and omits the name field when absent', async () => {
+    const spy = vi.spyOn(contacts, 'appendOrCreateContact');
+    await resolveContactId('shopper@example.com', 'Asha');
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        emails: [{ email: 'shopper@example.com' }],
+        name: { first: 'Asha' },
+      }),
+    );
+
+    spy.mockClear();
+    await resolveContactId('other@example.com');
+    const callArg = spy.mock.calls[0][0];
+    expect(callArg.name).toBeUndefined();
+  });
+
+  it('drops whitespace-only firstName so empty names do not pollute the contact', async () => {
+    const spy = vi.spyOn(contacts, 'appendOrCreateContact');
+    await resolveContactId('shopper@example.com', '   ');
+    const callArg = spy.mock.calls[0][0];
+    expect(callArg.name).toBeUndefined();
+  });
+});
+
+describe('cf-xdji · resolveContactId — validation', () => {
+  it('returns null for empty email', async () => {
+    expect(await resolveContactId('')).toBeNull();
+  });
+
+  it('returns null for null/undefined email', async () => {
+    expect(await resolveContactId(null)).toBeNull();
+    expect(await resolveContactId(undefined)).toBeNull();
+  });
+
+  it('returns null for non-string email', async () => {
+    expect(await resolveContactId(42)).toBeNull();
+    expect(await resolveContactId({})).toBeNull();
+  });
+
+  it('returns null for malformed email (no @, no dot)', async () => {
+    expect(await resolveContactId('notanemail')).toBeNull();
+    expect(await resolveContactId('foo@')).toBeNull();
+    expect(await resolveContactId('@bar.com')).toBeNull();
+  });
+
+  it('does not call appendOrCreateContact when the email fails validation', async () => {
+    const spy = vi.spyOn(contacts, 'appendOrCreateContact');
+    await resolveContactId('not-valid');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('cf-xdji · resolveContactId — failure modes', () => {
+  it('returns null when appendOrCreateContact throws', async () => {
+    vi.spyOn(contacts, 'appendOrCreateContact').mockRejectedValue(new Error('CRM unavailable'));
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await resolveContactId('shopper@example.com');
+    expect(result).toBeNull();
+    // Logged with the email + 'failed' substring so support can correlate
+    // a queue-side "no contact ID for recipient" with the upstream cause.
+    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
+    expect(logged).toContain('shopper@example.com');
+    expect(logged).toContain('appendOrCreateContact failed');
+    consoleErr.mockRestore();
+  });
+
+  it('returns null when appendOrCreateContact resolves with no contactId', async () => {
+    vi.spyOn(contacts, 'appendOrCreateContact').mockResolvedValue({});
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await resolveContactId('shopper@example.com');
+    expect(result).toBeNull();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('returned no contactId'),
+      expect.anything(),
+    );
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('cf-xdji · _resolveContactIdInternal — backend-to-backend bypass', () => {
+  it('returns a contactId string for a fresh email — same contract as webMethod wrapper', async () => {
+    const contactId = await _resolveContactIdInternal('helper-direct@example.com', 'Direct');
+    expect(typeof contactId).toBe('string');
+    expect(contactId.length).toBeGreaterThan(0);
+  });
+
+  it('honours the same validation guards', async () => {
+    expect(await _resolveContactIdInternal('')).toBeNull();
+    expect(await _resolveContactIdInternal('not-an-email')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Re-routed from shiny per melania. New helper at `src/backend/contacts/contactResolver.web.js` that wraps `contacts.appendOrCreateContact` so every EmailQueue producer has a stable contactId resolver to call before queuing. Closes the cf-icww F1 (welcome series for anonymous + member-self-trigger) and F7 (swatch confirmation for new visitors) silent failures.

### Contract
```
resolveContactId(email, firstName?) → contactId string | null
```
- Public `webMethod` with `Permissions.Anyone` (callers already rate-limit + validate upstream).
- Internal `_resolveContactIdInternal` export for backend-to-backend callers that want to skip the webMethod wrapper.
- Returns `null` on validation failure / upstream throw — caller decides fail-closed vs fail-open. All known callers fail closed.
- Validation: sanitize + lowercase + trim email; `validateEmail`; drop whitespace-only firstName so empty names don't pollute new contacts.
- Defensive id resolution across `@wix/crm` SDK shape variants (`result.contactId` / `result.contact._id` / `result._id`).

### Test coverage (14 tests)
Fresh email; existing email reuse; email lowercase+trim; firstName forwarding/omission; whitespace-only firstName drop; empty/null/non-string/malformed email guards; `appendOrCreateContact` throws → null + console.error with email; no contactId returned → null + console.warn; internal-export contract parity with the webMethod wrapper.

### Acceptance per bead
- [x] resolveContactId helper created + exported
- [x] Unit test for resolver (new + existing + validation + failure modes — 14 tests)
- [ ] Replace empty-string contactId at every queue site (separate sweep — `cf-xdji.fu`)
- [ ] Integration test: exit-intent → welcome series queued with valid contactId (covered by cf-3l0d's pre-staged tests once that branch rebases onto this helper)

### Unblocks
- `feat/cf-3l0d-subscribetonewsletter-auto-trigger` — pre-staged branch awaiting this helper, ready to rebase + open PR
- `feat/cf-hafn-contact-form-auto-reply` — already merged with inline `appendOrCreateContact`; refactor to helper in follow-up sweep
- swatchRequest.web.js / cartRecovery.web.js / giftCards.web.js — same one-line refactor opportunity, file separately to keep this PR scoped per bead acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)