### PR TITLE
refactor(cf-xdji.fu): route 4 queue sites through resolveContactId helper

### DIFF
--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -15,7 +15,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
-import { triggeredEmails, contacts } from 'wix-crm-backend';
+import { triggeredEmails } from 'wix-crm-backend';
 import { sanitize } from 'backend/utils/sanitize';
 import { generateRecoveryCoupon } from 'backend/couponsService.web';
 import { findMemberRecord, computeTierInfo } from 'backend/gamificationCore.web';
@@ -205,16 +205,15 @@ export const sendRecoveryEmail = webMethod(
         console.warn('[cartRecovery] Coupon generation failed for cartId:', cartId, '— sending email without discount:', couponResult.message);
       }
 
-      let contactId;
-      try {
-        const contactResult = await contacts.appendOrCreateContact({ emails: [{ email: cartEmail }] });
-        contactId = contactResult?.contactId;
-      } catch (crmErr) {
-        console.error('[cartRecovery] CRM appendOrCreateContact failed for cartId:', cartId, '— error:', crmErr.message);
-        return { success: false, message: 'Failed to resolve CRM contact for recovery email' };
-      }
+      // cf-xdji item-2: route through the shared resolveContactId helper so
+      // every queue site has a single CRM-upsert source of truth. Helper
+      // returns null on validation/upstream failure (logged with the email);
+      // we surface that as the same caller-facing error string as before
+      // to preserve cron-runner / dashboard observability.
+      const { _resolveContactIdInternal } = await import('backend/contacts/contactResolver.web');
+      const contactId = await _resolveContactIdInternal(cartEmail);
       if (!contactId) {
-        console.error('[cartRecovery] appendOrCreateContact returned no contactId for cartId:', cartId);
+        console.error('[cartRecovery] resolveContactId returned null for cartId:', cartId);
         return { success: false, message: 'Failed to resolve CRM contact for recovery email' };
       }
 

--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -42,6 +42,7 @@ import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { logError } from 'backend/utils/errorHandler';
 import { sendOrderConfirmation, sendFreightShippingNotification, sendShippingNotification, sendDeliveryConfirmation } from 'backend/emailService.web';
+import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 import { buildFreightTrackingPayload } from 'backend/freightTracking.web';
 import { scheduleSurvey } from 'backend/surveyService.web';
 import { _getReferralLinkForMember } from 'backend/referralService.web';
@@ -506,6 +507,16 @@ export const triggerWelcomeSeries = webMethod(
         console.warn('[emailAutomation] Welcome discount unavailable:', e.message);
       }
 
+      // cf-xdji item-2: resolve a CRM contactId before queueing so
+      // processQueue's send step has a non-empty recipientContactId. Pre-fix
+      // this path queued with '' and every welcome row failed at send time
+      // with "No contact ID for recipient" (cf-icww F1).
+      const cleanContactId = await _resolveContactIdInternal(cleanEmail, cleanName);
+      if (!cleanContactId) {
+        console.warn('[emailAutomation] triggerWelcomeSeries skipped — resolveContactId returned null for', cleanEmail);
+        return { success: false, queued: 0 };
+      }
+
       const abVariant = selectABVariant(cleanEmail);
       const abData = SEQUENCES.welcome.abVariants[abVariant] || {};
       const now = new Date();
@@ -523,7 +534,7 @@ export const triggerWelcomeSeries = webMethod(
         await queueEmail({
           templateId: step.templateId,
           recipientEmail: cleanEmail,
-          recipientContactId: '',
+          recipientContactId: cleanContactId,
           variables,
           sequenceType: 'welcome',
           sequenceStep: step.step,

--- a/src/backend/giftCards.web.js
+++ b/src/backend/giftCards.web.js
@@ -17,7 +17,8 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
-import { triggeredEmails, contacts } from 'wix-crm-backend';
+import { triggeredEmails } from 'wix-crm-backend';
+import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
 
@@ -271,12 +272,15 @@ async function sendGiftCardEmails(data) {
 
   // Send purchaser confirmation first — independent of recipient
   try {
-    const purchaserContact = await contacts.appendOrCreateContact({
-      emails: [{ email: data.purchaserEmail }],
-    });
+    // cf-xdji item-2: shared CRM-upsert helper. Returns null on validation
+    // or upstream failure — we throw so the existing catch+log path
+    // surfaces it as a "purchaser email not sent" outcome (recipient leg
+    // still runs independently below).
+    const purchaserContactId = await _resolveContactIdInternal(data.purchaserEmail);
+    if (!purchaserContactId) throw new Error('resolveContactId returned null for purchaser');
     await triggeredEmails.emailContact(
       'gift_card_purchase_confirmation',
-      purchaserContact.contactId,
+      purchaserContactId,
       {
         variables: {
           code: data.code,
@@ -294,12 +298,12 @@ async function sendGiftCardEmails(data) {
 
   // Send recipient notification — independent of purchaser
   try {
-    const recipientContact = await contacts.appendOrCreateContact({
-      emails: [{ email: data.recipientEmail }],
-    });
+    // cf-xdji item-2: shared CRM-upsert helper.
+    const recipientContactId = await _resolveContactIdInternal(data.recipientEmail);
+    if (!recipientContactId) throw new Error('resolveContactId returned null for recipient');
     await triggeredEmails.emailContact(
       'gift_card_received',
-      recipientContact.contactId,
+      recipientContactId,
       {
         variables: {
           code: data.code,

--- a/src/backend/swatchRequest.web.js
+++ b/src/backend/swatchRequest.web.js
@@ -131,6 +131,10 @@ async function upsertContact(contact) {
  * Enqueue swatch nurture sequence emails.
  */
 async function enqueueSwatch({ contactId, email, swatchNames, productSlug }) {
+  // cf-xdji item-2: caller is responsible for ensuring contactId is non-empty.
+  // We assert here so a future regression at the call site is loud rather than
+  // silently queueing a row that would fail at processQueue time.
+  if (!contactId) throw new Error('enqueueSwatch requires a non-empty contactId');
   const now = new Date();
   await Promise.all(
     SWATCH_NURTURE.map(({ step, templateId, delayHours }) => {
@@ -138,7 +142,7 @@ async function enqueueSwatch({ contactId, email, swatchNames, productSlug }) {
       return wixData.insert('EmailQueue', {
         templateId,
         recipientEmail: email,
-        recipientContactId: contactId || '',
+        recipientContactId: contactId,
         variables: {
           swatchNames,
           swatchCount: swatchNames.length,
@@ -211,16 +215,25 @@ export const submitSwatchRequest = webMethod(
       const inserted = await wixData.insert('SwatchRequests', record);
 
       // Enqueue nurture emails — log failure but don't fail the request
-      // (CMS record is already saved; email can be retried independently)
-      try {
-        await enqueueSwatch({
-          contactId: contactId || '',
-          email: contact.email,
-          swatchNames,
-          productSlug: cleanSlug || null,
-        });
-      } catch (emailErr) {
-        console.error('[swatchRequest] Failed to enqueue nurture emails:', emailErr);
+      // (CMS record is already saved; email can be retried independently).
+      // cf-xdji item-2: skip queueing entirely when contactId is empty —
+      // the queue row would just fail at processQueue time with "No contact
+      // ID for recipient" and consume retry budget. Without a contactId the
+      // nurture sequence can't deliver, so a missing-contact warn is the
+      // honest signal.
+      if (contactId) {
+        try {
+          await enqueueSwatch({
+            contactId,
+            email: contact.email,
+            swatchNames,
+            productSlug: cleanSlug || null,
+          });
+        } catch (emailErr) {
+          console.error('[swatchRequest] Failed to enqueue nurture emails:', emailErr);
+        }
+      } else {
+        console.warn('[swatchRequest] Skipping swatch nurture queue — upsertContact returned no contactId for', contact.email);
       }
 
       return { success: true, requestId: inserted._id };


### PR DESCRIPTION
## Summary
cf-xdji item-2 sweep per melania. Replace inline `contacts.appendOrCreateContact` (or empty-string contactId fallback) at four EmailQueue producers with the shared `_resolveContactIdInternal` helper from cf-xdji PR #1231. Single source of truth for CRM upsert; consistent validation + sanitization + error logging across the four touchpoints.

### Sites refactored
1. **`cartRecovery.web.js#triggerAbandonedCartRecovery`** — was inline `appendOrCreateContact` + manual error mapping. Drops the now-unused `contacts` import.
2. **`giftCards.web.js`** — both purchaser AND recipient legs (two sites). Throws when helper returns null so the existing catch+log surfaces it as "purchaser/recipient email not sent" without short-circuiting the other leg. Drops the `contacts` import.
3. **`swatchRequest.web.js#enqueueSwatch`** — caller skips queueing when `upsertContact` returned no contactId, with a warn. `enqueueSwatch` itself asserts non-empty contactId so a future regression is loud. Local rich-payload `upsertContact` (name + phone + address) preserved; only the empty-string queue fallback is fixed.
4. **`emailAutomation.web.js#triggerWelcomeSeries`** — resolves contactId via the helper before queueing 5 welcome rows; pre-fix this path inserted `recipientContactId: ''` and every send failed at processQueue time with "No contact ID for recipient" (cf-icww F1).

### Out of scope (file separately if desired)
- `emailAutomation.web.js` cart_recovery cron + tier_milestone paths also have empty-string queue rows but weren't named in this sweep's scope.
- `newsletterService.web.js#captureExitIntentEmail` direct callers are residual now that cf-3l0d's auto-trigger (PR #1234) routes the welcome flow through `resolveContactId`. Refactor in cf-xdji.fu2 if a staging probe shows them still in use.

### Tests
**861/861** across the four directly-touched modules + cf-xdji helper test file. No new tests added — this is a refactor; the helper's own 14-test coverage from PR #1231 plus existing call-site tests are sufficient. Each caller's behavior contract (returns existing error envelope on null contactId) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)