### PR TITLE
fix(cf-hafn+cf-obsb): use Wix dashboard template IDs + wire sendSwatchConfirmationEmail

### DIFF
--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -232,7 +232,11 @@ async function _sendCustomerContactAutoReply({ email, name, subject, message }) 
     console.warn('[emailService] customer auto-reply skipped — appendOrCreateContact returned empty', { email });
     return;
   }
-  await triggeredEmails.emailContact('contact_form_auto_reply', customerContactId, {
+  // cf-hafn / Wix CRM dashboard: 'contact_form_auto_reply' is the
+  // human-readable template name; the dashboard's opaque template ID is
+  // 'VJBOnfD' (set per Stilgar 2026-05-10). triggeredEmails.emailContact
+  // expects the dashboard ID.
+  await triggeredEmails.emailContact('VJBOnfD', customerContactId, {
     variables: {
       customerName: name,
       subject: subject || '',
@@ -322,8 +326,9 @@ export const submitSwatchRequest = webMethod(
           .limit(1)
           .find();
         if (contactResult.items.length > 0) {
+          // cf-obsb: Wix dashboard ID for swatch_confirmation.
           await triggeredEmails.emailContact(
-            'swatch_confirmation',
+            'VJBTzwh',
             contactResult.items[0]._id,
             {
               variables: {
@@ -389,8 +394,12 @@ export const sendSwatchConfirmationEmail = webMethod(
         ? `${estimatedDays} business days`
         : '5-7 business days';
 
+      // cf-obsb / Wix CRM dashboard: 'swatch_confirmation' is the
+      // human-readable template name; opaque dashboard template ID is
+      // 'VJBTzwh' (set per Stilgar 2026-05-10). triggeredEmails.emailContact
+      // expects the dashboard ID.
       await triggeredEmails.emailContact(
-        'swatch_confirmation',
+        'VJBTzwh',
         contactId,
         {
           variables: {

--- a/src/backend/swatchRequest.web.js
+++ b/src/backend/swatchRequest.web.js
@@ -19,6 +19,7 @@ import { contacts } from 'wix-crm-backend';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { triggerSwatchFollowupSequence } from 'backend/emailAutomation.web';
+import { sendSwatchConfirmationEmail } from 'backend/emailService.web';
 import { logError } from 'backend/utils/errorHandler';
 
 // Swatch nurture sequence: confirmation + Day 3 + Day 7 + Day 14
@@ -234,6 +235,23 @@ export const submitSwatchRequest = webMethod(
         }
       } else {
         console.warn('[swatchRequest] Skipping swatch nurture queue — upsertContact returned no contactId for', contact.email);
+      }
+
+      // cf-obsb Path A: send the customer-facing swatch confirmation email
+      // immediately on success. Non-blocking — CMS record is already saved
+      // and the nurture queue is independent, so a confirmation-email
+      // failure must not flip the request to a failure response.
+      if (contactId) {
+        const productNameForEmail = swatchNames[0] || 'fabric swatches';
+        sendSwatchConfirmationEmail({
+          contactId,
+          name: `${contact.firstName} ${contact.lastName}`.trim(),
+          email: contact.email,
+          swatchNames,
+          productName: productNameForEmail,
+        }).catch((emailErr) => {
+          console.warn('[swatchRequest] swatch_confirmation send failed (non-blocking):', emailErr?.message ?? emailErr);
+        });
       }
 
       return { success: true, requestId: inserted._id };

--- a/tests/contactFormAutoReply.cfhafn.test.js
+++ b/tests/contactFormAutoReply.cfhafn.test.js
@@ -26,7 +26,14 @@ import {
 
 import { sendEmail } from '../src/backend/emailService.web.js';
 
-const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+const flushMicrotasks = async () => {
+  // Drain multiple turns: cf-hafn auto-reply does
+  // await contacts.appendOrCreateContact → await triggeredEmails.emailContact,
+  // and each macrotask boundary may not catch both depending on the runtime.
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
 
 beforeEach(() => {
   resetData();
@@ -67,7 +74,7 @@ describe('cf-hafn · sendEmail customer auto-reply', () => {
     const log = __getEmailLog();
 
     const ownerEmail = log.find((e) => e.templateId === 'contact_form_submission');
-    const customerEmail = log.find((e) => e.templateId === 'contact_form_auto_reply');
+    const customerEmail = log.find((e) => e.templateId === 'VJBOnfD');
 
     expect(ownerEmail).toBeDefined();
     expect(ownerEmail.contactId).toBe('owner-contact-123');
@@ -82,7 +89,7 @@ describe('cf-hafn · sendEmail customer auto-reply', () => {
     await sendEmail(validSubmission());
     await flushMicrotasks();
 
-    const customerEmail = __getEmailLog().find((e) => e.templateId === 'contact_form_auto_reply');
+    const customerEmail = __getEmailLog().find((e) => e.templateId === 'VJBOnfD');
     expect(customerEmail.options.variables).toMatchObject({
       customerName: 'Asheville Andy',
       subject: 'Eureka availability',
@@ -100,7 +107,7 @@ describe('cf-hafn · sendEmail customer auto-reply', () => {
     await sendEmail(validSubmission());
     await flushMicrotasks();
 
-    const customerEmail = __getEmailLog().find((e) => e.templateId === 'contact_form_auto_reply');
+    const customerEmail = __getEmailLog().find((e) => e.templateId === 'VJBOnfD');
     // appendOrCreateContact dedupes by email; mock returns the existing _id.
     expect(customerEmail.contactId).toBe('contact-existing-9');
   });
@@ -143,7 +150,7 @@ describe('cf-hafn · auto-reply is non-blocking', () => {
     await flushMicrotasks();
 
     expect(result.success).toBe(true);
-    expect(__getEmailLog().some((e) => e.templateId === 'contact_form_auto_reply')).toBe(false);
+    expect(__getEmailLog().some((e) => e.templateId === 'VJBOnfD')).toBe(false);
     expect(consoleWarn).toHaveBeenCalledWith(
       expect.stringContaining('customer auto-reply skipped'),
       expect.any(Object),

--- a/tests/emailServiceDeep.test.js
+++ b/tests/emailServiceDeep.test.js
@@ -123,7 +123,7 @@ describe('submitSwatchRequest', () => {
     });
     // Should have 2 emails: owner notification + customer confirmation
     expect(_emailsSent).toHaveLength(2);
-    expect(_emailsSent[1].templateId).toBe('swatch_confirmation');
+    expect(_emailsSent[1].templateId).toBe('VJBTzwh'); // cf-obsb: Wix dashboard ID
     expect(_emailsSent[1].contactId).toBe('customer-contact-id');
   });
 });

--- a/tests/emailServiceDeepen.test.js
+++ b/tests/emailServiceDeepen.test.js
@@ -195,7 +195,7 @@ describe('submitSwatchRequest', () => {
     // Second emailContact call is the confirmation
     expect(mockEmailContact).toHaveBeenCalledTimes(2);
     expect(mockEmailContact).toHaveBeenCalledWith(
-      'swatch_confirmation',
+      'VJBTzwh', // cf-obsb: Wix dashboard ID for swatch_confirmation
       'contact-456',
       expect.objectContaining({
         variables: expect.objectContaining({
@@ -255,7 +255,7 @@ describe('sendSwatchConfirmationEmail', () => {
     });
     expect(res).toEqual({ success: true });
     expect(mockEmailContact).toHaveBeenCalledWith(
-      'swatch_confirmation',
+      'VJBTzwh', // cf-obsb: Wix dashboard ID for swatch_confirmation
       'c-100',
       expect.objectContaining({
         variables: expect.objectContaining({

--- a/tests/swatchConfirmationEmail.test.js
+++ b/tests/swatchConfirmationEmail.test.js
@@ -26,7 +26,7 @@ describe('sendSwatchConfirmationEmail', () => {
     expect(result).toEqual({ success: true });
     const emails = __getEmailLog();
     expect(emails).toHaveLength(1);
-    expect(emails[0].templateId).toBe('swatch_confirmation');
+    expect(emails[0].templateId).toBe('VJBTzwh'); // cf-obsb: Wix dashboard ID for swatch_confirmation
     expect(emails[0].contactId).toBe('customer-contact-456');
   });
 


### PR DESCRIPTION
## Summary
Two beads in one PR per melania:
- **cf-hafn** — `contact_form_auto_reply` outgoing send now uses the Wix CRM dashboard's opaque template ID `VJBOnfD` (per Stilgar 2026-05-10) instead of the human-readable name.
- **cf-obsb Path A** — `swatchRequest.web.js#submitSwatchRequest` now calls `sendSwatchConfirmationEmail` on success; the outgoing send uses dashboard ID `VJBTzwh`. Non-blocking — CMS row + nurture queue are independent, so a confirmation-email failure does not flip the request response.

### Sites changed
- `emailService.web.js` — three outgoing emailContact call sites flipped to dashboard IDs (`_sendCustomerContactAutoReply`, `sendSwatchConfirmationEmail`, and `submitSwatchRequest`'s customer-confirmation branch).
- `swatchRequest.web.js#submitSwatchRequest` — wires `sendSwatchConfirmationEmail` after the CMS insert + nurture-queue branch.
- Local `TEMPLATE_REGISTRY` in `emailTemplates.web.js` intentionally preserved with human-readable IDs (`contact_form_auto_reply`, `swatch_confirmation`) — that registry is internal-only and used for variable-validation lookups; the dashboard IDs are only for outgoing sends.

### Tests
- `swatchConfirmationEmail.test.js` — `VJBTzwh` expected
- `emailServiceDeepen.test.js` — both swatch_confirmation refs → `VJBTzwh`
- `emailServiceDeep.test.js` — submitSwatchRequest customer-email → `VJBTzwh`
- `contactFormAutoReply.cfhafn.test.js` — find-by-templateId → `VJBOnfD`. `flushMicrotasks` helper drains 5 ticks to handle the auto-reply chain (`appendOrCreateContact` → `emailContact`).
- **188/188 pass across all touched suites**

### Bead acceptance
- [x] cf-hafn: outgoing send uses Wix dashboard ID `VJBOnfD`
- [x] cf-obsb Path A: `sendSwatchConfirmationEmail` wired into `submitSwatchRequest`
- [x] cf-obsb Path A: outgoing send uses Wix dashboard ID `VJBTzwh`
- [ ] cf-obsb e2e: post-cf-c6g5 staging probe confirms email arrives (covered by cf-w1u1 row #21 once that runs)

### Out of scope (filed as cf-trm0 P3)
Empty-string contactId residuals at `emailAutomation` cart_recovery / tier_milestone paths, `captureExitIntentEmail`, and `analyticsDigest`. Pass-3 cleanup with the same pattern as cf-xdji item-2 sweep (PR #1236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)