### PR TITLE
fix: trim leading whitespace on communityPhoto imageUrl + clear stale cf-vtx5 comment

### DIFF
--- a/src/backend/communityPhoto.web.js
+++ b/src/backend/communityPhoto.web.js
@@ -111,6 +111,13 @@ export const submitCommunityPhoto = webMethod(
     const invalid = _validateCommunityPhoto(data);
     if (invalid) return { success: false, error: invalid.error };
 
+    // Trim once, reuse below — both the host-extraction regex and the
+    // sanitized CMS row need the leading-whitespace-stripped form.
+    // _validateCommunityPhoto only trims into a local var; without this
+    // line, a leading-space input would land 'unknown' in the host-axis
+    // bucket and a leading-space imageUrl in the CMS row.
+    const imageUrl = data.imageUrl.trim();
+
     // cf-k5vr: rate-limit on a per-client axis when the caller can supply
     // one (the post_submitCommunityPhoto wrapper extracts x-forwarded-for
     // and passes it). The previous host-axis was a coarse UGC abuse
@@ -119,7 +126,7 @@ export const submitCommunityPhoto = webMethod(
     // legitimate users while attackers under their own domain got fresh
     // buckets. Falling back to host preserves the old behavior for
     // direct webMethod callsites that don't have a request object.
-    const host = (data.imageUrl.match(/^https:\/\/([^/]+)/) || [])[1] || 'unknown';
+    const host = (imageUrl.match(/^https:\/\/([^/]+)/) || [])[1] || 'unknown';
     const rateLimitKey =
       typeof opts.rateLimitKey === 'string' && opts.rateLimitKey.length > 0
         ? opts.rateLimitKey
@@ -144,7 +151,7 @@ export const submitCommunityPhoto = webMethod(
     }
 
     const row = {
-      imageUrl: sanitize(data.imageUrl, FIELD_CAPS.imageUrl),
+      imageUrl: sanitize(imageUrl, FIELD_CAPS.imageUrl),
       customerName: sanitize(data.customerName, FIELD_CAPS.customerName),
       location: sanitize(data.location || '', FIELD_CAPS.location),
       caption: sanitize(data.caption || '', FIELD_CAPS.caption),

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -3475,10 +3475,10 @@ export function options_styleQuiz(request) { return response(corsPreflight(reque
 
 // ── cf-vtx5 concrete-gap wrappers ─────────────────────────────────────────
 //
-// Two of the three concrete gaps from cf-jqkg's audit are unblocked here.
-// The third (submitCommunityPhoto) is held pending Stilgar/mayor decision
-// on whether storage lives in a Wix CMS collection or external (Cloudinary
-// etc.) — tracked as a separate bead.
+// All three concrete gaps from cf-jqkg's audit are unblocked here. The
+// third (submitCommunityPhoto) was originally held pending a storage
+// decision; it later landed at post_submitCommunityPhoto below using
+// the Wix CMS CommunityPhotos collection (cf-0h9q).
 
 /**
  * @function post_recordSpinGrant

--- a/tests/communityPhoto.test.js
+++ b/tests/communityPhoto.test.js
@@ -165,6 +165,32 @@ describe('cf-0h9q · submitCommunityPhoto webMethod', () => {
     );
   });
 
+  // Trim guard: leading-whitespace imageUrl previously broke the host-axis
+  // bucket (regex /^https:.../ failed → 'unknown') AND landed leading
+  // whitespace in the CMS row. Trimming once at the top of the webMethod
+  // fixes both. Pin the host-bucket path so a future revert trips here.
+  it('trims leading whitespace on imageUrl for host-axis bucket', async () => {
+    await submitCommunityPhoto({
+      ...VALID_BODY,
+      imageUrl: '   https://cdn.example.com/uploads/p1.jpg',
+    });
+    expect(checkRateLimit).toHaveBeenCalledWith(
+      'CommunityPhotoRateLimit',
+      'cdn.example.com',
+      expect.anything(),
+    );
+  });
+
+  it('trims leading whitespace on imageUrl before inserting into CMS', async () => {
+    await submitCommunityPhoto({
+      ...VALID_BODY,
+      imageUrl: '   https://cdn.example.com/uploads/p1.jpg',
+    });
+    const rows = __getInserted('CommunityPhotos');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].imageUrl).toBe('https://cdn.example.com/uploads/p1.jpg');
+  });
+
   it('returns success:false on wixData.insert throw', async () => {
     __setInsertError('CommunityPhotos', new Error('Wix Data unavailable'));
     const result = await submitCommunityPhoto(VALID_BODY);


### PR DESCRIPTION
## Source
Sibling-audit findings A + E from the cf-edw3 audit of `communityPhoto.web.js` integration. melania approved A + E for tight-scope shipping; B (XFF leftmost/rightmost) gets its own bead under the cf-tvbi sweep.

## Finding A — leading-whitespace inputs slip past the trim
`_validateCommunityPhoto` only trimmed `imageUrl` into a local var. The webMethod body then read `data.imageUrl` directly on two lines:
- Host-extraction regex `/^https:\/\/([^/]+)/` did not match a leading-space input → host fallback bucket landed in `'unknown'` instead of the real CDN host (only matters when the IP-axis fallback path is active, but still wrong).
- `sanitize(data.imageUrl, FIELD_CAPS.imageUrl)` preserved the leading whitespace into the CMS row.

**Fix:** trim once at the top of `submitCommunityPhoto`; reuse the trimmed value for both the host regex and the row insert.

## Finding E — stale cf-vtx5 comment
`http-functions.js:3479` said:
> The third (submitCommunityPhoto) is held pending Stilgar/mayor decision on whether storage lives in a Wix CMS collection or external (Cloudinary etc.) — tracked as a separate bead.

That decision was made — cf-0h9q wired the Wix CMS path, and the wrapper landed at `http-functions.js:3705`. Updated the section comment to reflect that all three concrete cf-jqkg gaps are wired now.

## Tests
`tests/communityPhoto.test.js` — 30/30 green (28 pre-existing + 2 new whitespace-trim guards):
- pin: leading-whitespace `imageUrl` still routes to the correct host-axis bucket (not `'unknown'`)
- pin: leading-whitespace `imageUrl` is trimmed before the CMS row insert

A future revert that drops the trim trips both pins.

## Skipped per melania
- B. leftmost x-forwarded-for trust → cf-tvbi.fu sweep bead.
- C. whitespace-only `opts.rateLimitKey` `length>0` check.
- D. cf-mgnh validation 200+envelope contract.

No behavior change for the 100% case (well-formed inputs).