### PR TITLE
fix(cf-sq0d.fu2): JSDoc-strip filter for v3 detector + chunks 14+ matrix

### DIFF
--- a/docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.2.md
+++ b/docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.2.md
@@ -1,0 +1,145 @@
+# cf-4x7e Pass 1 Matrix — UPDATED v3.2 (post chunks 11–13 + JSDoc-strip filter)
+
+> **Generated**: 2026-05-10 by miquella · **Bead**: cf-sq0d.fu2 · **Supersedes**: [`PASS1-MATRIX-UPDATED-v3.1.md`](./PASS1-MATRIX-UPDATED-v3.1.md) for chunks 14+ planning.
+>
+> Fourth FP shape from morgott's chunk-14 sweep on `affiliateProgram.web.js`: the two methods classified ALIVE (`getMyAffiliateLinks`, `getAffiliateDashboard`) were credited to `src/public/affiliateHelpers.js` whose **only mentions of those names are in JSDoc `@param` description text**. The v3.1 same-name-collision filter requires a local declaration to trip; pure JSDoc text doesn't match. v3.2 strips JSDoc/block + line comments before any caller-hit check.
+
+---
+
+## Detector deltas (v3.1 → v3.2)
+
+| Bucket | v3.1 (any-match) | v3.2 (any-match) | Δ |
+|---|---:|---:|---:|
+| INTERNAL | 196 | (recompute below — pending stable run) | |
+| FRONTEND | 363 | (recompute) | |
+| HTTP-EXPOSED | 80 | 80 | 0 |
+| EVENT-WIRED | 9 | 9 | 0 |
+| FILESYSTEM-PATH-REFERENCED | 885 | (similar) | |
+| DEAD | 4 | **5** | **+1** |
+
+The new DEAD entry is `affiliateProgram` (via the JSDoc-FP correction promoting the entire file's 2 "alive" methods to PATH-ONLY — see below).
+
+A bonus surface from v3.2: 1 fresh **`GAP-CFW-WANTS`** appeared — `customEvents.web::trackCustomEvent` (cfw has 2 high-confidence callVelo references but no `post_trackCustomEvent` HTTP wrapper). Filing as a follow-up bead per cf-vtx5 norms.
+
+---
+
+## Chunks 14+ pickable list (post-JSDoc-strip)
+
+### 🟢 DELETE-WHOLE — graduated post-FP
+
+#### `affiliateProgram.web.js` — 10 methods (alive 0 / path-only 10)
+
+The two methods previously classified ALIVE-INTERNAL were credited to JSDoc text in `src/public/affiliateHelpers.js`:
+
+```
+affiliateHelpers.js:137:  * @param {Object} dashboardData - Dashboard data from getAffiliateDashboard
+affiliateHelpers.js:174:  * @param {Object} linkData     - Link data from getMyAffiliateLinks
+```
+
+Pure description strings, not code. `affiliateHelpers.js` itself has zero consumers; its `initAffiliateDashboard` / `initAffiliateLinkItem` helpers are uncalled.
+
+| Method | Status |
+|---|---|
+| `applyForAffiliate` | path-only |
+| `getMyAffiliateAccount` | path-only |
+| `createAffiliateLink` | path-only |
+| `getMyAffiliateLinks` | path-only **← FP corrected v3.2** |
+| `recordAffiliateConversion` | path-only |
+| `getMyCommissions` | path-only |
+| `getAffiliateDashboard` | path-only **← FP corrected v3.2** |
+| `requestPayout` | path-only |
+| `getMyPayouts` | path-only |
+| `updatePaymentInfo` | path-only |
+
+**Chunk 14 candidate**: drop the whole file + tests. Also clean up the dead `affiliateHelpers.js` in the same chunk (or follow-up) since it's the only file the JSDoc lived in.
+
+### 🔵 KEEP-PARTIAL — remaining 2 files
+
+#### `warrantyService.web.js` — 9 methods (alive 2 / path-only 7) — unchanged from v3.1
+
+| Method | Status | Caller |
+|---|---|---|
+| `registerWarranty` | ALIVE | `Warranty Registration.js` |
+| `getMyWarranties` | ALIVE | `src/public/WarrantyWidget.js` |
+| `getWarrantyPlans` | path-only | (tests) |
+| `calculateWarrantyPrice` | path-only | (tests) |
+| `purchaseWarranty` | path-only | (tests) |
+| `getWarrantyDetails` | path-only | (tests) |
+| `submitClaim` | path-only | (tests) |
+| `getClaimStatus` | path-only | (tests) |
+| `getMyClaims` | path-only | (tests) |
+
+**Chunk 15 candidate**. Stilgar-check open: claims UI planned or shelved?
+
+#### `photoReviews.web.js` — 6 methods (alive 1 / path-only 5) — unchanged
+
+| Method | Status | Caller |
+|---|---|---|
+| `submitPhotoReview` | ALIVE | `Submit Photo Review.js` |
+| `getPhotoReviews` | path-only | (tests) |
+| `moderatePhotoReview` | path-only | (tests) |
+| `getPhotoGallery` | path-only | (tests) |
+| `reportPhotoReview` | path-only | (tests) |
+| `getPhotoReviewStats` | path-only | (tests) |
+
+**Chunk 16 candidate**. Stilgar-check open: gallery/moderation feature.
+
+---
+
+## Already shipped (chunks 13 reconciliation)
+
+`inventoryService.web.js` shipped in chunk 13 — keep 3 / drop 7. Current status (post-chunk-13):
+
+| Method | Status | Caller |
+|---|---|---|
+| `getStockStatus` | ALIVE | `liveInventory.web.js`, `InventoryDisplay.js` |
+| `signUpBackInStock` | ALIVE | `liveInventory.web.js` |
+| `getInventoryUrgency` | ALIVE | `src/public/inventoryUrgency.js` |
+
+The 7 dropped methods (incl. `getLowStockAlerts`) are no longer present. Detector v3.2 confirms the file is now `KEEP-FULL` shape.
+
+---
+
+## Recommended chunk 14+ sequence (revised)
+
+| # | File | Action | Methods removed | Notes |
+|---|---|---|---:|---|
+| 14 | `affiliateProgram.web.js` | DELETE-WHOLE (post-JSDoc-FP graduation) | 10 | Also retire `src/public/affiliateHelpers.js` (zero consumers; was the JSDoc holder). |
+| 15 | `warrantyService.web.js` | KEEP-PARTIAL surgical (Stilgar-check first) | 7 | Claims UI roadmap question. |
+| 16 | `photoReviews.web.js` | KEEP-PARTIAL surgical (Stilgar-check first) | 5 | Gallery/moderation roadmap question. |
+
+Total chunks 14–16 deletion target: ~22 methods + matching tests + `affiliateHelpers.js`.
+
+## Tangential finding — file as separate bead
+
+**`customEvents.web::trackCustomEvent`** newly surfaced as `GAP-CFW-WANTS` under v3.2:
+- cfw has 2 high-confidence callVelo references for `trackCustomEvent`
+- No `post_trackCustomEvent` HTTP wrapper in cfutons `http-functions.js`
+- Same shape as the cf-vtx5 cluster — needs an HTTP wrapper for cfw to actually reach it
+
+Recommend filing as `cf-customEvents-wrapper` (P3, ~2hr work — single dispatcher entry + Permissions.Anyone gate + tests). Not in this PR's scope.
+
+---
+
+## Filter precedent
+
+cf-sq0d.fu2 strips comments at every caller-hit check site:
+1. Per-file caller scan (the inner loop)
+2. Same-file call detection
+3. http-functions.js / events.js text load (in `main()`)
+
+The two regexes are intentionally simple — `/\* … \*/` block-strip + `(^|[^:])//[^\n]*` line-strip with URL-scheme guard. JS template literals containing comment-like substrings are rare enough that the filter doesn't try to parse them; if a future regression surfaces, upgrade to a proper tokenizer at that point.
+
+If a fifth shape of FP surfaces:
+- **CSS-in-JS / template-literal mention** — the symbol name appears inside a backtick string. Mitigation: strip backtick-quoted regions too, with care that legitimate `\`/_functions/\${name}\`` callVelo patterns aren't lost (they're already matched by the URL pattern, which is path-aware).
+- **Generated artifact** — the symbol shows up in a `.next/`, `dist/`, or `coverage/` file we accidentally walked. Mitigation: add explicit ignore prefixes to `all_source_files()` if the walker isn't already filtering them.
+
+Both are out of scope here unless they bite a specific chunk.
+
+---
+
+## Refs
+- Bead: cf-sq0d.fu2 (JSDoc-strip filter)
+- Detector: `scripts/cf-dead-routes/audit.py` v3.2 (same PR)
+- Predecessor: `docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.1.md` (still authoritative for v3.1's collision-filter coverage)
+- Pass 1 origin: `docs/cf-66ne-phase-b2-decision-matrix-2026-05-10.md` (PR #1209)

--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -101,6 +101,25 @@ def all_source_files() -> list[Path]:
     return out
 
 
+# cf-sq0d.fu2 (v3.2): strip JSDoc/block + line comments before checking
+# caller hits. Without this, a JSDoc `@param {Object} foo - data from
+# getAffiliateDashboard` line is credited as a real caller of the backend
+# `getAffiliateDashboard` webMethod.
+#
+# Two passes:
+#   1. Strip `/* … */` block comments (covers JSDoc and inline blocks).
+#   2. Strip `// …` line comments — but preserve URL schemes like `https://`
+#      by requiring the `//` to NOT be preceded by a `:` character.
+_BLOCK_COMMENT_RE = re.compile(r"/\*[\s\S]*?\*/")
+_LINE_COMMENT_RE = re.compile(r"(^|[^:])//[^\n]*")
+
+
+def strip_js_comments(text: str) -> str:
+    text = _BLOCK_COMMENT_RE.sub("", text)
+    # Replace match with the captured non-`:` prefix so URL `://` survives.
+    return _LINE_COMMENT_RE.sub(lambda m: m.group(1), text)
+
+
 def collect_web_methods() -> dict[str, dict]:
     methods: dict[str, dict] = {}
     for fp in BACKEND.rglob("*.web.js"):
@@ -329,6 +348,10 @@ def classify_method(
                 self_text = fp.read_text(errors="ignore")
             except OSError:
                 continue
+            # cf-sq0d.fu2: strip comments before the same-file call check so
+            # a JSDoc `@example NAME()` snippet in the defining file's own
+            # docstring isn't credited as a real same-file caller.
+            self_text = strip_js_comments(self_text)
             if pat_call.search(self_text):
                 in_same_file = True
                 if len(sample_callers) < 5:
@@ -342,13 +365,18 @@ def classify_method(
             text = fp.read_text(errors="ignore")
         except OSError:
             continue
-        if not pat_import.search(text):
+        # cf-sq0d.fu2 (v3.2): comment-strip before checking caller hits so
+        # JSDoc-only mentions ("@param … from getAffiliateDashboard") don't
+        # masquerade as callers. The local-def + backend-import checks below
+        # still run against the stripped view for the same reason.
+        stripped = strip_js_comments(text)
+        if not pat_import.search(stripped):
             continue
         # cf-sq0d.fu1: skip same-name-collision callers. If the file defines
         # its own function/const with this name AND has no explicit string
         # reference to the defining backend module, the name match is local —
         # not a backend caller.
-        if pat_local_def.search(text) and not pat_backend_import_quoted.search(text):
+        if pat_local_def.search(stripped) and not pat_backend_import_quoted.search(stripped):
             continue
         # any reference counts; don't require call form (could be re-export, type ref)
         if rel.startswith("src/public/"):
@@ -446,12 +474,21 @@ def main() -> int:
     print(f"scanning {len(files)} src files", file=sys.stderr)
     print(f"webMethods discovered: {len(methods)}", file=sys.stderr)
 
-    http_text = HTTP_FILE.read_text(errors="ignore") if HTTP_FILE.exists() else ""
-    events_text = EVENTS_FILE.read_text(errors="ignore") if EVENTS_FILE.exists() else ""
+    # cf-sq0d.fu2: strip JSDoc/line comments from the http and events text up
+    # front so a JSDoc-only mention (e.g. `// see also: post_someName`) in
+    # those files doesn't count as a wiring of NAME.
+    http_text = (
+        strip_js_comments(HTTP_FILE.read_text(errors="ignore")) if HTTP_FILE.exists() else ""
+    )
+    events_text = (
+        strip_js_comments(EVENTS_FILE.read_text(errors="ignore"))
+        if EVENTS_FILE.exists()
+        else ""
+    )
     # Also fold any *.events.js into events_text
     for fp in BACKEND.rglob("*.events.js"):
         try:
-            events_text += "\n" + fp.read_text(errors="ignore")
+            events_text += "\n" + strip_js_comments(fp.read_text(errors="ignore"))
         except OSError:
             continue
 


### PR DESCRIPTION
## Summary
- Detector v3.2: strips JSDoc / block / line comments before any caller-hit check. Closes the 4th FP shape morgott surfaced in chunk-14 sweep on \`affiliateProgram\` (JSDoc \`@param\` mentions credited as callers).
- Updated matrix at \`docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.2.md\` — chunks 14+ roadmap revised.

## The fourth FP shape
\`getMyAffiliateLinks\` + \`getAffiliateDashboard\` were classified ALIVE-INTERNAL via \`src/public/affiliateHelpers.js\`, whose only mentions are JSDoc \`@param\` description text:

\`\`\`
affiliateHelpers.js:137:  * @param {Object} dashboardData - Dashboard data from getAffiliateDashboard
affiliateHelpers.js:174:  * @param {Object} linkData     - Link data from getMyAffiliateLinks
\`\`\`

The v3.1 collision filter only fires on local \`function\`/\`const\` declarations; pure JSDoc doesn't match. v3.2 strips comments first.

## Filter implementation
Two minimal regexes applied at every caller-hit site:
- \`/\\* … \\*/\` block-strip (covers JSDoc + inline blocks)
- \`(^|[^:])//[^\\n]*\` line-strip with URL-scheme guard (so \`https://\` survives)

Strip applied at:
1. Per-file caller scan (inner loop)
2. Same-file call detection
3. http-functions.js / events.js text load in \`main()\`

## Verification
| Symbol | Before (v3.1) | After (v3.2) |
|---|---|---|
| \`getMyAffiliateLinks\` | ALIVE-INTERNAL | **PATH-ONLY** ✓ |
| \`getAffiliateDashboard\` | ALIVE-INTERNAL | **PATH-ONLY** ✓ |
| \`getLowStockAlerts\` (chunk 13) | PATH-ONLY | PATH-ONLY (unchanged) ✓ |

## Knock-on: chunks 14+ roadmap revised
- **Chunk 14**: \`affiliateProgram.web.js\` graduates KEEP-PARTIAL → **DELETE-WHOLE** post-FP (both "alive" methods were JSDoc FPs). Drop the file + tests + retire dead consumer \`affiliateHelpers.js\`.
- **Chunk 15**: \`warrantyService.web.js\` (surgical 7/9, Stilgar-check open).
- **Chunk 16**: \`photoReviews.web.js\` (surgical 5/6, Stilgar-check open).
- **inventoryService**: shipped chunk 13; confirmed KEEP-FULL shape under v3.2.

Total chunks 14–16 deletion target: ~22 methods + tests + \`affiliateHelpers.js\`.

## Tangential finding (filing separately)
**\`customEvents.web::trackCustomEvent\`** newly surfaces as \`GAP-CFW-WANTS\` under v3.2 — cfw has 2 high-confidence callVelo references but no \`post_trackCustomEvent\` HTTP wrapper. Same shape as cf-vtx5 cluster. Recommend filing as \`cf-customEvents-wrapper\` (P3, ~2 hr work). Out of this PR's scope.

## Refs
- Bead: cf-sq0d.fu2 (JSDoc-strip filter)
- Predecessor: PR #1244 (cf-sq0d.fu1 — collision filter)
- Predecessor matrix: \`docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.1.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)