### PR TITLE
feat(cf-owrr): centralize trusted-client-IP extraction (rightmost-trust XFF parser)

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -3714,17 +3714,18 @@ export async function post_submitCommunityPhoto(request) {
     });
   }
 
-  // cf-k5vr: extract the original client IP from x-forwarded-for and
-  // pass it to the webMethod as the rate-limit axis. Wix HTTP runs
-  // behind its own CDN, so x-forwarded-for is a comma-separated chain
-  // — the leftmost entry is the original client (the rest are Wix's
-  // intermediate proxies). When the header is missing or malformed,
-  // omit opts.rateLimitKey and let the webMethod fall back to the old
-  // imageUrl-host axis.
-  const xff = request.headers && (request.headers['x-forwarded-for'] || request.headers['X-Forwarded-For']);
-  const clientIp = typeof xff === 'string'
-    ? xff.split(',')[0].trim()
-    : '';
+  // cf-owrr (was cf-k5vr): extract the trusted client IP from
+  // x-forwarded-for via the centralized helper. The previous leftmost-
+  // split implementation trusted client-controlled XFF values — an
+  // attacker could rotate spoofed leftmost IPs to land in fresh rate-
+  // limit buckets per request. extractTrustedClientIp strips the
+  // rightmost Wix-edge entry (default trustedProxies=1) and returns the
+  // entry just before it (the actual edge-observed client IP). When the
+  // chain is missing or shorter than expected, the helper returns null
+  // and we omit opts.rateLimitKey, letting the webMethod fall back to
+  // the imageUrl-host axis.
+  const { extractTrustedClientIp } = await import('backend/utils/rateLimit');
+  const clientIp = extractTrustedClientIp(request);
   const opts = clientIp ? { rateLimitKey: clientIp } : {};
 
   try {

--- a/src/backend/utils/rateLimit.js
+++ b/src/backend/utils/rateLimit.js
@@ -16,6 +16,62 @@ import { logError } from 'backend/utils/errorHandler';
 export const RATE_LIMIT_MAX = 3;
 export const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
+// cf-owrr: Wix's edge layer appends ONE entry to the X-Forwarded-For chain
+// when a request reaches the Velo HTTP function. The chain shape is:
+//
+//   <client-supplied entries>, <wix-edge-observed-client-ip>
+//
+// The leftmost entries are CLIENT-CONTROLLABLE (the client can ship any
+// X-Forwarded-For value in the request headers). Only the rightmost entry
+// is trustworthy because it was written by the Wix edge after observing
+// the actual TCP peer. Trusting the leftmost gives an attacker per-request
+// bucket bypass: rotate the leftmost spoofed IP each request, never share
+// a bucket with the previous request.
+//
+// Default trustedProxies = 1 strips the rightmost entry (Wix edge) and
+// returns the entry just before it (the real client). If the chain has
+// fewer entries than the trustedProxies count we don't have a reliable
+// client IP, so return null and let the caller fall back to a different
+// axis (e.g. imageUrl host).
+const DEFAULT_TRUSTED_PROXIES = 1;
+
+/**
+ * Extract the trusted client IP from a Velo HTTP function request.
+ *
+ * Reads `request.headers['x-forwarded-for']` (with a case-insensitive
+ * fallback), splits on commas, strips the rightmost `trustedProxies`
+ * entries (default 1 = the Wix edge entry), and returns the new
+ * rightmost entry — which is the actual client IP that Wix observed.
+ *
+ * Returns `null` when the chain is empty, the header is missing, or the
+ * chain has fewer entries than `trustedProxies` (in which case the
+ * caller should pick a different rate-limit axis rather than guess).
+ *
+ * @param {Object} request - Velo HTTP function `request` object.
+ * @param {Object} [opts]
+ * @param {number} [opts.trustedProxies] - Number of rightmost entries
+ *   to strip before reading the client IP. Defaults to 1 for the Wix
+ *   edge. Test harnesses can pass 0 when the test fakes the chain
+ *   without the edge entry.
+ * @returns {string|null} The trusted client IP, or null when unavailable.
+ */
+export function extractTrustedClientIp(request, opts = {}) {
+  const trustedProxies = opts.trustedProxies ?? DEFAULT_TRUSTED_PROXIES;
+  const headers = request && request.headers;
+  if (!headers) return null;
+  const xff = headers['x-forwarded-for'] || headers['X-Forwarded-For'];
+  if (typeof xff !== 'string' || xff.length === 0) return null;
+  const entries = xff
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (entries.length === 0) return null;
+  // Strip the rightmost `trustedProxies` entries. If we don't have enough
+  // entries to do that safely, return null (caller falls back).
+  if (entries.length <= trustedProxies) return null;
+  return entries[entries.length - 1 - trustedProxies];
+}
+
 /**
  * One-way FNV-1a hash of a rate-limit key.
  * CF-sec1 CMEK compliance: bucket keys stored in wixData must not contain

--- a/tests/communityPhoto.test.js
+++ b/tests/communityPhoto.test.js
@@ -14,9 +14,13 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('backend/utils/rateLimit', () => ({
-  checkRateLimit: vi.fn(),
-}));
+vi.mock('backend/utils/rateLimit', async (importOriginal) => {
+  // Real extractTrustedClientIp + hashRateLimitKey, mocked checkRateLimit.
+  // Tests assert on the post-trim rate-limit key, so the helper must
+  // execute with the real XFF parsing logic.
+  const actual = await importOriginal();
+  return { ...actual, checkRateLimit: vi.fn() };
+});
 
 import {
   post_submitCommunityPhoto,
@@ -226,22 +230,44 @@ describe('cf-0h9q · post_submitCommunityPhoto', () => {
     expect(JSON.parse(res.body).success).toBe(false);
   });
 
-  // cf-k5vr: wrapper extracts x-forwarded-for and forwards as the
-  // rate-limit axis. Two clients on the same image host should land in
-  // independent buckets; one client posting to two hosts should share a
-  // bucket.
-  it('cf-k5vr: wrapper extracts leftmost x-forwarded-for as rateLimitKey', async () => {
-    const req = flatReq(VALID_BODY, { 'x-forwarded-for': '203.0.113.42, 10.0.0.1, 10.0.0.2' });
+  // cf-owrr (was cf-k5vr): wrapper extracts the trusted client IP via
+  // extractTrustedClientIp. The Wix edge appends ONE rightmost entry
+  // (default trustedProxies=1), so the test chain shape is
+  // "<client-supplied entries>..., <wix-edge>".
+  //
+  // The leftmost-trust pattern was the cf-owrr bug: an attacker could
+  // spoof the leftmost XFF entry per request to land in fresh buckets.
+  // The "leftmost spoofed, real client, edge" case below is the
+  // regression pin for the actual fix.
+  it('cf-owrr: wrapper trusts the entry just before the Wix edge — NOT the leftmost spoofed entry', async () => {
+    // Chain: <attacker-spoofed>, <real-client>, <wix-edge>
+    const req = flatReq(VALID_BODY, { 'x-forwarded-for': '1.1.1.1, 203.0.113.42, 10.0.0.1' });
     await post_submitCommunityPhoto(req);
     expect(checkRateLimit).toHaveBeenCalledWith(
       'CommunityPhotoRateLimit',
-      '203.0.113.42',
+      '203.0.113.42', // NOT '1.1.1.1' (would be the leftmost-trust bug)
       expect.anything(),
     );
   });
 
+  it('cf-owrr: rotating leftmost spoof does NOT create fresh buckets', async () => {
+    // Same real-client behind Wix edge; attacker rotates leftmost
+    // entry per request. All 3 calls must land in the same bucket.
+    await post_submitCommunityPhoto(
+      flatReq(VALID_BODY, { 'x-forwarded-for': '1.1.1.1, 203.0.113.42, 10.0.0.1' }),
+    );
+    await post_submitCommunityPhoto(
+      flatReq(VALID_BODY, { 'x-forwarded-for': '2.2.2.2, 203.0.113.42, 10.0.0.1' }),
+    );
+    await post_submitCommunityPhoto(
+      flatReq(VALID_BODY, { 'x-forwarded-for': '9.9.9.9, 203.0.113.42, 10.0.0.1' }),
+    );
+    const keys = vi.mocked(checkRateLimit).mock.calls.map((call) => call[1]);
+    expect(keys).toEqual(['203.0.113.42', '203.0.113.42', '203.0.113.42']);
+  });
+
   it('cf-k5vr: wrapper accepts X-Forwarded-For (canonical capitalization)', async () => {
-    const req = flatReq(VALID_BODY, { 'X-Forwarded-For': '198.51.100.5' });
+    const req = flatReq(VALID_BODY, { 'X-Forwarded-For': '198.51.100.5, 10.0.0.1' });
     await post_submitCommunityPhoto(req);
     expect(checkRateLimit).toHaveBeenCalledWith(
       'CommunityPhotoRateLimit',
@@ -259,8 +285,23 @@ describe('cf-0h9q · post_submitCommunityPhoto', () => {
     );
   });
 
+  it('cf-owrr: chain shorter than trustedProxies (single edge entry) falls back to host axis', async () => {
+    // A single-entry chain means we only see the Wix edge entry — no
+    // client-supplied entries upstream. Helper returns null → host
+    // fallback fires. Without this fallback, we would rate-limit every
+    // request from the same edge instance into one bucket.
+    await post_submitCommunityPhoto(
+      flatReq(VALID_BODY, { 'x-forwarded-for': '10.0.0.1' }),
+    );
+    expect(checkRateLimit).toHaveBeenCalledWith(
+      'CommunityPhotoRateLimit',
+      'cdn.example.com', // host fallback, NOT '10.0.0.1'
+      expect.anything(),
+    );
+  });
+
   it('cf-k5vr: same client IP across different image hosts shares one bucket', async () => {
-    const xff = { 'x-forwarded-for': '203.0.113.99' };
+    const xff = { 'x-forwarded-for': '203.0.113.99, 10.0.0.1' };
     await post_submitCommunityPhoto(
       flatReq({ ...VALID_BODY, imageUrl: 'https://cdn-a.example.com/p1.jpg' }, xff),
     );
@@ -273,10 +314,10 @@ describe('cf-0h9q · post_submitCommunityPhoto', () => {
 
   it('cf-k5vr: different client IPs on the same image host get independent buckets', async () => {
     await post_submitCommunityPhoto(
-      flatReq(VALID_BODY, { 'x-forwarded-for': '203.0.113.10' }),
+      flatReq(VALID_BODY, { 'x-forwarded-for': '203.0.113.10, 10.0.0.1' }),
     );
     await post_submitCommunityPhoto(
-      flatReq(VALID_BODY, { 'x-forwarded-for': '203.0.113.20' }),
+      flatReq(VALID_BODY, { 'x-forwarded-for': '203.0.113.20, 10.0.0.1' }),
     );
     const keys = vi.mocked(checkRateLimit).mock.calls.map((call) => call[1]);
     expect(keys).toEqual(['203.0.113.10', '203.0.113.20']);

--- a/tests/extractTrustedClientIp.test.js
+++ b/tests/extractTrustedClientIp.test.js
@@ -1,0 +1,113 @@
+// cf-owrr: pin the trusted-proxy XFF parser. The leftmost X-Forwarded-For
+// entry is client-controllable (an attacker can ship any value in the
+// request header). Wix's edge appends ONE entry to the chain — the
+// actual TCP-peer client IP — at the rightmost position. The helper
+// strips trustedProxies entries from the right and returns the entry
+// just before that. Default trustedProxies=1 = rightmost is Wix edge.
+//
+// Critical regression cases pinned here:
+//   - leftmost-spoofed XFF must NOT determine the bucket key
+//   - missing/empty XFF returns null (caller falls back to other axis)
+//   - chain shorter than trustedProxies returns null (no guess)
+
+import { describe, it, expect } from 'vitest';
+
+import { extractTrustedClientIp } from 'backend/utils/rateLimit';
+
+function req(xff) {
+  return { headers: xff === undefined ? {} : { 'x-forwarded-for': xff } };
+}
+
+describe('cf-owrr · extractTrustedClientIp', () => {
+  it('returns null when request has no headers', () => {
+    expect(extractTrustedClientIp({})).toBeNull();
+    expect(extractTrustedClientIp(null)).toBeNull();
+    expect(extractTrustedClientIp(undefined)).toBeNull();
+  });
+
+  it('returns null when x-forwarded-for header is missing', () => {
+    expect(extractTrustedClientIp({ headers: {} })).toBeNull();
+  });
+
+  it('returns null when x-forwarded-for is an empty string', () => {
+    expect(extractTrustedClientIp(req(''))).toBeNull();
+  });
+
+  it('returns null when x-forwarded-for has only whitespace entries', () => {
+    expect(extractTrustedClientIp(req(' , , '))).toBeNull();
+  });
+
+  it('reads case-insensitive header name (X-Forwarded-For)', () => {
+    const r = { headers: { 'X-Forwarded-For': '1.2.3.4, 5.6.7.8' } };
+    expect(extractTrustedClientIp(r)).toBe('1.2.3.4');
+  });
+
+  it('default trustedProxies=1: chain "client, edge" → returns "client"', () => {
+    expect(extractTrustedClientIp(req('203.0.113.5, 198.51.100.1'))).toBe(
+      '203.0.113.5',
+    );
+  });
+
+  it('default trustedProxies=1: 3-entry chain "spoofed, real-client, edge" → returns "real-client" (NOT "spoofed")', () => {
+    // The bug we are fixing: leftmost-trust would return '1.1.1.1' (the
+    // attacker-supplied entry). Rightmost-trust with trustedProxies=1
+    // strips the Wix edge entry ('198.51.100.1') and returns the entry
+    // just before it (the actual edge-observed client, '203.0.113.5').
+    const r = req('1.1.1.1, 203.0.113.5, 198.51.100.1');
+    expect(extractTrustedClientIp(r)).toBe('203.0.113.5');
+  });
+
+  it('default trustedProxies=1: chain with ONE entry → returns null (cannot strip + read)', () => {
+    // If only the Wix edge entry is present (no client-supplied entries
+    // at all), there's no client IP to extract. Return null so the
+    // caller falls back to the host axis instead of using the edge IP.
+    expect(extractTrustedClientIp(req('198.51.100.1'))).toBeNull();
+  });
+
+  it('attacker bypass attempt: each request rotates a fresh leftmost IP — bucket stays stable', () => {
+    // Same real-client IP behind Wix edge; attacker rotates the
+    // leftmost entry per request. The trusted bucket key must be stable
+    // (the real-client IP) regardless of leftmost rotation.
+    const ip1 = extractTrustedClientIp(
+      req('1.1.1.1, 203.0.113.5, 198.51.100.1'),
+    );
+    const ip2 = extractTrustedClientIp(
+      req('2.2.2.2, 203.0.113.5, 198.51.100.1'),
+    );
+    const ip3 = extractTrustedClientIp(
+      req('9.9.9.9, 203.0.113.5, 198.51.100.1'),
+    );
+    expect(ip1).toBe('203.0.113.5');
+    expect(ip2).toBe('203.0.113.5');
+    expect(ip3).toBe('203.0.113.5');
+  });
+
+  it('opts.trustedProxies=0: returns the rightmost entry (test harness mode)', () => {
+    // For tests that fake the chain WITHOUT the Wix edge entry, the
+    // caller can pass trustedProxies=0 to read the rightmost as-is.
+    const r = req('1.2.3.4, 5.6.7.8');
+    expect(extractTrustedClientIp(r, { trustedProxies: 0 })).toBe('5.6.7.8');
+  });
+
+  it('opts.trustedProxies=2: strips two rightmost entries (multi-proxy hypothetical)', () => {
+    // Future-proofs against Wix changing the edge proxy count. If the
+    // chain has 3 entries and trustedProxies=2, the leftmost-of-three
+    // is the trusted client.
+    const r = req('203.0.113.5, edge1, edge2');
+    expect(extractTrustedClientIp(r, { trustedProxies: 2 })).toBe('203.0.113.5');
+  });
+
+  it('trims whitespace inside the chain', () => {
+    expect(extractTrustedClientIp(req('  1.2.3.4  ,  5.6.7.8  '))).toBe(
+      '1.2.3.4',
+    );
+  });
+
+  it('skips empty entries (e.g. ",,1.2.3.4, edge")', () => {
+    // Empty entries from malformed XFF chains shouldn't shift the
+    // trusted-strip count. Filter them out before counting.
+    expect(extractTrustedClientIp(req(',, 203.0.113.5, 198.51.100.1'))).toBe(
+      '203.0.113.5',
+    );
+  });
+});


### PR DESCRIPTION
## Bead
cf-owrr (P3, BUG) — cf-tvbi.fu sweep, surfaced from cf-edw3 sibling-audit and reassigned to radahn for execution per melania.

## Why
The previous leftmost-XFF parse in `post_submitCommunityPhoto` trusted client-controllable input. An attacker could ship a spoofed leftmost `X-Forwarded-For` value per request to land in fresh per-IP rate-limit buckets, bypassing the 5/hour cap.

## Sweep scope (smaller than expected)
Only ONE callsite in the entire backend reads `x-forwarded-for` (verified via grep): `post_submitCommunityPhoto`. The "cf-k5vr-style endpoints" sweep I anticipated in the bead description turned out to be a single-site migration. Future endpoints adopting per-IP rate-limit should use the new helper instead of hand-rolling the parse.

## What

### `backend/utils/rateLimit.js#extractTrustedClientIp(request, opts)`

- Reads `request.headers['x-forwarded-for']` (case-insensitive fallback).
- Splits on commas, trims, drops empty entries.
- If `entries.length <= trustedProxies`: returns `null` (caller falls back to a different axis — the helper does NOT guess).
- Otherwise: returns `entries[entries.length - 1 - trustedProxies]`.
- Default `trustedProxies = 1` corresponds to the Wix edge appending one entry to the chain when a request reaches the Velo HTTP function.

### Migrated callsite (`post_submitCommunityPhoto`)

- Dynamic-imports `extractTrustedClientIp` (matches the existing `checkRateLimit` dynamic-import pattern in `http-functions.js`).
- Replaces the inline `xff.split(',')[0].trim()` shape.
- Comment updated to describe the rightmost-trust contract and the cf-owrr provenance.

## Tests

### `tests/extractTrustedClientIp.test.js` (12 cases, new)
Covers: null inputs, missing header, empty XFF, whitespace-only, case-insensitive header, default trustedProxies=1 happy path, **leftmost-spoof regression case** (`"1.1.1.1, 203.0.113.5, 198.51.100.1"` → `"203.0.113.5"`, NOT `"1.1.1.1"`), **attacker-rotation bypass attempt** (3 calls with rotating leftmost return the same trusted IP), single-entry chain returns null, opts overrides (trustedProxies=0 / 2), whitespace inside entries, empty entries skipped.

The leftmost-spoof-rotation case is the load-bearing regression pin.

### `tests/communityPhoto.test.js` (33 cases, was 30)
Updated XFF chain shapes to include the Wix edge entry (so the test reflects production reality where the helper sees client + edge entries). Replaced the old `cf-k5vr: extracts leftmost x-forwarded-for as rateLimitKey` test with two cf-owrr regression pins:
- `cf-owrr: wrapper trusts the entry just before the Wix edge — NOT the leftmost spoofed entry`
- `cf-owrr: rotating leftmost spoof does NOT create fresh buckets` (3-call sequence asserting bucket key stability)

Plus a new `cf-owrr: chain shorter than trustedProxies (single edge entry) falls back to host axis` for the null-return path.

The `vi.mock` for `backend/utils/rateLimit` now uses `importOriginal()` so the real XFF parser executes while `checkRateLimit` stays mocked.

**45/45 green** across both files.

## Acceptance (from bead)
- [x] Helper added to `backend/utils/rateLimit.js`
- [x] All cf-k5vr-style endpoints (1) migrated to use it
- [x] Test pin per endpoint: leftmost-spoofed XFF does NOT create a fresh bucket (regression case + rotation case)
- [x] Doc comment cites Wix edge proxy count (1) and the rightmost-trust strategy

## Risk
Behavior change for the single migrated callsite. Pre-fix: leftmost-trust → bucket key was the leftmost (possibly spoofed) entry. Post-fix: rightmost-trust(strip 1) → bucket key is the actual edge-observed client IP. Net effect is the rate limit becomes harder to bypass, with no impact on legitimate traffic (the legit bucket key is now stable).

If Wix ever changes the edge proxy count from 1, this needs revisiting. Comment + helper signature both flag this.
