### PR TITLE
feat(cf-uwfw): add post_queueWelcomeEmail + post_queueCartRecovery wrappers

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -9,7 +9,7 @@ import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationService.web';
 import { sendEmail } from 'backend/emailService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
-import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence, getCampaignAnalytics, unsubscribeContact } from 'backend/emailAutomation.web';
+import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence, getCampaignAnalytics, unsubscribeContact, triggerWelcomeSeries } from 'backend/emailAutomation.web';
 import { scanAndTriggerWinback, runReviewRequestEmails } from 'backend/marketingSequences.web';
 import { processContentSchedule } from 'backend/contentScheduler.web';
 import { sendWeeklyBlogDigest } from 'backend/blogDigestService.web';
@@ -3671,6 +3671,113 @@ export async function post_submitSurvey(request) {
   }
 }
 export function options_submitSurvey(request) { return response(corsPreflight(request)); }
+
+// ── /_functions/queueWelcomeEmail (cf-uwfw / cf-7ozz.1) ──────────────────────
+//
+// cfw's src/app/api/email/trigger/route.ts posts to
+// /_functions/queueWelcomeEmail (via callVelo({method:'queueWelcomeEmail'}))
+// with body {args: [{type:'welcome', email}]}. Wix doesn't auto-route
+// /_functions/<name> to a webMethod of the same name — this wrapper
+// bridges to triggerWelcomeSeries(email, firstName).
+//
+// Auth: triggerWelcomeSeries is Permissions.SiteMember but bypasses the
+// permission check on backend-to-backend invocation; it self-guards via
+// resolveContactId (cf-xdji), so an anonymous trigger is safe — the
+// downstream queue still requires a resolvable email.
+
+export async function post_queueWelcomeEmail(request) {
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+  let body;
+  try {
+    body = await request.body.json();
+  } catch (_) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'invalid_json' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  // callVelo wraps the original payload in args:[payload] — accept both
+  // shapes so the wrapper works whether cfw routes via callVelo or a
+  // direct fetch.
+  const payload = (Array.isArray(body?.args) && body.args[0]) || body || {};
+  const email = typeof payload.email === 'string' ? payload.email.trim() : '';
+  const firstName = typeof payload.firstName === 'string' ? payload.firstName : '';
+  if (!email) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'email is required' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  try {
+    const result = await triggerWelcomeSeries(email, firstName);
+    return ok({ body: JSON.stringify(result), headers: JSON_HEADERS });
+  } catch (err) {
+    const errorId = _veloDispatchErrorId();
+    console.error(`HTTP function error (post_queueWelcomeEmail) errorId=${errorId}:`, err);
+    return serverError({
+      body: JSON.stringify({ success: false, error: 'server_error', errorId }),
+      headers: JSON_HEADERS,
+    });
+  }
+}
+export function options_queueWelcomeEmail(request) { return response(corsPreflight(request)); }
+
+// ── /_functions/queueCartRecovery (cf-uwfw / cf-7ozz.1) ──────────────────────
+//
+// cfw's same route posts here for cart-recovery triggers with body
+// {args: [{type:'cart-recovery', items:[{productId, quantity}]}]}. The
+// payload is intentionally lean — it's a hint to seed the abandoned-cart
+// pipeline, NOT a complete cart row. The cron-driven
+// triggerAbandonedCartRecovery scans the AbandonedCarts CMS collection
+// and queues recovery emails for rows that have an email + checkoutId.
+//
+// For now this wrapper validates + returns a stub-success envelope so the
+// cfw route succeeds (e2e contract). A follow-up bead can wire the items
+// hint into an AbandonedCarts row enrichment if PM wants the cfw-side
+// trigger to actively seed cart rows. The cron remains the canonical
+// cart-recovery trigger.
+
+export async function post_queueCartRecovery(request) {
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+  let body;
+  try {
+    body = await request.body.json();
+  } catch (_) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'invalid_json' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  const payload = (Array.isArray(body?.args) && body.args[0]) || body || {};
+  const items = Array.isArray(payload.items) ? payload.items : null;
+  if (!items || items.length === 0) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'items[] is required' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  // Validate item shape — productId + quantity required, prevents
+  // poisoned input from polluting any future AbandonedCarts seeding.
+  const valid = items.every((it) =>
+    it && typeof it === 'object'
+    && typeof it.productId === 'string' && it.productId.length > 0
+    && typeof it.quantity === 'number' && Number.isFinite(it.quantity) && it.quantity > 0,
+  );
+  if (!valid) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'each item must have productId (string) + quantity (positive number)' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  // Stub-success: the cron-side triggerAbandonedCartRecovery is the
+  // canonical path; this hint endpoint is a placeholder until a follow-up
+  // bead wires cfw items into an AbandonedCarts row creation.
+  return ok({
+    body: JSON.stringify({ success: true, accepted: items.length, note: 'cart-recovery hint accepted; cron remains canonical trigger' }),
+    headers: JSON_HEADERS,
+  });
+}
+export function options_queueCartRecovery(request) { return response(corsPreflight(request)); }
 
 // ── /_functions/submitCommunityPhoto ─────────────────────────────────────────
 //

--- a/tests/queueEmailWrappers.cfuwfw.test.js
+++ b/tests/queueEmailWrappers.cfuwfw.test.js
@@ -1,0 +1,153 @@
+/**
+ * @file queueEmailWrappers.cfuwfw.test.js
+ * @description cf-uwfw (cf-7ozz.1) — HTTP wrappers for cfw's
+ * /api/email/trigger route. cfw posts {args:[payload]} via callVelo to
+ * /_functions/queueWelcomeEmail and /_functions/queueCartRecovery; Wix
+ * doesn't auto-route those, so this PR adds explicit wrappers.
+ *
+ * Verifies:
+ *   - post_queueWelcomeEmail: validates email; calls triggerWelcomeSeries;
+ *     forwards firstName when present; surfaces the webMethod's envelope
+ *   - post_queueCartRecovery: validates items[]; stub-accepts the hint;
+ *     rejects empty/malformed item shapes
+ *   - Both: invalid_json on body parse failure; CORS headers on response;
+ *     accept both {args:[payload]} (callVelo shape) and direct payload body
+ *   - 500 server_error + errorId on unexpected throws
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the underlying webMethod so we can assert its argument shape.
+vi.mock('backend/emailAutomation.web', async () => {
+  const actual = await vi.importActual('backend/emailAutomation.web');
+  return {
+    ...actual,
+    triggerWelcomeSeries: vi.fn().mockResolvedValue({ success: true, queued: 5 }),
+  };
+});
+
+import { post_queueWelcomeEmail, options_queueWelcomeEmail, post_queueCartRecovery, options_queueCartRecovery } from '../src/backend/http-functions.js';
+import { triggerWelcomeSeries } from 'backend/emailAutomation.web';
+
+const goodOrigin = 'https://carolina-futons-web.vercel.app';
+
+const makeReq = (body) => ({
+  body: { json: async () => body },
+  headers: { origin: goodOrigin },
+});
+
+beforeEach(() => {
+  vi.mocked(triggerWelcomeSeries).mockReset();
+  vi.mocked(triggerWelcomeSeries).mockResolvedValue({ success: true, queued: 5 });
+});
+
+describe('cf-uwfw · post_queueWelcomeEmail', () => {
+  it('calls triggerWelcomeSeries with email + firstName from callVelo {args} shape', async () => {
+    const res = await post_queueWelcomeEmail(makeReq({ args: [{ type: 'welcome', email: 'shopper@example.com', firstName: 'Asha' }] }));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true, queued: 5 });
+    expect(vi.mocked(triggerWelcomeSeries)).toHaveBeenCalledWith('shopper@example.com', 'Asha');
+  });
+
+  it('accepts a direct payload body too (no callVelo wrapping)', async () => {
+    await post_queueWelcomeEmail(makeReq({ email: 'direct@example.com', firstName: 'Direct' }));
+    expect(vi.mocked(triggerWelcomeSeries)).toHaveBeenCalledWith('direct@example.com', 'Direct');
+  });
+
+  it('passes empty firstName when omitted', async () => {
+    await post_queueWelcomeEmail(makeReq({ args: [{ email: 'noname@example.com' }] }));
+    expect(vi.mocked(triggerWelcomeSeries)).toHaveBeenCalledWith('noname@example.com', '');
+  });
+
+  it('returns 400 invalid_json when body parse fails', async () => {
+    const req = {
+      body: { json: async () => { throw new SyntaxError('bad json'); } },
+      headers: { origin: goodOrigin },
+    };
+    const res = await post_queueWelcomeEmail(req);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('invalid_json');
+    expect(vi.mocked(triggerWelcomeSeries)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const res = await post_queueWelcomeEmail(makeReq({ args: [{ type: 'welcome' }] }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/email/i);
+    expect(vi.mocked(triggerWelcomeSeries)).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 + errorId when triggerWelcomeSeries throws', async () => {
+    vi.mocked(triggerWelcomeSeries).mockRejectedValue(new Error('Wix Data unavailable'));
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await post_queueWelcomeEmail(makeReq({ args: [{ email: 'shopper@example.com' }] }));
+    expect(res.status).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('server_error');
+    expect(typeof body.errorId).toBe('string');
+    consoleErr.mockRestore();
+  });
+
+  it('options preflight returns a CORS response', () => {
+    const res = options_queueWelcomeEmail({ headers: { origin: goodOrigin } });
+    expect(res.status).toBeGreaterThanOrEqual(200);
+  });
+});
+
+describe('cf-uwfw · post_queueCartRecovery', () => {
+  it('accepts a valid items[] payload via callVelo {args} shape', async () => {
+    const res = await post_queueCartRecovery(makeReq({
+      args: [{ type: 'cart-recovery', items: [{ productId: 'prod-1', quantity: 2 }] }],
+    }));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+    expect(body.accepted).toBe(1);
+  });
+
+  it('accepts direct payload (no callVelo wrapping)', async () => {
+    const res = await post_queueCartRecovery(makeReq({
+      items: [{ productId: 'prod-1', quantity: 1 }, { productId: 'prod-2', quantity: 3 }],
+    }));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body).accepted).toBe(2);
+  });
+
+  it('returns 400 when items is missing', async () => {
+    const res = await post_queueCartRecovery(makeReq({ args: [{ type: 'cart-recovery' }] }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/items\[\] is required/);
+  });
+
+  it('returns 400 when items is empty', async () => {
+    const res = await post_queueCartRecovery(makeReq({ args: [{ items: [] }] }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/items\[\] is required/);
+  });
+
+  it('returns 400 when an item has no productId', async () => {
+    const res = await post_queueCartRecovery(makeReq({ items: [{ quantity: 1 }] }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/productId/);
+  });
+
+  it('returns 400 when an item has zero or negative quantity', async () => {
+    const res = await post_queueCartRecovery(makeReq({ items: [{ productId: 'p-1', quantity: 0 }] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 invalid_json when body parse fails', async () => {
+    const req = {
+      body: { json: async () => { throw new SyntaxError('bad json'); } },
+      headers: { origin: goodOrigin },
+    };
+    const res = await post_queueCartRecovery(req);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('invalid_json');
+  });
+
+  it('options preflight returns a CORS response', () => {
+    const res = options_queueCartRecovery({ headers: { origin: goodOrigin } });
+    expect(res.status).toBeGreaterThanOrEqual(200);
+  });
+});


### PR DESCRIPTION
## Summary
cf-7ozz.1 production-correctness fix. cfw's `/api/email/trigger` route posts to `/_functions/queueWelcomeEmail` and `/_functions/queueCartRecovery` via `callVelo({method:'<name>'})`. Wix doesn't auto-route `/_functions/<name>` to a webMethod of the same name (cf-vtx5-class gap), so those calls were always failing — the e2e worked around it via fixture mode (cf-7ozz CI fix, cfw PR #539). This PR adds the explicit Velo wrappers so the route works against real Velo backend.

### `post_queueWelcomeEmail`
Bridges to `triggerWelcomeSeries(email, firstName)` in `emailAutomation.web.js`. Accepts both `{args:[payload]}` (callVelo shape) AND direct payload bodies so the wrapper works either way. 400 if email missing; 500 with errorId on throw.

### `post_queueCartRecovery`
Validates `items[]` shape (productId string + quantity positive number) and stub-accepts with `{success:true, accepted:N}`. The cron-driven `triggerAbandonedCartRecovery` remains the canonical cart-recovery trigger; this is a placeholder until a follow-up bead wires the cfw items hint into AbandonedCarts row enrichment if PM wants active seeding. Honest stub — input validation is rigorous so it won't accept malformed payloads.

## Test plan
- [x] 15/15 in `tests/queueEmailWrappers.cfuwfw.test.js` — happy paths, callVelo `{args}` vs direct-payload acceptance, validation rejections, invalid_json, 500 errorId, options CORS preflight
- [x] 675/675 across the broader email + http test surface (regression check)
- [ ] cfw e2e with `NEXT_PUBLIC_USE_FIXTURE_PRODUCTS=0` passes against real Velo (post Wix CLI publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)