### PR TITLE
fix(cf-lsat): post_trackCustomEvent delegates to webMethod for canonical event names

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -2838,9 +2838,10 @@ export function options_mailingListSignups(request) {
 // ── Public Analytics Event Tracking ─────────────────────────────────────────
 // URL: POST https://www.carolinafutons.com/_functions/trackCustomEvent
 // Receives events from the cfw Next.js host (server components, Server Actions).
-// Mirror of the customEvents/trackCustomEvent webMethod which is unreachable
+// Wraps the customEvents/trackCustomEvent webMethod which is unreachable
 // from external callers (Wix webMethods only run within the Wix site runtime).
-// Rate-limited: 30 events/min per source (matches webMethod limit). cf-3qt.5.3
+// Rate-limited: 30 events/min per source (enforced inside the webMethod).
+// cf-3qt.5.3 (initial wrapper); cf-lsat (delegate to webMethod for parity).
 
 export async function post_trackCustomEvent(request) {
   const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json' });
@@ -2859,36 +2860,44 @@ export async function post_trackCustomEvent(request) {
       return badRequest({ body: JSON.stringify({ success: false, error: 'missing_event_name' }), headers: JSON_HEADERS });
     }
 
-    const cleanName = sanitize(eventName, 100)
-      .replace(/[^a-zA-Z0-9_]/g, '_')
-      .replace(/_+/g, '_')
-      .replace(/^_|_$/g, '')
-      .toLowerCase();
-    if (!cleanName) {
+    // cf-lsat: if the event name sanitises to empty (only special chars),
+    // reject at the boundary. The webMethod doesn't do this — it would happily
+    // record `eventType: ''` — so the wrapper guards it before delegating.
+    if (eventName.replace(/[^a-zA-Z0-9_]/g, '').length === 0) {
       return badRequest({ body: JSON.stringify({ success: false, error: 'invalid_event_name' }), headers: JSON_HEADERS });
     }
 
     const safeParams = params && typeof params === 'object' && !Array.isArray(params) ? params : {};
 
     // Guard: public endpoint — cap payload to prevent unbounded storage writes.
+    // Enforced at the HTTP boundary (the webMethod doesn't size-cap because it
+    // trusts in-runtime callers); 8 KB caps a single event's payload at a
+    // reasonable upper bound for analytics use.
     if (JSON.stringify(safeParams).length > 8192) {
       return badRequest({ body: JSON.stringify({ success: false, error: 'payload_too_large' }), headers: JSON_HEADERS });
     }
 
-    const source = sanitize(String(safeParams.source || 'custom'), 50);
+    // cf-lsat: delegate to the webMethod for single-source-of-truth on event-
+    // name canonicalization (EVENT_NAME_MAP) + rate limiting + AnalyticsEvents
+    // schema. The previous inline implementation drifted from the webMethod —
+    // alias names like `quiz_start` landed raw instead of the canonical
+    // `quiz_started`, polluting the analytics table. Closes the cf-sq0d.fu2
+    // GAP-CFW-WANTS detector signal as a side effect (the webMethod now has a
+    // real symbol-level caller from http-functions.js).
+    const { trackCustomEvent } = await import('backend/customEvents.web');
+    const result = await trackCustomEvent(eventName, safeParams);
 
-    const { checkRateLimit } = await import('backend/utils/rateLimit');
-    const { allowed } = await checkRateLimit('CustomEventRateLimit', source, { max: 30, windowMs: 60_000 });
-    if (!allowed) {
-      return response({ status: 429, body: JSON.stringify({ success: false, error: 'rate_limited' }), headers: JSON_HEADERS });
+    if (result && result.success === false) {
+      // The webMethod returns {success:false} for both rate-limit hits and
+      // missing eventName. Here we know eventName is present (validated above),
+      // so a soft-fail is rate-limit. Surface as 429 so the cfw client can
+      // distinguish from a boundary-reject 400.
+      return response({
+        status: 429,
+        body: JSON.stringify({ success: false, error: 'rate_limited' }),
+        headers: JSON_HEADERS,
+      });
     }
-
-    await insertAnalyticsEvent({
-      memberId: safeParams.memberId || null,
-      eventType: cleanName,
-      source,
-      payload: safeParams,
-    });
 
     return ok({ body: JSON.stringify({ success: true }), headers: JSON_HEADERS });
   } catch (err) {

--- a/tests/trackCustomEvent.http.test.js
+++ b/tests/trackCustomEvent.http.test.js
@@ -61,9 +61,40 @@ describe('post_trackCustomEvent — success', () => {
     expect(row.eventType).toBe('winback_landing_view');
   });
 
-  it('defaults source to "custom" when params has no source', async () => {
+  // cf-lsat: aliases via EVENT_NAME_MAP must canonicalize on the HTTP path.
+  // Pre-cf-lsat, the wrapper sanitized inline (regex only) and skipped the
+  // alias map — so a cfw caller sending "quiz_start" landed it raw instead
+  // of "quiz_started". Now the wrapper delegates to the webMethod, which
+  // applies EVENT_NAME_MAP.
+  it.each([
+    ['quiz_start', 'quiz_started'],
+    ['quiz_complete', 'quiz_completed'],
+    ['email_captured', 'quiz_lead_captured'],
+    ['swatch_request', 'swatch_requested'],
+    ['spin_wheel', 'spin_played'],
+    ['compare_add', 'compare_started'],
+  ])('canonicalizes alias %s → %s via EVENT_NAME_MAP', async (alias, canonical) => {
+    await post_trackCustomEvent(
+      makeRequest(veloBody(alias, { source: 'test' })),
+    );
+    const [row] = __getInserted('AnalyticsEvents');
+    expect(row.eventType).toBe(canonical);
+  });
+
+  // cf-lsat: source defaults to the event's category from CUSTOM_EVENTS
+  // (e.g. quiz_started → quiz) when params.source is absent. Falls back to
+  // 'custom' only when neither a category mapping nor a params.source exists.
+  it('auto-categorises source from CUSTOM_EVENTS when params has no source', async () => {
     await post_trackCustomEvent(
       makeRequest(veloBody('quiz_started', {})),
+    );
+    const [row] = __getInserted('AnalyticsEvents');
+    expect(row.source).toBe('quiz');
+  });
+
+  it('defaults source to "custom" for events outside CUSTOM_EVENTS taxonomy', async () => {
+    await post_trackCustomEvent(
+      makeRequest(veloBody('one_off_smoke_test', {})),
     );
     const [row] = __getInserted('AnalyticsEvents');
     expect(row.source).toBe('custom');


### PR DESCRIPTION
## Summary
- \`post_trackCustomEvent\` now delegates to \`backend/customEvents.web.trackCustomEvent\` instead of inline-reimplementing the validation/insert path
- Fixes a real data-quality bug: cfw callers sending alias names like \`quiz_start\` were landing them raw in AnalyticsEvents instead of canonical \`quiz_started\` (EVENT_NAME_MAP wasn't applied on the HTTP path)
- Closes the cf-sq0d.fu2 GAP-CFW-WANTS detector signal as a side effect

## Background
The wrapper was added in cf-3qt.5.3 but inline-implemented validation + sanitization rather than calling the webMethod. The two paths drifted:

| Path | Sanitization | Alias canonicalization | Source auto-cat |
|---|---|---|---|
| webMethod (Velo-internal callers) | regex + EVENT_NAME_MAP | ✓ | ✓ via CUSTOM_EVENTS taxonomy |
| HTTP wrapper (cfw callers) | regex only | ✗ | ✗ — defaulted to \`'custom'\` |

So a cfw call to \`trackCustomEvent('quiz_start', {})\` landed:
- eventType: \`quiz_start\` (should be \`quiz_started\`)
- source: \`custom\` (should be \`quiz\`)

Bug surfaces in: winback page view, quiz lifecycle (started/completed/lead-captured), and any future cfw caller using the convenience aliases.

## Fix
HTTP-boundary guards retained:
- \`invalid_json\` (parse failure)
- \`missing_event_name\` (args[0] missing or non-string)
- \`payload_too_large\` (>8 KB params)
- \`invalid_event_name\` **NEW** (name sanitises to empty — the webMethod would silently accept \`eventType: ''\`)

After validation, delegates to the webMethod. Soft-fail surfaces as 429 \`rate_limited\` (only soft-fail path remaining since boundary catches missing-name).

## Tests
- 6 new \`it.each\` cases pinning EVENT_NAME_MAP canonicalization on the HTTP path (\`quiz_start\` → \`quiz_started\` etc.)
- Source-default test split into two: auto-categorise when in CUSTOM_EVENTS, fall back to \`'custom'\` for one-off events
- 23/23 \`trackCustomEvent.http.test.js\`, 125/125 \`customEvents.test.js\` + \`httpFunctionsCoverage.test.js\` still pass

## No Vercel impact
cfutons-only change. cfw's existing \`src/lib/wix/custom-events.ts\` helper is unchanged — it already calls \`/_functions/trackCustomEvent\` correctly. Only the Velo-side handling improves.

## Refs
Bead: cf-lsat. Surfaced by cf-sq0d.fu2 detector v3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)