### PR TITLE
chore(cf-trm0): route 4 residual queue sites through resolveContactId helper

### DIFF
--- a/src/backend/analyticsDigest.web.js
+++ b/src/backend/analyticsDigest.web.js
@@ -11,6 +11,7 @@ import wixData from 'wix-data';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { CUSTOM_EVENTS } from 'backend/customEvents.web';
 import { ANALYTICS_EVENTS_COLLECTION } from 'backend/utils/analyticsEvents';
+import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 
 const ORDERS_COLLECTION = 'Stores/Orders';
 const TOP_PRODUCTS_LIMIT = 5;
@@ -160,11 +161,19 @@ export const sendWeeklyDigestEmail = webMethod(
       const html = buildDigestEmailHtml(digest);
       const subject = `Weekly Analytics Digest — ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
 
+      // cf-trm0: resolve contactId before queueing — skip if helper can't
+      // resolve so processQueue doesn't reject the row at dispatch time.
+      const digestContactId = await _resolveContactIdInternal(recipient);
+      if (!digestContactId) {
+        console.error('[analyticsDigest] sendWeeklyDigestEmail: resolveContactId returned null for', recipient);
+        return { success: false, error: 'Failed to resolve CRM contact for digest email' };
+      }
+
       // Queue the email
       await wixData.insert('EmailQueue', {
         templateId: 'analytics_digest',
         recipientEmail: recipient,
-        recipientContactId: '',
+        recipientContactId: digestContactId,
         variables: JSON.stringify({ subject, html }),
         sequenceType: 'analytics_digest',
         sequenceStep: 1,

--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -1005,6 +1005,16 @@ export const triggerAbandonedCartRecovery = webMethod(
         const cartTotalNum = Number(cart.cartTotal) || 0;
         const qualifiesForFreeShipping = cartTotalNum >= CART_FREE_SHIPPING_THRESHOLD;
 
+        // cf-trm0: resolve contactId once for all cart_recovery steps. Same
+        // pattern as cartRecovery.web.js webMethod path (PR #1236) — skip the
+        // entire cart if the helper can't resolve so we don't queue rows
+        // that processQueue would reject for missing contactId.
+        const cartContactId = await _resolveContactIdInternal(cartEmail);
+        if (!cartContactId) {
+          console.warn('[emailAutomation] cart_recovery: resolveContactId returned null for', cartEmail, '— skipping cart', cart.checkoutId);
+          continue;
+        }
+
         for (const step of SEQUENCES.cart_recovery.steps) {
           const scheduledFor = new Date(abandonedAt.getTime() + step.delayHours * 60 * 60 * 1000);
 
@@ -1056,7 +1066,7 @@ export const triggerAbandonedCartRecovery = webMethod(
           await queueEmail({
             templateId: step.templateId,
             recipientEmail: cartEmail,
-            recipientContactId: '',
+            recipientContactId: cartContactId,
             variables,
             sequenceType: 'cart_recovery',
             sequenceStep: step.step,
@@ -2173,12 +2183,20 @@ export async function checkAndTriggerTierMilestone(memberId, email, firstName, n
 
       if (alreadySent) continue;
 
+      // cf-trm0: resolve contactId before queueing — skip this milestone if
+      // the helper can't resolve so processQueue doesn't reject the row.
+      const milestoneContactId = await _resolveContactIdInternal(cleanEmail, cleanName);
+      if (!milestoneContactId) {
+        console.warn('[emailAutomation] tier_milestone: resolveContactId returned null for', cleanEmail, '— skipping', milestone.milestoneKey);
+        continue;
+      }
+
       // Queue email
       try {
         await wixData.insert('EmailQueue', {
           templateId: milestone.templateId,
           recipientEmail: cleanEmail,
-          recipientContactId: '',
+          recipientContactId: milestoneContactId,
           variables: {
             firstName: cleanName,
             currentPoints: newTotal,

--- a/src/backend/newsletterService.web.js
+++ b/src/backend/newsletterService.web.js
@@ -22,6 +22,7 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 
 const DISCOUNT_CODE = 'WELCOME10';
 const KLAVIYO_API_BASE = 'https://a.klaviyo.com/api';
@@ -485,6 +486,18 @@ export const captureExitIntentEmail = webMethod(
         return { success: false, message: 'Too many requests. Please try again later.' };
       }
 
+      // cf-trm0: resolve contactId once before queueing the welcome
+      // series. Stage3-velo's exitIntentCapture.js still calls this entry
+      // point (cfutons routes through subscribeToNewsletter → resolveContactId
+      // post-cf-3l0d, but stage3 hasn't caught up yet). Helper returns null
+      // on validation/CRM upstream failure — surface as the same caller-
+      // facing failure shape so the popup can retry/show error.
+      const exitContactId = await _resolveContactIdInternal(cleaned);
+      if (!exitContactId) {
+        console.error('[newsletterService] captureExitIntentEmail: resolveContactId returned null for', cleaned);
+        return { success: false, message: 'Failed to resolve CRM contact for welcome email' };
+      }
+
       // Queue all 3 welcome series steps into EmailQueue
       const now = new Date();
       for (const step of WELCOME_STEPS) {
@@ -492,7 +505,7 @@ export const captureExitIntentEmail = webMethod(
         await wixData.insert('EmailQueue', {
           templateId: step.templateId,
           recipientEmail: cleaned,
-          recipientContactId: '',
+          recipientContactId: exitContactId,
           variables: {
             discountCode: DISCOUNT_CODE,
             email: cleaned,

--- a/tests/emailAutomationDeepen.test.js
+++ b/tests/emailAutomationDeepen.test.js
@@ -3,7 +3,15 @@ import { __seed, __reset, __onInsert, __onUpdate } from './__mocks__/wix-data.js
 
 vi.mock('wix-crm-backend', () => ({
   triggeredEmails: { emailContact: vi.fn(async () => ({})) },
-  contacts: { queryContacts: vi.fn() },
+  // cf-trm0: cart_recovery cron + tier_milestone now resolve contactId
+  // before queueing via _resolveContactIdInternal → appendOrCreateContact.
+  // Mock returns a deterministic id so the cart-iteration path proceeds.
+  contacts: {
+    queryContacts: vi.fn(),
+    appendOrCreateContact: vi.fn(async (info) => ({
+      contactId: `contact-${info?.emails?.[0]?.email || 'unknown'}`,
+    })),
+  },
 }));
 
 vi.mock('wix-secrets-backend', () => ({


### PR DESCRIPTION
## Summary
Pass-3 cleanup for the residual empty-string \`recipientContactId\` queue sites that were intentionally left out of cf-xdji item-2 sweep (PR #1236). Same shape as that prior sweep: import \`_resolveContactIdInternal\`, resolve contactId BEFORE the queue insert, skip queueing (warn log + early return / continue) if the helper returns null.

## Sites refactored

| # | File | Path | Action |
|---|---|---|---|
| 1 | \`emailAutomation.web.js\` | \`triggerAbandonedCartRecovery\` cron (~L1047) | Resolve once before steps loop; \`continue\` skips entire cart (3 rows) if null |
| 2 | \`emailAutomation.web.js\` | \`checkAndTriggerTierMilestone\` (~L2166) | Resolve with \`cleanEmail\`+\`cleanName\`; \`continue\` skips milestone if null |
| 3 | \`newsletterService.web.js\` | \`captureExitIntentEmail\` (~L453) | Resolve once before WELCOME_STEPS loop; return \`{success: false, message}\` if null |
| 4 | \`analyticsDigest.web.js\` | \`sendWeeklyDigestEmail\` (~L167) | Resolve before single insert; return \`{success: false, error}\` if null |

## Site 3 — refactor vs. delete decision
Per bead: "audit then either refactor to use the helper OR delete if no remaining production callers." Cfutons \`exitIntentCapture.js\` no longer calls \`captureExitIntentEmail\` (post-cf-3l0d auto-trigger via subscribeToNewsletter), but **stage3-velo's \`exitIntentCapture.js:209\` still imports + invokes it**. Refactored rather than deleted to keep the next monorepo→stage3 publish from breaking the popup welcome flow on stage3.

## Helper-import note
\`emailAutomation.web.js\` already imported \`_resolveContactIdInternal\` at line 45 for an existing call site — sites 1+2 just needed the extra usages. \`newsletterService.web.js\` and \`analyticsDigest.web.js\` got the import added at the top of the imports block.

## Acceptance (from bead)
- [x] All 4 sites resolve contactId via the helper
- [x] No EmailQueue rows insert with \`recipientContactId: ''\` — verified with a final \`grep -rE "recipientContactId:\s*['\"]['\"]"\` sweep across \`src/\`. Only hit is a docstring in \`contactResolver.web.js:13\` (describing the old pattern the helper replaces) — not a queue insert.
- [x] Existing tests pass at all touched files
- [x] No webMethod surface change → cf-hpwy v3.2 buckets unaffected

## Test changes
\`tests/emailAutomationDeepen.test.js\` — extended the file's inline \`vi.mock('wix-crm-backend', ...)\` to add a \`contacts.appendOrCreateContact\` mock returning \`{contactId: 'contact-<email>'}\`. Required because site 1's new helper call resolves through CRM at runtime; without the mock, 2 cart_recovery edge-case tests skipped the cart and expected-3-inserts assertions failed.

The 8 other \`emailAutomation*.test.js\` files use the **global** \`tests/__mocks__/wix-crm-backend.js\` (which already exports \`appendOrCreateContact\`) — pass as-is. Newsletter + analyticsDigest test suites either already mock the helper or use the global mock — all pass.

## Diff
**+48 LOC net** across 4 files (53 insertions, 5 deletions). Each webMethod site +~10 LOC for helper call + null-skip block; test mock +6 LOC.

## Test plan
- [x] Targeted vitest on 11 affected test files: **456/456 pass**
- [x] Full vitest: **38,468 / 38,530 pass**

> 3 pre-existing emailServiceCoverage.test.js failures from PR #1239 + #1243 TEMPLATE_ID_MAP interaction — same flakes flagged in cf-ivpn PR #1250 description. Reproduces on origin/main without my changes; not in cf-trm0 scope.

## Cross-rig
Stage3-velo mirrors all 3 modified backend files. Next monorepo→stage3 publish picks up the new behavior; stage3 already has \`_resolveContactIdInternal\` helper post-PR #1231 sync.

Closes cf-trm0.
Refs cf-xdji.fu (PR #1231 helper), cf-xdji.fu2, PR #1236 (item-2 sweep), cf-icww F1.