### PR TITLE
test(cf-4x7e.fu1): polish — regex caveat + parser sanity

### DIFF
--- a/progress-report.md
+++ b/progress-report.md
@@ -1,5 +1,13 @@
 # CF Project Progress Report
-**Auto-refreshed every 10 min | Last updated: 2026-05-10 03:20 MT**
+**Auto-refreshed every 10 min | Last updated: 2026-05-10 03:35 MT**
+
+## Session 2026-05-10 — Wave 22
+| Done | Detail |
+|------|--------|
+| ✅ cfutons PR #1259 MERGED | fix/cf-4x7e-fu1: jobs.config orphans fixed (4 broken crons) + jobsConfigIntegrity.test.js (22 tests). test(20)+test(22) PASS. |
+| ✅ cfutons PR #1260 MERGED | cf-3pwy: Wix Stores V1/V3 audit doc — clean V1/V3 boundary. cf-3pwy closed. |
+| ⏳ PR #540 (cfw) | ALL CI GREEN incl. e2e 6s pass. BLOCKED: Stilgar AM visual confirm → batch window. |
+| 📦 Batch queue (7 PRs) | morgott cf-641x, miquella cf-bbo8, jasper cf-ceex, obsidian cf-e55k, onyx cf-nm6p, opal cf-zmsq, quartz cf-mu05. All holding locally. |
 
 ## Session 2026-05-10 — Wave 21
 | Done | Detail |

--- a/tests/jobsConfigIntegrity.test.js
+++ b/tests/jobsConfigIntegrity.test.js
@@ -30,6 +30,12 @@ const BACKEND_DIR = resolve(REPO_ROOT, 'src/backend');
 
 function parseJobsConfig() {
   const text = readFileSync(JOBS_CONFIG_PATH, 'utf8');
+  // Matches `<key>: { functionLocation: '/file.web.js'`. Captures the cron
+  // entry name + the `functionLocation` path. Requires `functionLocation`
+  // to be the FIRST line inside the `{` — a future entry that puts
+  // `description` first would silently slip past validation. Verified
+  // safe today by the entry-count sanity check below + the existing
+  // jobs.config style.
   const re = /^\s*(\w+):\s*\{\s*\n\s*functionLocation:\s*['"](\/[^'"]+)['"]/gm;
   const out = [];
   let m;
@@ -39,10 +45,25 @@ function parseJobsConfig() {
   return out;
 }
 
+// Sanity floor — independent of the integrity assertions, this catches a
+// future jobs.config refactor that breaks the parser regex (entries written
+// in a different shape would yield 0 hits, integrity tests would silently
+// pass with no entries scanned, and a deletion regression could escape).
+function countJobsConfigEntriesCheap() {
+  const text = readFileSync(JOBS_CONFIG_PATH, 'utf8');
+  // Count `functionLocation:` lines — every entry has exactly one.
+  return (text.match(/^\s*functionLocation:/gm) || []).length;
+}
+
 function fileHasExport(filePath, exportName) {
   if (!existsSync(filePath)) return false;
   const src = readFileSync(filePath, 'utf8');
   const escaped = exportName.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  // Matches `export const NAME =`, `export function NAME`, `export async
+  // function NAME`. Does NOT match named-export blocks (`export { NAME }`)
+  // or re-exports (`export { NAME } from './foo'`) — no cron currently
+  // points at those forms, so a future re-exported cron target would
+  // false-fail this test. Extend the alternation if/when that lands.
   const re = new RegExp(`^export\\s+(?:async\\s+)?(?:const|function)\\s+${escaped}\\b`, 'm');
   return re.test(src);
 }
@@ -52,6 +73,13 @@ describe('jobs.config — every cron entry resolves to a real export', () => {
 
   it('found at least one cron entry (sanity)', () => {
     expect(entries.length).toBeGreaterThan(5);
+  });
+
+  it('parser caught every functionLocation: line — no entries silently dropped', () => {
+    // Detects a regex regression where entries are written in a shape the
+    // primary regex doesn't match (e.g. `description` placed before
+    // `functionLocation`). pr-test-analyzer #2.
+    expect(entries.length).toBe(countJobsConfigEntriesCheap());
   });
 
   for (const { name, location } of entries) {


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #1259 (merged as a2bb5e48) folding the non-blocking review polish that 4 of the 5 review agents flagged. Filed separately because PR #1259 merged before I could amend.

| Change | Reviewer source |
|---|---|
| Inline comment on `fileHasExport` regex documenting that `export { NAME }` named-export blocks and re-exports are NOT matched (no cron currently uses those forms; latent gap if a future cron target is re-exported) | silent-failure-hunter MEDIUM + code-reviewer + pr-test-analyzer |
| New `countJobsConfigEntriesCheap()` + parser-sanity test asserting the primary regex caught every `functionLocation:` line — detects a future jobs.config refactor that breaks the parser shape | pr-test-analyzer #2 |
| Inline comment on `parseJobsConfig` regex documenting the "first line after `{`" requirement | code-simplifier optional |

23 tests now (was 22).

## Deferred — for separate beads (also flagged in PR #1259 reviews)

- **HIGH**: file a tracking bead for re-adding `dailySocialStories` + `dailyContentRotation` once a replacement scheduler lands (silent-failure-hunter).
- **HIGH**: cron observability gap — white-glove SMS reminders were dark for 6 weeks (CF-rjxq merged 2026-03-29 → cf-4x7e audit 2026-05-10) with no observability hook. Suggest a separate cron-emit-success-metric bead. silent-failure-hunter CRITICAL.

## Test plan
- [x] `vitest run tests/jobsConfigIntegrity.test.js` — 23/23 pass
- [x] No production behavior change — test-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)