### PR TITLE
feat(cf-khqd): add concurrency cancel-in-progress to cfutons ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ on:
 permissions:
   contents: read
 
+# cf-khqd: cancel in-progress runs on the same branch when a new push lands.
+# Force-pushes / fixup commits on a feature branch leave the prior CI run
+# orphan; without this, both runs compete for runners + Vercel preview build
+# slots. `github.ref` keys per branch (PR or main), so concurrent PRs run
+# fully in parallel — only same-branch successive pushes cancel the old.
+# Main pushes are also covered: a quick succession of merges lands only one
+# CI run for the latest sha (squash-merge equivalent).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Unit Tests ───────────────────────────────────────────────────────────────
   # Runs Vitest across Node 20 + 22 matrix. On Node 22: also collects coverage


### PR DESCRIPTION
## Summary

Adds GitHub Actions `concurrency` group to cfutons `ci.yml` to cancel in-progress runs when a new push lands on the same branch. Force-pushes / fixup commits on feature branches otherwise leave orphan runs competing for runner capacity.

## Diff

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

Group key is `ci-${{ github.ref }}`:
- **Per-branch isolation** — concurrent PRs still run fully in parallel
- **Same-branch successive pushes** — prior run cancels, new run starts
- **Main pushes** — a quick succession of squash-merges lands only one CI run for the latest sha

## Matrix parallelism — bead hypothesis was wrong

The bead asked to "make test(20)/test(22) parallel via `matrix.shard`". Investigated: the existing `strategy.matrix.node-version: [20, 22]` already runs the two jobs **in parallel by default** — GitHub Actions matrix entries spawn concurrently unless `max-parallel` caps them, and there's no cap here. Same shape as the cf-qmxf finding (morgott earlier today proved the e2e queue-saturation hypothesis was also wrong; jobs were just being canceled). **No matrix change needed.**

Vitest test-file sharding (the more aggressive variant: split test files across N shards × M Node versions) is NOT in this PR. That's a separate optimization that risks file-discovery surprises with 1100+ existing test files. If wall-clock time becomes a real bottleneck, file a follow-up bead.

## cfw repo — deferred per cf-ukc6

Per Stilgar's overnight build-conservation directive, the same concurrency change to `carolina-futons-web/.github/workflows/ci.yml` is deferred to the next cfw merge window — adding it now would be one Vercel build burn for a non-customer-facing infra change. Tracked in cf-khqd note.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` — clean
- [x] `concurrency` block placed before `jobs:` per GitHub Actions schema
- [x] Workflow file diff is +11 insertions, no other lines changed
- [ ] Next push to a same-branch PR cancels the prior run (observable via `gh run list` showing `cancelled` for the prior run)

cfutons-only, no Vercel impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)