### PR TITLE
chore(cf-dbw9): add *.pem + *.key to .gitignore (security hardening)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ jsconfig.json
 *.conf
 *.env
 *.secret
+*.pem
+*.key
 credentials*
 coverage/
 


### PR DESCRIPTION
## Bead
cf-dbw9 (P2, BUG) — security audit follow-up from cf-1vov LOW finding.

## Source
cf-1vov security audit (radahn 2026-05-09) flagged that the existing `*.secret` / `*.env` / `*.conf` / `credentials*` patterns cover most committed-secret cases but pem/key files (TLS certs, SSH keys, signing keys) would slip past on a future drop-by-mistake.

## Diff
Two-line addition to `.gitignore`:

```
*.pem
*.key
```

## Verification
`git ls-files "*.pem" "*.key"` returns nothing — no tracked .pem or .key files exist in the repo today, so this is purely forward-looking. No `git rm --cached` needed.

## Scope
Pure-additive. Affects nothing currently tracked. No CI/test impact. No build impact.

## Related cf-dbw9 follow-ups (separate PRs)
- cfw dependabot security updates: ✅ ENABLED via `gh api -X PUT vulnerability-alerts` (no PR needed)
- HIGH cfw branch protection on main: pending melania approval before push
- MEDIUM cfutons branch protection enforce_admins flip: pending mayor approval
- MEDIUM cfutons d3-color + @tootallnate/once dependabot triage: separate work
- LOW cfutons `.dolt-data/.doltcfg/` gitignore + `git rm --cached`: pending mayor confirm (may be intentional Gas Town pattern)