### PR TITLE
feat(cf-ra41): extend concurrency cancel-in-progress to 3 remaining workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,14 @@ permissions:
   contents: read
   security-events: write
 
+# cf-ra41: cancel stale CodeQL scans when a new push lands on the same ref.
+# CodeQL scans take ~5min each; force-push iteration leaves the prior scan
+# running uselessly while the new one boots. Group key includes the workflow
+# name so other workflows' concurrency groups don't collide.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze JavaScript

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# cf-ra41: same-PR successive pushes cancel the older labeler run. Lightweight
+# but keeps the workflow consistent with ci.yml/codeql.yml/coverage-ratchet.yml.
+concurrency:
+  group: labeler-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Path-based labels from .github/labeler.yml
   label:

--- a/.github/workflows/velo-smoke.yml
+++ b/.github/workflows/velo-smoke.yml
@@ -37,6 +37,14 @@ permissions:
   contents: read
   issues: write
 
+# cf-ra41: cancel stale velo-smoke runs on the same ref. The smoke script
+# hits 5 external Wix /_functions endpoints; concurrent runs double the
+# external rate-limit pressure for no extra signal. Group key per-workflow
+# so this doesn't collide with ci/codeql/labeler/etc on shared refs.
+concurrency:
+  group: velo-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Extends the cf-khqd `concurrency` pattern (PR #1265) from `ci.yml` to the three remaining cfutons workflows that lacked it: `codeql.yml`, `labeler.yml`, `velo-smoke.yml`.

## Why each

| Workflow | Concrete win |
| --- | --- |
| `codeql.yml` | ~5min per scan. Force-push iter on a PR leaves the prior scan running uselessly while the new one boots — pure CI-minute waste. |
| `velo-smoke.yml` | Hits 5 external Wix `/_functions` endpoints per run. Concurrent runs double the external rate-limit pressure for no additional signal. |
| `labeler.yml` | Lightweight, but consistency win — every workflow on the same concurrency model. |

## Group keys

Workflow-distinct: `codeql-${ref}`, `velo-smoke-${ref}`, `labeler-${ref}` — prevents collisions across files when refs match.

## Coverage post-PR

```
✓ ci.yml              (cf-khqd, PR #1265)
✓ codeql.yml          (this PR)
✓ coverage-ratchet.yml (prior work)
✓ labeler.yml         (this PR)
✓ merge-guard.yml     (cf-r1cl, PR #1201)
✓ velo-smoke.yml      (this PR)
```

All 6 workflows on the same model.

## Constraints

- cfutons-only — no Vercel impact, passes cf-ukc6
- 22 insertions, 0 deletions

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` clean for all 3 modified files
- [ ] Post-merge: force-push to a draft PR, confirm older runs cancel rather than completing in parallel
- [ ] Post-merge: verify nightly velo-smoke still fires (cron unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)