### PR TITLE
docs(cf-3qt.8.31): UptimeRobot activation handoff — status PENDING_KEY

### DIFF
--- a/monitoring-setup.md
+++ b/monitoring-setup.md
@@ -1,9 +1,32 @@
-# Uptime Monitoring — cf-3qt.8.3
+# Uptime Monitoring — cf-3qt.8.3 + cf-3qt.8.31
 
-**Service:** UptimeRobot (free tier)  
-**Target:** carolinafutons.com  
-**Alert email:** carolinafutons@gmail.com  
-**Status:** Awaiting API key — run `scripts/setup-monitors.sh` once key is added to secrets.env
+**Service:** UptimeRobot (free tier)
+**Target:** carolinafutons.com (post-cutover) / `https://carolina-futons-web.vercel.app` (pre-cutover preview)
+**Alert email:** carolinafutons@gmail.com
+**Status:** **PENDING_KEY** — engineering side complete, blocked on Stilgar UptimeRobot account creation. Cloudflare Turnstile gates the signup so headless / programmatic creation is not possible.
+
+> **Endpoint:** `/api/health` ships in cfw PR #554 (cf-x6ph + cf-x0ks). Schema:
+> `{ status: 'ok', uptime: <int>, commit: <sha>, ts: <ISO> }` with
+> `Cache-Control: no-store`. UptimeRobot keyword check on `"ok"` will match.
+> 9 unit tests pin the contract. Full ops runbook at
+> `carolina-futons-web/docs/monitoring-runbook.md` (lands with PR #554).
+
+## Activation handoff to Stilgar
+
+To activate monitoring (cf-3qt.8.31 acceptance):
+
+1. **Stilgar:** sign up at https://uptimerobot.com using `carolinafutons@gmail.com` (resolves the Turnstile gate).
+2. **Stilgar:** Profile → API Settings → **Create Main API Key** → copy.
+3. **Stilgar OR godfrey:** add to `/Users/hal/gt/cfutons/refinery/rig/scripts/secrets.env`:
+   ```
+   UPTIMEROBOT_API_KEY=ur1234567-...
+   UPTIMEROBOT_ALERT_CONTACT_ID=<see step 4 below>
+   ```
+   **Never commit secrets.env.**
+4. **Stilgar OR godfrey:** Dashboard → **My Settings → Alert Contacts** → confirm `carolinafutons@gmail.com` is verified (it auto-creates from the signup email; the contact ID is the integer in the row's edit URL).
+5. **godfrey:** ETA <10 min from key delivery — runs `bash scripts/setup-monitors.sh`, verifies 4 monitors live, fires the mis-config alert test (§4 of `carolina-futons-web/docs/monitoring-runbook.md`), commits this doc with `Status: LIVE` + monitor IDs to main.
+
+The setup script is ready (`scripts/setup-monitors.sh`) and gated on `UPTIMEROBOT_API_KEY:?` so it errors loudly if the key is missing.
 
 ---
 
@@ -91,4 +114,4 @@ UptimeRobot free includes a public status page. After setup, enable at:
 
 ---
 
-*Setup scripted by miquella for cf-3qt.8.3. Awaiting UPTIMEROBOT_API_KEY in secrets.env to run.*
+*Setup scripted by miquella for cf-3qt.8.3. cf-3qt.8.31 (godfrey 2026-05-10): doc updated with current status + Stilgar handoff. Mayor escalation `hq-wisp-wgxbf` filed for the API-key block. Endpoint contract documented in `carolina-futons-web/docs/monitoring-runbook.md` (cfw PR #554).*


### PR DESCRIPTION
## Summary

cf-3qt.8.31 doc-completion path per melania 2026-05-10 ("Reply when UptimeRobot PR filed or doc completed"). Engineering side is done; the remaining step is gated on Stilgar's manual UptimeRobot signup (Cloudflare Turnstile blocks any headless/programmatic path).

## Doc changes

- **Status header**: "Awaiting API key" → **PENDING_KEY** with explicit Turnstile note.
- **New "Activation handoff to Stilgar" section**: 5-step play-by-play attributing each step to Stilgar vs godfrey so the dependency is unambiguous.
- **Cross-link to PR #554** (cfw): `/api/health` endpoint contract (schema `{status, uptime, commit, ts}` + Cache-Control: no-store + 9 unit tests + ops runbook).
- Footer cites mayor escalation `hq-wisp-wgxbf` for the API-key block.

## Activation ETA after Stilgar drops the key

<10 min: godfrey runs `scripts/setup-monitors.sh`, verifies 4 monitors live, fires mis-config alert test, re-commits this doc flipping `PENDING_KEY` → `LIVE` with the 4 monitor IDs.

## Test plan
- [x] No production behavior change — doc-only, cfutons (no Vercel cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)