### PR TITLE
chore(cf-q5hd): trim previewWeeklyBlogDigest from blogDigestService.web.js (cf-hpwy v3)

### DIFF
--- a/src/backend/blogDigestService.web.js
+++ b/src/backend/blogDigestService.web.js
@@ -126,43 +126,6 @@ export const sendWeeklyBlogDigest = webMethod(
 );
 
 /**
- * Preview what this week's digest would include without sending.
- *
- * @function previewWeeklyBlogDigest
- * @param {number} [lookbackDays=7]
- * @returns {Promise<{success: boolean, posts?: Array, subscriberCount?: number, weekLabel?: string, alreadySent?: boolean, error?: string}>}
- * @permission Admin
- */
-export const previewWeeklyBlogDigest = webMethod(
-  Permissions.Admin,
-  async (lookbackDays = 7) => {
-    try {
-      const safeDays = Math.max(1, Math.min(30, Math.floor(lookbackDays)));
-      const since = new Date(Date.now() - safeDays * 24 * 60 * 60 * 1000);
-      const weekOf = getWeekStart(new Date());
-
-      const alreadySent = await wixData.query('BlogDigestLog')
-        .ge('weekOf', weekOf)
-        .find();
-
-      const recentPosts = await fetchRecentPosts(since);
-      const subscribers = await fetchActiveSubscribers();
-
-      return {
-        success: true,
-        posts: recentPosts.map(normalizePostForEmail),
-        subscriberCount: subscribers.length,
-        weekLabel: formatWeekLabel(since, new Date()),
-        alreadySent: alreadySent.items.length > 0,
-      };
-    } catch (err) {
-      logError('blogDigestService.previewWeeklyBlogDigest', err);
-      return { success: false, error: err.message };
-    }
-  }
-);
-
-/**
  * Fetch up to MAX_POSTS_FETCH posts from the blog API, filter to those published
  * on or after `since`, sort newest-first, then slice to MAX_POSTS_IN_DIGEST.
  * @param {Date} since

--- a/tests/blogDigestService.test.js
+++ b/tests/blogDigestService.test.js
@@ -1,5 +1,5 @@
 // blogDigestService.test.js — CF-e3yo: Blog → newsletter automation weekly digest
-// Covers: sendWeeklyBlogDigest, previewWeeklyBlogDigest, helper functions.
+// Covers: sendWeeklyBlogDigest + helper functions.
 import { describe, it, expect, beforeEach } from 'vitest';
 import { __reset, __seed, __onInsert, __setInsertError } from 'wix-data';
 import { __reset as blogReset, __setPosts } from 'wix-blog-backend';
@@ -8,7 +8,6 @@ import { get_weeklyBlogDigestCron } from '../src/backend/http-functions.js';
 
 import {
   sendWeeklyBlogDigest,
-  previewWeeklyBlogDigest,
   _DIGEST_TEMPLATE,
   _SEQUENCE_TYPE,
   _SITE_URL,
@@ -368,60 +367,6 @@ describe('sendWeeklyBlogDigest — error handling', () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Blog API unavailable/);
     expect(result.queued).toBe(0);
-  });
-});
-
-// ── previewWeeklyBlogDigest ───────────────────────────────────────────
-
-describe('previewWeeklyBlogDigest', () => {
-  it('returns posts and subscriber count without sending', async () => {
-    __setPosts([makePost()]);
-    __seed('NewsletterSubscribers', [
-      { _id: 'sub-1', email: 'alice@example.com', status: 'active' },
-      { _id: 'sub-2', email: 'bob@example.com', status: 'active' },
-    ]);
-
-    const inserted = makeInsertSpy();
-
-    const result = await previewWeeklyBlogDigest();
-
-    expect(result.success).toBe(true);
-    expect(result.posts).toHaveLength(1);
-    expect(result.subscriberCount).toBe(2);
-    expect(result.alreadySent).toBe(false);
-    expect(inserted.filter(i => i._coll === 'EmailQueue')).toHaveLength(0);
-  });
-
-  it('reports alreadySent=true when log exists for this week', async () => {
-    __setPosts([makePost()]);
-    __seed('BlogDigestLog', [
-      { _id: 'log-1', weekOf: _getWeekStart(new Date()), sentAt: new Date() },
-    ]);
-
-    const result = await previewWeeklyBlogDigest();
-
-    expect(result.success).toBe(true);
-    expect(result.alreadySent).toBe(true);
-  });
-
-  it('includes weekLabel in preview', async () => {
-    __setPosts([makePost()]);
-
-    const result = await previewWeeklyBlogDigest();
-
-    expect(result.weekLabel).toBeDefined();
-    expect(typeof result.weekLabel).toBe('string');
-    expect(result.weekLabel.length).toBeGreaterThan(0);
-  });
-
-  it('returns success=false on error', async () => {
-    const { __setListError } = await import('wix-blog-backend');
-    __setListError(new Error('oops'));
-
-    const result = await previewWeeklyBlogDigest();
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Bead
cf-q5hd (P3, task) — sibling cf-4x7e Pass-3 chunk under cf-567r umbrella (PR #1283).

## Why
cf-hpwy v3 audit (2026-05-10) flagged `previewWeeklyBlogDigest` (src/backend/blogDigestService.web.js:136) as `UNUSED-CAN-DELETE`. Caller verification:
- `import .* previewWeeklyBlogDigest` in src/: zero hits
- http-functions.js wrappers: zero
- events.js / *.events.js: zero
- Test refs: only tests/blogDigestService.test.js (import + 1 describe block)

`sendWeeklyBlogDigest` (sibling export at line 45) is **alive** — wired through http-functions.js `get_weeklyBlogDigestCron` at line 2620. This PR is a **TRIM**, not a full file delete.

## Edits (2 files)
- `src/backend/blogDigestService.web.js`: drop the JSDoc + export block for previewWeeklyBlogDigest (~36 LOC).
- `tests/blogDigestService.test.js`: drop previewWeeklyBlogDigest from the import + delete the describe block (~54 LOC) + update file-header coverage comment.

Net diff: 1 insertion, 93 deletions, 0 file deletes.

## Tests
- `tests/blogDigestService.test.js`: **40 passed** (was 44; the 4 preview tests removed cleanly; sendWeeklyBlogDigest + helper coverage unchanged).
- Spot-check siblings (blogNewsletterDeep, blogRssNewsletterCoverage): **77 passed** unchanged.

## Pattern
Same shape as cf-567r. Two more cf-hpwy v3 UNUSED-CAN-DELETE candidates remain in blogNewsletter.web.js (notifySubscribersOfNewPost + previewBlogNewsletter + getBlogNewsletterStatus — 3 dead methods, likely full-file delete). Not bundled here to keep scope tight; melania's call on whether to file as the next sibling chunk.