### PR TITLE
fix(cf-za1o): RegistryPurchaseRateLimit keyed per-buyer-per-item — F3 fix

### DIFF
--- a/src/backend/giftRegistry.web.js
+++ b/src/backend/giftRegistry.web.js
@@ -378,7 +378,13 @@ export const markItemPurchased = webMethod(Permissions.Anyone, async (itemId, da
     });
     if (schemaErrors.length > 0) return { success: false, error: schemaErrors[0] };
 
-    const { allowed } = await checkRateLimit('RegistryPurchaseRateLimit', itemId);
+    // cf-za1o (cf-3ldu F3): rate-limit by buyer+item, not item alone.
+    // The previous itemId-only key meant 3 buyers total could claim
+    // any given registry item per hour — a legitimate baby shower
+    // with multiple attendees would block the 4th+ buyer.
+    const rlBuyer = sanitize(data?.buyerName || 'anonymous', 50).toLowerCase();
+    const rlKey = `${rlBuyer}:${itemId}`;
+    const { allowed } = await checkRateLimit('RegistryPurchaseRateLimit', rlKey);
     if (!allowed) return { success: false, error: 'Too many requests. Please try again later.' };
 
     const item = await wixData.get('GiftRegistryItems', itemId);

--- a/tests/giftRegistry.test.js
+++ b/tests/giftRegistry.test.js
@@ -427,6 +427,39 @@ describe('markItemPurchased', () => {
     const result = await markItemPurchased('i-1', null);
     expect(result.success).toBe(false);
   });
+
+  // cf-za1o (cf-3ldu F3): rate-limit must be keyed per-buyer-per-item,
+  // not per-item alone. Multiple legitimate buyers should each be able
+  // to claim the same item without blocking each other.
+  it('rate-limit allows different buyers to claim the same item', async () => {
+    __seed('GiftRegistryItems', [
+      { _id: 'i-rl', registryId: 'r-1', quantity: 10, purchasedQuantity: 0 },
+    ]);
+
+    // Default canonical helper allows 3 calls per key per hour. Run 4
+    // consecutive purchases from 4 different buyers — none should be
+    // rate-limited.
+    for (const buyer of ['Alice', 'Bob', 'Charlie', 'Dana']) {
+      const result = await markItemPurchased('i-rl', { buyerName: buyer, quantity: 1 });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rate-limit blocks the same buyer after RATE_LIMIT_MAX claims on the same item', async () => {
+    __seed('GiftRegistryItems', [
+      { _id: 'i-spam', registryId: 'r-1', quantity: 10, purchasedQuantity: 0 },
+    ]);
+
+    // Same buyer + same item = same bucket. After 3 successes the 4th
+    // should be rate-limited (default max=3).
+    for (let i = 0; i < 3; i++) {
+      const result = await markItemPurchased('i-spam', { buyerName: 'Eve', quantity: 1 });
+      expect(result.success).toBe(true);
+    }
+    const blocked = await markItemPurchased('i-spam', { buyerName: 'Eve', quantity: 1 });
+    expect(blocked.success).toBe(false);
+    expect(blocked.error).toMatch(/Too many requests/);
+  });
 });
 
 // ── deleteRegistry ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Resolves cf-3ldu **F3**. \`markItemPurchased\` was calling \`checkRateLimit('RegistryPurchaseRateLimit', itemId)\` keyed on item alone. With the canonical default of 3/hr, this meant **only 3 buyers total could claim any given registry item per hour, regardless of who they were** — a baby shower with 4+ attendees attempting claims would hit the limit.

### Fix
New key: \`\${sanitizedBuyerName}:\${itemId}\` (lowercased buyer name). Bucket scope is now per-buyer-per-item:
- 3 separate buyers can each claim the same item without blocking each other
- One buyer spamming the same item 4× in an hour still gets blocked (anti-spam preserved)

### Tests
- Added: 4 different buyers each successfully claim the same item (would fail under old keying)
- Added: same buyer hits the limit after 3 claims on the same item (anti-spam intact)
- All **46 markItemPurchased tests pass**

## Test plan
- [x] Unit: 4-distinct-buyers-same-item passes
- [x] Unit: same-buyer-spam-same-item correctly blocks at 4th
- [ ] Manual: post-merge, exercise gift registry public page → confirm legitimate multi-buyer flow works

Refs: \`docs/audits/rate-limit-audit-2026-05-10.md\` F3, cf-3ldu, cf-za1o.

🤖 Generated with [Claude Code](https://claude.com/claude-code)