### PR TITLE
feat(cf-3ldu.F2): pre-cutover rate-limit collection probe (P2)

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -23,6 +23,7 @@ import { sanitize, validateEmail, validateSlug, validateId } from 'backend/utils
 import { getEnhancedCatalogFields, exportCustomerAudienceData } from 'backend/facebookCatalog.web';
 import { timingSafeEqual, decodeHtmlEntities, stripHtmlSafe, escapeXml } from 'backend/utils/httpHelpers';
 import { corsHeaders, corsPreflight } from 'backend/utils/cors';
+import { verifyRateLimitCollections } from 'backend/utils/rateLimit';
 import { getDeliveryZone as _getDeliveryZone } from 'backend/deliveryZoneService.web';
 import { CLUSTERS, SITE_URL } from 'backend/utils/topicClusterData';
 import { listBundles, getBundleBySlug, addBundleToCart } from 'backend/bundleDeals.web';
@@ -3931,3 +3932,62 @@ export async function post_referralService(request) {
   return _veloDispatch(request, _REFERRAL_METHODS, 'referralService');
 }
 export function options_referralService(request) { return response(corsPreflight(request)); }
+
+// ── cf-3ldu.F2: rate-limit collection-existence probe ────────────────
+//
+// URL: GET /_functions/verifyRateLimitCollections
+// Auth: X-Cron-Secret header matching ALERT_CRON_KEY (timingSafeEqual)
+// Purpose: pre-cutover gate. The shared `checkRateLimit` helper FAILS
+// OPEN on wixData errors — including "Collection does not exist". A
+// missing rate-limit collection silently disables protection on every
+// endpoint that uses it. cf-3qt.8 cutover risk: if staging doesn't
+// mirror production's 46 rate-limit collections, an attacker can
+// exploit the gap before anyone notices (no customer-visible signal).
+//
+// Response body shape:
+//   {
+//     status: 'ok' | 'missing_collections',
+//     total: <int>,
+//     existing: [<collection>, ...],
+//     missing: [{collection, error}, ...],
+//     errored: [{collection, error}, ...],
+//     timestamp: <ISO>
+//   }
+// status === 'missing_collections' iff missing[].length > 0.
+//
+// Ops play: pre-cutover, curl this endpoint with the cron key. If the
+// response includes any missing collections, create them in Wix
+// Dashboard with the standard `key text / count number / windowStart
+// dateTime` schema before flipping DNS.
+export async function get_verifyRateLimitCollections(request) {
+  const HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+  try {
+    const { getSecret } = await import('wix-secrets-backend');
+    const cronKey = await getSecret('ALERT_CRON_KEY');
+    const requestKey = request.headers?.['x-cron-secret'];
+
+    if (!cronKey || !requestKey || !timingSafeEqual(requestKey, cronKey)) {
+      return forbidden({
+        body: JSON.stringify({ error: 'Unauthorized' }),
+        headers: HEADERS,
+      });
+    }
+
+    const report = await verifyRateLimitCollections();
+    const status = report.missing.length > 0 ? 'missing_collections' : 'ok';
+    return ok({
+      body: JSON.stringify({
+        status,
+        timestamp: new Date().toISOString(),
+        ...report,
+      }),
+      headers: HEADERS,
+    });
+  } catch (err) {
+    console.error('HTTP function error (verifyRateLimitCollections):', err);
+    return serverError({
+      body: JSON.stringify({ error: 'Internal server error' }),
+      headers: HEADERS,
+    });
+  }
+}

--- a/src/backend/utils/rateLimit.js
+++ b/src/backend/utils/rateLimit.js
@@ -156,3 +156,113 @@ export async function checkRateLimit(collection, key, opts = {}) {
     return { allowed: true }; // Fail open — don't block on DB errors
   }
 }
+
+// cf-3ldu.F2 (P2): canonical list of every wixData collection used as a
+// rate-limit bucket in this codebase. Built statically (extracted via
+// grep at audit time, 2026-05-10) — Velo's stateless dispatch means
+// there's no module-load inventory phase to discover this at runtime.
+// Update this list any time a new `checkRateLimit('XYZ', ...)` call
+// lands; the `verifyRateLimitCollections()` probe relies on it to
+// detect missing pre-cutover collections that would otherwise silently
+// fail-open on the helper's catch-all.
+//
+// Includes `ReturnsLookupRateLimit` (cf-3ldu.1 added in PR #1288) and
+// `NewsletterRateLimit` (newsletterService.web.js custom impl, F4).
+export const RATE_LIMIT_COLLECTIONS = Object.freeze([
+  'AbTestEventRateLimit',
+  'AchievementsRateLimit',
+  'ActivityRateLimit',
+  'AnalyticsEventRateLimit',
+  'BackInStockRateLimit',
+  'BadgesPublicRateLimit',
+  'BrowseSessionRateLimit',
+  'BundleAddRateLimit',
+  'BurnRateLimit',
+  'BusEventRateLimit',
+  'ChatMessageRateLimit',
+  'CheckoutTrackingRateLimit',
+  'ComfortTimelineRateLimit',
+  'CommunityPhotoRateLimit',
+  'ComparisonRateLimit',
+  'ContactRateLimits',
+  'CouponValidationRateLimit',
+  'CustomerRoomPhotosRateLimit',
+  'DeliveryReservationRateLimit',
+  'EmailEventRateLimit',
+  'ErrorLogRateLimit',
+  'ExperimentVariantRateLimit',
+  'GiftCardBalanceRateLimit',
+  'LeaderboardPublicRateLimit',
+  'MetricsReportRateLimit',
+  'NewsletterRateLimit',
+  'PriceLockRateLimit',
+  'ProtectionPlanRateLimit',
+  'QARateLimit',
+  'QuizLeadRateLimit',
+  'RealRoomsRateLimit',
+  'RegistryPurchaseRateLimit',
+  'RemindMeRateLimit',
+  'ResubscribeRateLimit',
+  'ReturnsLookupRateLimit',
+  'ReviewRateLimit',
+  'SommelierRateLimit',
+  'SpinWheelRateLimit',
+  'SupportTicketRateLimit',
+  'SwatchRequestRateLimit',
+  'TrackingRateLimit',
+  'UnsubscribeRateLimit',
+  'ViewerCountRateLimit',
+  'ViewerTrackerRateLimit',
+  'VisualSearchExportRateLimit',
+  'WhiteGloveBookingRateLimit',
+]);
+
+/**
+ * Probe every rate-limit collection and report which exist vs which
+ * are missing. Pre-cutover gate (cf-3qt.8): if a rate-limit collection
+ * doesn't exist on the live site, the helper's fail-open catch silently
+ * disables protection on every endpoint that uses it.
+ *
+ * Each collection is queried for one item (`limit(1)`) — cheap, no
+ * mutation. A missing collection rejects with `WD_COLLECTION_NOT_FOUND`
+ * (or substrings like "not found" / "does not exist") which we capture
+ * verbatim in the report.
+ *
+ * @returns {Promise<{
+ *   total: number,
+ *   existing: string[],
+ *   missing: Array<{collection: string, error: string}>,
+ *   errored: Array<{collection: string, error: string}>,
+ * }>}
+ */
+export async function verifyRateLimitCollections() {
+  const existing = [];
+  const missing = [];
+  const errored = [];
+
+  for (const collection of RATE_LIMIT_COLLECTIONS) {
+    try {
+      await wixData.query(collection).limit(1).find();
+      existing.push(collection);
+    } catch (err) {
+      const msg = String(err && (err.message || err)) || '';
+      const lowered = msg.toLowerCase();
+      if (
+        lowered.includes('not found')
+        || lowered.includes('does not exist')
+        || lowered.includes('wd_collection_not_found')
+      ) {
+        missing.push({ collection, error: msg });
+      } else {
+        errored.push({ collection, error: msg });
+      }
+    }
+  }
+
+  return {
+    total: RATE_LIMIT_COLLECTIONS.length,
+    existing,
+    missing,
+    errored,
+  };
+}

--- a/tests/rateLimitCollections.test.js
+++ b/tests/rateLimitCollections.test.js
@@ -1,0 +1,112 @@
+/**
+ * @file rateLimitCollections.test.js
+ * @description cf-3ldu.F2 (P2) — verifyRateLimitCollections pre-cutover probe
+ * + canonical RATE_LIMIT_COLLECTIONS list integrity.
+ *
+ * The shared `checkRateLimit` helper fails OPEN on wixData errors. If a
+ * rate-limit collection doesn't exist in production, every endpoint that
+ * uses it silently has zero protection. This test pins the canonical list
+ * + the probe behavior so cf-3qt.8 cutover gates can rely on it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import wixData, {
+  __setQueryError,
+  __reset as resetData,
+} from './__mocks__/wix-data.js';
+import {
+  RATE_LIMIT_COLLECTIONS,
+  verifyRateLimitCollections,
+} from '../src/backend/utils/rateLimit.js';
+
+beforeEach(() => {
+  resetData();
+});
+
+describe('RATE_LIMIT_COLLECTIONS — canonical list', () => {
+  it('contains the 46 known rate-limit collections (cf-3ldu audit + cf-3ldu.1 + F4)', () => {
+    expect(RATE_LIMIT_COLLECTIONS.length).toBe(46);
+  });
+
+  it('is frozen (Object.freeze) so callers cannot mutate the canonical list', () => {
+    expect(Object.isFrozen(RATE_LIMIT_COLLECTIONS)).toBe(true);
+  });
+
+  it('includes ReturnsRateLimit (cf-3ldu.1 / PR #1288)', () => {
+    expect(RATE_LIMIT_COLLECTIONS).toContain('ReturnsLookupRateLimit');
+  });
+
+  it('includes NewsletterRateLimit (F4 — newsletterService custom impl)', () => {
+    expect(RATE_LIMIT_COLLECTIONS).toContain('NewsletterRateLimit');
+  });
+
+  it('includes the only-plural ContactRateLimits (F5 quirk preserved)', () => {
+    expect(RATE_LIMIT_COLLECTIONS).toContain('ContactRateLimits');
+  });
+
+  it('has no duplicate entries', () => {
+    const set = new Set(RATE_LIMIT_COLLECTIONS);
+    expect(set.size).toBe(RATE_LIMIT_COLLECTIONS.length);
+  });
+
+  it('every entry matches the canonical naming pattern (CamelCase + RateLimit suffix)', () => {
+    const re = /^[A-Z][A-Za-z]+(RateLimits?)$/;
+    for (const c of RATE_LIMIT_COLLECTIONS) {
+      expect(c, `${c} doesn't match RateLimit naming convention`).toMatch(re);
+    }
+  });
+});
+
+describe('verifyRateLimitCollections — probe behavior', () => {
+  it('reports all collections as existing when wixData succeeds', async () => {
+    const report = await verifyRateLimitCollections();
+    expect(report.total).toBe(RATE_LIMIT_COLLECTIONS.length);
+    expect(report.existing).toHaveLength(RATE_LIMIT_COLLECTIONS.length);
+    expect(report.missing).toHaveLength(0);
+    expect(report.errored).toHaveLength(0);
+  });
+
+  it('classifies "Collection does not exist" rejections as missing', async () => {
+    __setQueryError('QARateLimit', new Error('Collection does not exist: QARateLimit'));
+    const report = await verifyRateLimitCollections();
+    expect(report.missing.map((m) => m.collection)).toContain('QARateLimit');
+    expect(report.missing.find((m) => m.collection === 'QARateLimit').error).toMatch(/does not exist/);
+    expect(report.existing).not.toContain('QARateLimit');
+  });
+
+  it('classifies "WD_COLLECTION_NOT_FOUND" rejections as missing', async () => {
+    __setQueryError('ReviewRateLimit', new Error('WD_COLLECTION_NOT_FOUND'));
+    const report = await verifyRateLimitCollections();
+    expect(report.missing.map((m) => m.collection)).toContain('ReviewRateLimit');
+  });
+
+  it('classifies "not found" rejections as missing (case-insensitive)', async () => {
+    __setQueryError('SwatchRequestRateLimit', new Error('Wix Data: collection NOT FOUND'));
+    const report = await verifyRateLimitCollections();
+    expect(report.missing.map((m) => m.collection)).toContain('SwatchRequestRateLimit');
+  });
+
+  it('classifies non-missing errors (network, auth) as errored, not missing', async () => {
+    __setQueryError('ChatMessageRateLimit', new Error('Network timeout'));
+    const report = await verifyRateLimitCollections();
+    expect(report.errored.map((e) => e.collection)).toContain('ChatMessageRateLimit');
+    expect(report.missing.map((m) => m.collection)).not.toContain('ChatMessageRateLimit');
+  });
+
+  it('separates multiple missing collections + multiple errors in one pass', async () => {
+    __setQueryError('QARateLimit', new Error('Collection does not exist'));
+    __setQueryError('ReviewRateLimit', new Error('not found'));
+    __setQueryError('ChatMessageRateLimit', new Error('Auth failure'));
+    const report = await verifyRateLimitCollections();
+    expect(report.missing.map((m) => m.collection).sort()).toEqual(['QARateLimit', 'ReviewRateLimit']);
+    expect(report.errored.map((e) => e.collection)).toEqual(['ChatMessageRateLimit']);
+    expect(report.existing).toHaveLength(RATE_LIMIT_COLLECTIONS.length - 3);
+  });
+
+  it('captures the verbatim error message so ops can debug', async () => {
+    const msg = 'Collection does not exist (WD_COLLECTION_NOT_FOUND): foo';
+    __setQueryError('AchievementsRateLimit', new Error(msg));
+    const report = await verifyRateLimitCollections();
+    const entry = report.missing.find((m) => m.collection === 'AchievementsRateLimit');
+    expect(entry.error).toBe(msg);
+  });
+});


### PR DESCRIPTION
## Summary

Closes cf-3ldu audit finding F2 (P2). Sibling to **cf-3ldu.1** (PR #1288, Stilgar).

The shared `checkRateLimit` helper FAILS OPEN on wixData errors. If a rate-limit collection doesn't exist on the live site, every endpoint that uses it silently has zero protection — the only signal is an attacker noticing first. cf-3qt.8 cutover risk: if staging doesn't mirror production's 46 rate-limit collections, an attacker can exploit the gap before anyone sees customer-visible breakage.

## What lands

- `RATE_LIMIT_COLLECTIONS` — frozen list of all 46 rate-limit collections in this codebase (44 canonical via `checkRateLimit(...)` + `ReturnsLookupRateLimit` (PR #1288) + `NewsletterRateLimit` (F4 custom impl))
- `verifyRateLimitCollections()` — probes each via `wixData.query(c).limit(1).find()`, classifies each as existing / missing / errored
- `GET /_functions/verifyRateLimitCollections` — gated on `ALERT_CRON_KEY` (`X-Cron-Secret` header). Returns JSON with the missing-collection list. Cheap, idempotent, no mutations.
- 14 new tests covering both layers

## Branch hygiene

This was previously folded onto PR #1286 alongside my F1 attempt. #1286 was closed in favor of Stilgar's #1288 (smaller F1 fix using `ReturnsLookupRateLimit` collection name). This re-files F2 cleanly off latest main with the corrected name in the canonical list.

## Ops play pre-cutover

```bash
curl -H "X-Cron-Secret: $ALERT_CRON_KEY" \
     https://www.carolinafutons.com/_functions/verifyRateLimitCollections | jq .
```

Body shape:
```json
{
  "status": "ok" | "missing_collections",
  "total": 46,
  "existing": ["...", ...],
  "missing": [{"collection": "...", "error": "..."}, ...],
  "errored": [{"collection": "...", "error": "..."}, ...],
  "timestamp": "..."
}
```

If `missing.length > 0`, create those collections in Wix Dashboard with the standard schema (`key:text, count:number, windowStart:dateTime`) before flipping DNS.

## Test plan

- [x] `vitest run tests/rateLimitCollections.test.js` — 14/14 pass
- [x] All 5 rateLimit test files pass — 80/80
- [x] No production behavior change — adds list + probe + read-only HTTP endpoint

## Audit reference

`docs/audits/rate-limit-audit-2026-05-10.md` §F2 — closes the recommendation verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)