### PR TITLE
fix(cf-8p52): canonical checkRateLimit fails CLOSED on DB error — F2 fix

### DIFF
--- a/src/backend/utils/rateLimit.js
+++ b/src/backend/utils/rateLimit.js
@@ -95,8 +95,15 @@ export function hashRateLimitKey(key) {
 /**
  * Check and record a rate-limit attempt for a given key in a given collection.
  * Allows up to RATE_LIMIT_MAX calls per RATE_LIMIT_WINDOW_MS per key.
- * Fails open (allows) if the DB check itself errors, to avoid blocking
- * legitimate users on infrastructure issues.
+ *
+ * cf-3ldu F2 / cf-8p52: fails CLOSED on DB error. Previously returned
+ * {allowed: true} to preserve availability when wixData itself was sick;
+ * the cf-3ldu audit flagged that this also silently disabled rate-limit
+ * protection when a backing collection was missing at cutover (failure
+ * mode indistinguishable from a transient outage). Closed-on-error
+ * surfaces the issue immediately and trades one transient blast radius
+ * (5xx during a real wixData outage) for a much smaller cutover blast
+ * radius (no silent protection bypass).
  *
  * @param {string} collection - wixData collection name (e.g. 'QARateLimit').
  * @param {string} key - Normalized identifier (typically email).
@@ -104,7 +111,7 @@ export function hashRateLimitKey(key) {
  * @param {number} [opts.now] - Timestamp override for testing (internal use only — never accept from callers).
  * @param {number} [opts.max] - Max calls per window (defaults to RATE_LIMIT_MAX). Callers may override per endpoint.
  * @param {number} [opts.windowMs] - Window duration in ms (defaults to RATE_LIMIT_WINDOW_MS = 1 hour). Use 60_000 for per-minute limits.
- * @returns {Promise<{allowed: boolean, reason?: string}>}
+ * @returns {Promise<{allowed: boolean, reason?: string}>} — `reason: 'rate_limited'` when over limit, `'db_error'` when the wixData call itself failed (fail-closed).
  */
 export async function checkRateLimit(collection, key, opts = {}) {
   const now = opts.now ?? Date.now();
@@ -153,6 +160,8 @@ export async function checkRateLimit(collection, key, opts = {}) {
     return { allowed: true };
   } catch (err) {
     logError(`rateLimit.checkRateLimit[${collection}/${storedKey}]`, err);
-    return { allowed: true }; // Fail open — don't block on DB errors
+    // cf-3ldu F2 / cf-8p52: fail CLOSED on DB error so a missing collection
+    // (or any wixData fault) cannot silently disable protection.
+    return { allowed: false, reason: 'db_error' };
   }
 }

--- a/tests/orderTrackingRateLimit.test.js
+++ b/tests/orderTrackingRateLimit.test.js
@@ -138,16 +138,19 @@ describe('subscribeToNotifications — rate limiting', () => {
     expect(result.success).toBe(true);
   });
 
-  it('fails open (allows) when the rate limit DB check throws, and still persists the subscription', async () => {
+  it('fails closed (denies) when the rate limit DB check throws, and does NOT persist the subscription', async () => {
+    // cf-3ldu F2 / cf-8p52: helper fails CLOSED on DB error so a
+    // missing rate-limit collection (or wixData hiccup) can't silently
+    // disable protection at cutover.
     seedOrderAndFulfillment();
     __setQueryError(TRACKING_RATE_COLLECTION, new Error('DB down'));
     const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    let insertedCollection, insertedItem;
-    __onInsert((col, item) => { if (col === 'TrackingNotifications') { insertedCollection = col; insertedItem = item; } });
+    let insertedCollection;
+    __onInsert((col) => { if (col === 'TrackingNotifications') { insertedCollection = col; } });
     const result = await subscribeToNotifications('ORD-001', 'buyer@example.com');
-    expect(result.success).toBe(true);
-    expect(insertedCollection).toBe('TrackingNotifications');
-    expect(insertedItem.email).toBe('buyer@example.com');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/too many requests/i);
+    expect(insertedCollection).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/rateLimit/i), expect.any(String));
     warnSpy.mockRestore();
   });
@@ -230,12 +233,14 @@ describe('unsubscribeFromNotifications — rate limiting', () => {
     expect(result.success).toBe(true);
   });
 
-  it('fails open (allows) when the rate limit DB check throws', async () => {
+  it('fails closed (denies) when the rate limit DB check throws', async () => {
+    // cf-3ldu F2 / cf-8p52: fail-closed semantic.
     seedSubscription();
     __setQueryError(TRACKING_RATE_COLLECTION, new Error('DB down'));
     const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await unsubscribeFromNotifications('ORD-001', 'buyer@example.com');
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/too many requests/i);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/rateLimit/i), expect.any(String));
     warnSpy.mockRestore();
   });

--- a/tests/rateLimitCmek.test.js
+++ b/tests/rateLimitCmek.test.js
@@ -5,8 +5,8 @@
  * contain plaintext PII such as email addresses. The hash must be deterministic
  * so rate limiting continues to work correctly.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
-import { __reset, __getInserted, __onInsert } from './__mocks__/wix-data.js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { __reset, __getInserted, __onInsert, __setQueryError } from './__mocks__/wix-data.js';
 import {
   hashRateLimitKey,
   checkRateLimit,
@@ -85,5 +85,32 @@ describe('checkRateLimit — stores hashed key, not plaintext PII', () => {
     // Should be allowed (count 1 < max 3) and no second insert
     expect(secondResult.allowed).toBe(true);
     expect(inserted).toHaveLength(1);
+  });
+});
+
+// ── cf-3ldu F2 / cf-8p52 — fail-closed on DB error ──────────────────────────
+
+describe('checkRateLimit — fails CLOSED on wixData error', () => {
+  it('returns { allowed: false, reason: "db_error" } when query throws', async () => {
+    __setQueryError('TestRateLimit', new Error('wixData unavailable'));
+    // Avoid noisy unhandled-error logs during the test.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await checkRateLimit('TestRateLimit', 'user@example.com', { now: NOW });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('db_error');
+    errSpy.mockRestore();
+  });
+
+  it('returns { allowed: false, reason: "db_error" } when collection is missing (same fault as a real "Collection does not exist" error)', async () => {
+    // Simulating the cutover-time failure mode: a backing collection
+    // that was never created in the staging CMS produces the same
+    // wixData rejection as a generic outage. Either way the helper
+    // must fail closed so the missing-collection bug is loud.
+    __setQueryError('NonexistentRateLimit', new Error('Collection does not exist'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await checkRateLimit('NonexistentRateLimit', 'shopper@example.com', { now: NOW });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('db_error');
+    errSpy.mockRestore();
   });
 });

--- a/tests/rateLimitQAReview.test.js
+++ b/tests/rateLimitQAReview.test.js
@@ -63,10 +63,10 @@ describe('checkRateLimit', () => {
     expect(result.allowed).toBe(false);
   });
 
-  it('fails open when DB query throws', async () => {
+  it('fails CLOSED when DB query throws (cf-3ldu F2 / cf-8p52)', async () => {
     __setQueryError(COLLECTION_QA, new Error('DB down'));
     const result = await checkRateLimit(COLLECTION_QA, 'test@example.com', { now: NOW });
-    expect(result).toEqual({ allowed: true });
+    expect(result).toEqual({ allowed: false, reason: 'db_error' });
   });
 
   it('window boundary — just expired (age > window) allows', async () => {

--- a/tests/shippingIntelligenceRateLimit.test.js
+++ b/tests/shippingIntelligenceRateLimit.test.js
@@ -147,12 +147,12 @@ describe('getShippingEstimate — rate limiting (20 req/min per member)', () => 
     expect(result.error ?? '').not.toMatch(/too many requests/i);
   });
 
-  it('fails open (allows) when the rate limit DB check throws', async () => {
+  it('fails CLOSED when the rate limit DB check throws (cf-3ldu F2 / cf-8p52)', async () => {
     __setMember(makeMember('m1'));
     __setQueryError(ESTIMATE_COLLECTION, new Error('DB down'));
     const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await getShippingEstimate('prod-1', '28701');
-    expect(result.error ?? '').not.toMatch(/too many requests/i);
+    expect(result.error ?? '').toMatch(/too many requests/i);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/rateLimit/i),
       expect.any(String),
@@ -227,12 +227,12 @@ describe('calculateBundleQuote — rate limiting (10 req/min per member)', () =>
     expect(result.error ?? '').not.toMatch(/too many requests/i);
   });
 
-  it('fails open (allows) when the rate limit DB check throws', async () => {
+  it('fails CLOSED when the rate limit DB check throws (cf-3ldu F2 / cf-8p52)', async () => {
     __setMember(makeMember('m1'));
     __setQueryError(BUNDLE_COLLECTION, new Error('DB down'));
     const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await calculateBundleQuote(ITEMS, '28701');
-    expect(result.error ?? '').not.toMatch(/too many requests/i);
+    expect(result.error ?? '').toMatch(/too many requests/i);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringMatching(/rateLimit/i),
       expect.any(String),


### PR DESCRIPTION
## Summary
Resolves cf-3ldu **F2 (P2)**. The canonical \`checkRateLimit\` helper previously returned \`{ allowed: true }\` when wixData itself rejected — an availability choice that **silently disabled rate-limit protection any time a backing collection was missing**. The cf-3ldu audit flagged that this failure mode was indistinguishable from a transient outage at cutover: a mis-provisioned staging CMS would surface zero observable signal while every protected endpoint ran fully exposed.

### Fix
Now returns \`{ allowed: false, reason: 'db_error' }\` on wixData fault. The \`reason\` field distinguishes a real over-limit (\`rate_limited\`) from a DB-fault denial (\`db_error\`) for downstream observability.

**Trade**: a true wixData outage during the brief retry window now returns "Too many requests" to legitimate users on every protected surface. That blast radius is bounded — Wix's wixData has been production-stable — and far smaller than the cutover-time silent-disable scenario this closes.

### Tests
- \`rateLimitCmek\` — added 2 new tests: \`db_error\` semantic + the cutover "missing collection" failure mode
- \`rateLimitQAReview\` — flipped "fails open" → "fails CLOSED"
- \`shippingIntelligenceRateLimit\` — 2 fail-open assertions flipped (getShippingEstimate + calculateBundleQuote)
- \`orderTrackingRateLimit\` — 2 fail-open assertions flipped (subscribe / unsubscribe). Added explicit "subscription is NOT persisted on DB-fault" guard.
- **All 117 rate-limit tests pass**
- Full suite: 38,139 passed / 22 failed. The 22 failures are in 3 files (errorMonitoring × 2 + funnelTracker) — confirmed pre-existing on main before this change.

## Test plan
- [x] Direct: 2 new \`rateLimitCmek\` tests cover the new return shape
- [x] Consumer-side: 4 fail-open assertions flipped to fail-closed, all pass
- [x] Stash verification: 3 failing files are pre-existing
- [ ] Manual post-deploy: simulate one missing rate-limit collection on staging → confirm protected endpoint surfaces "Too many requests" (not silent allow)

Refs: \`docs/audits/rate-limit-audit-2026-05-10.md\` F2, cf-3ldu, cf-8p52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)