### PR TITLE
fix(cf-32u1.F4): hash deliveryScheduling booking rate-limit key (cf-sec1)

### DIFF
--- a/src/backend/deliveryScheduling.web.js
+++ b/src/backend/deliveryScheduling.web.js
@@ -32,7 +32,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
-import { checkRateLimit } from 'backend/utils/rateLimit';
+import { checkRateLimit, hashRateLimitKey } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { validateSchema } from 'backend/utils/validateSchema';
 import { sendDeliveryBookingConfirmationSms } from 'backend/deliveryNotifications.web';
@@ -481,7 +481,13 @@ const CANCEL_RL_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 export async function _checkBookingRateLimit(email, opts = {}) {
   const now = opts.now != null ? opts.now : Date.now();
   try {
-    const cleanKey = sanitize(email, 254).toLowerCase();
+    // cf-32u1.F4 (cf-sec1 CMEK): hash the key before storing/querying so
+    // the rate-limit collection never holds plaintext customer email at
+    // rest. Mirrors the canonical helper at utils/rateLimit.js (FNV-1a,
+    // hashRateLimitKey). Sanitize-then-lowercase before hashing so the
+    // hash input matches the canonical helper's contract.
+    const cleanEmail = sanitize(email, 254).toLowerCase();
+    const cleanKey = hashRateLimitKey(cleanEmail);
     const existing = await wixData.query(BOOKING_RL_COLLECTION)
       .eq('key', cleanKey).limit(1).find();
 

--- a/tests/deliveryScheduling.test.js
+++ b/tests/deliveryScheduling.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { __seed, __reset as resetData } from './__mocks__/wix-data.js';
+import { __seed, __onInsert, __reset as resetData } from './__mocks__/wix-data.js';
 import { __setMember, __reset as resetMembers } from './__mocks__/wix-members-backend.js';
 import {
   getAvailableDeliverySlots,
@@ -13,6 +13,7 @@ import {
   _checkBookingRateLimit,
   _checkCancelRateLimit,
 } from '../src/backend/deliveryScheduling.web.js';
+import { hashRateLimitKey } from '../src/backend/utils/rateLimit.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -733,7 +734,7 @@ describe('bookAppointment — rate limiting (CF-ylof)', () => {
     // Seed a rate limit record that is already at max (5)
     __seed(BOOKING_RL_COLLECTION, [{
       _id: 'rl-bob',
-      key: 'bob@test.com',
+      key: hashRateLimitKey('bob@test.com'),
       count: 5,
       windowStart: new Date(Date.now() - 60 * 60 * 1000), // 1 hour ago — still within 24h window
     }]);
@@ -746,7 +747,7 @@ describe('bookAppointment — rate limiting (CF-ylof)', () => {
     // Seed exhausted limit but with old window (>24h ago)
     __seed(BOOKING_RL_COLLECTION, [{
       _id: 'rl-bob',
-      key: 'bob@test.com',
+      key: hashRateLimitKey('bob@test.com'),
       count: 5,
       windowStart: new Date(Date.now() - 25 * 60 * 60 * 1000), // 25h ago
     }]);
@@ -762,7 +763,7 @@ describe('bookAppointment — rate limiting (CF-ylof)', () => {
   it('_checkBookingRateLimit blocks at limit', async () => {
     __seed(BOOKING_RL_COLLECTION, [{
       _id: 'rl-x',
-      key: 'flood@test.com',
+      key: hashRateLimitKey('flood@test.com'),
       count: 5,
       windowStart: new Date(Date.now() - 1000),
     }]);
@@ -773,13 +774,29 @@ describe('bookAppointment — rate limiting (CF-ylof)', () => {
   it('_checkBookingRateLimit increments count on each call', async () => {
     __seed(BOOKING_RL_COLLECTION, [{
       _id: 'rl-inc',
-      key: 'inc@test.com',
+      key: hashRateLimitKey('inc@test.com'),
       count: 2,
       windowStart: new Date(Date.now() - 1000),
     }]);
     const result = await _checkBookingRateLimit('inc@test.com');
     expect(result.allowed).toBe(true);
     // Count should now be 3 — verify via a 5-count seed + call that hits limit
+  });
+
+  // cf-32u1.F4 (cf-sec1 CMEK): regression guard — the rate-limit
+  // collection must never persist plaintext customer email at rest.
+  it('persists a hashed key, NOT plaintext email (cf-32u1.F4 cf-sec1 compliance)', async () => {
+    let inserted;
+    __onInsert((collection, record) => {
+      if (collection === BOOKING_RL_COLLECTION) inserted = record;
+    });
+    await _checkBookingRateLimit('cmek-check@test.com');
+    expect(inserted).toBeDefined();
+    expect(inserted.key).not.toBe('cmek-check@test.com');
+    expect(inserted.key).not.toContain('@');
+    expect(inserted.key).toBe(hashRateLimitKey('cmek-check@test.com'));
+    // Hash output is FNV-1a 8-char hex per the canonical helper.
+    expect(inserted.key).toMatch(/^[0-9a-f]{8}$/);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes cf-32u1 audit finding **F4 (P3, cf-sec1 CMEK)**. `deliveryScheduling._checkBookingRateLimit` stored **plaintext customer email** at rest in the `AppointmentBookingRateLimit` collection. The canonical helper at `utils/rateLimit.js` already hashes keys per cf-sec1 (FNV-1a, `hashRateLimitKey`); this local re-impl skipped the hash.

## Fix

- Import `hashRateLimitKey` from the canonical helper.
- After sanitize+lowercase, hash before insert/query.
- `_checkCancelRateLimit` keys on an opaque token-prefix and is already PII-free — left alone.

## Why hash-only (not full canonical-helper migration)

The audit's "better fix: replace with `checkRateLimit('BookingRateLimit', ...)`" would also rename the collection (`BookingRateLimit` vs current `AppointmentBookingRateLimit`) which requires a Wix Dashboard migration. Hash-only closes the cf-sec1 gap without state changes — minimal pre-cutover surface.

## Tests

- Updated 3 existing tests to seed with `hashRateLimitKey(email)` per the new contract.
- New regression guard asserts `__onInsert` capture record's `key`:
  - is NOT the plaintext email
  - contains no `@`
  - equals `hashRateLimitKey(email)`
  - matches FNV-1a 8-char hex format

**79/79 deliveryScheduling tests pass.**

## Audit reference

`docs/audits/webmethod-permissions-audit-2026-05-10.md` §F4.

## Test plan
- [x] `vitest run tests/deliveryScheduling.test.js` — 79/79 pass
- [x] No production behavior change beyond the hash; rate-limit semantics identical
- [ ] **Note for ops:** existing rows in `AppointmentBookingRateLimit` will become orphaned (their plaintext keys will never match again). They naturally expire after the 24h window, but ops can manually clear the collection post-merge if a cleaner state is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)