### PR TITLE
chore(cf-4ogf): cf-hpwy v3 TRULY-ORPHAN cleanup — trim 2 dead webMethods

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -13,7 +13,6 @@ import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, t
 import { scanAndTriggerWinback, runReviewRequestEmails } from 'backend/marketingSequences.web';
 import { processContentSchedule } from 'backend/contentScheduler.web';
 import { sendWeeklyBlogDigest } from 'backend/blogDigestService.web';
-import { getAssemblyFollowUpData } from 'backend/postPurchaseCare.web';
 import { insertAnalyticsEvent } from 'backend/utils/analyticsEvents';
 import { getAllBlogPosts } from 'backend/blogContent';
 import { getSitemapData, buildSitemapXml, getRobotsTxtContent } from 'backend/seoHelpers.web';

--- a/src/backend/marketingSequences.web.js
+++ b/src/backend/marketingSequences.web.js
@@ -141,40 +141,6 @@ export const triggerCartAbandonSequence = webMethod(Permissions.Admin, async (pa
   }
 });
 
-// ── triggerPostPurchaseSequence ───────────────────────────────────────────────
-
-/**
- * Trigger the post-purchase follow-up sequence.
- *
- * @param {Object} params
- * @param {string} params.email
- * @param {string} params.contactId
- * @param {string} [params.firstName]
- * @param {string} params.orderNumber
- * @param {number} [params.total]
- * @returns {Promise<{success: boolean, enqueued: number, error?: string}>}
- */
-export const triggerPostPurchaseSequence = webMethod(Permissions.Admin, async (params) => {
-  const { email, contactId, firstName = '', orderNumber, total = 0 } = params ?? {};
-
-  if (!email) return { success: false, error: 'email is required' };
-  if (!contactId) return { success: false, error: 'contactId is required' };
-
-  try {
-    const steps = await loadActiveSteps('post_purchase');
-    const enqueued = await enqueueSequenceSteps(steps, {
-      email,
-      contactId,
-      sequenceType: 'post_purchase',
-      variables: { firstName, orderNumber, total: String(total) },
-    });
-    return { success: true, enqueued };
-  } catch (err) {
-    logError('triggerPostPurchaseSequence failed', err);
-    return { success: false, error: err?.message ?? 'unknown error' };
-  }
-});
-
 // ── triggerReviewRequestSequence ──────────────────────────────────────────────
 
 /**

--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -345,63 +345,6 @@ const SUPPORT_PHONE = '(828) 252-9449';
 const SUPPORT_EMAIL = 'support@carolinafutons.com';
 
 /**
- * Get assembly follow-up data for Day 3 email (72h post-purchase).
- * Returns assembly guides relevant to the ordered products plus support info.
- *
- * @param {string} orderId - The order ID.
- * @param {string[]} productCategories - Categories of products in the order.
- * @returns {Promise<{success: boolean, guides: Array, supportPhone: string, supportEmail: string, error?: string}>}
- */
-export const getAssemblyFollowUpData = webMethod(
-  Permissions.Anyone,
-  async (orderId, productCategories) => {
-    try {
-      const cleanOrderId = validateId(orderId);
-      if (!cleanOrderId) {
-        return { success: false, error: 'Valid order ID is required.', guides: [], supportPhone: '', supportEmail: '' };
-      }
-
-      if (!Array.isArray(productCategories) || productCategories.length === 0) {
-        return { success: false, error: 'Product categories are required.', guides: [], supportPhone: '', supportEmail: '' };
-      }
-
-      const categories = productCategories
-        .slice(0, 10)
-        .map(c => sanitize(c, 100))
-        .filter(Boolean);
-
-      if (categories.length === 0) {
-        return { success: true, guides: [], supportPhone: SUPPORT_PHONE, supportEmail: SUPPORT_EMAIL };
-      }
-
-      const result = await wixData.query('ProductCareGuides')
-        .hasSome('productCategory', categories)
-        .eq('guideType', 'assembly')
-        .eq('active', true)
-        .ascending('priority')
-        .limit(20)
-        .find();
-
-      const guides = result.items.map(item => ({
-        _id: item._id,
-        productCategory: item.productCategory,
-        title: item.title,
-        summary: item.summary,
-        content: item.content,
-        steps: parseSteps(item.steps),
-        videoUrl: item.videoUrl || '',
-        imageUrl: item.imageUrl || '',
-      }));
-
-      return { success: true, guides, supportPhone: SUPPORT_PHONE, supportEmail: SUPPORT_EMAIL };
-    } catch (err) {
-      console.error('[postPurchaseCare] Error getting assembly follow-up data:', err);
-      return { success: false, error: 'Failed to load assembly data.', guides: [], supportPhone: '', supportEmail: '' };
-    }
-  }
-);
-
-/**
  * Get review solicitation data for Day 7 email (168h post-purchase).
  * Returns review URLs and product info for the email template.
  *

--- a/tests/marketingSequences.test.js
+++ b/tests/marketingSequences.test.js
@@ -5,7 +5,6 @@
  * Tests:
  *   triggerWelcomeSequence — reads welcome steps from EmailSequences CMS, enqueues with 0 delay
  *   triggerCartAbandonSequence — enqueues with 1hr delay, passes checkoutId
- *   triggerPostPurchaseSequence — enqueues with 72hr delay
  *   triggerReviewRequestSequence — enqueues with 168hr delay
  *   triggerWinbackSequence — enqueues with 720hr delay
  *   All sequences: skips inactive steps, handles empty CMS, validates required params
@@ -23,7 +22,6 @@ import { __reset as resetCRM } from './__mocks__/wix-crm-backend.js';
 import {
   triggerWelcomeSequence,
   triggerCartAbandonSequence,
-  triggerPostPurchaseSequence,
   triggerReviewRequestSequence,
   triggerWinbackSequence,
   scanAndTriggerWinback,
@@ -283,71 +281,6 @@ describe('triggerCartAbandonSequence', () => {
   });
 });
 
-// ── triggerPostPurchaseSequence ───────────────────────────────────────────────
-
-describe('triggerPostPurchaseSequence', () => {
-  it('enqueues post_purchase step with 72hr delay', async () => {
-    seedSequence('post_purchase', [{ delayHours: 72, templateId: 'tpl-post-purchase-1' }]);
-    __seed(EMAIL_QUEUE_COLLECTION, []);
-
-    const before = Date.now();
-    await triggerPostPurchaseSequence({
-      email: 'alice@example.com',
-      contactId: 'contact-1',
-      firstName: 'Alice',
-      orderNumber: '#1001',
-      total: 299.99,
-    });
-
-    const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
-    expect(queued.length).toBe(1);
-    const scheduledMs = queued[0].scheduledFor.getTime();
-    expect(scheduledMs).toBeGreaterThanOrEqual(before + 72 * 3600 * 1000 - 100);
-  });
-
-  it('uses sequenceType post_purchase', async () => {
-    seedSequence('post_purchase', [{ delayHours: 72 }]);
-    __seed(EMAIL_QUEUE_COLLECTION, []);
-
-    await triggerPostPurchaseSequence({
-      email: 'alice@example.com',
-      contactId: 'contact-1',
-      firstName: 'Alice',
-      orderNumber: '#1001',
-      total: 299.99,
-    });
-
-    const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
-    expect(queued[0].sequenceType).toBe('post_purchase');
-  });
-
-  it('passes orderNumber in variables', async () => {
-    seedSequence('post_purchase', [{ delayHours: 72 }]);
-    __seed(EMAIL_QUEUE_COLLECTION, []);
-
-    await triggerPostPurchaseSequence({
-      email: 'alice@example.com',
-      contactId: 'contact-1',
-      firstName: 'Alice',
-      orderNumber: '#1001',
-      total: 299.99,
-    });
-
-    const queued = __getInserted(EMAIL_QUEUE_COLLECTION);
-    const vars = JSON.parse(queued[0].variables);
-    expect(vars.orderNumber).toBe('#1001');
-  });
-
-  it('returns error on missing email', async () => {
-    const result = await triggerPostPurchaseSequence({
-      contactId: 'contact-1',
-      orderNumber: '#1001',
-      total: 99,
-    });
-    expect(result.success).toBe(false);
-  });
-});
-
 // ── triggerReviewRequestSequence ──────────────────────────────────────────────
 
 describe('triggerReviewRequestSequence', () => {
@@ -581,23 +514,6 @@ describe('triggerCartAbandonSequence — error path', () => {
       email: 'alice@example.com',
       contactId: 'contact-1',
       checkoutId: 'checkout-1',
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBeTruthy();
-    consoleSpy.mockRestore();
-  });
-});
-
-describe('triggerPostPurchaseSequence — error path', () => {
-  it('returns success:false when CMS query throws', async () => {
-    __setQueryError(EMAIL_SEQUENCES_COLLECTION, new Error('DB error'));
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    const result = await triggerPostPurchaseSequence({
-      email: 'alice@example.com',
-      contactId: 'contact-1',
-      orderNumber: 'ORD-001',
     });
 
     expect(result.success).toBe(false);

--- a/tests/orderFulfillmentHardening.test.js
+++ b/tests/orderFulfillmentHardening.test.js
@@ -368,23 +368,6 @@ describe('postPurchaseCare hardening', () => {
     });
   });
 
-  describe('getAssemblyFollowUpData — empty categories after sanitize', () => {
-    it('returns empty guides for all-empty categories', async () => {
-      const r = await postPurchaseMod.getAssemblyFollowUpData('o1', ['', '', '']);
-      expect(r.success).toBe(true);
-      expect(r.guides).toEqual([]);
-      expect(r.supportPhone).toBeTruthy();
-    });
-
-    it('returns guides with steps parsed', async () => {
-      __seed('ProductCareGuides', [
-        { _id: 'g1', productCategory: 'futons', guideType: 'assembly', active: true, priority: 1, title: 'Build It', steps: '["step1","step2"]' },
-      ]);
-      const r = await postPurchaseMod.getAssemblyFollowUpData('o1', ['futons']);
-      expect(r.guides[0].steps).toEqual(['step1', 'step2']);
-    });
-  });
-
   describe('getReviewSolicitationData — product reviewUrl construction', () => {
     it('builds per-product review URLs', async () => {
       const r = await postPurchaseMod.getReviewSolicitationData('o1', 'Jane', [

--- a/tests/postPurchaseCare.test.js
+++ b/tests/postPurchaseCare.test.js
@@ -7,7 +7,6 @@ import {
   getUpsellRecommendations,
   trackGuideEngagement,
   logUpsellConversion,
-  getAssemblyFollowUpData,
   getReviewSolicitationData,
 } from '../src/backend/postPurchaseCare.web.js';
 
@@ -611,96 +610,6 @@ describe('logUpsellConversion', () => {
     });
     expect(res.success).toBe(true);
     expect(inserted.item.sourceProductId).toBe('');
-  });
-});
-
-// ── getAssemblyFollowUpData ───────────────────────────────────────────
-
-describe('getAssemblyFollowUpData', () => {
-  beforeEach(seedAll);
-
-  it('returns assembly guides and support info', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['futon-frames']);
-    expect(res.success).toBe(true);
-    expect(res.guides).toHaveLength(1);
-    expect(res.guides[0].title).toBe('Frame Assembly Guide');
-    expect(res.supportPhone).toBe('(828) 252-9449');
-    expect(res.supportEmail).toBe('support@carolinafutons.com');
-  });
-
-  it('only returns assembly-type guides', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['futon-frames']);
-    expect(res.success).toBe(true);
-    // g-2 is maintenance, should not appear
-    const ids = res.guides.map(g => g._id);
-    expect(ids).toContain('g-1');
-    expect(ids).not.toContain('g-2');
-  });
-
-  it('returns assembly guides across multiple categories', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['futon-frames', 'mattresses']);
-    expect(res.success).toBe(true);
-    expect(res.guides).toHaveLength(2);
-  });
-
-  it('returns empty guides when category has no assembly guides', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['covers']);
-    expect(res.success).toBe(true);
-    expect(res.guides).toEqual([]);
-    expect(res.supportPhone).toBe('(828) 252-9449');
-    expect(res.supportEmail).toBe('support@carolinafutons.com');
-  });
-
-  it('returns error for invalid order ID', async () => {
-    const res = await getAssemblyFollowUpData('!!!', ['futon-frames']);
-    expect(res.success).toBe(false);
-    expect(res.error).toContain('order ID');
-    expect(res.guides).toEqual([]);
-    expect(res.supportPhone).toBe('');
-    expect(res.supportEmail).toBe('');
-  });
-
-  it('returns error for empty order ID', async () => {
-    const res = await getAssemblyFollowUpData('', ['futon-frames']);
-    expect(res.success).toBe(false);
-    expect(res.error).toContain('order ID');
-  });
-
-  it('returns error for empty categories array', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', []);
-    expect(res.success).toBe(false);
-    expect(res.error).toContain('categories');
-  });
-
-  it('returns error for non-array categories', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', 'futon-frames');
-    expect(res.success).toBe(false);
-  });
-
-  it('returns error for null categories', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', null);
-    expect(res.success).toBe(false);
-  });
-
-  it('returns support info with empty guides when all categories sanitize to empty', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['', '']);
-    expect(res.success).toBe(true);
-    expect(res.guides).toEqual([]);
-    expect(res.supportPhone).toBeTruthy();
-    expect(res.supportEmail).toBeTruthy();
-  });
-
-  it('returns guide objects with expected fields', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['futon-frames']);
-    const g = res.guides[0];
-    expect(g).toHaveProperty('_id');
-    expect(g).toHaveProperty('productCategory');
-    expect(g).toHaveProperty('title');
-    expect(g).toHaveProperty('summary');
-    expect(g).toHaveProperty('content');
-    expect(g).toHaveProperty('steps');
-    expect(g).toHaveProperty('videoUrl');
-    expect(g).toHaveProperty('imageUrl');
   });
 });
 

--- a/tests/postPurchaseCareDeep.test.js
+++ b/tests/postPurchaseCareDeep.test.js
@@ -88,7 +88,6 @@ const {
   getUpsellRecommendations,
   trackGuideEngagement,
   logUpsellConversion,
-  getAssemblyFollowUpData,
   getReviewSolicitationData,
 } = mod;
 
@@ -382,49 +381,6 @@ describe('logUpsellConversion', () => {
     _mockMemberId = null;
     const result = await logUpsellConversion({ sourceOrderId: 'o1', sourceProductId: 'p1', recommendedProductId: 'p2' });
     expect(result.success).toBe(false);
-  });
-});
-
-// ═════════════════════════════════════════════════════════════════════
-// getAssemblyFollowUpData
-// ═════════════════════════════════════════════════════════════════════
-describe('getAssemblyFollowUpData', () => {
-  it('returns assembly guides and support info', async () => {
-    __seed('ProductCareGuides', [
-      { _id: 'g1', productCategory: 'futon-frames', guideType: 'assembly', active: true, priority: 1, title: 'Frame Assembly', steps: null },
-    ]);
-    const result = await getAssemblyFollowUpData('order-1', ['futon-frames']);
-    expect(result.success).toBe(true);
-    expect(result.guides).toHaveLength(1);
-    expect(result.supportPhone).toBe('(828) 252-9449');
-    expect(result.supportEmail).toBe('support@carolinafutons.com');
-  });
-
-  it('requires valid orderId', async () => {
-    const result = await getAssemblyFollowUpData('', ['futon-frames']);
-    expect(result.success).toBe(false);
-  });
-
-  it('requires categories array', async () => {
-    const result = await getAssemblyFollowUpData('order-1', null);
-    expect(result.success).toBe(false);
-  });
-
-  it('returns empty guides with support info for empty valid categories', async () => {
-    const result = await getAssemblyFollowUpData('order-1', ['', '']);
-    expect(result.success).toBe(true);
-    expect(result.guides).toEqual([]);
-    expect(result.supportPhone).toBeTruthy();
-  });
-
-  it('only returns assembly-type guides', async () => {
-    __seed('ProductCareGuides', [
-      { _id: 'g1', productCategory: 'futons', guideType: 'assembly', active: true, priority: 1, steps: null },
-      { _id: 'g2', productCategory: 'futons', guideType: 'warranty', active: true, priority: 2, steps: null },
-    ]);
-    const result = await getAssemblyFollowUpData('o1', ['futons']);
-    expect(result.guides).toHaveLength(1);
-    expect(result.guides[0]._id).toBe('g1');
   });
 });
 

--- a/tests/postPurchaseCareHardening.test.js
+++ b/tests/postPurchaseCareHardening.test.js
@@ -7,7 +7,6 @@ import {
   getUpsellRecommendations,
   trackGuideEngagement,
   logUpsellConversion,
-  getAssemblyFollowUpData,
   getReviewSolicitationData,
 } from '../src/backend/postPurchaseCare.web.js';
 
@@ -382,52 +381,6 @@ describe('logUpsellConversion hardening', () => {
     });
     expect(res.success).toBe(true);
     expect(inserted.item.sourceProductId).toBe('');
-  });
-});
-
-// ── getAssemblyFollowUpData hardening ───────────────────────────────
-
-describe('getAssemblyFollowUpData hardening', () => {
-  beforeEach(seedAll);
-
-  it('handles undefined orderId', async () => {
-    const res = await getAssemblyFollowUpData(undefined, ['futon-frames']);
-    expect(res.success).toBe(false);
-  });
-
-  it('handles numeric orderId', async () => {
-    const res = await getAssemblyFollowUpData(12345, ['futon-frames']);
-    expect(res.success).toBe(false);
-  });
-
-  it('handles categories with only whitespace entries', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['   ', '  ']);
-    // sanitize trims whitespace → empty → filtered out → empty categories
-    // But the code returns success:true with empty guides + support info
-    expect(res.success).toBe(true);
-    expect(res.guides).toEqual([]);
-    expect(res.supportPhone).toBeTruthy();
-  });
-
-  it('limits categories to 10', async () => {
-    const cats = Array.from({ length: 15 }, (_, i) => `cat-${i}`);
-    const res = await getAssemblyFollowUpData('order-abc123', cats);
-    expect(res.success).toBe(true);
-  });
-
-  it('returns only active assembly guides', async () => {
-    // g-3 is inactive warranty guide for futon-frames — should not appear
-    const res = await getAssemblyFollowUpData('order-abc123', ['futon-frames']);
-    expect(res.success).toBe(true);
-    const ids = res.guides.map(g => g._id);
-    expect(ids).toContain('g-1');     // assembly, active
-    expect(ids).not.toContain('g-2'); // maintenance (wrong type)
-    expect(ids).not.toContain('g-3'); // warranty + inactive
-  });
-
-  it('returns assembly guides with parsed steps', async () => {
-    const res = await getAssemblyFollowUpData('order-abc123', ['futon-frames']);
-    expect(res.guides[0].steps).toEqual(['Unbox', 'Attach legs', 'Secure bolts']);
   });
 });
 


### PR DESCRIPTION
## Bead
cf-4ogf (P3, task) — closes the 2 TRULY-ORPHAN findings from `docs/audits/wrapped-no-consumer-2026-05-10.md`. Sibling cf-4x7e Pass-3 chunk under cf-567r/cf-q5hd/cf-cw6e batch.

## Edits

### 1. `triggerPostPurchaseSequence` — `marketingSequences.web.js:157`
Duplicate of the alive `emailAutomation.web.js:584` version (called from `events.js:241`). The marketingSequences version was never imported by http-functions.js — confirmed via grep.
- `src/backend/marketingSequences.web.js` (-32 LOC)
- `tests/marketingSequences.test.js` (2 describe blocks, -65 LOC + import + header doc-comment)

### 2. `getAssemblyFollowUpData` — `postPurchaseCare.web.js:355`
Imported at `http-functions.js:16` but no wrapper body dispatched to it. Leftover from a removed wrapper.
- `src/backend/postPurchaseCare.web.js` (-48 LOC)
- `src/backend/http-functions.js` (drop dead import, -1 LOC)
- `tests/postPurchaseCare.test.js` (1 describe, -89 LOC + import)
- `tests/postPurchaseCareHardening.test.js` (1 describe, -45 LOC + import)
- `tests/postPurchaseCareDeep.test.js` (1 describe, -41 LOC + import)
- `tests/orderFulfillmentHardening.test.js` (1 describe, -16 LOC)

Net diff: 8 files changed, 375 deletions, 0 insertions.

## Verification
- 0 grep hits for `getAssemblyFollowUpData` outside 3 harmless `vi.mock` stubs (blogRssFeedEdgeCases / topicClusterEndpoint / topicClusterEndpointUrlEncoding) — these mock the postPurchaseCare module surface but don't use the dropped value. Kept as-is to avoid touching unrelated test files.
- All remaining `triggerPostPurchaseSequence` refs point at the alive `emailAutomation.web.js` version (events.js, http-functions.js import block, multiple direct test files).

## Tests
- Targeted (4 affected test files): **178/178 PASS**
- Full suite: **1099/1099 files, 38070 tests pass**, 59 todo. **Zero fallout.**

## Pattern + batch completion
Closes the cf-hpwy v3 audit batch end-to-end. 4 cleanup PRs total:
- PR #1283 **cf-567r**: contactImport.web.js retire (1 method)
- PR #1290 **cf-q5hd**: previewWeeklyBlogDigest trim (1 method)
- PR #1294 **cf-cw6e**: blogNewsletter.web.js retire (3 methods)
- **This PR cf-4ogf**: 2 TRULY-ORPHAN trims (2 methods)

~1700 LOC dead-code removed across the 4 PRs.