### PR TITLE
fix(cf-secrets.F1): explicit fail path for missing SITE_OWNER_CONTACT_ID (P2)

### DIFF
--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -99,6 +99,43 @@ export async function _checkEmailRateLimit(key, opts = {}) {
 const RATE_LIMIT_MESSAGE = 'Too many requests. Please try again later.';
 
 /**
+ * Resolve the site owner Wix contact ID with explicit error handling
+ * (cf-secrets.F1 — secrets-audit P2).
+ *
+ * Wix Secrets Manager rejects with a "Secret not found" error when
+ * `SITE_OWNER_CONTACT_ID` isn't configured. The bare `await` was
+ * propagating the rejection up to the caller's catch which logged a
+ * generic "Failed to send …" — Stilgar saw no signal that the root
+ * cause was secret misconfiguration, customers hit failure-soft with
+ * no owner notification.
+ *
+ * @param {string} [callSite] - Diagnostic label for the warn log
+ *   (e.g. 'sendEmail', 'submitSwatchRequest'). Helps triage which
+ *   surface tripped the missing-secret path.
+ * @returns {Promise<string|null>} Contact ID, or `null` if the secret
+ *   is missing/empty (with an explicit warn logged).
+ */
+async function _resolveSiteOwnerContactId(callSite = 'unknown') {
+  let value;
+  try {
+    value = await getSecret('SITE_OWNER_CONTACT_ID');
+  } catch (err) {
+    console.warn(
+      `[emailService] SITE_OWNER_CONTACT_ID missing — owner notification skipped (${callSite}):`,
+      err?.message ?? err,
+    );
+    return null;
+  }
+  if (!value) {
+    console.warn(
+      `[emailService] SITE_OWNER_CONTACT_ID resolved to empty value — owner notification skipped (${callSite})`,
+    );
+    return null;
+  }
+  return value;
+}
+
+/**
  * Send a contact form submission to the store owner via triggered email.
  * Also saves the submission to the `ContactSubmissions` CMS collection.
  *
@@ -145,7 +182,16 @@ export const sendEmail = webMethod(
 
       // Retrieve the site owner's Wix contact ID from Secrets Manager.
       // This is the recipient of all contact form notifications.
-      const siteOwnerContactId = await getSecret('SITE_OWNER_CONTACT_ID');
+      // cf-secrets.F1 (P2): explicit fail path. If the secret is missing
+      // the bare await rejects and propagates up to the outer catch which
+      // returns the generic "Failed to send message" error — Stilgar gets
+      // no signal that the cause was secret misconfiguration, customers
+      // hit the failure-soft path with no owner notification (silent
+      // customer-service blackout).
+      const siteOwnerContactId = await _resolveSiteOwnerContactId('sendEmail');
+      if (!siteOwnerContactId) {
+        return { success: false, message: 'Could not deliver your message. Please call (828) 252-9449.' };
+      }
       await triggeredEmails.emailContact(
         resolveTemplateId('contact_form_submission'),
         siteOwnerContactId,
@@ -287,7 +333,11 @@ export const submitSwatchRequest = webMethod(
         return { success: false, message: RATE_LIMIT_MESSAGE };
       }
 
-      const siteOwnerContactId = await getSecret('SITE_OWNER_CONTACT_ID');
+      // cf-secrets.F1 (P2): explicit fail path — see sendEmail for context.
+      const siteOwnerContactId = await _resolveSiteOwnerContactId('submitSwatchRequest');
+      if (!siteOwnerContactId) {
+        return { success: false, message: 'Could not deliver your swatch request. Please call (828) 252-9449.' };
+      }
 
       // Persist to CMS for record-keeping
       await wixData.insert('ContactSubmissions', {
@@ -436,7 +486,11 @@ export const sendOrderNotification = webMethod(
   Permissions.SiteMember,
   async (orderDetails) => {
     try {
-      const siteOwnerContactId = await getSecret('SITE_OWNER_CONTACT_ID');
+      // cf-secrets.F1 (P2): explicit fail path — see sendEmail for context.
+      const siteOwnerContactId = await _resolveSiteOwnerContactId('sendOrderNotification');
+      if (!siteOwnerContactId) {
+        return { success: false };
+      }
       await triggeredEmails.emailContact(
         resolveTemplateId('new_order_notification'),
         siteOwnerContactId,

--- a/tests/emailServiceSecretsF1.test.js
+++ b/tests/emailServiceSecretsF1.test.js
@@ -1,0 +1,119 @@
+/**
+ * @file emailServiceSecretsF1.test.js
+ * @description cf-secrets.F1 (P2) — explicit fail path for missing
+ * SITE_OWNER_CONTACT_ID. Pre-fix the bare `await getSecret(...)` would
+ * propagate a "Secret not found" rejection up to the caller's catch,
+ * which logged a generic "Failed to send …" — Stilgar saw no signal,
+ * customers hit failure-soft with no owner notification (silent
+ * customer-service blackout).
+ *
+ * Post-fix: `_resolveSiteOwnerContactId(callSite)` wraps the secret
+ * lookup, logs an explicit `SITE_OWNER_CONTACT_ID missing` warn
+ * naming the call site, and the caller skips the email send + returns
+ * `success: false`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { __reset as resetSecrets } from './__mocks__/wix-secrets-backend.js';
+import { __reset as resetCrm, __getEmailLog } from './__mocks__/wix-crm-backend.js';
+import {
+  sendEmail,
+  submitSwatchRequest,
+  sendOrderNotification,
+} from '../src/backend/emailService.web.js';
+
+beforeEach(() => {
+  resetSecrets(); // No SITE_OWNER_CONTACT_ID configured in any test below.
+  resetCrm();
+});
+
+const validContactForm = {
+  name: 'Bob Test',
+  email: 'bob@example.com',
+  phone: '828-555-0100',
+  subject: 'Question',
+  message: 'Hello',
+};
+
+describe('sendEmail — SITE_OWNER_CONTACT_ID missing (cf-secrets.F1)', () => {
+  it('returns success: false with a customer-facing call-us message', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await sendEmail(validContactForm);
+    expect(res.success).toBe(false);
+    expect(res.message).toMatch(/call/i);
+    warnSpy.mockRestore();
+  });
+
+  it('logs the explicit "SITE_OWNER_CONTACT_ID missing" warn with sendEmail call-site label', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await sendEmail(validContactForm);
+    const warnings = warnSpy.mock.calls.map((args) => args.map(String).join(' '));
+    const found = warnings.find(
+      (w) => w.includes('SITE_OWNER_CONTACT_ID missing') && w.includes('sendEmail'),
+    );
+    expect(found, `expected explicit warn naming sendEmail; got: ${JSON.stringify(warnings)}`).toBeDefined();
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT emit any owner-notification email (no triggeredEmails.emailContact call)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await sendEmail(validContactForm);
+    expect(__getEmailLog()).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+});
+
+describe('submitSwatchRequest — SITE_OWNER_CONTACT_ID missing (cf-secrets.F1)', () => {
+  const validRequest = {
+    name: 'Alice Test',
+    email: 'alice@example.com',
+    swatches: ['ESP-1'],
+    productName: 'Eureka Frame',
+    productId: 'p-1',
+    address: '123 Main St',
+  };
+
+  it('returns success: false with a customer-facing call-us message', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await submitSwatchRequest(validRequest);
+    expect(res.success).toBe(false);
+    expect(res.message).toMatch(/call/i);
+    warnSpy.mockRestore();
+  });
+
+  it('logs the warn naming the submitSwatchRequest call site', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await submitSwatchRequest(validRequest);
+    const found = warnSpy.mock.calls
+      .map((args) => args.map(String).join(' '))
+      .find((w) => w.includes('SITE_OWNER_CONTACT_ID missing') && w.includes('submitSwatchRequest'));
+    expect(found).toBeDefined();
+    warnSpy.mockRestore();
+  });
+});
+
+describe('sendOrderNotification — SITE_OWNER_CONTACT_ID missing (cf-secrets.F1)', () => {
+  const validOrder = {
+    number: 'CF-12345',
+    buyerName: 'Order Buyer',
+    total: '$100.00',
+    lineItems: [{}],
+  };
+
+  it('returns success: false (silent failure to caller) without throwing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await sendOrderNotification(validOrder);
+    expect(res).toEqual({ success: false });
+    warnSpy.mockRestore();
+  });
+
+  it('logs the warn naming the sendOrderNotification call site', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await sendOrderNotification(validOrder);
+    const found = warnSpy.mock.calls
+      .map((args) => args.map(String).join(' '))
+      .find((w) => w.includes('SITE_OWNER_CONTACT_ID missing') && w.includes('sendOrderNotification'));
+    expect(found).toBeDefined();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Closes secrets-audit finding **F1 (P2)**. Three call sites in `emailService.web.js` called `getSecret('SITE_OWNER_CONTACT_ID')` bare. The audit:

> Customer-facing impact: Contact form submission appears to succeed (the user sees the auto-reply branch fail-soft per cf-hafn) but the OWNER never gets the inbound message → silent customer-service blackout. Same shape for swatch request.

## Fix

Extract `_resolveSiteOwnerContactId(callSite)` helper. On rejection or empty value, logs an explicit `[emailService] SITE_OWNER_CONTACT_ID missing — owner notification skipped (<callSite>):` warn and returns `null`. Each caller short-circuits.

| Call site | Behavior on missing secret |
|---|---|
| `sendEmail` (contact form) | `success: false` + customer-facing "call (828) 252-9449" |
| `submitSwatchRequest` | `success: false` + customer-facing "call …" |
| `sendOrderNotification` (admin) | `success: false` (no customer-facing message needed) |

`notificationService.web.js:353` already had explicit handling (`if (!ownerId)` → console fallback); left alone.

## Tests (7 new, 147/147 emailService total)

3 call sites × {returns success:false with the right message, logs warn naming the call site} + a "no email log entry" assertion on `sendEmail` to prove no partial owner-notification side effect.

## Cutover-night handoff

The populated `SITE_OWNER_CONTACT_ID` belongs in the cf-3qt.8 cutover-checklist gate. With this PR, if it's missing on cutover night, ops will see the explicit warn in the Wix logs naming exactly which surface tripped — far better signal than a generic "Failed to send …" returning to the customer with no log breadcrumb tying it back to the secret.

## Audit reference

`docs/audits/secrets-audit-2026-05-10.md` §F1.

## Test plan
- [x] `vitest run tests/emailServiceSecretsF1.test.js` — 7/7 pass
- [x] All 147 emailService tests pass post-fix
- [x] No production behavior change when the secret IS configured (lookup still returns the value, the helper is a thin wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)