### PR TITLE
fix(cf-sazb): logError distinguishes rate-limit db_error from throttle (CI red on main)

### DIFF
--- a/src/backend/errorMonitoring.web.js
+++ b/src/backend/errorMonitoring.web.js
@@ -100,8 +100,17 @@ export const logError = webMethod(
 
       const rateLimitKey = cleanUserId || cleanPage || 'anon';
       const rateLimitMax = rateLimitKey === 'anon' ? 200 : 30;
-      const { allowed } = await checkRateLimit('ErrorLogRateLimit', rateLimitKey, { max: rateLimitMax, windowMs: 60_000 });
+      const { allowed, reason } = await checkRateLimit('ErrorLogRateLimit', rateLimitKey, { max: rateLimitMax, windowMs: 60_000 });
       if (!allowed) {
+        // cf-sazb: distinguish 'rate_limited' (intentional throttle, caller can drop)
+        // from 'db_error' (rate-limit collection sick — we did NOT log the original
+        // error and the caller deserves to know). cf-3ldu.F2 introduced the
+        // db_error path; reporting it as `success: true, throttled: true` made
+        // a real failure look like a deliberate throttle.
+        if (reason === 'db_error') {
+          console.error(`[errorMonitoring] Rate-limit DB error; original error NOT logged for key=${rateLimitKey}`);
+          return { success: false, error: 'rate_limit_db_error' };
+        }
         console.warn(`[errorMonitoring] Error flood throttled for key=${rateLimitKey}`);
         return { success: true, throttled: true };
       }


### PR DESCRIPTION
## Summary

**CI is red on main as of HEAD 427ccf2** — 7 test failures across `tests/errorMonitoringDeep.test.js` and `tests/errorMonitoringWiring.test.js`. Surfaced when the FAILURE checks on PR #1298 still merged because of admin override; visible to anyone running `npx vitest run` locally.

## Root cause

PR #1288 (cf-3ldu.F2 fail-closed rate-limit) made `checkRateLimit` return `{allowed: false, reason: 'db_error'}` when the rate-limit collection insert/update throws.

`logError()` in `src/backend/errorMonitoring.web.js` didn't read `reason` — it just saw `!allowed` and returned `{success: true, throttled: true}` for any blocked path. Two consequences:

1. **Semantics** — a DB error returning `success: true` makes the caller think the error log was recorded when it wasn't. The original error silently drops. Operationally bad: lose error signal during the exact incident type the rate-limit is supposed to protect against.

2. **Test cascade** — `'never throws when logError fails internally'` test monkey-patches `wixData.insert` to throw, expects `success: false`, gets `success: true`. The assertion fails BEFORE the manual cleanup line runs, leaving `wixData.insert` broken for the next 3 tests in the same file. Same shape in both test files. 7 failures total.

## Fix

Distinguish `reason` in `logError`:

- `db_error` → `{success: false, error: 'rate_limit_db_error'}` (real failure)
- `rate_limited` → `{success: true, throttled: true}` (intentional throttle, caller can drop)

10 lines added, 1 modified.

## Verification

```
$ npx vitest run tests/errorMonitoringDeep.test.js tests/errorMonitoringWiring.test.js
Test Files  2 passed (2)
     Tests  36 passed (36)

$ npx vitest run --reporter=dot
Test Files  1098 passed (1098)
     Tests  37915 passed | 59 todo (37974)
```

**Zero collateral.**

## Why a P1

Surfaced as the failure check on PR #1298 (cf-jzux). main is currently CI-red — every subsequent PR will inherit the failure unless this lands first. Bug also affects production behavior: error-monitoring drops original errors silently when the rate-limit collection is sick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)