### PR TITLE
fix(cf-c0np): migrate 3 remaining local rate-limit helpers to canonical — F4 sweep

### DIFF
--- a/src/backend/contactSubmissions.web.js
+++ b/src/backend/contactSubmissions.web.js
@@ -33,7 +33,10 @@ const CONTACT_RATE_LIMIT_COLLECTION = 'ContactRateLimits';
 /**
  * Check and increment the per-email rate limit for contact form submissions.
  * Returns { allowed: true } or { allowed: false, reason: 'rate_limited' }.
- * Fails open on DB error to avoid blocking legitimate submissions.
+ *
+ * cf-c0np (cf-3ldu F4): migrated from local re-implementation to the
+ * canonical wixData-backed helper. Closes the cf-sec1 plaintext-key gap
+ * and aligns with cf-8p52 fail-closed-on-DB-error policy.
  *
  * @param {string} key - Normalized email address
  * @param {Object} [opts]
@@ -41,49 +44,11 @@ const CONTACT_RATE_LIMIT_COLLECTION = 'ContactRateLimits';
  * @returns {Promise<{allowed: boolean, reason?: string}>}
  */
 export async function _checkContactRateLimit(key, opts = {}) {
-  const now = (opts && opts.now != null) ? opts.now : Date.now();
-  try {
-    const cleanKey = sanitize(key, 254).toLowerCase();
-
-    const existing = await wixData.query(CONTACT_RATE_LIMIT_COLLECTION)
-      .eq('key', cleanKey)
-      .limit(1)
-      .find();
-
-    if (existing.items.length === 0) {
-      await wixData.insert(CONTACT_RATE_LIMIT_COLLECTION, {
-        key: cleanKey,
-        count: 1,
-        windowStart: new Date(now),
-      });
-      return { allowed: true };
-    }
-
-    const record = existing.items[0];
-    const windowAge = now - new Date(record.windowStart).getTime();
-
-    if (windowAge > CONTACT_RATE_LIMIT_WINDOW_MS) {
-      await wixData.update(CONTACT_RATE_LIMIT_COLLECTION, {
-        ...record,
-        count: 1,
-        windowStart: new Date(now),
-      });
-      return { allowed: true };
-    }
-
-    if (record.count >= CONTACT_RATE_LIMIT_MAX) {
-      return { allowed: false, reason: 'rate_limited' };
-    }
-
-    await wixData.update(CONTACT_RATE_LIMIT_COLLECTION, {
-      ...record,
-      count: record.count + 1,
-    });
-    return { allowed: true };
-  } catch (err) {
-    console.warn('[contactSubmissions] Rate limit check failed, allowing request:', err?.message ?? err);
-    return { allowed: true }; // Fail open — don't block on DB errors
-  }
+  return checkRateLimit(CONTACT_RATE_LIMIT_COLLECTION, key, {
+    now: opts && opts.now,
+    max: CONTACT_RATE_LIMIT_MAX,
+    windowMs: CONTACT_RATE_LIMIT_WINDOW_MS,
+  });
 }
 
 /**

--- a/src/backend/newsletterService.web.js
+++ b/src/backend/newsletterService.web.js
@@ -23,6 +23,7 @@ import { currentMember } from 'wix-members-backend';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
+import { checkRateLimit } from 'backend/utils/rateLimit';
 
 const DISCOUNT_CODE = 'WELCOME10';
 const KLAVIYO_API_BASE = 'https://a.klaviyo.com/api';
@@ -37,9 +38,12 @@ export const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 /**
  * Check and record a rate-limit attempt for a given key.
- * Allows up to RATE_LIMIT_MAX calls per RATE_LIMIT_WINDOW_MS per key.
- * Fails open (allows) if the DB check itself errors, to avoid blocking
- * legitimate users on infrastructure issues.
+ *
+ * cf-c0np (cf-3ldu F4): migrated from local re-implementation to the
+ * canonical wixData-backed helper. The previous local impl stored
+ * plaintext lowercased emails as bucket keys (cf-sec1 CMEK gap) and
+ * failed-open on DB error (cf-8p52 flipped the canonical helper to
+ * fail-closed). Both gaps close by deferring to the canonical.
  *
  * @param {string} key - Normalized identifier (email).
  * @param {Object} [opts]
@@ -47,50 +51,11 @@ export const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
  * @returns {Promise<{allowed: boolean, reason?: string}>}
  */
 export async function _checkRateLimit(key, opts = {}) {
-  const now = (opts && opts.now != null) ? opts.now : Date.now();
-  try {
-    const cleanKey = sanitize(key, 254).toLowerCase();
-
-    const existing = await wixData.query('NewsletterRateLimit')
-      .eq('key', cleanKey)
-      .limit(1)
-      .find();
-
-    if (existing.items.length === 0) {
-      await wixData.insert('NewsletterRateLimit', {
-        key: cleanKey,
-        count: 1,
-        windowStart: new Date(now),
-      });
-      return { allowed: true };
-    }
-
-    const record = existing.items[0];
-    const windowAge = now - new Date(record.windowStart).getTime();
-
-    if (windowAge > RATE_LIMIT_WINDOW_MS) {
-      // Window expired — reset counter
-      await wixData.update('NewsletterRateLimit', {
-        ...record,
-        count: 1,
-        windowStart: new Date(now),
-      });
-      return { allowed: true };
-    }
-
-    if (record.count >= RATE_LIMIT_MAX) {
-      return { allowed: false, reason: 'rate_limited' };
-    }
-
-    await wixData.update('NewsletterRateLimit', {
-      ...record,
-      count: record.count + 1,
-    });
-    return { allowed: true };
-  } catch (err) {
-    console.warn('[newsletterService] Rate limit check failed, allowing request:', err.message);
-    return { allowed: true }; // Fail open — don't block on DB errors
-  }
+  return checkRateLimit('NewsletterRateLimit', key, {
+    now: opts && opts.now,
+    max: RATE_LIMIT_MAX,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  });
 }
 
 /**

--- a/src/backend/promotionsEngine.web.js
+++ b/src/backend/promotionsEngine.web.js
@@ -47,6 +47,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
+import { checkRateLimit } from 'backend/utils/rateLimit';
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -62,7 +63,10 @@ const PROMO_RATE_LIMIT_COLLECTION = 'PromoRateLimits';
 /**
  * Check and increment the per-key rate limit for promo code attempts.
  * Returns { allowed: true } or { allowed: false, reason: 'rate_limited' }.
- * Fails open on DB error (prefer availability over false rejections for promo codes).
+ *
+ * cf-c0np (cf-3ldu F4): migrated from local re-implementation to the
+ * canonical wixData-backed helper. Closes the cf-sec1 plaintext-key gap
+ * and aligns with cf-8p52 fail-closed-on-DB-error policy.
  *
  * @param {string} key - Rate limit bucket key (IP or injectable token for tests)
  * @param {Object} [opts]
@@ -70,49 +74,11 @@ const PROMO_RATE_LIMIT_COLLECTION = 'PromoRateLimits';
  * @returns {Promise<{allowed: boolean, reason?: string}>}
  */
 export async function _checkPromoRateLimit(key, opts = {}) {
-  const now = (opts && opts.now != null) ? opts.now : Date.now();
-  try {
-    const cleanKey = sanitize(String(key || ''), 100);
-
-    const existing = await wixData.query(PROMO_RATE_LIMIT_COLLECTION)
-      .eq('key', cleanKey)
-      .limit(1)
-      .find();
-
-    if (existing.items.length === 0) {
-      await wixData.insert(PROMO_RATE_LIMIT_COLLECTION, {
-        key: cleanKey,
-        count: 1,
-        windowStart: new Date(now),
-      });
-      return { allowed: true };
-    }
-
-    const record = existing.items[0];
-    const windowAge = now - new Date(record.windowStart).getTime();
-
-    if (windowAge > PROMO_RATE_LIMIT_WINDOW_MS) {
-      await wixData.update(PROMO_RATE_LIMIT_COLLECTION, {
-        ...record,
-        count: 1,
-        windowStart: new Date(now),
-      });
-      return { allowed: true };
-    }
-
-    if (record.count >= PROMO_RATE_LIMIT_MAX) {
-      return { allowed: false, reason: 'rate_limited' };
-    }
-
-    await wixData.update(PROMO_RATE_LIMIT_COLLECTION, {
-      ...record,
-      count: record.count + 1,
-    });
-    return { allowed: true };
-  } catch (err) {
-    console.warn('[promotionsEngine] Promo rate limit check failed, allowing request:', err?.message ?? err);
-    return { allowed: true }; // Fail open — don't block on DB errors
-  }
+  return checkRateLimit(PROMO_RATE_LIMIT_COLLECTION, String(key || ''), {
+    now: opts && opts.now,
+    max: PROMO_RATE_LIMIT_MAX,
+    windowMs: PROMO_RATE_LIMIT_WINDOW_MS,
+  });
 }
 
 // ── Public API ─────────────────────────────────────────────────────

--- a/tests/newsletterRateLimit.test.js
+++ b/tests/newsletterRateLimit.test.js
@@ -18,6 +18,9 @@ import {
   subscribeToNewsletter,
   captureExitIntentEmail,
 } from '../src/backend/newsletterService.web.js';
+// cf-c0np: _checkRateLimit now defers to canonical helper which hashes
+// keys before storage. Seeded records must use hashRateLimitKey.
+import { hashRateLimitKey } from '../src/backend/utils/rateLimit.js';
 
 // Note: no vi.mock() needed — vitest.config.js resolve.alias auto-redirects
 // all wix-* imports to tests/__mocks__/wix-*.js, and setup.js resets state
@@ -25,8 +28,8 @@ import {
 
 const NOW = 1_700_000_000_000; // fixed timestamp
 
-function makeRateLimitRecord(count, windowStart = NOW) {
-  return { _id: 'rl-1', key: 'test@example.com', count, windowStart: new Date(windowStart) };
+function makeRateLimitRecord(count, windowStart = NOW, email = 'test@example.com') {
+  return { _id: 'rl-1', key: hashRateLimitKey(email.toLowerCase()), count, windowStart: new Date(windowStart) };
 }
 
 function seedSubscriber(email = 'test@example.com') {
@@ -82,10 +85,12 @@ describe('_checkRateLimit', () => {
     expect(result.allowed).toBe(false);
   });
 
-  it('fails open when DB query throws', async () => {
+  it('fails CLOSED when DB query throws (cf-c0np / cf-8p52)', async () => {
     __setQueryError('NewsletterRateLimit', new Error('DB down'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await _checkRateLimit('test@example.com', { now: NOW });
-    expect(result).toEqual({ allowed: true });
+    expect(result).toEqual({ allowed: false, reason: 'db_error' });
+    errSpy.mockRestore();
   });
 
   it('window boundary — just expired allows (age > window)', async () => {

--- a/tests/rateLimiting.test.js
+++ b/tests/rateLimiting.test.js
@@ -30,16 +30,18 @@ import {
 const NOW = 1_700_000_000_000;
 const ONE_HOUR = 60 * 60 * 1000;
 
+// cf-c0np: both _checkPromoRateLimit and _checkContactRateLimit now
+// thin-wrap canonical checkRateLimit which hashes keys before storage.
+// Seed records using the FNV-1a hash of the raw input.
 function makePromoRecord(count, windowStart = NOW) {
-  return { _id: 'pr-1', key: 'test-ip', count, windowStart: new Date(windowStart) };
+  return { _id: 'pr-1', key: hashRateLimitKey('test-ip'), count, windowStart: new Date(windowStart) };
 }
 
-// Raw key — for tests of _checkContactRateLimit (local impl, no hashing)
 function makeContactRecord(count, windowStart = NOW) {
-  return { _id: 'cr-1', key: 'test@example.com', count, windowStart: new Date(windowStart) };
+  return { _id: 'cr-1', key: hashRateLimitKey('test@example.com'), count, windowStart: new Date(windowStart) };
 }
 
-// Hashed key — for tests of submitContactForm (uses shared checkRateLimit which hashes)
+// Hashed key for submitContactForm tests (same canonical helper).
 function makeHashedContactRecord(email, count, windowStart = NOW) {
   return { _id: 'cr-1', key: hashRateLimitKey(email.toLowerCase()), count, windowStart: new Date(windowStart) };
 }
@@ -81,16 +83,16 @@ describe('_checkPromoRateLimit', () => {
     expect(result).toEqual({ allowed: false, reason: 'rate_limited' });
   });
 
-  it('fails open (allows) when wixData query throws', async () => {
+  it('fails CLOSED when wixData query throws (cf-c0np / cf-8p52)', async () => {
     __setQueryError('PromoRateLimits', new Error('DB unavailable'));
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await _checkPromoRateLimit('test-ip', { now: NOW });
-    expect(result).toEqual({ allowed: true });
-    warnSpy.mockRestore();
+    expect(result).toEqual({ allowed: false, reason: 'db_error' });
+    errSpy.mockRestore();
   });
 
-  it('uses key as-is (for IP tokens, not lowercased like email)', async () => {
-    __seed('PromoRateLimits', [{ _id: 'pr-2', key: '192.168.1.1', count: 10, windowStart: new Date(NOW) }]);
+  it('uses key as-is then hashes (IP tokens are not lowercased like emails)', async () => {
+    __seed('PromoRateLimits', [{ _id: 'pr-2', key: hashRateLimitKey('192.168.1.1'), count: 10, windowStart: new Date(NOW) }]);
     const result = await _checkPromoRateLimit('192.168.1.1', { now: NOW + 1 });
     expect(result).toEqual({ allowed: false, reason: 'rate_limited' });
   });
@@ -186,12 +188,12 @@ describe('_checkContactRateLimit', () => {
     expect(result).toEqual({ allowed: false, reason: 'rate_limited' });
   });
 
-  it('fails open (allows) when wixData query throws', async () => {
+  it('fails CLOSED when wixData query throws (cf-c0np / cf-8p52)', async () => {
     __setQueryError('ContactRateLimits', new Error('DB unavailable'));
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await _checkContactRateLimit('test@example.com', { now: NOW });
-    expect(result).toEqual({ allowed: true });
-    warnSpy.mockRestore();
+    expect(result).toEqual({ allowed: false, reason: 'db_error' });
+    errSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
Resolves cf-3ldu **F4 (P3)**. Three local rate-limit re-implementations predated the canonical helper:
- \`newsletterService._checkRateLimit\` (NewsletterRateLimit)
- \`contactSubmissions._checkContactRateLimit\` (ContactRateLimits)
- \`promotionsEngine._checkPromoRateLimit\` (PromoRateLimits)

Each was a ~50-line wixData-backed re-impl that **stored plaintext keys** (cf-sec1 CMEK gap) and **failed open on DB error** (cf-8p52 flipped the canonical helper to fail-closed; the locals drifted).

Each helper now thin-wraps \`checkRateLimit()\` with its existing collection name + per-helper max/window. **Net diff: -153 / +56 lines.**

### Tests
- \`rateLimiting.test.js\` — seeded keys updated to \`hashRateLimitKey(...)\`. 2 fail-open assertions flipped to fail-closed.
- \`newsletterRateLimit.test.js\` — same migration.
- All 22 rateLimiting + 30 newsletterRateLimit tests pass.
- Full suite: only pre-existing funnelTracker / errorMonitoring failures remain (unrelated).

### Pre-merge note
\`NewsletterRateLimit\`, \`ContactRateLimits\`, \`PromoRateLimits\` collections already exist in production CMS. Existing rows hold plaintext keys; new lookups will not match them (effectively a counter reset to 0 for each user). Existing rows age out within their windows (1 hour each) — **no operator migration required.**

### Companion / family
- cf-3ldu.1 (PR #1288) — returnsService migrated
- cf-qjhf (PR #1301) — deliveryScheduling migrated
- This PR — newsletter, contactSubmissions, promotionsEngine

After merge: zero remaining local rate-limit re-implementations in \`src/backend/\`. Every wixData-backed rate-limit goes through the canonical helper with hashed keys + fail-closed-on-DB-error.

## Test plan
- [x] Unit: 52 affected tests pass (22 + 30)
- [x] Hash-at-rest: existing canonical tests cover this
- [x] Fail-closed: 3 \`fails open\` assertions flipped + verified
- [ ] Manual post-deploy: subscribe to newsletter → query NewsletterRateLimit → confirm \`key\` is hash, not email

Refs: \`docs/audits/rate-limit-audit-2026-05-10.md\` F4, cf-3ldu, cf-c0np.

🤖 Generated with [Claude Code](https://claude.com/claude-code)