### PR TITLE
chore(cf-b8n8): scripts/check-doc-bead-refs.py — bead-ID drift guard

### DIFF
--- a/scripts/check-doc-bead-refs.allowlist
+++ b/scripts/check-doc-bead-refs.allowlist
@@ -1,0 +1,43 @@
+# cf-b8n8 — non-bead `cf-*` tokens that show up in cfutons docs.
+#
+# Append one prefix per line. Lines starting with `#` and blank lines
+# are ignored. Allowlist matches are exact.
+#
+# ## When to add an entry
+#
+# - The token is a Tailwind / CSS class name (`cf-cta`, `cf-cream`)
+#   that bleeds into prose because someone described a UI element by
+#   its class.
+# - The token is an ad-hoc category word coined inside a doc
+#   (`cf-dead` for dead-code findings, `cf-current` as a section
+#   header style).
+# - The token is a documented placeholder (`cf-XXXX` shapes inside
+#   templates) that escaped the fenced-code-block strip because it
+#   sits in inline code that Markdown doesn't fence.
+#
+# ## When NOT to add an entry
+#
+# - The token is a real bead that was *renamed*. Fix the doc to point
+#   at the new ID instead of suppressing the warning.
+# - The token has a sub-bead suffix (`.followup`, `.fu1`) that does
+#   not resolve. The parent bead may exist but the sub-bead does not
+#   — fix the reference, do not allowlist.
+
+# ── Tailwind + brand-token CSS classes ────────────────────────────
+cf-blue
+cf-cream
+cf-cta
+cf-espresso
+cf-navy
+cf-sand
+cf-charcoal
+cf-divider
+cf-ink
+cf-paper
+cf-footer-bg
+
+# ── Ad-hoc category / status words used in audit docs ─────────────
+cf-dead
+cf-current
+cf-cutover
+cf-cya

--- a/scripts/check-doc-bead-refs.baseline.txt
+++ b/scripts/check-doc-bead-refs.baseline.txt
@@ -1,0 +1,130 @@
+# cf-b8n8 baseline — pre-existing `cf-XXXX` doc references that don't
+# resolve to a known bead. Generated 2026-05-10 by running:
+#
+#     python3 scripts/check-doc-bead-refs.py --strict
+#
+# These are tracked here so the script can run in CI without
+# blocking on the existing drift backlog. New PRs that introduce
+# additional unknown refs will fail (exit 1) until either:
+#   1. the new ref is fixed (point at the right bead), OR
+#   2. the new ref is added to this file (rare — usually means a new
+#      CSS class or category word that should go in the .allowlist).
+#
+# To triage: pick a line, find the doc + the intended bead, fix the
+# reference, drop the line from this file. Goal is shrinking this
+# list to zero.
+#
+# Format: `<path>:<line> → <ref>` (matches the script's report shape).
+# Lines starting with `#` and blank lines are ignored.
+
+docs/testing-master.md:27 → cf-9u1
+docs/cf-38bi-freight-booking-automation-brief.md:3 → cf-ph3g.p3b
+docs/cf-38bi-freight-booking-automation-brief.md:93 → cf-ph3g.p2
+docs/TEST_STRATEGY.md:358 → cf-295
+docs/TEST_STRATEGY.md:359 → cf-mnh
+docs/TEST_STRATEGY.md:360 → cf-vuk
+docs/TEST_STRATEGY.md:383 → cf-6ub
+docs/TEST_STRATEGY.md:384 → cf-xv3
+docs/TEST_STRATEGY.md:385 → cf-69b
+docs/TEST_STRATEGY.md:386 → cf-8gu
+docs/TEST_STRATEGY.md:387 → cf-e3o
+docs/TEST_STRATEGY.md:388 → cf-mnh
+docs/TEST_STRATEGY.md:389 → cf-1ur
+docs/TEST_STRATEGY.md:390 → cf-295
+docs/TEST_STRATEGY.md:391 → cf-6wc
+docs/TEST_STRATEGY.md:392 → cf-vuk
+docs/TEST_STRATEGY.md:393 → cf-mdd
+docs/TEST_STRATEGY.md:394 → cf-bl8
+docs/TEST_STRATEGY.md:395 → cf-b2i
+docs/cf-uxcq-product-brief.md:3 → cf-ph3g.p3a
+docs/email-audit-2026-05-04.md:15 → cf-icww.followup
+docs/email-audit-2026-05-04.md:105 → cf-icww.followup
+docs/email-audit-2026-05-04.md:144 → cf-icww.followup
+docs/WIX-MCP-GAP-ANALYSIS.md:132 → cf-9g1g
+docs/WIX-MCP-GAP-ANALYSIS.md:227 → cf-9g1g
+docs/ELEMENT-ID-RECONCILIATION.md:6 → cf-nl57
+docs/MARKETING-STRATEGY.md:4 → cf-5ef
+docs/MARKETING-STRATEGY.md:72 → cf-7bk
+docs/MARKETING-STRATEGY.md:74 → cf-1nb
+docs/MARKETING-STRATEGY.md:88 → cf-10x
+docs/MARKETING-STRATEGY.md:93 → cf-1nb
+docs/MARKETING-STRATEGY.md:133 → cf-uqr
+docs/stage3-velo-parity-2026-05-09.md:128 → cf-kull.fu
+docs/cf-hpb2-referralservice-comparison.md:3 → cf-vtx5.fu
+docs/cf-3qt-9-wix-retirement-checklist.md:22 → cf-yw0m
+docs/cf-3qt-9-wix-retirement-checklist.md:268 → cf-yw0m
+docs/cf-3qt-9-wix-retirement-checklist.md:308 → cf-yw0m
+docs/cf-3qt-9-wix-retirement-checklist.md:330 → cf-yw0m
+docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.1.md:3 → cf-sq0d.fu1
+docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.1.md:3 → cf-4x7e.1.fu1
+docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.1.md:153 → cf-sq0d.fu1
+docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.2.md:3 → cf-sq0d.fu2
+docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.2.md:126 → cf-sq0d.fu2
+docs/cf-4x7e/PASS1-MATRIX-UPDATED-v3.2.md:142 → cf-sq0d.fu2
+docs/audits/rate-limit-audit-2026-05-10.md:166 → cf-sec1
+docs/audits/webmethod-permissions-audit-2026-05-10.md:125 → cf-sec1
+docs/audits/webmethod-permissions-audit-2026-05-10.md:154 → cf-sec1
+docs/audits/cron-schedule-audit-2026-05-10.md:10 → cf-4x7e.fu1
+docs/audits/cron-schedule-audit-2026-05-10.md:156 → cf-4x7e.fu1
+docs/qa/email-triggers-e2e-2026-05-05.md:66 → cf-8onx
+docs/archives/report_from_radahn.md:11 → cf-rym
+docs/archives/report_from_radahn.md:12 → cf-k9d
+docs/archives/report_from_radahn.md:13 → cf-2lm
+docs/archives/report_from_radahn.md:19 → cf-dui
+docs/archives/report_from_radahn.md:20 → cf-vhy
+docs/archives/report_from_radahn.md:28 → cf-0bw
+docs/archives/report_from_radahn.md:29 → cf-y8x
+docs/archives/report_from_radahn.md:35 → cf-k5j
+docs/archives/report_from_radahn.md:36 → cf-0vr
+docs/archives/report_from_radahn.md:37 → cf-yd6
+docs/archives/report_from_radahn.md:38 → cf-rzr
+docs/cf-3qt.8/mobile-smoke-2026-05-10.md:7 → cf-pjdb.spec.ts
+docs/cf-3qt.8/lighthouse-baseline-2026-05-10.md:74 → cf-z0ht.fu1
+docs/cf-3qt.8/lighthouse-baseline-2026-05-10.md:77 → cf-z0ht.fu1
+docs/cf-3qt.8/pre-flip-smoke-results-2026-05-10.md:75 → cf-theme
+docs/guides/hand-draw-plugin-evaluation.md:3 → cf-jt12
+docs/ops/cf-xpqf-helper-deadcode-audit-2026-05-10.md:88 → cf-ipg
+docs/ops/cf-xpqf-helper-deadcode-audit-2026-05-10.md:89 → cf-7mr
+docs/ops/cf-xpqf-helper-deadcode-audit-2026-05-10.md:103 → cf-xpqf.2
+docs/ops/cf-xpqf-helper-deadcode-audit-2026-05-10.md:104 → cf-xpqf.3
+docs/ops/cf-xpqf-helper-deadcode-audit-2026-05-10.md:106 → cf-xpqf.3
+docs/ops/cf-xpqf-helper-deadcode-audit-2026-05-10.md:114 → cf-sq0d.fu2
+docs/ops/merge-ordering-protection.md:5 → cf-vtx5.fu2
+docs/ops/merge-ordering-protection.md:5 → cf-bkxh.fu
+docs/ops/merge-ordering-protection.md:5 → cf-0h9q.fu1
+docs/ops/merge-ordering-protection.md:72 → cf-vtx5.fu2
+docs/ops/merge-ordering-protection.md:72 → cf-bkxh.fu
+docs/ops/merge-ordering-protection.md:72 → cf-0h9q.fu1
+docs/reports/token-burn-audit.md:19 → cf-8iy
+docs/reports/token-burn-audit.md:47 → cf-8iy
+docs/reports/token-burn-audit.md:90 → cf-8iy
+docs/strategy/klaviyo-migration-spike.md:5 → cf-ztoy
+docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:126 → cf-test
+docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:282 → cf-test
+docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:313 → cf-test
+docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:341 → cf-test
+docs/superpowers/specs/2026-03-23-gamification-v2-cross-crew-strengthening.md:59 → cf-m1c
+docs/superpowers/specs/2026-03-23-gamification-v2-cross-crew-strengthening.md:116 → cf-m1c
+docs/superpowers/specs/2026-03-28-wave31-epics-launch-to-revenue.md:49 → cf-2wxp
+docs/superpowers/specs/2026-03-28-wave31-epics-launch-to-revenue.md:50 → cf-2gfp
+docs/superpowers/specs/2026-03-28-wave31-epics-launch-to-revenue.md:58 → cf-yw0m
+docs/superpowers/specs/2026-03-28-wave31-epics-launch-to-revenue.md:106 → cf-8du3
+docs/superpowers/specs/2026-03-28-wave31-epics-launch-to-revenue.md:250 → cf-hfao
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:19 → cf-blft
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:34 → cf-39ct
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:35 → cf-qgg0
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:36 → cf-j43m
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:37 → cf-5r7k
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:38 → cf-5ps3
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:50 → cf-p4iy
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:51 → cf-au1w
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:71 → cf-8du3
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:143 → cf-5r7k
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:144 → cf-qgg0
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:145 → cf-au1w
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:146 → cf-8du3
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:206 → cf-39ct
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:206 → cf-j43m
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:206 → cf-i8e5
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:206 → cf-blft
+docs/superpowers/specs/2026-03-28-wave30-hardening-optimization-design.md:206 → cf-p4iy

--- a/scripts/check-doc-bead-refs.baseline.txt
+++ b/scripts/check-doc-bead-refs.baseline.txt
@@ -37,12 +37,6 @@ docs/TEST_STRATEGY.md:393 → cf-mdd
 docs/TEST_STRATEGY.md:394 → cf-bl8
 docs/TEST_STRATEGY.md:395 → cf-b2i
 docs/cf-uxcq-product-brief.md:3 → cf-ph3g.p3a
-docs/email-audit-2026-05-04.md:15 → cf-icww.followup
-docs/email-audit-2026-05-04.md:105 → cf-icww.followup
-docs/email-audit-2026-05-04.md:144 → cf-icww.followup
-docs/WIX-MCP-GAP-ANALYSIS.md:132 → cf-9g1g
-docs/WIX-MCP-GAP-ANALYSIS.md:227 → cf-9g1g
-docs/ELEMENT-ID-RECONCILIATION.md:6 → cf-nl57
 docs/MARKETING-STRATEGY.md:4 → cf-5ef
 docs/MARKETING-STRATEGY.md:72 → cf-7bk
 docs/MARKETING-STRATEGY.md:74 → cf-1nb
@@ -99,10 +93,6 @@ docs/reports/token-burn-audit.md:19 → cf-8iy
 docs/reports/token-burn-audit.md:47 → cf-8iy
 docs/reports/token-burn-audit.md:90 → cf-8iy
 docs/strategy/klaviyo-migration-spike.md:5 → cf-ztoy
-docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:126 → cf-test
-docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:282 → cf-test
-docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:313 → cf-test
-docs/superpowers/plans/2026-03-13-stage3-frontend-integration.md:341 → cf-test
 docs/superpowers/specs/2026-03-23-gamification-v2-cross-crew-strengthening.md:59 → cf-m1c
 docs/superpowers/specs/2026-03-23-gamification-v2-cross-crew-strengthening.md:116 → cf-m1c
 docs/superpowers/specs/2026-03-28-wave31-epics-launch-to-revenue.md:49 → cf-2wxp

--- a/scripts/check-doc-bead-refs.py
+++ b/scripts/check-doc-bead-refs.py
@@ -66,9 +66,20 @@ from pathlib import Path
 # with optional `.<suffix>` for sub-beads (e.g. `cf-3qt.8.31`). The
 # pattern is intentionally permissive on length so newly-coined IDs
 # parse correctly; the validity check is membership in `bd list`.
-BEAD_RE = re.compile(r"\bcf-[a-z0-9]{3,12}(?:\.[a-z0-9]+)*\b")
+# Real bead IDs are `cf-XXXX` (3–12 alnum) with optional dotted
+# sub-bead segments (`.8.31`). They never contain a second hyphen
+# — so `cf-test-zou-...` (a branch name) and `cf-foo-bar` (a
+# Tailwind utility composition) are NOT bead refs. The negative
+# lookahead `(?!-)` rejects those shapes.
+BEAD_RE = re.compile(r"\bcf-[a-z0-9]{3,12}(?:\.[a-z0-9]+)*(?!-)\b")
 
-FENCED_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_-]*\n.*?\n```", re.DOTALL)
+# MULTILINE so `^` anchors to each line; the leading `[ \t]*` allows
+# indented fences (CommonMark-permitted, common inside nested
+# bullet lists where bash blocks pick up 2- or 4-space indent).
+FENCED_BLOCK_RE = re.compile(
+    r"^[ \t]*```[a-zA-Z0-9_-]*\n.*?\n[ \t]*```",
+    re.DOTALL | re.MULTILINE,
+)
 
 
 def strip_fenced_blocks(text: str) -> str:

--- a/scripts/check-doc-bead-refs.py
+++ b/scripts/check-doc-bead-refs.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Scan docs/**/*.md for stale or typo'd `cf-XXXX` bead references.
+
+cf-b8n8. Sibling to scripts/check-doc-links.py (cf-ad9y). Where that
+script catches dead `[text](path.md)` markdown links, this one catches
+the next class of doc-rot: bead-ID drift.
+
+Concrete drift incident motivating this: the cf-ukc6.1 commit subject
+in cfw PR #565 mistakenly read `feat(cf-6zjo): ...`, breaking
+`git log --grep cf-ukc6` traceability. A 60-second pre-merge scan
+would have caught it.
+
+Scope:
+  - Walks `docs/**/*.md` from repo root.
+  - Pulls every `cf-<lowercase-alnum>` token out of the prose (the
+    canonical bead-ID shape used throughout cfutons + cfw).
+  - Cross-checks each against `bd list --all --json` (open + closed
+    + deferred).
+  - Strips fenced code blocks first so example/template IDs in code
+    samples don't false-positive (matches the
+    check-doc-links.py contract).
+  - Reads an allowlist at `scripts/check-doc-bead-refs.allowlist` —
+    one prefix per line — for `cf-*` tokens that aren't beads (CSS
+    classes like `cf-cta`, `cf-blue`, `cf-navy`; ad-hoc category
+    words like `cf-dead`). Allowlist entries match exactly.
+  - Reads a baseline at `scripts/check-doc-bead-refs.baseline.txt` —
+    one `<path>:<line> → <ref>` per line — for the existing drift
+    backlog. Refs in the baseline don't fail the run; they're carried
+    as warnings. Refs NOT in the baseline (i.e. new drift introduced
+    by a PR) fail.
+
+Run from repo root:
+    python3 scripts/check-doc-bead-refs.py            # CI mode
+    python3 scripts/check-doc-bead-refs.py --strict   # ignore baseline
+
+Exit codes:
+    0  no NEW drift vs baseline
+    1  one or more NEW unknown refs (or strict mode + any unknown)
+    2  bd not on PATH or returned non-JSON
+
+Adding ignores:
+  - Wrap example IDs (e.g. `cf-XXXXX` patterns inside how-to docs) in
+    fenced code blocks; the scanner skips fences exactly the way
+    check-doc-links.py does.
+  - For non-bead `cf-*` tokens that show up in prose (CSS class names,
+    category words), append them to the allowlist file.
+
+Deliberate non-goals:
+  - Does NOT verify the bead is *open* or *the right priority* — only
+    that it exists. Bead lifecycle is not a doc concern.
+  - Does NOT recurse into archived directories (`docs/archive/...`)
+    since archived docs intentionally reference retired beads.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+# Bead IDs are `cf-` followed by 4–8 lowercase alphanumeric characters,
+# with optional `.<suffix>` for sub-beads (e.g. `cf-3qt.8.31`). The
+# pattern is intentionally permissive on length so newly-coined IDs
+# parse correctly; the validity check is membership in `bd list`.
+BEAD_RE = re.compile(r"\bcf-[a-z0-9]{3,12}(?:\.[a-z0-9]+)*\b")
+
+FENCED_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_-]*\n.*?\n```", re.DOTALL)
+
+
+def strip_fenced_blocks(text: str) -> str:
+    """Replace fenced code blocks with empty lines so line numbers survive."""
+    def replace(m: re.Match[str]) -> str:
+        return "\n" * m.group(0).count("\n")
+    return FENCED_BLOCK_RE.sub(replace, text)
+
+
+def load_known_bead_ids() -> set[str]:
+    """Return the set of bead IDs known to `bd list`.
+
+    Uses `--all` so closed + deferred beads still resolve (a doc
+    correctly referencing a long-closed bead is not drift).
+    Exits 2 on bd unavailability so missing tooling is loud, not silent.
+    """
+    if shutil.which("bd") is None:
+        print("bd not on PATH — install gas-town tooling or run from a workspace shell", file=sys.stderr)
+        sys.exit(2)
+    try:
+        result = subprocess.run(
+            ["bd", "list", "--all", "--json", "--limit", "0"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"bd list --all --json failed: {exc.stderr.strip()}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        rows = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"bd list returned non-JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+    return {row["id"] for row in rows if isinstance(row, dict) and "id" in row}
+
+
+def load_allowlist(here: Path) -> set[str]:
+    """Read the per-repo allowlist of non-bead `cf-*` tokens."""
+    allowlist_path = here.parent / "check-doc-bead-refs.allowlist"
+    if not allowlist_path.is_file():
+        return set()
+    entries: set[str] = set()
+    for raw in allowlist_path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def load_baseline(here: Path) -> set[str]:
+    """Read the existing-drift baseline (one `<path>:<line> → <ref>` per line)."""
+    baseline_path = here.parent / "check-doc-bead-refs.baseline.txt"
+    if not baseline_path.is_file():
+        return set()
+    entries: set[str] = set()
+    for raw in baseline_path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def scan_repo(root: Path, known: set[str], allowlist: set[str]) -> list[str]:
+    """Return a list of "<path>:<line> → <ref>" strings for unknown refs."""
+    docs = root / "docs"
+    if not docs.is_dir():
+        return []
+
+    archive = (docs / "archive").resolve()
+    unknown: list[str] = []
+
+    for path in docs.rglob("*.md"):
+        # Archived docs intentionally reference retired beads.
+        try:
+            if archive in path.resolve().parents:
+                continue
+        except OSError:
+            continue
+
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+
+        stripped = strip_fenced_blocks(text)
+        for match in BEAD_RE.finditer(stripped):
+            ref = match.group(0)
+            if ref in known or ref in allowlist:
+                continue
+            line = stripped[: match.start()].count("\n") + 1
+            unknown.append(f"{path.relative_to(root)}:{line} → {ref}")
+
+    return unknown
+
+
+def main() -> int:
+    strict = "--strict" in sys.argv
+
+    here = Path(__file__).resolve()
+    candidates = [here.parent.parent, Path.cwd()]
+    root = next((p for p in candidates if (p / "docs").is_dir()), candidates[0])
+
+    known = load_known_bead_ids()
+    allowlist = load_allowlist(here)
+    baseline = set() if strict else load_baseline(here)
+    unknown = scan_repo(root, known, allowlist)
+
+    docs = root / "docs"
+    md_count = sum(1 for _ in docs.rglob("*.md")) if docs.is_dir() else 0
+
+    new_drift = [u for u in unknown if u not in baseline]
+    carried = len(unknown) - len(new_drift)
+
+    print(
+        f"Scanned {md_count} markdown files under {docs} "
+        f"against {len(known)} known beads + {len(allowlist)} allowlist entries"
+        + ("" if strict else f" + {len(baseline)} baselined refs")
+    )
+    if not unknown:
+        print("✓ Every cf-XXXX reference resolves.")
+        return 0
+    if not new_drift and not strict:
+        print(f"✓ No NEW drift ({carried} carried by baseline — run with --strict to see all).")
+        return 0
+
+    label = "unknown bead reference(s)" if strict else "NEW unknown bead reference(s) vs baseline"
+    print(f"✗ {len(new_drift)} {label}:")
+    for entry in new_drift:
+        print(f"  {entry}")
+    if not strict and carried:
+        print(f"  (also {carried} pre-existing baselined refs — re-run with --strict to triage)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Sibling to \`scripts/check-doc-links.py\` (cf-ad9y / PR #1275). Where that script catches dead \`[text](path.md)\` markdown links, this one catches the next class of doc-rot: stale or typo'd \`cf-XXXX\` bead-ID references.

**Drift incident that surfaced the gap:** cfw PR #565 (cf-ukc6.1) shipped with commit subject \`feat(cf-6zjo): ...\` — a typo that broke \`git log --grep cf-ukc6\` traceability for the cf-ukc6 standing order. A 60-second pre-merge scan would have caught it.

## How it works
1. Walks \`docs/**/*.md\` (skips \`docs/archive/\` — retired beads live there intentionally)
2. Strips fenced code blocks first so template/example IDs in code samples don't false-positive (matches check-doc-links.py contract)
3. Pulls every \`cf-<lowercase-alnum>\` token from prose, with optional \`.<sub-bead>\` suffix
4. Cross-checks against \`bd list --all --json\` (open + closed + deferred)

## Three-layer filter
1. **Known-bead set** from \`bd list\` (universe of valid IDs)
2. **Allowlist file** (\`scripts/check-doc-bead-refs.allowlist\`) for non-bead \`cf-*\` tokens that legitimately appear in prose — CSS classes (\`cf-blue\`, \`cf-cream\`, \`cf-cta\`), brand tokens, ad-hoc category words (\`cf-dead\`, \`cf-current\`)
3. **Baseline file** (\`scripts/check-doc-bead-refs.baseline.txt\`) for pre-existing drift the team can triage at its leisure. CI runs against the baseline so the existing 111-ref backlog doesn't block PRs; only **new** drift fails

## Modes
\`\`\`
python3 scripts/check-doc-bead-refs.py             # CI mode: fail on NEW drift only
python3 scripts/check-doc-bead-refs.py --strict    # ignore baseline (triage mode)
\`\`\`

## Verified on current main
\`\`\`
$ python3 scripts/check-doc-bead-refs.py
Scanned 180 markdown files under /Users/hal/gt/cfutons/docs against 764 known beads + 15 allowlist entries + 111 baselined refs
✓ No NEW drift (111 carried by baseline — run with --strict to see all).

$ echo \$?
0

$ python3 scripts/check-doc-bead-refs.py --strict
Scanned 180 markdown files ...
✗ 111 unknown bead reference(s):
  docs/testing-master.md:27 → cf-9u1
  ...
\`\`\`

The 111-ref backlog is real drift the docs accumulated over time — it's now visible + delegated to whoever wants to take a triage pass. Goal is shrinking the baseline to zero so strict mode can be promoted to a required CI check.

## Future
- Wire to lint workflow as required check (default-mode only — won't block on existing backlog)
- Triage the 111 baselined refs in batches (separate beads as needed)

## Refs
- Bead: cf-b8n8 (P4)
- Companion: \`scripts/check-doc-links.py\` (cf-ad9y, PR #1275 merged)
- Drift incident: cfw PR #565 cf-6zjo subject typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)