### PR TITLE
fix(cf-ds): distinguish db_error from rate_limit in bookAppointment

### DIFF
--- a/src/backend/deliveryScheduling.web.js
+++ b/src/backend/deliveryScheduling.web.js
@@ -612,6 +612,9 @@ export const bookAppointment = webMethod(
 
       const rlCheck = await _checkBookingRateLimit(data.customerEmail || '');
       if (!rlCheck.allowed) {
+        if (rlCheck.reason === 'db_error') {
+          return { success: false, message: 'Failed to book appointment. Please try again.' };
+        }
         return { success: false, message: 'Too many booking attempts. Please try again later.' };
       }
 


### PR DESCRIPTION
## Summary
- `bookAppointment` now checks `reason === 'db_error'` from `_checkBookingRateLimit` and returns `{success: false, message: 'Failed to book appointment. Please try again.'}` instead of the rate-limit message
- Same pattern as PR #1305 (errorMonitoring logError fix)
- Root cause: PR #1297 (fail-closed rate limit) + PR #1301 (canonical helper migration) changed `_checkBookingRateLimit` to return `{allowed: false, reason: 'db_error'}` on DB error; `bookAppointment` didn't check `reason`

## Test plan
- [x] `tests/deliverySchedulingCoverage.test.js` — 7/7 pass locally
- [x] `bookAppointment returns failure on unexpected error` now correctly returns "Failed to book appointment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)