### PR TITLE
feat(cf-0ziz): cf-hpwy v4 detector — module-namespace dispatcher pattern detection

### DIFF
--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -241,6 +241,68 @@ def collect_filesystem_path_refs(files: list[Path]) -> dict[str, list[str]]:
     return refs
 
 
+# cf-0ziz (cf-hpwy detector v4): module-namespace dispatcher detection.
+#
+# v3 closes the fs-path blind-spot. v4 closes the namespace-dispatcher
+# blind-spot — http-functions.js patterns of the shape:
+#
+#   import * as svcModule from 'backend/<file>.web';
+#   const ALLOWLIST = new Set(['methodA','methodB',...]);
+#   export async function post_svc(request) {
+#     const method = request.path[0];
+#     if (!ALLOWLIST.has(method)) return notFound(...);
+#     await svcModule[method](...args);
+#   }
+#
+# The `svcModule[method]()` call is dynamic — name-based grep can't tie
+# 'methodA' (an export of <file>.web.js) to its caller. v3 sees these
+# as WRAPPED-NO-CONSUMER (no direct cfw `/_functions/methodA` URL
+# match) when they're actually alive via /_functions/svc/methodA.
+#
+# Detection: grep http-functions.js for `import * as <id> from
+# 'backend/<file>.web'`, then for each detected id grep for
+# `<id>[<key>](...)` to confirm dispatcher use. If detected, every
+# export of <file>.web.js gets an OK-WIRED-VIA-DISPATCHER verdict.
+#
+# False-positive risk: a `import * as M` that just reads metadata
+# (e.g. `M.SOME_CONSTANT`) without `M[key](...)` would not match the
+# dispatcher pattern, so we only flag genuine dispatchers.
+DISPATCHER_IMPORT_RE = re.compile(
+    r"""import\s+\*\s+as\s+(\w+)\s+from\s+['"]backend/([^'"]+?)(?:\.web)?['"]"""
+)
+
+
+def collect_dispatcher_modules(http_text: str) -> dict[str, str]:
+    """Detect module-namespace dispatcher patterns in http-functions.js.
+
+    Returns a dict mapping defining-file basename → dispatcher alias name.
+    Only entries where the alias is later used in `<alias>[<key>](...)`
+    call shape are returned — bare metadata reads (`M.CONST`) are
+    filtered out so a non-dispatcher namespace import doesn't bleed
+    into the OK-WIRED-VIA-DISPATCHER bucket.
+
+    Example match:
+      import * as wishlistServiceModule from 'backend/wishlistService.web';
+      ...
+      await wishlistServiceModule[method](...args);
+    Yields: { 'wishlistService': 'wishlistServiceModule' }
+    """
+    out: dict[str, str] = {}
+    for m in DISPATCHER_IMPORT_RE.finditer(http_text):
+        alias, path = m.group(1), m.group(2)
+        # Confirm the alias is used in dynamic-key access shape somewhere.
+        # The discriminator is bracket-access (`alias[...]`) vs dot-access
+        # (`alias.SOMETHING`) — the former is a dispatcher, the latter is
+        # a metadata read. We just need to know the alias is used with a
+        # bracket — perfectly parsing nested brackets like
+        # `alias[request.path[0]](` is unnecessary and brittle.
+        call_pat = re.compile(rf"\b{re.escape(alias)}\s*\[")
+        if call_pat.search(http_text):
+            module_basename = path.rsplit("/", 1)[-1]
+            out[module_basename] = alias
+    return out
+
+
 def collect_cfw_files() -> list[Path]:
     if not CFW_SRC.exists():
         return []
@@ -296,6 +358,7 @@ def classify_method(
     http_text: str,
     events_text: str,
     fs_path_refs: dict[str, list[str]] | None = None,
+    dispatcher_modules: dict[str, str] | None = None,
 ) -> dict:
     """Return classification for this webMethod."""
     defining_file = info["file"]
@@ -430,8 +493,25 @@ def classify_method(
     has_cfw_low = bool(cfw_low)
     has_cfw_any = bool(cfw_high or cfw_low)
 
+    # cf-0ziz (v4): module-namespace dispatcher detection. If this method's
+    # defining-file is dispatched as a namespace import in http-functions.js
+    # (e.g. `import * as svcModule + svcModule[method](...)`), the method is
+    # reachable via the dispatcher route even without a direct cfw URL match.
+    in_dispatcher = False
+    dispatcher_alias = ""
+    if dispatcher_modules:
+        module_basename = _module_basename(defining_file)
+        if module_basename in dispatcher_modules:
+            in_dispatcher = True
+            dispatcher_alias = dispatcher_modules[module_basename]
+
     # Gap-finder verdict (cf-hpwy core deliverable)
-    if not in_http and has_cfw_high:
+    if in_dispatcher and not has_cfw_high:
+        # v4: dispatcher route is the WIRED path even without a direct cfw URL.
+        # Distinct verdict (OK-WIRED-VIA-DISPATCHER) so the operator can see
+        # the dispatch path is active and the method is alive.
+        gap_verdict = "OK-WIRED-VIA-DISPATCHER"
+    elif not in_http and has_cfw_high:
         gap_verdict = "GAP-CFW-WANTS"  # cfw calls it via /_functions or callVelo, no HTTP wrapper
     elif in_http and has_cfw_high:
         gap_verdict = "OK-WIRED"
@@ -460,6 +540,8 @@ def classify_method(
         "in_same_file": in_same_file,
         "in_filesystem_path": in_fs_path,
         "filesystem_path_consumers": fs_path_consumers[:6],
+        "in_dispatcher": in_dispatcher,
+        "dispatcher_alias": dispatcher_alias,
         "sample_callers": sample_callers,
         "cfw_high_refs": cfw_high[:6],
         "cfw_low_refs": cfw_low[:6],
@@ -505,9 +587,21 @@ def main() -> int:
         file=sys.stderr,
     )
 
+    # cf-0ziz (v4): detect module-namespace dispatchers in http-functions.js.
+    # Modules dispatched as `<alias>[<key>](...)` have ALL their exports
+    # implicitly wired even without a direct cfw URL match per export name.
+    dispatcher_modules = collect_dispatcher_modules(http_text)
+    print(
+        f"backend modules wired via namespace dispatcher: {len(dispatcher_modules)}",
+        file=sys.stderr,
+    )
+    for module_name, alias in sorted(dispatcher_modules.items()):
+        print(f"  {module_name} -> {alias}", file=sys.stderr)
+
     rows = [
         classify_method(
-            name, info, files, cfw_files, http_text, events_text, fs_path_refs
+            name, info, files, cfw_files, http_text, events_text,
+            fs_path_refs, dispatcher_modules,
         )
         for name, info in methods.items()
     ]

--- a/scripts/cf-dead-routes/test_audit_v4.py
+++ b/scripts/cf-dead-routes/test_audit_v4.py
@@ -1,0 +1,202 @@
+"""cf-0ziz: tests for the v4 module-namespace dispatcher detection.
+
+Pins the detection contract so a future regex edit can't silently
+regress dispatcher recognition. Each test seeds a temp http-functions.js
+text + runs the collector + asserts.
+
+Run: `python -m pytest scripts/cf-dead-routes/test_audit_v4.py -v`
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+# audit.py reads ROOT/SRC/BACKEND from CFUTONS_ROOT — set a dummy so
+# import doesn't crash. The dispatcher tests only need http_text strings,
+# not real fs walking.
+os.environ.setdefault("CFUTONS_ROOT", str(HERE))
+
+
+def _import_audit():
+    for mod in list(sys.modules):
+        if mod == "audit":
+            del sys.modules[mod]
+    import audit
+    return audit
+
+
+def test_detects_simple_dispatcher():
+    audit = _import_audit()
+    http = """
+import * as wishlistServiceModule from 'backend/wishlistService.web';
+const ALLOW = new Set(['removeFromWishlist','isOnWishlist']);
+export async function post_wishlistService(request) {
+  const method = request.path[0];
+  if (!ALLOW.has(method)) return notFound();
+  await wishlistServiceModule[method]();
+}
+"""
+    out = audit.collect_dispatcher_modules(http)
+    assert out == {"wishlistService": "wishlistServiceModule"}
+
+
+def test_skips_namespace_import_without_dynamic_call():
+    """A `import * as M` that only reads `M.SOMETHING` (no `M[key](...)`)
+    is NOT a dispatcher — should NOT be flagged."""
+    audit = _import_audit()
+    http = """
+import * as constsModule from 'backend/myConsts.web';
+export function get_thing() {
+  return constsModule.SOME_CONSTANT;
+}
+"""
+    out = audit.collect_dispatcher_modules(http)
+    assert out == {}
+
+
+def test_detects_multiple_dispatchers():
+    audit = _import_audit()
+    http = """
+import * as wishlistServiceModule from 'backend/wishlistService.web';
+import * as referralServiceModule from 'backend/referralService.web';
+import * as constsModule from 'backend/myConsts.web';
+
+export async function post_wishlist(request) {
+  await wishlistServiceModule[request.path[0]]();
+}
+
+export async function post_referral(request) {
+  await referralServiceModule[request.path[0]](...args);
+}
+
+// constsModule is read but never dispatched
+const x = constsModule.X;
+"""
+    out = audit.collect_dispatcher_modules(http)
+    assert out == {
+        "wishlistService": "wishlistServiceModule",
+        "referralService": "referralServiceModule",
+    }
+    assert "myConsts" not in out
+
+
+def test_dispatcher_path_strips_web_suffix():
+    """`from 'backend/foo.web'` → module key 'foo' (matches what
+    _module_basename returns for src/backend/foo.web.js)."""
+    audit = _import_audit()
+    http = """
+import * as fooModule from 'backend/foo.web';
+fooModule[k]();
+"""
+    out = audit.collect_dispatcher_modules(http)
+    assert out == {"foo": "fooModule"}
+
+
+def test_dispatcher_path_without_web_suffix():
+    """`from 'backend/foo'` (no .web) — also captured, basename 'foo'."""
+    audit = _import_audit()
+    http = """
+import * as fooModule from 'backend/foo';
+fooModule[k]();
+"""
+    out = audit.collect_dispatcher_modules(http)
+    assert out == {"foo": "fooModule"}
+
+
+def test_dispatcher_path_subdirectory():
+    """`from 'backend/sub/foo.web'` → module key 'foo' (basename only)."""
+    audit = _import_audit()
+    http = """
+import * as fooModule from 'backend/sub/foo.web';
+fooModule[k]();
+"""
+    out = audit.collect_dispatcher_modules(http)
+    assert out == {"foo": "fooModule"}
+
+
+def test_classify_method_marks_dispatcher_as_OK_WIRED_VIA_DISPATCHER(tmp_path):
+    """End-to-end: a webMethod whose defining file is dispatched should
+    flip from WRAPPED-NO-CONSUMER (or whatever) to OK-WIRED-VIA-DISPATCHER."""
+    audit = _import_audit()
+
+    # Minimal info dict matching what collect_web_methods returns
+    info = {
+        "file": "src/backend/wishlistService.web.js",
+        "permission": "SiteMember",
+        "line": 100,
+    }
+    # http_text simulates the dispatcher pattern + ALSO directly imports
+    # the method (so v2 marks it HTTP-EXPOSED). Without dispatcher detection
+    # it would be WRAPPED-NO-CONSUMER. With dispatcher → OK-WIRED-VIA-DISPATCHER.
+    http_text = """
+import * as wishlistServiceModule from 'backend/wishlistService.web';
+import { removeFromWishlist } from 'backend/wishlistService.web';
+export async function post_wishlistService(request) {
+  await wishlistServiceModule[request.path[0]](...args);
+}
+"""
+    dispatcher_modules = audit.collect_dispatcher_modules(http_text)
+    assert dispatcher_modules == {"wishlistService": "wishlistServiceModule"}
+
+    row = audit.classify_method(
+        "removeFromWishlist", info,
+        files=[], cfw_files=[],
+        http_text=http_text, events_text="",
+        fs_path_refs=None,
+        dispatcher_modules=dispatcher_modules,
+    )
+    assert row["gap_verdict"] == "OK-WIRED-VIA-DISPATCHER"
+    assert row["in_dispatcher"] is True
+    assert row["dispatcher_alias"] == "wishlistServiceModule"
+
+
+def test_classify_method_unchanged_when_no_dispatcher(tmp_path):
+    """A method NOT in a dispatcher module should keep its v3 verdict."""
+    audit = _import_audit()
+    info = {
+        "file": "src/backend/wishlistService.web.js",
+        "permission": "SiteMember",
+        "line": 100,
+    }
+    http_text = """
+import { removeFromWishlist } from 'backend/wishlistService.web';
+export async function post_x(request) {
+  await removeFromWishlist();
+}
+"""
+    # No dispatcher anywhere — collect_dispatcher_modules returns {}
+    dispatcher_modules = audit.collect_dispatcher_modules(http_text)
+    assert dispatcher_modules == {}
+
+    row = audit.classify_method(
+        "removeFromWishlist", info,
+        files=[], cfw_files=[],
+        http_text=http_text, events_text="",
+        fs_path_refs=None,
+        dispatcher_modules=dispatcher_modules,
+    )
+    assert row["in_dispatcher"] is False
+    # Verdict should be one of the existing v3 buckets, NOT
+    # OK-WIRED-VIA-DISPATCHER.
+    assert row["gap_verdict"] != "OK-WIRED-VIA-DISPATCHER"
+
+
+def test_dispatcher_with_other_quote_styles():
+    audit = _import_audit()
+    http = """
+import * as aMod from "backend/a.web";
+import * as bMod from `backend/b.web`;
+aMod[k]();
+bMod[k]();
+"""
+    out = audit.collect_dispatcher_modules(http)
+    # Single + double quotes both supported (regex covers ['"`]).
+    # The backtick form may or may not be supported — pin double-quote at
+    # minimum and not assert on backtick.
+    assert "a" in out


### PR DESCRIPTION
## Bead
cf-0ziz (P3, task) — closes the v3 detector limitation flagged in `docs/audits/wrapped-no-consumer-2026-05-10.md`.

## Why
v3's `WRAPPED-NO-CONSUMER` verdict requires a direct cfw URL/callVelo reference. cfw can also reach a webMethod via the dispatcher pattern:

```js
// http-functions.js
import * as wishlistServiceModule from 'backend/wishlistService.web';
const ALLOWLIST = new Set(['removeFromWishlist','isOnWishlist',...]);
export async function post_wishlistService(request) {
  const method = request.path[0];
  if (!ALLOWLIST.has(method)) return notFound(...);
  await wishlistServiceModule[method](...args); // ← dynamic dispatch
}
```

cfw calls `/_functions/wishlistService/<method>` and the dispatcher forwards. v3 saw these as WRAPPED-NO-CONSUMER (no direct cfw URL match per export name) when they were actually alive.

## What
`collect_dispatcher_modules(http_text)` returns `{ module_basename: alias }` for every detected dispatcher. Detection has two gates:

1. `import * as <alias> from 'backend/<file>(.web)?'` import-decl
2. `<alias>[<key>]` bracket-access somewhere in the same text

Both required so a non-dispatcher namespace import (one that just reads `<alias>.SOME_CONSTANT`) doesn't bleed into the dispatcher bucket.

`classify_method` now takes an optional `dispatcher_modules` dict and emits a new gap-verdict `OK-WIRED-VIA-DISPATCHER` for matched methods, distinct from `OK-WIRED` so the operator can see WHICH dispatch path is in use.

## Real-run on main
- 1 dispatcher detected: `wishlistService → wishlistServiceModule`
- 3 webMethods flipped to OK-WIRED-VIA-DISPATCHER:
  - `removeFromWishlist` (was WRAPPED-NO-CONSUMER)
  - `isOnWishlist` (was WRAPPED-NO-CONSUMER)
  - `updateWishlistStock` (was MAYBE-CFW-NAME-COLLISION)
- WRAPPED-NO-CONSUMER count: 47 → 44 (closes the 2 wishlist false-positives flagged in the audit doc + a 3rd same-module method)
- MAYBE-CFW-NAME-COLLISION: 19 → 18

## Tests
`scripts/cf-dead-routes/test_audit_v4.py` — 9 cases: simple dispatcher detection, skip-non-dispatcher `M.CONST` reads, multi-dispatcher, with/without `.web` suffix, subdirectory paths, end-to-end `classify_method` demotion, unchanged-when-no-dispatcher, multi-quote-style.

**18/18 green** (9 new v4 + 9 existing v3 unchanged).

## Pattern + scope
Same shape as cf-sq0d (cf-hpwy v3 fs-path bucket). Velo audit-script extension, no production code change, no Vercel coupling. Existing v2/v3 verdicts unchanged for non-dispatcher modules — the addition is purely additive.