### PR TITLE
fix(cf-sxo7): stagger Monday 15:00 UTC cron cluster — F1 fix

### DIFF
--- a/src/backend/jobs.config
+++ b/src/backend/jobs.config
@@ -112,22 +112,24 @@ export function config() {
     },
 
     // cf-rjxq: White-glove delivery 48-hour SMS reminder at 10 AM EST
+    // cf-sxo7 (cf-ox0h F1): minute offset 1 to spread the 15:00 cluster.
     processDelivery48hReminders: {
       functionLocation: '/deliveryNotifications.web.js',
       description: 'Send 48-hour SMS reminders to white-glove delivery customers scheduled 2 days out',
       executionConfig: {
-        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+        cronExpression: '1 15 * * *', // 15:01 UTC ≈ 10 AM EST
       },
     },
 
     // cf-u30i: Weekly analytics digest email to Brenda Deal every Monday at 8 AM MT
     // Aggregates AnalyticsEvents, funnel metrics, loyalty stats, and referral stats
     // into a mobile-readable email queued via EmailQueue collection.
+    // cf-sxo7 (cf-ox0h F1): minute offset 4 to spread the Monday 15:00 cluster.
     sendWeeklyDigestEmail: {
       functionLocation: '/analyticsDigest.web.js',
       description: 'Build and queue weekly analytics digest email for carolinafutons@gmail.com',
       executionConfig: {
-        cronExpression: '0 15 * * 1', // 15:00 UTC = 8 AM MT (Monday)
+        cronExpression: '4 15 * * 1', // 15:04 UTC ≈ 8 AM MT (Monday)
       },
     },
 
@@ -184,11 +186,12 @@ export function config() {
 
     // GH-994: Daily challenge reminders at 10 AM EST — sends triggered emails to members
     // with in-progress challenges who haven't been notified within the last 24 hours.
+    // cf-sxo7 (cf-ox0h F1): minute offset 2 to spread the 15:00 cluster.
     runDailyChallengeReminders: {
       functionLocation: '/lifecycleCron.web.js',
       description: 'Send daily challenge reminder emails to eligible members (cadence-gated via MemberChallengeProgress.notifiedAt)',
       executionConfig: {
-        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+        cronExpression: '2 15 * * *', // 15:02 UTC ≈ 10 AM EST
       },
     },
 
@@ -196,22 +199,24 @@ export function config() {
     // 30-37 days ago and triggers the winback email sequence via
     // marketingSequences.triggerWinbackSequence. EmailQueue-level dedup keeps
     // re-runs idempotent.
+    // cf-sxo7 (cf-ox0h F1): minute offset 5 to spread the Monday 15:00 cluster.
     scanAndTriggerWinback: {
       functionLocation: '/marketingSequences.web.js',
       description: 'Scan Stores/Orders for buyers 30-37 days post-purchase and trigger the winback email sequence',
       executionConfig: {
-        cronExpression: '0 15 * * 1', // 15:00 UTC Monday = 10 AM EST / 11 AM EDT
+        cronExpression: '5 15 * * 1', // 15:05 UTC Monday ≈ 10 AM EST / 11 AM EDT
       },
     },
 
     // cf-fsm: Daily review-request emails at 10 AM EST — fires review_request
     // sequence for orders placed 7 days ago (±1 day tolerance window).
     // Idempotent via enqueueEmail dedup on (email, sequenceType, step).
+    // cf-sxo7 (cf-ox0h F1): minute offset 3 to spread the 15:00 cluster.
     runReviewRequestEmails: {
       functionLocation: '/marketingSequences.web.js',
       description: 'Scan Stores/Orders placed 6–8 days ago and enqueue review-request email sequence',
       executionConfig: {
-        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+        cronExpression: '3 15 * * *', // 15:03 UTC ≈ 10 AM EST
       },
     },
 


### PR DESCRIPTION
## Summary
Resolves cf-ox0h **F1**. Six jobs were scheduled to fire at 15:00 UTC (4 daily, 2 Monday-only). On Mondays this peaked at ~6 simultaneous fires plus other always-on-hour jobs — past Wix Velo's runner soft-cap of ~5.

### New stagger
| minute | job | cadence |
|--------|-----|---------|
| 0 | checkStreakMilestoneNotifications | daily (anchor) |
| 1 | processDelivery48hReminders | daily |
| 2 | runDailyChallengeReminders | daily |
| 3 | runReviewRequestEmails | daily |
| 4 | sendWeeklyDigestEmail | Monday |
| 5 | scanAndTriggerWinback | Monday |

After: peak is **1 job per minute** on any day. All jobs still land within the human-readable "10 AM EST" / "8 AM MT" windows the descriptions promise (a 5-minute spread is invisible downstream).

### Tests
- \`jobsConfigIntegrity\` — 23 tests pass (no hardcoded time asserts).
- Consumer suites for renamed crons: marketingSequences, analyticsDigest, runReviewRequestEmails, lifecycleCron, deliveryNotifications — **161 tests pass**.

## Test plan
- [x] Unit: 161 consumer tests + 23 integrity tests pass
- [ ] Manual post-deploy: observe Wix Jobs dashboard on first post-merge Monday — confirm staggered fires across 15:00–15:05 with no overlap timeout failures

Refs: \`docs/audits/cron-schedule-audit-2026-05-10.md\` F1, cf-ox0h, cf-sxo7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)