### PR TITLE
fix(cf-nej3): stagger daily 13:00 UTC cron cluster — F2 fix

### DIFF
--- a/src/backend/jobs.config
+++ b/src/backend/jobs.config
@@ -103,11 +103,13 @@ export function config() {
     },
 
     // cf-rjxq: White-glove delivery day-of SMS reminder at 8 AM EST
+    // cf-nej3 (cf-ox0h F2): minute offset 1 to spread the 13:00 cluster
+    // (4 jobs at 13:00 = past Wix runner soft-cap of ~5 with other always-on-hour jobs).
     processDeliveryDayOfReminders: {
       functionLocation: '/deliveryNotifications.web.js',
       description: 'Send day-of SMS reminders to white-glove delivery customers who opted in',
       executionConfig: {
-        cronExpression: '0 13 * * *', // 13:00 UTC = 8 AM EST
+        cronExpression: '1 13 * * *', // 13:01 UTC ≈ 8 AM EST
       },
     },
 
@@ -154,22 +156,24 @@ export function config() {
     // export `runWhiteGlove48hReminders` in whiteGloveScheduling.web.js. Wix
     // Jobs Scheduler resolves the cron entry KEY as the function name in the
     // target file, so the prior `send*` key was dead-on-arrival.
+    // cf-nej3 (cf-ox0h F2): minute offset 2 to spread the 13:00 cluster.
     runWhiteGlove48hReminders: {
       functionLocation: '/whiteGloveScheduling.web.js',
       description: 'SMS 48h reminders for white-glove appointments 2 days from now; deduped via SMSLog',
       executionConfig: {
-        cronExpression: '0 13 * * *',
+        cronExpression: '2 13 * * *', // 13:02 UTC
       },
     },
 
     // CF-rjxq: Send day-of SMS to white-glove appointments scheduled for today.
     // cf-4x7e.fu1: renamed from sendWhiteGloveDayOfReminders to match the
     // actual export `runWhiteGloveDayOfReminders` (same dead-on-arrival fix).
+    // cf-nej3 (cf-ox0h F2): minute offset 3 to spread the 13:00 cluster.
     runWhiteGloveDayOfReminders: {
       functionLocation: '/whiteGloveScheduling.web.js',
       description: 'Day-of SMS reminders for white-glove appointments today; deduped via SMSLog',
       executionConfig: {
-        cronExpression: '0 13 * * *',
+        cronExpression: '3 13 * * *', // 13:03 UTC
       },
     },
 


### PR DESCRIPTION
## Summary
Resolves cf-ox0h **F2**. Four jobs were scheduled to fire at 13:00 UTC daily — \`detectPriceDrops\`, \`processDeliveryDayOfReminders\`, \`runWhiteGlove48hReminders\`, \`runWhiteGloveDayOfReminders\`. With other always-on-hour jobs firing alongside, the runner exceeded Wix's ~5 simultaneous-job soft cap.

### New stagger
| minute | job | rationale |
|--------|-----|-----------|
| 0 | detectPriceDrops | anchor — downstream notify crons assume fresh price-drop data |
| 1 | processDeliveryDayOfReminders | |
| 2 | runWhiteGlove48hReminders | |
| 3 | runWhiteGloveDayOfReminders | |

After: peak is 1 job per minute; downstream "8 AM EST" reminder windows are unchanged from a customer-visible perspective.

### Tests
- \`jobsConfigIntegrity\` (23 tests) + \`deliveryNotifications\` + \`whiteGloveScheduling\` — **99 tests pass**.

### Companion
- cf-sxo7 (PR #1313) — 15:00 UTC cluster (F1)
- This (cf-nej3) — 13:00 UTC cluster (F2)
- Remaining: F4 (5 HTTP cron / Wix-job duplicates) + F5 (4 orphan HTTP crons) need scheduler-side decisions, not just config edits.

## Test plan
- [x] Unit: 99 affected tests pass
- [ ] Manual post-deploy: observe Wix Jobs dashboard at next 13:00 UTC fire — confirm 4 jobs spread across 13:00–13:03

Refs: \`docs/audits/cron-schedule-audit-2026-05-10.md\` F2, cf-ox0h, cf-nej3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)