### PR TITLE
fix(cf-ox0h.F1-F3): stagger cron concurrency clusters (P2)

### DIFF
--- a/src/backend/jobs.config
+++ b/src/backend/jobs.config
@@ -102,32 +102,40 @@ export function config() {
       },
     },
 
-    // cf-rjxq: White-glove delivery day-of SMS reminder at 8 AM EST
+    // cf-rjxq: White-glove delivery day-of SMS reminder at 8 AM EST.
+    // cf-ox0h F2 stagger: was 0 13 * * * (cluster of 4); offset +1m to
+    // spread the 13:00 UTC fan-out across the minute. Same logical fire
+    // window — SMS sends are not customer-time-sensitive at the
+    // sub-minute level.
     processDeliveryDayOfReminders: {
       functionLocation: '/deliveryNotifications.web.js',
       description: 'Send day-of SMS reminders to white-glove delivery customers who opted in',
       executionConfig: {
-        cronExpression: '0 13 * * *', // 13:00 UTC = 8 AM EST
+        cronExpression: '1 13 * * *', // 13:01 UTC = 8:01 AM EST (cf-ox0h F2 stagger)
       },
     },
 
-    // cf-rjxq: White-glove delivery 48-hour SMS reminder at 10 AM EST
+    // cf-rjxq: White-glove delivery 48-hour SMS reminder at 10 AM EST.
+    // cf-ox0h F3 stagger: was 0 15 * * * (cluster of 4 daily, 6 Mondays);
+    // offset +1m to spread the 15:00 UTC fan-out.
     processDelivery48hReminders: {
       functionLocation: '/deliveryNotifications.web.js',
       description: 'Send 48-hour SMS reminders to white-glove delivery customers scheduled 2 days out',
       executionConfig: {
-        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+        cronExpression: '1 15 * * *', // 15:01 UTC = 10:01 AM EST (cf-ox0h F3 stagger)
       },
     },
 
     // cf-u30i: Weekly analytics digest email to Brenda Deal every Monday at 8 AM MT
     // Aggregates AnalyticsEvents, funnel metrics, loyalty stats, and referral stats
     // into a mobile-readable email queued via EmailQueue collection.
+    // cf-ox0h F1 stagger: was 0 15 * * 1; offset +3m off the Monday
+    // 15:00 cluster (which is the worst-case 6-job concurrency point).
     sendWeeklyDigestEmail: {
       functionLocation: '/analyticsDigest.web.js',
       description: 'Build and queue weekly analytics digest email for carolinafutons@gmail.com',
       executionConfig: {
-        cronExpression: '0 15 * * 1', // 15:00 UTC = 8 AM MT (Monday)
+        cronExpression: '3 15 * * 1', // 15:03 UTC Monday = 8:03 AM MT (cf-ox0h F1 stagger)
       },
     },
 
@@ -154,22 +162,24 @@ export function config() {
     // export `runWhiteGlove48hReminders` in whiteGloveScheduling.web.js. Wix
     // Jobs Scheduler resolves the cron entry KEY as the function name in the
     // target file, so the prior `send*` key was dead-on-arrival.
+    // cf-ox0h F2 stagger: was 0 13 * * *; offset +2m off the cluster.
     runWhiteGlove48hReminders: {
       functionLocation: '/whiteGloveScheduling.web.js',
       description: 'SMS 48h reminders for white-glove appointments 2 days from now; deduped via SMSLog',
       executionConfig: {
-        cronExpression: '0 13 * * *',
+        cronExpression: '2 13 * * *',
       },
     },
 
     // CF-rjxq: Send day-of SMS to white-glove appointments scheduled for today.
     // cf-4x7e.fu1: renamed from sendWhiteGloveDayOfReminders to match the
     // actual export `runWhiteGloveDayOfReminders` (same dead-on-arrival fix).
+    // cf-ox0h F2 stagger: was 0 13 * * *; offset +3m off the cluster.
     runWhiteGloveDayOfReminders: {
       functionLocation: '/whiteGloveScheduling.web.js',
       description: 'Day-of SMS reminders for white-glove appointments today; deduped via SMSLog',
       executionConfig: {
-        cronExpression: '0 13 * * *',
+        cronExpression: '3 13 * * *',
       },
     },
 
@@ -184,11 +194,12 @@ export function config() {
 
     // GH-994: Daily challenge reminders at 10 AM EST — sends triggered emails to members
     // with in-progress challenges who haven't been notified within the last 24 hours.
+    // cf-ox0h F3 stagger: was 0 15 * * *; offset +2m off the cluster.
     runDailyChallengeReminders: {
       functionLocation: '/lifecycleCron.web.js',
       description: 'Send daily challenge reminder emails to eligible members (cadence-gated via MemberChallengeProgress.notifiedAt)',
       executionConfig: {
-        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+        cronExpression: '2 15 * * *', // 15:02 UTC = 10:02 AM EST (cf-ox0h F3 stagger)
       },
     },
 
@@ -196,22 +207,26 @@ export function config() {
     // 30-37 days ago and triggers the winback email sequence via
     // marketingSequences.triggerWinbackSequence. EmailQueue-level dedup keeps
     // re-runs idempotent.
+    // cf-ox0h F1 stagger: was 0 15 * * 1; offset +4m off the Monday
+    // 15:00 cluster.
     scanAndTriggerWinback: {
       functionLocation: '/marketingSequences.web.js',
       description: 'Scan Stores/Orders for buyers 30-37 days post-purchase and trigger the winback email sequence',
       executionConfig: {
-        cronExpression: '0 15 * * 1', // 15:00 UTC Monday = 10 AM EST / 11 AM EDT
+        cronExpression: '4 15 * * 1', // 15:04 UTC Monday (cf-ox0h F1 stagger)
       },
     },
 
     // cf-fsm: Daily review-request emails at 10 AM EST — fires review_request
     // sequence for orders placed 7 days ago (±1 day tolerance window).
     // Idempotent via enqueueEmail dedup on (email, sequenceType, step).
+    // cf-ox0h F3 stagger: was 0 15 * * * (cluster of 4 daily, 6 Mondays);
+    // offset +6m to push fully off the cluster per audit recommendation.
     runReviewRequestEmails: {
       functionLocation: '/marketingSequences.web.js',
       description: 'Scan Stores/Orders placed 6–8 days ago and enqueue review-request email sequence',
       executionConfig: {
-        cronExpression: '0 15 * * *', // 15:00 UTC = 10 AM EST
+        cronExpression: '6 15 * * *', // 15:06 UTC = 10:06 AM EST (cf-ox0h F3 stagger)
       },
     },
 


### PR DESCRIPTION
## Summary

Closes cron-schedule-audit findings F1+F2+F3 (P2). Three clusters of jobs all fired at the same cron minute, risking Wix's documented ~5-concurrent-job soft cap.

| Cluster | Before | After |
|---|---|---|
| Daily 13:00 UTC (F2) | 4 simultaneous | 1 simultaneous |
| Daily 15:00 UTC (F3) | 4 simultaneous | 1 simultaneous |
| **Monday 15:00 UTC (F1) — worst-case** | **9 simultaneous** | **1 simultaneous** |

Worst-case minute now drops from 9 → 4 (the irreducible `*/15` + `*/30` background-task crons at the `:00` minute — none of which is business-logic).

## Changes

| Job | Was | Now |
|---|---|---|
| detectPriceDrops | `0 13 * * *` | `0 13 * * *` (anchor) |
| processDeliveryDayOfReminders | `0 13 * * *` | `1 13 * * *` |
| runWhiteGlove48hReminders | `0 13 * * *` | `2 13 * * *` |
| runWhiteGloveDayOfReminders | `0 13 * * *` | `3 13 * * *` |
| checkStreakMilestoneNotifications | `0 15 * * *` | `0 15 * * *` (anchor) |
| processDelivery48hReminders | `0 15 * * *` | `1 15 * * *` |
| runDailyChallengeReminders | `0 15 * * *` | `2 15 * * *` |
| runReviewRequestEmails | `0 15 * * *` | `6 15 * * *` |
| sendWeeklyDigestEmail | `0 15 * * 1` | `3 15 * * 1` |
| scanAndTriggerWinback | `0 15 * * 1` | `4 15 * * 1` |

Comments inline cite the audit reference + before/after for each entry.

## Why this is safe

Per the audit: these are email / SMS / notification fan-outs. "Running 4 minutes earlier or later is invisible to customers" — no SLA tied to sub-minute timing. The audit explicitly recommended this exact change.

The 23 `jobsConfigIntegrity.test.js` tests verify every staggered key still resolves to a real export.

## Audit reference

`docs/audits/cron-schedule-audit-2026-05-10.md` §F1, §F2, §F3.

## Test plan
- [x] `vitest run tests/jobsConfigIntegrity.test.js` — 23/23 pass
- [x] Re-ran cluster check: 13:00, 15:00 daily, 15:00 Monday clusters all reduced to 1
- [x] No code changes; jobs.config is the only file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)