### PR TITLE
fix(cf-0z43): remove deprecated poolOptions from vitest.config.js

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -46,10 +46,10 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.js'],
     setupFiles: ['tests/setup.js'],
-    poolOptions: {
-      threads: { isolate: true },
-      forks: { isolate: true },
-    },
+    // cf-0z43: Vitest 4 removed `test.poolOptions.{threads,forks}.isolate` —
+    // isolate is now a single top-level boolean and defaults to true. The
+    // previous block restated the default and emitted DEPRECATED on every
+    // run; deletion is the migration. Behavior unchanged (isolate stays on).
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'lcov', 'html'],


### PR DESCRIPTION
## Summary

Vitest 4 removed `test.poolOptions.{threads,forks}.isolate` — `isolate` is now a single top-level boolean defaulting to `true`. The previous block restated the default while emitting:

```
DEPRECATED  test.poolOptions was removed in Vitest 4. All previous poolOptions
are now top-level options. Please, refer to the migration guide:
https://vitest.dev/guide/migration#pool-rework
```

…on every test run, every CI job, every coverage capture. Pure noise.

## Change

8-line diff (4 lines deleted, 4-line comment added). Migration is just a deletion since the behavior we were re-asserting is already the default.

| Before | After |
|---|---|
| `poolOptions: { threads: { isolate: true }, forks: { isolate: true } }` | (deleted; default `isolate: true` preserved) |

## Test plan

- [x] `npx vitest run` no longer emits the DEPRECATED line
- [x] Local test runs still pass
- [ ] CI run on this PR confirms green

cfutons-only — no Vercel impact, passes cf-ukc6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)