### PR TITLE
docs(cf-8c2f): V1↔V3 sync caveats in catalogPriceFix.web.js — F1 fix

### DIFF
--- a/src/backend/catalogPriceFix.web.js
+++ b/src/backend/catalogPriceFix.web.js
@@ -10,6 +10,32 @@
  *
  * CF-azrt: Native Wix gallery price audit
  *
+ * ## ⚠ V1↔V3 sync caveats (cf-3pwy F1 / cf-8c2f)
+ *
+ * This module writes via the Wix Stores **V1** SDK (`wix-stores-backend` →
+ * `products.updateProductFields`). The Next.js front-end (`carolina-futons-web`)
+ * reads through the **V3** SDK (`@wix/auto_sdk_stores_products` → `actualPriceRange`,
+ * `compareAtPriceRange`, `priceData`). Wix synchronizes V1 writes to V3 reads
+ * internally, but two specific gaps apply when this migration runs:
+ *
+ *   1. **price=0 surfaces differently across SDKs.** V1 `price=0` is a number;
+ *      native Wix Pro Gallery shows "Price unavailable". V3 `actualPriceRange`
+ *      may surface as `Out of stock` rather than as `$0.00` display, depending
+ *      on the storefront component. Verified safe in cfutons Velo widgets;
+ *      **NOT verified post-cutover in cfw V3 widgets.** Re-spot-check after
+ *      DNS flip if any call-for-price products still have price=$1 to migrate.
+ *
+ *   2. **Per-variant prices stay frozen.** `products.updateProductFields(id, {price: 0})`
+ *      writes only the parent product price. Variants inherit pricing unless
+ *      they have their own override. If any call-for-price product has variant-level
+ *      prices set in V1, those overrides will continue to surface in V3 reads.
+ *      As of audit date (2026-05-10) no call-for-price product in the catalog
+ *      has variant-level price overrides, but verify before re-running.
+ *
+ * **Pre-cutover guidance**: do not schedule this migration in the cf-3qt.8 cutover
+ * window. Run it well before or well after — never in the same hour as the DNS flip,
+ * to avoid amplifying any V1↔V3 sync lag during the transition.
+ *
  * @requires wix-web-module
  * @requires wix-stores-backend
  */
@@ -73,6 +99,9 @@ export const fixCallForPricePlaceholders = webMethod(
         }
 
         try {
+          // cf-3pwy F1 / cf-8c2f: V1 write — see module-level caveats. The
+          // V1↔V3 sync should propagate `price=0` to the Headless reader,
+          // but per-variant overrides will NOT update from this call.
           await products.updateProductFields(product._id, { price: 0 });
           updated.push(`Updated: ${label} → price=0`);
         } catch (err) {


### PR DESCRIPTION
## Summary
Resolves cf-3pwy **F1**. \`catalogPriceFix.fixCallForPricePlaceholders\` writes via Wix Stores **V1** SDK (\`products.updateProductFields\`); cfw reads through **V3** SDK (\`actualPriceRange\`, \`compareAtPriceRange\`, \`priceData\`).

Wix's internal V1↔V3 sync handles propagation in most cases, but two specific gaps apply:

1. **price=0 surfaces differently across SDKs.** V1 price=0 → native Pro Gallery shows "Price unavailable". V3 \`actualPriceRange\` may surface as "Out of stock" rather than "$0.00 / Price unavailable" depending on the storefront component. Verified safe in cfutons Velo widgets; **not verified post-cutover in cfw V3 widgets.**

2. **Per-variant prices stay frozen.** \`updateProductFields(id, {price: 0})\` writes only parent. Variant-level overrides won't update.

### Fix
Added: module-level caveat block + inline comment at the \`updateProductFields\` call site. Pre-cutover guidance reminds the operator **not to schedule this migration in the cf-3qt.8 cutover window** — never the same hour as DNS flip.

**No code change** — docs-only fix per the audit's specific recommendation.

### Tests
- 8 catalogPriceFix tests pass (untouched)

## Test plan
- [x] Existing tests pass
- [ ] Post-cutover spot-check: if any call-for-price products still need migration, verify cfw V3 widget rendering on price=0 before bulk-running this command

Refs: \`docs/audits/wix-stores-catalog-v1v3-audit-2026-05-10.md\` F1, cf-3pwy, cf-8c2f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)