### PR TITLE
fix(cf-ybsf): align UptimeRobot keyword to /api/health JSON envelope (P1)

### DIFF
--- a/monitoring-setup.md
+++ b/monitoring-setup.md
@@ -24,7 +24,7 @@ To activate monitoring (cf-3qt.8.31 acceptance):
    ```
    **Never commit secrets.env.**
 4. **Stilgar OR godfrey:** Dashboard → **My Settings → Alert Contacts** → confirm `carolinafutons@gmail.com` is verified (it auto-creates from the signup email; the contact ID is the integer in the row's edit URL).
-5. **godfrey:** ETA <10 min from key delivery — runs `bash scripts/setup-monitors.sh`, verifies 4 monitors live, fires the mis-config alert test (§4 of `carolina-futons-web/docs/monitoring-runbook.md`), commits this doc with `Status: LIVE` + monitor IDs to main.
+5. **godfrey:** ETA <10 min from key delivery — runs `bash scripts/setup-monitors.sh`, verifies 5 monitors live (4 HTTP up/down + 1 `/api/health` keyword on `"status":"ok"` per cf-ybsf), fires the mis-config alert test (§4 of `carolina-futons-web/docs/monitoring-runbook.md`), commits this doc with `Status: LIVE` + monitor IDs to main.
 
 The setup script is ready (`scripts/setup-monitors.sh`) and gated on `UPTIMEROBOT_API_KEY:?` so it errors loudly if the key is missing.
 
@@ -44,14 +44,15 @@ UptimeRobot free tier supports **5-minute** check intervals, not 1-minute. 1-min
 
 ## Monitors Configured
 
-| # | Name | URL | Type |
-|---|------|-----|------|
-| 1 | CF Home | https://carolinafutons.com/ | HTTP(S) |
-| 2 | CF Futon Frames PLP | https://carolinafutons.com/shop/futon-frames | HTTP(S) |
-| 3 | CF Products (spot check) | https://carolinafutons.com/products/kingston-futon-frame | HTTP(S) |
-| 4 | CF Contact | https://carolinafutons.com/contact | HTTP(S) |
+| # | Name | URL | Type | Keyword check |
+|---|------|-----|------|---|
+| 1 | CF Home | https://carolinafutons.com/ | HTTP(S) | — |
+| 2 | CF Futon Frames PLP | https://carolinafutons.com/shop/futon-frames | HTTP(S) | — |
+| 3 | CF Products (spot check) | https://carolinafutons.com/products/kingston-futon-frame | HTTP(S) | — |
+| 4 | CF Contact | https://carolinafutons.com/contact | HTTP(S) | — |
+| 5 | CF API Health | https://carolinafutons.com/api/health | **Keyword** | `"status":"ok"` exists |
 
-All monitors: expect HTTP 200, alert on non-2xx or timeout >30s.
+Monitors 1-4 expect HTTP 200, alert on non-2xx or timeout >30s. Monitor 5 also verifies the response body contains `"status":"ok"` (the quoted-colon-quoted substring is a stable marker that only appears in a healthy JSON response from `/api/health` per cf-x6ph + cf-x0ks; the bare word `ok` would false-positive on any HTML page that contains it — cf-ybsf alignment).
 
 ---
 

--- a/scripts/setup-monitors.sh
+++ b/scripts/setup-monitors.sh
@@ -10,19 +10,43 @@ KEY="${UPTIMEROBOT_API_KEY:?UPTIMEROBOT_API_KEY is required — see monitoring-s
 ALERT="${UPTIMEROBOT_ALERT_CONTACT_ID:-}"  # optional; omit to use account default
 INTERVAL=300  # 300s = 5min (free tier minimum); change to 60 for Pro
 
-# Monitors to create: "Friendly Name|URL"
+# Monitors to create: "Friendly Name|URL|MonitorType[|KeywordType|KeywordValue]"
+# MonitorType: 1 = HTTP(S) up/down (alert on non-2xx + timeout)
+#              2 = Keyword (alert on keyword presence/absence)
+# KeywordType (only used when MonitorType=2):
+#              1 = "exists" — alert when keyword NOT found in response body
+#              2 = "not exists" — alert when keyword IS found
+#
+# /api/health (cf-x6ph + cf-x0ks + cf-ybsf): the endpoint returns the
+# JSON envelope `{"status":"ok","uptime":N,"commit":"sha","ts":"..."}`.
+# UptimeRobot keyword `"status":"ok"` (the quoted-colon-quoted substring)
+# is a stable marker that only appears in a healthy response — the bare
+# word `ok` false-positives on any HTML / 404 page that happens to
+# contain it. Aligned per cf-ybsf.
 declare -a MONITORS=(
-  "CF Home|https://carolinafutons.com/"
-  "CF Futon Frames PLP|https://carolinafutons.com/shop/futon-frames"
-  "CF Products (Kingston)|https://carolinafutons.com/products/kingston-futon-frame"
-  "CF Contact|https://carolinafutons.com/contact"
+  "CF Home|https://carolinafutons.com/|1"
+  "CF Futon Frames PLP|https://carolinafutons.com/shop/futon-frames|1"
+  "CF Products (Kingston)|https://carolinafutons.com/products/kingston-futon-frame|1"
+  "CF Contact|https://carolinafutons.com/contact|1"
+  'CF API Health|https://carolinafutons.com/api/health|2|1|"status":"ok"'
 )
 
 create_monitor() {
   local name="$1"
   local url="$2"
+  local monitor_type="${3:-1}"
+  local keyword_type="${4:-}"
+  local keyword_value="${5:-}"
 
-  local data="api_key=${KEY}&friendly_name=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${name}'))")&url=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${url}'))")&type=1&interval=${INTERVAL}&format=json"
+  local data="api_key=${KEY}&friendly_name=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${name}'))")&url=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${url}'))")&type=${monitor_type}&interval=${INTERVAL}&format=json"
+  if [[ "${monitor_type}" == "2" ]]; then
+    if [[ -z "$keyword_type" || -z "$keyword_value" ]]; then
+      echo "  ✗ Failed:  ${name} — keyword monitor requires keyword_type + keyword_value"
+      return 1
+    fi
+    data+="&keyword_type=${keyword_type}"
+    data+="&keyword_value=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "${keyword_value}")"
+  fi
   if [[ -n "$ALERT" ]]; then
     data+="&alert_contacts=${ALERT}"
   fi
@@ -51,9 +75,9 @@ echo "Interval: ${INTERVAL}s | Alert contact: ${ALERT:-account default}"
 echo ""
 
 for entry in "${MONITORS[@]}"; do
-  IFS='|' read -r name url <<< "$entry"
+  IFS='|' read -r name url monitor_type keyword_type keyword_value <<< "$entry"
   echo "Creating: ${name}"
-  create_monitor "$name" "$url"
+  create_monitor "$name" "$url" "$monitor_type" "$keyword_type" "$keyword_value"
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Closes cf-ybsf (P1) — health endpoint keyword fix. cf-x6ph + cf-x0ks shipped `/api/health` returning the JSON envelope `{"status":"ok","uptime":N,"commit":"sha","ts":"..."}` (cfw PR #554). The bead flagged the alignment gap with `setup-monitors.sh`: needed an explicit keyword monitor for `/api/health` so UptimeRobot actually verifies the response body, not just HTTP 200.

Picked option (a) per the bead: update `setup-monitors.sh` to use a specific JSON substring as the keyword. Option (b) (change route to return plain text) would break the schema-shape lock test in cf-x6ph.

## Changes

| File | Change |
|---|---|
| `scripts/setup-monitors.sh` | MONITORS array extended from 2 fields to 5 (`Name\|URL\|Type\|KeywordType\|KeywordValue`). 4 existing monitors keep `type=1`. New 5th monitor `CF API Health` uses `type=2` (keyword) with `keyword_value="status":"ok"`. `create_monitor` validates + URL-encodes via Python's urllib.parse. |
| `monitoring-setup.md` | Monitors table now shows all 5 + keyword-check column. Footer explains why `"status":"ok"` is the right keyword vs the bare `ok` (which false-positives on any HTML page). |

## Why `"status":"ok"` (not just `ok`)

The bare word `ok` matches any 404 page or marketing copy that contains the word. `"status":"ok"` is the quoted-colon-quoted JSON substring that ONLY appears in a healthy response from `/api/health` (verified by the schema-shape lock test in cf-x6ph's test suite). Single load-bearing substring, no false positives.

## Test plan
- [x] `bash -n scripts/setup-monitors.sh` — syntax clean
- [x] Dry-run parse confirms each MONITORS entry splits to the right 5 fields
- [x] No code changes outside the script + the doc — keyword-only change

## Unblocks
cf-3qt.8.31 (UptimeRobot activation gate) — when Stilgar finally provides the API key, the script will create 5 monitors including the health-specific keyword check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)