### PR TITLE
fix(cf-0sdo): allowlist sendSwatchConfirmationEmail in audit.py

### DIFF
--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -73,6 +73,14 @@ INTENTIONAL_ANYONE = frozenset({
     # (no DB writes, no privileged reads, no PII), so Wix auto-RPC
     # exposure is harmless. cf-quba.fu1.
     "pinterestCatalogSync.generatePinContent",
+    # emailService.sendSwatchConfirmationEmail — Permissions.Anyone
+    # because the customer-facing swatchRequest.submitSwatchRequest
+    # (also Anyone, rate-limited) calls it directly to dispatch the
+    # swatch confirmation email. Live internal caller at
+    # swatchRequest.web.js:258. The "send" verb prefix trips SUSPICIOUS;
+    # allowlisted because the function only consumes a sanitized
+    # payload from the same-rig swatch flow. cf-0sdo (cf-ykmj #2).
+    "emailService.sendSwatchConfirmationEmail",
 })
 
 


### PR DESCRIPTION
## Summary
Resolves cf-0sdo (P3) — cf-ykmj SUSPICIOUS #2 false-positive.

\`emailService.sendSwatchConfirmationEmail\` is \`Permissions.Anyone\` because its caller \`swatchRequest.submitSwatchRequest\` is also Anyone (guest swatch-request flow). The "send" verb prefix in the public-verb regex trips SUSPICIOUS, but the function has a live internal caller at \`swatchRequest.web.js:258\` and only consumes a sanitized payload from the same-rig flow.

Added an entry to \`INTENTIONAL_ANYONE\` keyed \`emailService.sendSwatchConfirmationEmail\` with the inline rationale.

### Tests
- All 25 audit tests (\`test_audit_v3\` + \`test_audit_v4\`) pass.

## Test plan
- [x] Allowlist contains the new key
- [x] Audit tests pass
- [ ] Next dead-routes report: confirm sendSwatchConfirmationEmail no longer appears in SUSPICIOUS

Refs: cf-0sdo, parent cf-4x7e, audit cf-ykmj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)