### PR TITLE
chore(cf-4x7e.3): drop handleDeliveryConfirmed (orphan post-B5)

### DIFF
--- a/src/backend/notificationOrchestrator.web.js
+++ b/src/backend/notificationOrchestrator.web.js
@@ -6,9 +6,14 @@
  * Wiring:
  *  - wixEcom_onOrderFulfilled → handleOrderFulfilled → sendOrderShippedSMS
  *    (live: dispatched from src/backend/events.js via dynamic import)
- *  - UPS delivered status → handleDeliveryConfirmed → sendDeliveryConfirmedSMS
- *    (NOT yet wired: handler is in place but no poller / webhook calls it today.
- *     cf-4x7e.3 tracks whether to retire the handler or land the trigger.)
+ *
+ * The UPS-delivered SMS path is intentionally absent — cf-4x7e.3 dropped
+ * the handleDeliveryConfirmed handler because no poller or webhook was
+ * landing in the foreseeable plan window. If/when delivery-confirmation
+ * SMS becomes a requirement, re-author from git history (last good commit
+ * pre-4x7e.3) and land the trigger in the same PR so handler + caller
+ * arrive together — avoids the orphan-handler shape that triggered this
+ * retirement.
  *
  * Opt-in gate: SMS only fires if the member has SMS enabled and phone on record.
  * The gate is enforced inside smsService.checkPreferences — callers here do not
@@ -19,7 +24,6 @@
  * Wix Secrets Manager.
  *
  * @requires backend/smsService.web
- * @requires backend/ups-shipping.web
  */
 import { sanitize } from 'backend/utils/sanitize';
 
@@ -62,30 +66,6 @@ export async function handleOrderFulfilled({ memberId, orderNumber, trackingNumb
     return { sent: result.success, reason: result.reason };
   } catch (err) {
     console.error('[notificationOrchestrator] handleOrderFulfilled error:', err);
-    return { sent: false, reason: 'error' };
-  }
-}
-
-/**
- * Handle UPS delivery confirmed event.
- * Sends a "delivery confirmed" SMS to the member.
- *
- * @param {Object} params
- * @param {string} params.memberId - Wix member ID.
- * @param {string} params.orderNumber - Order number.
- * @returns {Promise<{sent: boolean, reason?: string}>}
- */
-export async function handleDeliveryConfirmed({ memberId, orderNumber } = {}) {
-  if (!memberId || !orderNumber) {
-    return { sent: false, reason: 'missing_params' };
-  }
-
-  try {
-    const { sendDeliveryConfirmedSMS } = await import('backend/smsService.web');
-    const result = await sendDeliveryConfirmedSMS({ memberId, orderNumber });
-    return { sent: result.success, reason: result.reason };
-  } catch (err) {
-    console.error('[notificationOrchestrator] handleDeliveryConfirmed error:', err);
     return { sent: false, reason: 'error' };
   }
 }

--- a/tests/notificationOrchestrator.test.js
+++ b/tests/notificationOrchestrator.test.js
@@ -7,23 +7,19 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock smsService dynamic import
 const mockSendOrderShippedSMS = vi.fn();
-const mockSendDeliveryConfirmedSMS = vi.fn();
 
 vi.mock('backend/smsService.web', () => ({
   sendOrderShippedSMS: (...args) => mockSendOrderShippedSMS(...args),
-  sendDeliveryConfirmedSMS: (...args) => mockSendDeliveryConfirmedSMS(...args),
 }));
 
 import {
   buildTrackingUrl,
   handleOrderFulfilled,
-  handleDeliveryConfirmed,
 } from '../src/backend/notificationOrchestrator.web.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockSendOrderShippedSMS.mockResolvedValue({ success: true });
-  mockSendDeliveryConfirmedSMS.mockResolvedValue({ success: true });
 });
 
 // ── buildTrackingUrl ────────────────────────────────────────────────
@@ -119,47 +115,6 @@ describe('handleOrderFulfilled', () => {
 
     expect(result.sent).toBe(false);
     expect(result.reason).toBe('sms_disabled');
-  });
-});
-
-// ── handleDeliveryConfirmed ─────────────────────────────────────────
-
-describe('handleDeliveryConfirmed', () => {
-  it('sends delivery confirmed SMS', async () => {
-    const result = await handleDeliveryConfirmed({
-      memberId: 'mem-1',
-      orderNumber: 'ORD-001',
-    });
-
-    expect(result.sent).toBe(true);
-    expect(mockSendDeliveryConfirmedSMS).toHaveBeenCalledWith({
-      memberId: 'mem-1',
-      orderNumber: 'ORD-001',
-    });
-  });
-
-  it('returns missing_params without memberId', async () => {
-    const result = await handleDeliveryConfirmed({ orderNumber: 'ORD-001' });
-    expect(result.sent).toBe(false);
-    expect(result.reason).toBe('missing_params');
-  });
-
-  it('returns missing_params without orderNumber', async () => {
-    const result = await handleDeliveryConfirmed({ memberId: 'mem-1' });
-    expect(result.sent).toBe(false);
-    expect(result.reason).toBe('missing_params');
-  });
-
-  it('handles smsService failure gracefully', async () => {
-    mockSendDeliveryConfirmedSMS.mockRejectedValue(new Error('Network error'));
-
-    const result = await handleDeliveryConfirmed({
-      memberId: 'mem-1',
-      orderNumber: 'ORD-001',
-    });
-
-    expect(result.sent).toBe(false);
-    expect(result.reason).toBe('error');
   });
 });
 

--- a/tests/transactionalSms.test.js
+++ b/tests/transactionalSms.test.js
@@ -5,7 +5,6 @@
  * Covers:
  *  - buildTrackingUrl: URL construction
  *  - handleOrderFulfilled: opt-in gate, tracking URL injection, SMS fired
- *  - handleDeliveryConfirmed: opt-in gate, cooldown gate, SMS fired
  *  - sendOrderShippedSMS: message format, Twilio call, SMSLog insert
  *  - sendDeliveryConfirmedSMS: message format, Twilio call, cooldown, SMSLog insert
  */
@@ -17,7 +16,6 @@ import { __setHandler } from './__mocks__/wix-fetch.js';
 import {
   buildTrackingUrl,
   handleOrderFulfilled,
-  handleDeliveryConfirmed,
 } from '../src/backend/notificationOrchestrator.web.js';
 import {
   sendOrderShippedSMS,
@@ -385,35 +383,3 @@ describe('handleOrderFulfilled', () => {
   });
 });
 
-// ── handleDeliveryConfirmed ───────────────────────────────────────────────────
-
-describe('handleDeliveryConfirmed', () => {
-  it('fires delivery confirmed SMS for opted-in member', async () => {
-    seedPrefs();
-    seedTwilioSecrets();
-    mockTwilioSuccess('SM_HDC');
-
-    const result = await handleDeliveryConfirmed({ memberId: MEMBER_ID, orderNumber: ORDER_NUM });
-    expect(result.sent).toBe(true);
-  });
-
-  it('returns sent=false for member with SMS disabled', async () => {
-    seedPrefs({ smsEnabled: false });
-    seedTwilioSecrets();
-
-    const result = await handleDeliveryConfirmed({ memberId: MEMBER_ID, orderNumber: ORDER_NUM });
-    expect(result.sent).toBe(false);
-  });
-
-  it('returns sent=false with reason=missing_params when memberId absent', async () => {
-    const result = await handleDeliveryConfirmed({ orderNumber: ORDER_NUM });
-    expect(result.sent).toBe(false);
-    expect(result.reason).toBe('missing_params');
-  });
-
-  it('returns sent=false with reason=missing_params when orderNumber absent', async () => {
-    const result = await handleDeliveryConfirmed({ memberId: MEMBER_ID });
-    expect(result.sent).toBe(false);
-    expect(result.reason).toBe('missing_params');
-  });
-});


### PR DESCRIPTION
## Summary

Follow-up to cf-4x7e.B5 (#1333). radahn flagged \`handleDeliveryConfirmed\` as orphan-by-association during that review — only src/ caller was the dropped \`triggerDeliveryConfirmedSMS\` at the old line 119. Deferred to this PR rather than expanding B-5 scope (would have invalidated radahn's approval).

## Drops
- \`src/backend/notificationOrchestrator.web.js\` — \`handleDeliveryConfirmed\` (zero callers verified across cfutons + stage3-velo + cfw)
- \`tests/notificationOrchestrator.test.js\` — matching describe block + the unused mock entry
- \`tests/transactionalSms.test.js\` — matching describe block + import

## Kept
- \`handleOrderFulfilled\` — live, dispatched from \`events.js:358\` on \`wixEcom_onOrderFulfilled\`
- \`buildTrackingUrl\` — used by \`handleOrderFulfilled\`
- \`sendDeliveryConfirmedSMS\` — kept in \`smsService.web.js\` with its own tests in transactionalSms; only the orchestrator wrapper is gone

## Module doc-comment update
Rewrote the Wiring block to drop the "NOT yet wired" UPS-delivered line and document the retirement reasoning: re-author handler + caller together if/when delivery-confirmation SMS becomes a requirement.

## Pre-deletion sweep
- ✅ Static import sweep clean
- ✅ Dynamic \`await import(...)\` sweep clean
- ✅ events.js / jobs.config / http-functions.js — no reference
- ✅ \`node --check\` on all 3 modified files passes
- ✅ vitest: 37/37 pass on notificationOrchestrator + transactionalSms

5-agent review per mayor 2026-05-15 — dispatching after open.

## Coverage
May tick branches/functions a fraction of a percent. Per cf-4x7e.B5 precedent, will apply same-shape ratchet adjustment in a follow-on commit if CI fails (current thresholds: branches 84.8, functions 88.8).

Refs cf-4x7e, cf-4x7e.B5 (#1333), cf-4x7e.3 (this bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)