### PR TITLE
fix(cf-4x7e.4 + cf-4x7e.5): handleOrderFulfilled logError + History marker

### DIFF
--- a/src/backend/notificationOrchestrator.web.js
+++ b/src/backend/notificationOrchestrator.web.js
@@ -7,6 +7,13 @@
  *  - wixEcom_onOrderFulfilled → handleOrderFulfilled → sendOrderShippedSMS
  *    (live: dispatched from src/backend/events.js via dynamic import)
  *
+ * History:
+ *  - cf-4x7e.B5.fu (#1337) retired the delivery-confirmed SMS surface
+ *    (handleDeliveryConfirmed + sendDeliveryConfirmedSMS) as orphan-by-
+ *    association after the UPS-delivered trigger never landed. Re-author
+ *    handler + caller together if/when delivery-confirmation SMS becomes
+ *    a requirement again — avoid re-creating the orphan-handler shape.
+ *
  * Opt-in gate: SMS only fires if the member has SMS enabled and phone on record.
  * The gate is enforced inside smsService.checkPreferences — callers here do not
  * need to re-check it.

--- a/src/backend/notificationOrchestrator.web.js
+++ b/src/backend/notificationOrchestrator.web.js
@@ -11,20 +11,39 @@
  * The gate is enforced inside smsService.checkPreferences — callers here do not
  * need to re-check it.
  *
+ * Observability (cf-4x7e.4):
+ *  - All caught errors route through `logError(context, err)` so Wix runtime
+ *    logs carry a stable context string for grep/alerting. The context names
+ *    both the surface and the failure stage (e.g. `:module-load` vs `:send`).
+ *  - The returned `{sent:false, reason}` envelope distinguishes failure
+ *    classes the upstream event handler can branch on:
+ *      `missing_params`         — caller didn't pass memberId or orderNumber
+ *      `smsService_unavailable` — dynamic import failed (Wix runtime, code split)
+ *      `send_error`             — Twilio/network/other thrown failure
+ *      whatever smsService returned (e.g. `sms_disabled` opt-out)
+ *
  * NOTE: Twilio credentials (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER)
  * are pending Stilgar. The integration will go live once secrets are added to
  * Wix Secrets Manager.
  *
  * @requires backend/smsService.web
+ * @requires backend/utils/errorHandler
  */
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const UPS_TRACKING_BASE = 'https://www.ups.com/track?tracknum=';
 
 /**
  * Build a UPS tracking URL from a tracking number.
- * @param {string} trackingNumber
- * @returns {string}
+ *
+ * Strips non-alphanumeric chars (UPS tracking numbers are A-Z + 0-9 only)
+ * after sanitizing to the first 50 chars so a pathologically long input
+ * can't grow an unbounded URL.
+ *
+ * @param {string} trackingNumber - Raw tracking number (any case, hyphens OK).
+ * @returns {string} The full UPS tracking URL, or `""` if the cleaned
+ *   tracking number is empty.
  */
 export function buildTrackingUrl(trackingNumber) {
   const clean = sanitize(String(trackingNumber || ''), 50).replace(/[^A-Z0-9]/gi, '');
@@ -33,32 +52,53 @@ export function buildTrackingUrl(trackingNumber) {
 }
 
 /**
- * Handle the wixEcom_onOrderFulfilled event.
- * Looks up the member by contactId, constructs the tracking URL, and
- * sends an "order shipped" SMS if the member opted in.
+ * Handle the `wixEcom_onOrderFulfilled` event.
+ *
+ * Constructs the tracking URL and dispatches an "order shipped" SMS via
+ * smsService. The downstream service enforces the member's SMS opt-in
+ * preference; callers here treat its `{success:false, reason}` envelope
+ * as a normal negative response (no log) vs a thrown error (logged).
+ *
+ * Failure handling (cf-4x7e.4) splits two error classes so operators can
+ * branch on which surface broke without scraping log lines:
+ *   - Dynamic import of `backend/smsService.web` failed → `smsService_unavailable`
+ *   - `sendOrderShippedSMS` threw at send time → `send_error`
+ *
+ * Both paths route through `logError(context, err)` with a context string
+ * that names the failure stage, so Wix runtime logs are greppable.
  *
  * Called from src/backend/events.js → wixEcom_onOrderFulfilled.
  *
- * @param {Object} params
+ * @param {Object} [params]
  * @param {string} params.memberId - Wix member ID from buyer info.
  * @param {string} params.orderNumber - Order number.
  * @param {string} [params.trackingNumber] - UPS tracking number from fulfillment.
- * @returns {Promise<{sent: boolean, reason?: string}>}
+ * @returns {Promise<{sent: boolean, reason?: string}>} Envelope where
+ *   `sent` is the success flag and `reason` is the failure class (see
+ *   the module-level "Observability" block for the value set).
  */
 export async function handleOrderFulfilled({ memberId, orderNumber, trackingNumber } = {}) {
   if (!memberId || !orderNumber) {
     return { sent: false, reason: 'missing_params' };
   }
 
+  // Split the dynamic import from the send so a runtime/code-split failure
+  // reports differently from a Twilio/network failure — they need different
+  // operator responses (deploy regression vs upstream-provider outage).
+  let sendOrderShippedSMS;
   try {
-    const { sendOrderShippedSMS } = await import('backend/smsService.web');
-    const trackingUrl = buildTrackingUrl(trackingNumber || '');
+    ({ sendOrderShippedSMS } = await import('backend/smsService.web'));
+  } catch (err) {
+    logError('notificationOrchestrator.handleOrderFulfilled:module-load', err);
+    return { sent: false, reason: 'smsService_unavailable' };
+  }
 
+  try {
+    const trackingUrl = buildTrackingUrl(trackingNumber || '');
     const result = await sendOrderShippedSMS({ memberId, orderNumber, trackingUrl });
     return { sent: result.success, reason: result.reason };
   } catch (err) {
-    console.error('[notificationOrchestrator] handleOrderFulfilled error:', err);
-    return { sent: false, reason: 'error' };
+    logError('notificationOrchestrator.handleOrderFulfilled:send', err);
+    return { sent: false, reason: 'send_error' };
   }
 }
-

--- a/tests/notificationOrchestrator.test.js
+++ b/tests/notificationOrchestrator.test.js
@@ -12,10 +12,17 @@ vi.mock('backend/smsService.web', () => ({
   sendOrderShippedSMS: (...args) => mockSendOrderShippedSMS(...args),
 }));
 
+// cf-4x7e.4: structured logger — we assert it's called with the right context
+// string instead of relying on `console.error` line-grep.
+vi.mock('backend/utils/errorHandler', () => ({
+  logError: vi.fn(),
+}));
+
 import {
   buildTrackingUrl,
   handleOrderFulfilled,
 } from '../src/backend/notificationOrchestrator.web.js';
+import { logError } from 'backend/utils/errorHandler';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -93,7 +100,12 @@ describe('handleOrderFulfilled', () => {
     expect(result.reason).toBe('missing_params');
   });
 
-  it('handles smsService failure gracefully', async () => {
+  // cf-4x7e.4: a send-time failure (Twilio down, network error, etc.) now
+  // reports `reason: 'send_error'` so operators can distinguish it from
+  // module-load failures (`smsService_unavailable`) and missing-params
+  // (`missing_params`) without grepping logs. logError is called with a
+  // context string that names the surface AND the failure stage.
+  it('handles smsService send failure with reason=send_error + logError', async () => {
     mockSendOrderShippedSMS.mockRejectedValue(new Error('Twilio down'));
 
     const result = await handleOrderFulfilled({
@@ -102,7 +114,11 @@ describe('handleOrderFulfilled', () => {
     });
 
     expect(result.sent).toBe(false);
-    expect(result.reason).toBe('error');
+    expect(result.reason).toBe('send_error');
+    expect(logError).toHaveBeenCalledWith(
+      'notificationOrchestrator.handleOrderFulfilled:send',
+      expect.any(Error),
+    );
   });
 
   it('passes through opt-out reason from smsService', async () => {
@@ -115,6 +131,19 @@ describe('handleOrderFulfilled', () => {
 
     expect(result.sent).toBe(false);
     expect(result.reason).toBe('sms_disabled');
+    // Opt-out is a normal `{success:false}` envelope, not an error — logError
+    // must not fire on the happy-path negative.
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  // cf-4x7e.4: no console.error left behind. Catches a regression where
+  // someone copies the old pattern back in.
+  it('does not call console.error on any path', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockSendOrderShippedSMS.mockRejectedValue(new Error('Twilio down'));
+    await handleOrderFulfilled({ memberId: 'mem-1', orderNumber: 'ORD-001' });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes silent-failure-hunter sub-agent observation from PR #1337 review: \`handleOrderFulfilled\` was the last orchestrator surface still using \`console.error\` + a single broad \`reason: 'error'\` envelope. This PR aligns it with the rest of the module observability shape.

## Behavior change

| Path | Before | After |
|---|---|---|
| Module-load failure (\`await import('backend/smsService.web')\` throws) | \`console.error\` + \`reason: 'error'\` | \`logError(':module-load', err)\` + \`reason: 'smsService_unavailable'\` |
| Send-time failure (Twilio/network throw) | \`console.error\` + \`reason: 'error'\` | \`logError(':send', err)\` + \`reason: 'send_error'\` |
| Opt-in negative (\`smsService\` returned \`{success:false}\`) | passed through (unchanged) | passed through, AND now asserts \`logError\` is NOT called |
| \`missing_params\` | unchanged | unchanged |
| Success | unchanged | unchanged |

Operators can branch on the reason without log-grep:
- \`smsService_unavailable\` → code-split / Wix-runtime regression (page on deploy)
- \`send_error\` → Twilio / network / provider outage (page on Twilio)
- \`sms_disabled\` → member opt-out (normal, no page)

## TDD

3 cases added/updated under \`handleOrderFulfilled\`:
- \`send_error\` reason + \`logError\` context-string assertion (red→green)
- opt-out explicitly asserts \`logError\` NOT called (regression guard)
- \`console.error\` never called regression guard

11/11 pass on \`notificationOrchestrator.test.js\`; 19/19 on adjacent \`transactionalSms.test.js\` (no surface touched).

## Out of scope

Bead scope #2 (apply same shape to \`emailAutomation.handleOrderDelivered\`) inspected: it ALREADY uses \`logError\` via per-helper \`.catch()\` chains on its three downstream calls. No drift there.

## Stage3-velo

Mirror PR will follow this one's merge, same pattern as #39 (cf-4x7e.B5) and #40 (cf-4x7e.3).

## Test plan
- [x] vitest notificationOrchestrator.test.js — 11/11
- [x] vitest transactionalSms.test.js — 19/19 (adjacent)
- [x] node --check syntax pass
- [ ] CI green + 5-agent crew sign-offs per mayor 2026-05-15

5-agent review dispatching now.

Refs cf-4x7e.4, cf-4x7e.3 (#1337), cf-4x7e.B5 (#1333).

🤖 Generated with [Claude Code](https://claude.com/claude-code)