### PR TITLE
docs(cf-zb6j): drop stale-alias parenthetical from cf-094q triage title

### DIFF
--- a/docs/audits/cf-fp19-triage-2026-05-10.md
+++ b/docs/audits/cf-fp19-triage-2026-05-10.md
@@ -1,4 +1,10 @@
-# cf-094q (cf-fp19) — MAYBE-CFW-NAME-COLLISION triage
+# cf-094q — MAYBE-CFW-NAME-COLLISION triage
+
+<!-- cf-zb6j: dropped a stale-alias parenthetical from the title.
+     The aliased ID didn't resolve in bd; the doc-bead-refs checker was
+     flagging it as a NEW unknown reference on every run. Filename
+     retained for inbound-link backwards compat. -->
+
 
 **Bead**: cf-094q · **Author**: cfutons/crew/morgott · **Date**: 2026-05-10 · **Source**: PR #1320 (`cf-hpwy v3.2 snapshot`)
 


### PR DESCRIPTION
## Summary
Resolves cf-zb6j (P4 doc-drift). The cf-094q triage doc title carried a stale-alias parenthetical referencing a bead ID that never resolved in bd. \`scripts/check-doc-bead-refs.py\` was flagging it as a NEW unknown reference on every run.

### Fix
- Title: dropped the parenthetical so the canonical bead ID stands alone
- Added an HTML-comment audit trail that deliberately avoids the \`cf-NNNN\` regex shape (so the checker doesn't re-flag it on the next pass)
- Filename retained for inbound-link backwards compat

### Verification
\`\`\`
$ python3 scripts/check-doc-bead-refs.py
Scanned 191 markdown files under /docs against 814 known beads + 15 allowlist entries + 68 baselined refs
✓ No NEW drift (68 carried by baseline — run with --strict to see all).
\`\`\`
Down from 1 NEW unknown reference pre-fix. Pre-existing 68 baselined refs unchanged.

### Reviewers (5-agent gate per Stilgar 2026-05-15, all repos)
- [ ] reviewer 1
- [ ] reviewer 2
- [ ] reviewer 3
- [ ] reviewer 4
- [ ] reviewer 5

## Test plan
- [x] check-doc-bead-refs.py reports 0 NEW drift on the fixed file
- [x] Audit-trail comment in the doc avoids the cf-NNNN token shape so the regex doesn't re-flag it

Refs: cf-zb6j, parent cf-b8n8 (doc-bead-refs check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)