### PR TITLE
feat(cf-9fqc): observability dashboard Phase 2 — TDD red phase

### DIFF
--- a/docs/ops/observability-dashboard-spec.md
+++ b/docs/ops/observability-dashboard-spec.md
@@ -3,7 +3,7 @@
 **Bead:** cf-4tqw (Phase 1 — spec)
 **Author:** millicent (cfutons/crew, CI/devops lane)
 **Roadmap context:** Week 1-2 of the 6-week observability + email + security plan (Stilgar directive 2026-05-15)
-**Metric target:** Time-to-detect (TTD) for production outages — < 5 min for 5xx spikes, < 2 min for full outage
+**Metric target:** Time-to-detect (TTD) for production outages — see § "TTD targets (revised post-review)" below for the tier-aware breakdown. Headline: **< 5 min for 5xx-rate spikes** via Sentry (no polling limit); full-outage TTD bounded by the UptimeRobot tier we provision (5 min on FREE, 1 min on PAID — Phase 2 reviewer feedback)
 
 ## Purpose
 
@@ -219,6 +219,36 @@ The script reads from APIs every run. No local state, no cache file (operator ca
 | `SENTRY_AUTH_TOKEN` | env var | **Stilgar provisioning** | 🔴 blocked (cf-3qt.8.34 go/no-go gate item) |
 
 When Phase 2 ships, **both Sentry + UptimeRobot tokens MUST also be set as GitHub Actions secrets** if the dashboard is wired into a cron workflow.
+
+## TTD targets (revised post-review)
+
+PR #1341 reviewer flagged a constraint that requires re-tuning the original metric target. Documenting here as the source of truth:
+
+**UptimeRobot polling intervals by tier:**
+
+| Tier | Poll interval | Effective floor on full-outage TTD |
+|---|---|---|
+| FREE | 5 min | ≥ 5 min (one poll cycle + alert dispatch) |
+| Solo / Team (paid) | 1 min | ≥ 1 min (same) |
+| Enterprise | 30 s | ≥ 30 s |
+
+The original target ("< 2 min for full outage") **is unreachable on FREE tier**. Two ways forward:
+
+1. **Stilgar provisions the PAID plan** when delivering the API key → 1-min UptimeRobot polling → full-outage TTD < 2 min achievable. Recommended for cutover-night + the 30-day stability window.
+2. **Stilgar stays on FREE** → full-outage TTD floor is **5 min** → Sentry (no polling limit; event-driven) becomes the < 1-min signal for 5xx-rate spikes. 5xx spikes are usually the leading-indicator before full-outage anyway, so this is workable but reduces the safety margin.
+
+**Revised metric target by signal type:**
+
+| Signal | Source | Target TTD |
+|---|---|---|
+| 5xx error-rate spike (≥ 5/min sustained 30s) | Sentry event stream | **< 1 min** (event-driven, no polling) |
+| `/api/health` non-200 | UptimeRobot poll | **< UptimeRobot tier interval** + alert dispatch |
+| Production deploy rolled back | Vercel `/v6/deployments` `state=ERROR` | next dashboard pull (operator-paced) |
+| Customer report | inbox / support channel | unbounded (canary metric — should always lag the others) |
+
+**Dashboard role in the TTD picture**: the dashboard itself is a **pull-snapshot** tool — not the alerting layer. UptimeRobot + Sentry handle the push alerts; the dashboard is what the on-call agent runs to consolidate state after the page fires.
+
+**Action on Stilgar (Phase 2 prereq):** confirm which UptimeRobot tier we're provisioning so the dashboard cell thresholds (and these TTD targets) match real polling cadence.
 
 ## Cron cadence (Phase 2 follow-on, not this PR)
 

--- a/scripts/ops/dashboard.sh
+++ b/scripts/ops/dashboard.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# cf-9fqc (Phase 2 of cf-4tqw) — observability dashboard.
+#
+# THIS IS A TDD STUB. Tests live in tests/ops/dashboard.test.mjs and pin
+# the 5 contracts from docs/ops/observability-dashboard-spec.md. This stub
+# exits non-zero so all tests are RED; the GREEN implementation lands in
+# a follow-up commit once Stilgar provisions the API keys
+# (UPTIMEROBOT_API_KEY + SENTRY_AUTH_TOKEN) for the live-API integration
+# tests, OR earlier if we ship the fixture-mode path first.
+#
+# When implementing:
+#   1. Make each Contract test pass one at a time
+#   2. Do NOT add features beyond what a test requires
+#   3. Refactor only after every test is green
+#
+# Usage (post-impl):
+#   bash scripts/ops/dashboard.sh > /tmp/snapshot.md
+#   # stdout = YAML summary block; /tmp/snapshot.md = full Markdown doc
+#
+# Modes:
+#   DASHBOARD_TEST_MODE=live      — hit real APIs (default in production)
+#   DASHBOARD_TEST_MODE=fixtures  — read canned JSON from
+#                                   $DASHBOARD_TEST_FIXTURES_DIR (test only)
+#
+# Output file: $DASHBOARD_OUTPUT_FILE (default: docs/ops/dashboard-<DATE>.md)
+
+set -u
+
+echo "[dashboard] not yet implemented — TDD red phase (cf-9fqc)" >&2
+echo "[dashboard] tests at tests/ops/dashboard.test.mjs pin the 5 contracts" >&2
+exit 99

--- a/tests/ops/dashboard.test.js
+++ b/tests/ops/dashboard.test.js
@@ -1,0 +1,263 @@
+/**
+ * cf-9fqc (Phase 2 of cf-4tqw) — TDD test suite for scripts/ops/dashboard.sh
+ *
+ * Tests are written BEFORE the script body per the 2026-05-15 TDD discipline
+ * standing order. Each test pins one of the 5 contracts from
+ * docs/ops/observability-dashboard-spec.md § "Implementation contract".
+ *
+ * The script is invoked as a shell subprocess (it's a bash script that calls
+ * curl + python3 helpers). We capture stdout, stderr, exit code, and the
+ * generated Markdown file, and assert against the contract.
+ *
+ * Some tests are SKIPPED until Stilgar provisions the live credentials
+ * (UPTIMEROBOT_API_KEY, SENTRY_AUTH_TOKEN). The skipped tests pin contracts
+ * that depend on live API calls; they un-skip automatically once the env
+ * vars exist (no further test edits needed when Stilgar's keys land).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile, mkdir, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT = "scripts/ops/dashboard.sh";
+
+// Test mode: when DASHBOARD_TEST_MODE=fixtures the script reads canned
+// JSON responses from $DASHBOARD_TEST_FIXTURES_DIR instead of hitting the
+// real APIs. Lets the test suite run deterministically in CI without
+// network or live tokens.
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "dashboard-test-"));
+});
+
+afterEach(async () => {
+  if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Run the dashboard script with fixture-mode env and return
+ * { stdout, stderr, exitCode, outputDocPath }.
+ *
+ * `fixtures` is an object mapping data-source name → JSON the script
+ * should see. The helper writes each as a file under tmpDir and points
+ * the script at the directory via DASHBOARD_TEST_FIXTURES_DIR.
+ *
+ * Exit code is captured even on non-zero (Contract 2 requires us to assert
+ * across the 0/1/2/3 range), so we never throw on non-zero exit.
+ */
+async function runDashboard(fixtures = {}, extraEnv = {}) {
+  const fixtureDir = join(tmpDir, "fixtures");
+  await mkdir(fixtureDir, { recursive: true });
+  for (const [key, body] of Object.entries(fixtures)) {
+    await writeFile(join(fixtureDir, `${key}.json`), JSON.stringify(body));
+  }
+  const outFile = join(tmpDir, "snapshot.md");
+  const env = {
+    ...process.env,
+    DASHBOARD_TEST_MODE: "fixtures",
+    DASHBOARD_TEST_FIXTURES_DIR: fixtureDir,
+    DASHBOARD_OUTPUT_FILE: outFile,
+    ...extraEnv,
+  };
+  try {
+    const { stdout, stderr } = await execFileAsync("bash", [SCRIPT], { env });
+    return { stdout, stderr, exitCode: 0, outputDocPath: outFile };
+  } catch (err) {
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      exitCode: err.code ?? 1,
+      outputDocPath: outFile,
+    };
+  }
+}
+
+// ─── Contract 1: stdout = YAML summary, file = full doc ─────────────────
+
+describe("Contract 1 — output split", () => {
+  it("writes the YAML summary block to stdout (machine-readable)", async () => {
+    const { stdout } = await runDashboard(greenFixtures());
+    expect(stdout).toContain("# OPS-DASHBOARD-V1");
+    expect(stdout).toContain("overall:");
+    expect(stdout).toContain("generated_at:");
+  });
+
+  it("writes the full Markdown doc to DASHBOARD_OUTPUT_FILE (human-readable)", async () => {
+    const { outputDocPath } = await runDashboard(greenFixtures());
+    const body = await readFile(outputDocPath, "utf8");
+    expect(body).toMatch(/^# Production Dashboard/m);
+    expect(body).toContain("## Headline scorecard");
+    expect(body).toContain("## Full breakdown");
+  });
+
+  it("stdout does NOT contain the full Markdown body (avoids chat-paste-clobbering)", async () => {
+    const { stdout } = await runDashboard(greenFixtures());
+    expect(stdout).not.toContain("# Production Dashboard");
+    expect(stdout).not.toContain("## Headline scorecard");
+  });
+});
+
+// ─── Contract 2: exit codes 0 / 1 / 2 / 3 ────────────────────────────────
+
+describe("Contract 2 — exit codes per overall verdict", () => {
+  it("exits 0 when every cell is GREEN", async () => {
+    const { exitCode } = await runDashboard(greenFixtures());
+    expect(exitCode).toBe(0);
+  });
+
+  it("exits 1 when at least one cell is YELLOW and none are RED", async () => {
+    const { exitCode } = await runDashboard(yellowFixtures());
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits 2 when at least one cell is RED", async () => {
+    const { exitCode } = await runDashboard(redFixtures());
+    expect(exitCode).toBe(2);
+  });
+
+  it("exits 3 when at least one data source is unreachable", async () => {
+    // Omit a required fixture — script sees missing input → INCOMPLETE.
+    const fixtures = greenFixtures();
+    delete fixtures.health;
+    const { exitCode } = await runDashboard(fixtures);
+    expect(exitCode).toBe(3);
+  });
+});
+
+// ─── Contract 3: degraded operation ─────────────────────────────────────
+
+describe("Contract 3 — degraded operation when a source is unreachable", () => {
+  it("renders the unreachable cell as ❔ with a reason and still emits the rest", async () => {
+    const fixtures = greenFixtures();
+    delete fixtures.sentry;
+    const { outputDocPath } = await runDashboard(fixtures);
+    const body = await readFile(outputDocPath, "utf8");
+    expect(body).toContain("❔");
+    expect(body).toMatch(/sentry.*unreachable/i);
+    // Vercel + UptimeRobot + health cells must still render.
+    expect(body).toMatch(/vercel/i);
+    expect(body).toMatch(/uptimerobot/i);
+    expect(body).toMatch(/api\/health/i);
+  });
+
+  it("downgrades OVERALL to YELLOW (not RED) when a source is merely unreachable", async () => {
+    const fixtures = greenFixtures();
+    delete fixtures.sentry;
+    const { stdout } = await runDashboard(fixtures);
+    expect(stdout).toMatch(/overall:\s*(YELLOW|INCOMPLETE)/);
+    expect(stdout).not.toMatch(/overall:\s*RED/);
+  });
+});
+
+// ─── Contract 4: no PII or secrets in output ────────────────────────────
+
+describe("Contract 4 — no PII or secrets in output", () => {
+  it("strips email-shaped strings from cell rendering", async () => {
+    const fixtures = greenFixtures();
+    fixtures.sentry.issues[0].culprit = "user@example.com triggered handler";
+    const { outputDocPath } = await runDashboard(fixtures);
+    const body = await readFile(outputDocPath, "utf8");
+    expect(body).not.toContain("user@example.com");
+  });
+
+  it("never prints any *_API_KEY or *_TOKEN env value", async () => {
+    const { outputDocPath, stdout } = await runDashboard(greenFixtures(), {
+      UPTIMEROBOT_API_KEY: "fake-key-cf-9fqc-test-must-not-leak",
+      SENTRY_AUTH_TOKEN: "fake-token-cf-9fqc-test-must-not-leak",
+    });
+    const body = await readFile(outputDocPath, "utf8");
+    expect(body).not.toContain("fake-key-cf-9fqc-test-must-not-leak");
+    expect(body).not.toContain("fake-token-cf-9fqc-test-must-not-leak");
+    expect(stdout).not.toContain("fake-key-cf-9fqc-test-must-not-leak");
+    expect(stdout).not.toContain("fake-token-cf-9fqc-test-must-not-leak");
+  });
+});
+
+// ─── Contract 5: re-runnable without state ──────────────────────────────
+
+describe("Contract 5 — re-runnable without local state", () => {
+  it("produces identical output (modulo timestamp) on two back-to-back runs with the same fixtures", async () => {
+    const fx = greenFixtures();
+    const run1 = await runDashboard(fx);
+    const run2 = await runDashboard(fx);
+    const strip = (s) => s.replace(/generated_at: [^\s]+/g, "generated_at: <T>");
+    expect(strip(run1.stdout)).toBe(strip(run2.stdout));
+  });
+
+  it("does NOT write any cache file outside DASHBOARD_OUTPUT_FILE", async () => {
+    const before = (await readdir("scripts/ops/")).sort();
+    await runDashboard(greenFixtures());
+    const after = (await readdir("scripts/ops/")).sort();
+    expect(after).toEqual(before);
+  });
+});
+
+// ─── Live-API tests (SKIPPED until Stilgar provisions tokens) ───────────
+
+describe("Live-API integration (auto-skips without Stilgar tokens)", () => {
+  const hasUptimeRobot = !!process.env.UPTIMEROBOT_API_KEY;
+  const hasSentry = !!process.env.SENTRY_AUTH_TOKEN;
+
+  it.skipIf(!hasUptimeRobot)(
+    "fetches at least one active monitor from UptimeRobot live API",
+    async () => {
+      const { stdout } = await runDashboard({}, { DASHBOARD_TEST_MODE: "live" });
+      expect(stdout).toMatch(/monitors_active_count:\s*[1-9]/);
+    },
+  );
+
+  it.skipIf(!hasSentry)(
+    "fetches issues page from Sentry live API",
+    async () => {
+      const { stdout } = await runDashboard({}, { DASHBOARD_TEST_MODE: "live" });
+      expect(stdout).toMatch(/error_rate_per_min:/);
+    },
+  );
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────
+
+function greenFixtures() {
+  return {
+    vercel: {
+      deployments: [
+        {
+          uid: "dpl_green1",
+          state: "READY",
+          target: "production",
+          created: Date.now() - 5 * 60 * 1000,
+          meta: { githubCommitSha: "abc1234", githubCommitMessage: "feat: ok" },
+        },
+      ],
+    },
+    uptimeRobot: {
+      monitors: [
+        { id: 1, status: 2, friendly_name: "/", custom_uptime_ratio: "99.97" },
+        { id: 2, status: 2, friendly_name: "/api/health", custom_uptime_ratio: "99.99" },
+      ],
+    },
+    sentry: {
+      issues: [{ id: "s1", count: "3", level: "warning", culprit: "ok" }],
+      errorRatePerMin: 0.2,
+    },
+    health: { status: "ok", timestamp: new Date().toISOString(), version: "abc1234" },
+  };
+}
+
+function yellowFixtures() {
+  const fx = greenFixtures();
+  fx.sentry.errorRatePerMin = 2; // 0.5 < x < 5 → YELLOW per spec
+  return fx;
+}
+
+function redFixtures() {
+  const fx = greenFixtures();
+  fx.sentry.errorRatePerMin = 12; // ≥ 5 → RED per spec
+  return fx;
+}


### PR DESCRIPTION
## Summary

Phase 2 follow-up to cf-4tqw (spec, PR #1341 merged). Per the **2026-05-15 TDD discipline mandate**, this PR ships tests FIRST + a stub script + a spec amendment. The GREEN implementation lands in a follow-up commit on this branch when Stilgar's API keys arrive (or earlier via fixture-mode).

## What's in this PR

| File | Role | Lines |
|---|---|---|
| `tests/ops/dashboard.test.js` | **Tests pin 5 spec contracts** | 240 |
| `scripts/ops/dashboard.sh` | **Stub — exits 99 ("not implemented")** | 25 |
| `docs/ops/observability-dashboard-spec.md` | **Amendment** for UptimeRobot tier reality | +50 |

## TDD red phase confirmed

```
Test Files  1 failed (1)
     Tests  10 failed | 3 passed | 2 skipped (15)
```

10 RED (expected), 3 coincidentally green against the stub (e.g. "stdout does NOT contain Markdown body" passes because the stub stdout is empty), 2 auto-skipped behind `it.skipIf(no live token)` — they un-skip automatically when Stilgar's tokens land.

## Spec amendment (responding to PR #1341 review feedback)

PR #1341 reviewer flagged: **UptimeRobot FREE tier polls every 5 min — original <2 min TTD target is unachievable**. Amended the spec to:

- Document the tier → polling-interval reality (FREE 5 min, paid 1 min, Enterprise 30s)
- Revise TTD targets by signal type — Sentry event-driven < 1 min for 5xx-rate spikes (no polling limit); UptimeRobot full-outage TTD bounded by tier
- Flag the PAID-vs-FREE provisioning question for Stilgar

## Test contracts pinned

| Contract | What it asserts |
|---|---|
| 1 — output split | stdout = YAML summary; file = full doc; stdout never contains the full body |
| 2 — exit codes | 0/1/2/3 = GREEN/YELLOW/RED/INCOMPLETE |
| 3 — degraded | unreachable source → ❔ cell, rest renders, OVERALL ≤ YELLOW |
| 4 — no PII / no secrets | email-shaped stripped; `*_API_KEY` / `*_TOKEN` env values never leak |
| 5 — re-runnable | identical output between back-to-back runs (modulo timestamp); no cache files |

Plus 2 live-API integration tests behind `it.skipIf` — auto-un-skip when Stilgar's tokens land.

## Fixture mode

`DASHBOARD_TEST_MODE=fixtures` has the script read canned JSON from `$DASHBOARD_TEST_FIXTURES_DIR` instead of hitting real APIs. The test suite uses this; CI runs deterministically without network or live tokens.

## Cross-crew deps (unchanged from Phase 1)

| Crew | Provides |
|---|---|
| **Stilgar** | UptimeRobot API key + tier decision, Sentry production connection + token |
| **godfrey** | cf-3qt.8.31 (UptimeRobot setup) completion |

## 5-agent review

Per mayor's 2026-05-15 mandate. Looking for 4 more crew sign-offs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)