### PR TITLE
feat(cf-5dto): cf-hpwy v5 detector — close 3 FP-shape blind spots from cf-4x7e wave

### DIFF
--- a/docs/audits/cf-hpwy-v5-snapshot-2026-05-15.md
+++ b/docs/audits/cf-hpwy-v5-snapshot-2026-05-15.md
@@ -63,13 +63,18 @@ backend modules wired via namespace dispatcher: 1
 | GAP-CFW-WANTS | 0 |
 | UNUSED-CAN-DELETE | 0 |
 
-**Headline: DEAD count = 0.** The cf-4x7e wave (231 methods retired, ~-54k LOC across B-3/B-4/B-5/B-5.fu plus parallel crew work) cleared every truly-dead webMethod in scope. v5's allowlist propagation reclassified the 5 false-DEAD entries (cartSessionService.{createSession,updateCartItems}, ups-shipping.trackShipment, pinterestCatalogSync.generatePinContent, emailService.sendSwatchConfirmationEmail) into their correct `HTTP-EXPOSED-INTENTIONAL` bucket.
+**Headline: DEAD count = 0.** (Status hit zero with cf-4x7e.B5.fu / PR #1337; v5 does not change the dead-method tally, only reclassifies the 5 allowlisted-Anyone entries that v4 was incorrectly bucketing as DEAD.) The cf-4x7e wave (231 methods retired, ~-54k LOC across B-3/B-4/B-5/B-5.fu plus parallel crew work) cleared every truly-dead webMethod in scope. v5's allowlist propagation reclassified the 5 false-DEAD entries (cartSessionService.{createSession,updateCartItems}, ups-shipping.trackShipment, pinterestCatalogSync.generatePinContent, emailService.sendSwatchConfirmationEmail) into their correct `HTTP-EXPOSED-INTENTIONAL` bucket.
+
+> **Allowlist removal hazard** (radahn observation): removing any entry from `INTENTIONAL_ANYONE` in `audit.py` flips the corresponding method from `OK-INTENTIONAL-ANYONE` back to `UNUSED-CAN-DELETE` overnight. The allowlist is load-bearing — entries should be removed only when their out-of-tree consumer is also being retired. The frozenset's existing comment-block above each entry pins the consumer rationale; preserve it on edits.
 
 ## Non-webMethod export inventory
 
 149 non-webMethod function exports across `src/backend/*.web.js`. The majority are deliberate test-seam underscores (`_check*RateLimit`, `__resetCache`, `__clearCache`) — these are exposed for tests to drive specific paths but aren't part of the production caller graph.
 
 Operator action: before a whole-file delete, cross-check the non-webMethod inventory for the target file. If any export is consumed outside of the same module's tests or its own webMethod handlers, surgical-drop instead of whole-file.
+
+### Inventory vs row separation
+`collect_non_webmethod_exports()` produces a separate dict from `collect_web_methods()`; the v5 design keeps the two surfaces side-by-side rather than merging them. Rationale: webMethods are the gap-finder unit (HTTP-exposed contract); non-webMethod exports are the survivor-detection unit (call them out so the operator doesn't unintentionally retire them). The `classify_method` row format remains webMethod-keyed; the non-webMethod inventory is consulted at planning time during whole-file delete decisions.
 
 ## Test coverage
 

--- a/docs/audits/cf-hpwy-v5-snapshot-2026-05-15.md
+++ b/docs/audits/cf-hpwy-v5-snapshot-2026-05-15.md
@@ -1,0 +1,87 @@
+# cf-hpwy v5 detector snapshot — 2026-05-15
+
+**Bead:** cf-5dto
+**Branch:** `feat/cf-hpwy-v5-detector`
+**Detector version:** v5 (cf-5dto — closes 3 FP-shape blind spots surfaced during cf-4x7e.B3/B4/B5)
+
+## What's new in v5
+
+Three enhancements, each closing a specific false-positive shape that cost a 1-PR revert during cf-4x7e:
+
+### 1. Non-webMethod export inventory
+v4 only scanned `export const NAME = webMethod(...)`. v5 adds a parallel inventory of `export [async] function NAME(...)` exports in `src/backend/*.web.js`. Result: 149 non-webMethod function exports surfaced.
+
+**Trap closed:** cf-4x7e.B5 (PR #1333) initially planned to whole-file-delete `comfortTimeline.web.js`. All 4 webMethods were correctly DEAD, but the file also exported a non-webMethod `async function createTimeline(...)` that `tests/integration/purchaseFlowSmoke.test.js` dynamically imports. v4 was blind to this; v5 reports it as a separate inventory so the operator decides surgical-drop vs whole-file before the revert.
+
+### 2. INTENTIONAL_ANYONE bucket propagation
+v4 had the `INTENTIONAL_ANYONE` allowlist but only used it to gate the SUSPICIOUS flag. Allowlisted methods with no in-tree callers still bucketed DEAD. v5 adds an explicit `HTTP-EXPOSED-INTENTIONAL` bucket and `OK-INTENTIONAL-ANYONE` gap-verdict so allowlisted endpoints are correctly flagged as kept-by-design.
+
+**Trap closed:** cf-4x7e.B4 (PR #1331) initially picked `cartSessionService.web.js` for whole-file delete. The allowlist correctly suppressed SUSPICIOUS but the file still bucketed DEAD in the planning report. The mobile-rig consumer (out of in-tree scope) is what kept the file alive.
+
+### 3. CI-sentinel sub-classification
+v4 had one bucket: `FILESYSTEM-PATH-REFERENCED`. v5 splits each consumer into a sub-classification:
+
+| Sub-bucket | Consumer path shape | Deletion semantic |
+|---|---|---|
+| `FS-PATH-TEST-IMPORT` | `tests/*.test.{js,ts}` | Test-target; migrate test then safe to delete |
+| `FS-PATH-DATA-SOURCE` | `scripts/*.{js,ts,py,sh,mjs,cjs}` | Tooling depends on file body; refactor tooling FIRST |
+| `FS-PATH-OTHER` | anything else | Operator inspects manually |
+
+**Trap closed:** cf-4x7e.B4 (PR #1331) initially picked `loadCatalogMaster.web.js` for whole-file delete. v3 caught the fs-path reference but didn't distinguish `scripts/validate-catalog.js` (parses VALID_CATEGORIES from file body — data-source) from `tests/validateCatalog.test.js` (test-import). Reverted by hand; v5 now exposes both kinds on the row.
+
+## v5 live tally (cfutons + cfw cross-rig scan)
+
+```
+scanning 2056 src files
+webMethods discovered: 755
+cfw src files: 808
+backend modules referenced by filesystem-path: 23
+backend modules wired via namespace dispatcher: 1
+  wishlistService -> wishlistServiceModule
+```
+
+### Primary bucket (first match per row)
+| Bucket | Count |
+|---|---:|
+| FRONTEND | 319 |
+| FILESYSTEM-PATH-REFERENCED | 286 |
+| HTTP-EXPOSED | 75 |
+| INTERNAL | 64 |
+| EVENT-WIRED | 6 |
+| HTTP-EXPOSED-INTENTIONAL | **5** ← new in v5 |
+| **DEAD** | **0** ← was 287 pre-B3 baseline |
+
+### Gap-verdict tally (cf-hpwy core)
+| Verdict | Count |
+|---|---:|
+| VELO-INTERNAL | 658 |
+| WRAPPED-NO-CONSUMER | 44 |
+| OK-WIRED | 29 |
+| MAYBE-CFW-NAME-COLLISION | 17 |
+| **OK-INTENTIONAL-ANYONE** | **5** ← new in v5 |
+| OK-WIRED-VIA-DISPATCHER | 2 |
+| GAP-CFW-WANTS | 0 |
+| UNUSED-CAN-DELETE | 0 |
+
+**Headline: DEAD count = 0.** The cf-4x7e wave (231 methods retired, ~-54k LOC across B-3/B-4/B-5/B-5.fu plus parallel crew work) cleared every truly-dead webMethod in scope. v5's allowlist propagation reclassified the 5 false-DEAD entries (cartSessionService.{createSession,updateCartItems}, ups-shipping.trackShipment, pinterestCatalogSync.generatePinContent, emailService.sendSwatchConfirmationEmail) into their correct `HTTP-EXPOSED-INTENTIONAL` bucket.
+
+## Non-webMethod export inventory
+
+149 non-webMethod function exports across `src/backend/*.web.js`. The majority are deliberate test-seam underscores (`_check*RateLimit`, `__resetCache`, `__clearCache`) — these are exposed for tests to drive specific paths but aren't part of the production caller graph.
+
+Operator action: before a whole-file delete, cross-check the non-webMethod inventory for the target file. If any export is consumed outside of the same module's tests or its own webMethod handlers, surgical-drop instead of whole-file.
+
+## Test coverage
+
+`scripts/cf-dead-routes/test_audit_v5.py`: 10 tests, all green. Pinning:
+- 3× non-webMethod export shape detection (async function, plain function, const-value skip)
+- 2× INTENTIONAL_ANYONE propagation (allowlist hit → bucket; non-allowlist Anyone still DEAD)
+- 4× fs-path consumer classification (test-import, data-source-js, data-source-py, other-fallthrough)
+- 1× integration: classify_method row includes `fs_path_consumer_kinds` field with both data-source and test-import for a mixed consumer set
+
+Full v3+v4+v5 suite: 35/35 pass, no regression.
+
+## Refs
+- Source bead: cf-5dto
+- Lineage: cf-hpwy v2 (CF-byib) → v3 (cf-sq0d) → v3.1 (cf-sq0d.fu1) → v3.2 (cf-sq0d.fu2) → v4 (cf-eov3, PR #1315) → **v5 (cf-5dto, this PR)**
+- Traps closed during: cf-4x7e.B3 (PR #1325), B4 (PR #1331), B5 (PR #1333), B5.fu (PR #1337)

--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -42,6 +42,25 @@ WM_RE = re.compile(
     re.MULTILINE,
 )
 
+# cf-5dto (v5): Non-webMethod function exports.
+# Matches `export [async] function NAME(...)`. The trap that motivated this:
+# cf-4x7e.B5 (PR #1333) initially planned to whole-file-delete
+# comfortTimeline.web.js — all 4 webMethods were correctly DEAD, but the
+# file also exported a non-webMethod `async function createTimeline(...)`
+# that purchaseFlowSmoke.test.js dynamically imports. The v4 detector only
+# sees webMethods, so this surface was invisible. v5 reports it as a
+# separate inventory so the operator decides surgical-drop vs whole-file
+# rather than discovering the survivor after the revert.
+#
+# We deliberately limit to function declarations (callable surface). Value
+# const exports (`export const FOO = 5`) are out of scope — those have
+# different deletion semantics and we'd rather not pollute the report
+# with constants whose consumers are everywhere.
+NON_WM_FN_RE = re.compile(
+    r"^export\s+(async\s+)?function\s+(\w+)\s*\(",
+    re.MULTILINE,
+)
+
 PUBLIC_VERB_RE = re.compile(
     r"^(submit|create|track|register|capture|send|notify|subscribe|"
     r"unsubscribe|redeem|claim|generate|update|delete)",
@@ -128,6 +147,40 @@ def strip_js_comments(text: str) -> str:
     return _LINE_COMMENT_RE.sub(lambda m: m.group(1), text)
 
 
+def collect_non_webmethod_exports(backend_root: Path | None = None) -> dict[str, dict]:
+    """cf-5dto (v5): Inventory non-webMethod function exports in backend .web.js.
+
+    Returns a dict keyed by export name → {file, line, kind} where kind is
+    'async function' or 'function'. Matches `export [async] function NAME(...)`
+    only — value const exports are out of scope (see NON_WM_FN_RE comment).
+
+    `backend_root` overrides the module-level BACKEND for tests; falls back
+    to the production path when None.
+    """
+    root = backend_root if backend_root is not None else BACKEND
+    out: dict[str, dict] = {}
+    for fp in root.rglob("*.web.js"):
+        try:
+            text = fp.read_text(errors="ignore")
+        except OSError:
+            continue
+        text = strip_js_comments(text)
+        for m in NON_WM_FN_RE.finditer(text):
+            is_async = m.group(1) is not None
+            name = m.group(2)
+            line = text[: m.start()].count("\n") + 1
+            try:
+                file_str = str(fp.relative_to(ROOT))
+            except ValueError:
+                file_str = str(fp)
+            out[name] = {
+                "file": file_str,
+                "line": line,
+                "kind": "async function" if is_async else "function",
+            }
+    return out
+
+
 def collect_web_methods() -> dict[str, dict]:
     methods: dict[str, dict] = {}
     for fp in BACKEND.rglob("*.web.js"):
@@ -190,6 +243,33 @@ def _module_basename(file_rel: str) -> str:
         if base.endswith(suffix):
             return base[: -len(suffix)]
     return base
+
+
+# cf-5dto (v5): Sub-classify filesystem-path consumers so the operator can
+# distinguish file-as-test-target from file-as-data-source. The B-4 trap:
+# loadCatalogMaster.web.js was read by BOTH validate-catalog.js (script,
+# parses VALID_CATEGORIES from the file body — file-as-data-source) AND
+# validateCatalog.test.js (test). Treating them uniformly as
+# FILESYSTEM-PATH-REFERENCED hides the asymmetry — a test-import-only
+# consumer is migrate-then-delete; a data-source consumer requires
+# refactoring the tooling FIRST.
+_FS_PATH_TEST_RE = re.compile(r"^tests/.*\.(test|spec)\.[jt]s$")
+_FS_PATH_SCRIPT_RE = re.compile(r"^scripts/.*\.(js|ts|mjs|cjs|py|sh)$")
+
+
+def classify_fs_path_consumer(rel_path: str) -> str:
+    """Classify a fs-path consumer path into a v5 sub-bucket.
+
+    Returns:
+      FS-PATH-TEST-IMPORT  — `tests/*.test.{js,ts}` consumer (test-target)
+      FS-PATH-DATA-SOURCE  — `scripts/*.{js,ts,py,sh,...}` consumer (tooling)
+      FS-PATH-OTHER        — any other path (operator inspects manually)
+    """
+    if _FS_PATH_TEST_RE.match(rel_path):
+        return "FS-PATH-TEST-IMPORT"
+    if _FS_PATH_SCRIPT_RE.match(rel_path):
+        return "FS-PATH-DATA-SOURCE"
+    return "FS-PATH-OTHER"
 
 
 def collect_filesystem_path_refs(files: list[Path]) -> dict[str, list[str]]:
@@ -531,10 +611,28 @@ def classify_method(
         module_basename = _module_basename(defining_file)
         fs_path_consumers = list(fs_path_refs.get(module_basename, []))
     in_fs_path = bool(fs_path_consumers)
+    # cf-5dto (v5): sub-classify each consumer so the operator sees whether
+    # the file is held by tests (migrate-then-delete) vs tooling
+    # (refactor-tooling-first). Sorted+deduped for stable output.
+    fs_path_consumer_kinds = sorted({
+        classify_fs_path_consumer(c) for c in fs_path_consumers
+    })
+
+    # cf-5dto (v5): INTENTIONAL_ANYONE allowlist propagation. A method on
+    # the allowlist is kept-by-design (out-of-tree consumer like cfutons_mobile
+    # is invisible to the in-tree scan). v4 only gated the SUSPICIOUS flag on
+    # the allowlist; v5 also adds an explicit bucket so the row doesn't fall
+    # through to DEAD just because no in-tree caller exists. The B-4 trap:
+    # cartSessionService.createSession/updateCartItems bucketed DEAD despite
+    # the allowlist + the mobile-rig caller.
+    qualified_early = _module_qualified_name(defining_file, name)
+    is_intentional_anyone = qualified_early in INTENTIONAL_ANYONE
 
     buckets: list[str] = []
     if in_http:
         buckets.append("HTTP-EXPOSED")
+    if is_intentional_anyone:
+        buckets.append("HTTP-EXPOSED-INTENTIONAL")
     if in_events:
         buckets.append("EVENT-WIRED")
     if in_public or in_pages:
@@ -553,13 +651,13 @@ def classify_method(
 
     # cf-quba: allowlist filter — gate the SUSPICIOUS classification so
     # known-intentional Anyone endpoints stop generating noise.
-    qualified = _module_qualified_name(defining_file, name)
     suspicious = (
         info["permission"] == "Anyone"
         and "HTTP-EXPOSED" not in buckets
+        and "HTTP-EXPOSED-INTENTIONAL" not in buckets
         and "FRONTEND" not in buckets
         and PUBLIC_VERB_RE.match(name) is not None
-        and qualified not in INTENTIONAL_ANYONE
+        and not is_intentional_anyone
     )
 
     cfw_high, cfw_low = cfw_references(name, cfw_files)
@@ -580,7 +678,14 @@ def classify_method(
             dispatcher_alias = dispatcher_modules[module_basename]
 
     # Gap-finder verdict (cf-hpwy core deliverable)
-    if in_dispatcher and not has_cfw_high:
+    if is_intentional_anyone:
+        # cf-5dto (v5): allowlisted-Anyone endpoints are kept-by-design.
+        # Out-of-tree consumers (mobile rig, third-party calls into
+        # /_functions/<name>) aren't visible to the in-tree scan; the
+        # allowlist is the operator's declaration that the surface is
+        # intentional. Don't surface as a cleanup candidate.
+        gap_verdict = "OK-INTENTIONAL-ANYONE"
+    elif in_dispatcher and not has_cfw_high:
         # v4: dispatcher route is the WIRED path even without a direct cfw URL.
         # Distinct verdict (OK-WIRED-VIA-DISPATCHER) so the operator can see
         # the dispatch path is active and the method is alive.
@@ -615,6 +720,8 @@ def classify_method(
         "in_same_file": in_same_file,
         "in_filesystem_path": in_fs_path,
         "filesystem_path_consumers": fs_path_consumers[:6],
+        # cf-5dto (v5): sub-classification of each fs-path consumer.
+        "fs_path_consumer_kinds": fs_path_consumer_kinds,
         "in_dispatcher": in_dispatcher,
         "dispatcher_alias": dispatcher_alias,
         "sample_callers": sample_callers,

--- a/scripts/cf-dead-routes/test_audit_v5.py
+++ b/scripts/cf-dead-routes/test_audit_v5.py
@@ -1,0 +1,221 @@
+"""cf-5dto: tests for the v5 detector — 3 FP-shape blind spots surfaced
+during cf-4x7e.B3/B4/B5.
+
+Each cf-4x7e revert cost a PR; v5 closes the three shapes that caused them.
+
+1. Non-webMethod export scanning (B-5 trap: comfortTimeline.createTimeline)
+2. INTENTIONAL_ANYONE bucket propagation (B-4 trap: cartSessionService)
+3. CI-sentinel sub-classification (B-4 trap: loadCatalogMaster)
+
+Run: `python -m pytest scripts/cf-dead-routes/test_audit_v5.py -v`
+"""
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+os.environ.setdefault("CFUTONS_ROOT", str(HERE))
+
+
+def _import_audit():
+    for mod in list(sys.modules):
+        if mod == "audit":
+            del sys.modules[mod]
+    import audit
+    return audit
+
+
+# ── Enhancement 1: Non-webMethod export scanning ──────────────────────
+
+
+def test_collect_non_webmethod_exports_finds_async_function(tmp_path):
+    """`export async function NAME(...)` is the comfortTimeline.createTimeline
+    shape — a backend export that is alive via test-only callers but invisible
+    to the v4 webMethod-only scan."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "sample.web.js").write_text(textwrap.dedent("""
+        import { Permissions, webMethod } from 'wix-web-module';
+
+        export async function helperA({ orderId }) {
+          return { ok: true, orderId };
+        }
+
+        export const wmB = webMethod(Permissions.Admin, async () => ({}));
+    """))
+
+    out = audit.collect_non_webmethod_exports(backend)
+    # Only the async-function export should appear (the webMethod is its own dict)
+    assert "helperA" in out
+    assert out["helperA"]["kind"] == "async function"
+    assert out["helperA"]["file"].endswith("sample.web.js")
+    assert "wmB" not in out  # webMethod, not a non-webMethod export
+
+
+def test_collect_non_webmethod_exports_finds_plain_function(tmp_path):
+    """`export function NAME(...)` (non-async) also counts."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "util.web.js").write_text(textwrap.dedent("""
+        export function buildTrackingUrl(trackingNumber) {
+          return `https://ups.com/track?t=${trackingNumber}`;
+        }
+    """))
+
+    out = audit.collect_non_webmethod_exports(backend)
+    assert "buildTrackingUrl" in out
+    assert out["buildTrackingUrl"]["kind"] == "function"
+
+
+def test_collect_non_webmethod_exports_skips_const_assignments(tmp_path):
+    """`export const FOO = 5` is a value export, not a function — outside
+    the v5 scope (we care about callable surface that consumers might invoke)."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "consts.web.js").write_text(textwrap.dedent("""
+        export const MAX_ITEMS = 50;
+        export const _MILESTONES = [1, 7, 14];
+        export async function makeBatch(items) { return items; }
+    """))
+
+    out = audit.collect_non_webmethod_exports(backend)
+    # The function lands; the const exports do not (they're caught by a
+    # separate v5 future-work pass if needed).
+    assert "makeBatch" in out
+    assert "MAX_ITEMS" not in out
+    assert "_MILESTONES" not in out
+
+
+# ── Enhancement 2: INTENTIONAL_ANYONE → bucket propagation ────────────
+
+
+def test_intentional_anyone_propagates_to_bucket(tmp_path):
+    """Methods in INTENTIONAL_ANYONE should bucket as HTTP-EXPOSED-INTENTIONAL
+    instead of falling through to DEAD when they have no in-tree callers
+    (out-of-tree consumers like cfutons_mobile aren't visible to the scan)."""
+    audit = _import_audit()
+    info = {
+        "file": "src/backend/cartSessionService.web.js",
+        "permission": "Anyone",
+        "line": 42,
+    }
+    # No callers anywhere — without v5, this falls through to DEAD.
+    row = audit.classify_method(
+        name="createSession",
+        info=info,
+        files=[],
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs={},
+        dispatcher_modules={},
+    )
+    assert "HTTP-EXPOSED-INTENTIONAL" in row["bucket"]
+    assert row["bucket"] != ["DEAD"]
+    assert row["gap_verdict"] != "UNUSED-CAN-DELETE"
+
+
+def test_non_allowlisted_anyone_still_dead_when_no_caller(tmp_path):
+    """A method NOT in the allowlist but with Permissions.Anyone and zero
+    callers still buckets DEAD — the propagation must be allowlist-gated,
+    not Permissions.Anyone-gated, otherwise we'd lose the cleanup signal."""
+    audit = _import_audit()
+    info = {
+        "file": "src/backend/randomService.web.js",
+        "permission": "Anyone",
+        "line": 10,
+    }
+    row = audit.classify_method(
+        name="someUnusedMethod",
+        info=info,
+        files=[],
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs={},
+        dispatcher_modules={},
+    )
+    assert "HTTP-EXPOSED-INTENTIONAL" not in row["bucket"]
+    assert row["bucket"] == ["DEAD"]
+
+
+# ── Enhancement 3: CI-sentinel filesystem-path read sub-classification ─
+
+
+def test_classify_fs_path_consumer_test_import():
+    """Consumer path matching `tests/*.test.(js|ts)` → FS-PATH-TEST-IMPORT.
+    Test-only consumers represent a `keep-because-tested` signal, weaker than
+    a script reading the file body as a data source."""
+    audit = _import_audit()
+    kind = audit.classify_fs_path_consumer("tests/validateCatalog.test.js")
+    assert kind == "FS-PATH-TEST-IMPORT"
+
+
+def test_classify_fs_path_consumer_data_source_script():
+    """Consumer path matching `scripts/*.js` → FS-PATH-DATA-SOURCE.
+    The loadCatalogMaster trap: validate-catalog.js reads the file body to
+    parse VALID_CATEGORIES — deleting the file ENOENTs the tooling."""
+    audit = _import_audit()
+    kind = audit.classify_fs_path_consumer("scripts/validate-catalog.js")
+    assert kind == "FS-PATH-DATA-SOURCE"
+
+
+def test_classify_fs_path_consumer_data_source_python():
+    """Same shape, .py extension — the cf-hpwy detector itself reading
+    a manifest file would hit this path."""
+    audit = _import_audit()
+    kind = audit.classify_fs_path_consumer("scripts/cf-dead-routes/audit.py")
+    assert kind == "FS-PATH-DATA-SOURCE"
+
+
+def test_classify_fs_path_consumer_other_unspecified():
+    """Anything not matching tests/ or scripts/ buckets to FS-PATH-OTHER —
+    operator inspects manually rather than auto-inferring intent."""
+    audit = _import_audit()
+    kind = audit.classify_fs_path_consumer("src/some/other/path.js")
+    assert kind == "FS-PATH-OTHER"
+
+
+def test_bucket_reflects_fs_path_sub_classification(tmp_path):
+    """When a defining file has both test-import and data-source consumers,
+    the row should expose both sub-classifications so the operator can decide
+    delete-strategy (test-only is safer to delete after migrating the test;
+    data-source requires refactoring the tooling first)."""
+    audit = _import_audit()
+    fs_path_refs = {
+        "loadCatalogMaster": [
+            "scripts/validate-catalog.js",
+            "tests/validateCatalog.test.js",
+        ]
+    }
+    info = {
+        "file": "src/backend/loadCatalogMaster.web.js",
+        "permission": "Admin",
+        "line": 1,
+    }
+    row = audit.classify_method(
+        name="getCategories",
+        info=info,
+        files=[],
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs=fs_path_refs,
+        dispatcher_modules={},
+    )
+    assert "FILESYSTEM-PATH-REFERENCED" in row["bucket"]
+    # New v5 field: per-consumer sub-classification
+    assert "fs_path_consumer_kinds" in row
+    kinds = row["fs_path_consumer_kinds"]
+    assert "FS-PATH-DATA-SOURCE" in kinds
+    assert "FS-PATH-TEST-IMPORT" in kinds


### PR DESCRIPTION
## Summary
Each of cf-4x7e.B3/B4/B5 cost a 1-PR revert from inverted false-positive shapes the v4 detector missed. v5 closes all three with TDD-first changes. Pure detector/tooling work — no production code touched.

## Three enhancements

### 1. Non-webMethod export inventory
v4 only scanned `export const X = webMethod(...)`. v5 adds a parallel inventory of `export [async] function NAME(...)` exports. **149 non-webMethod function exports surfaced** across `src/backend/*.web.js`.

**Trap closed:** cf-4x7e.B5 (PR #1333) initially planned to whole-file-delete `comfortTimeline.web.js`. All 4 webMethods were correctly DEAD, but the file also exported a non-webMethod `async function createTimeline(...)` consumed by `tests/integration/purchaseFlowSmoke.test.js`. v5 surfaces this up-front so the surgical-drop decision happens at planning time, not on revert.

### 2. INTENTIONAL_ANYONE bucket propagation
v4 had the `INTENTIONAL_ANYONE` allowlist but only used it to gate the SUSPICIOUS flag. Allowlisted methods with no in-tree callers still bucketed DEAD. v5 adds explicit `HTTP-EXPOSED-INTENTIONAL` bucket + `OK-INTENTIONAL-ANYONE` gap-verdict.

**Trap closed:** cf-4x7e.B4 (PR #1331) initially picked `cartSessionService.web.js` for whole-file delete. The allowlist correctly suppressed SUSPICIOUS, but the file still bucketed DEAD. The mobile-rig consumer (out of in-tree scope) is what kept it alive.

### 3. FS-path consumer sub-classification
v3/v4 had one bucket: `FILESYSTEM-PATH-REFERENCED`. v5 sub-classifies each consumer:

| Sub-bucket | Consumer path shape | Deletion semantic |
|---|---|---|
| `FS-PATH-TEST-IMPORT` | `tests/*.test.{js,ts}` | Migrate test, then safe to delete |
| `FS-PATH-DATA-SOURCE` | `scripts/*.{js,ts,py,sh,mjs,cjs}` | Refactor tooling FIRST |
| `FS-PATH-OTHER` | anything else | Operator inspects |

**Trap closed:** cf-4x7e.B4 (PR #1331) initially picked `loadCatalogMaster.web.js`. v3 caught the fs-path reference but didn't distinguish `scripts/validate-catalog.js` (parses VALID_CATEGORIES from file body — data-source) from `tests/validateCatalog.test.js` (test-target).

## TDD

10 new tests in `scripts/cf-dead-routes/test_audit_v5.py`, all green:
- 3× non-webMethod export shape detection (async function, plain function, const-value skip)
- 2× INTENTIONAL_ANYONE propagation (allowlist hit → bucket; non-allowlist Anyone still DEAD)
- 4× fs-path consumer classification (test-import, data-source-js, data-source-py, other-fallthrough)
- 1× integration: classify_method row exposes `fs_path_consumer_kinds`

**Full v3+v4+v5 suite: 35/35 pass.** Zero regressions in v3 (9 tests) or v4 (16 tests).

## Live tally (cfutons + cfw cross-rig scan)

| Primary bucket | Count |
|---|---:|
| FRONTEND | 319 |
| FILESYSTEM-PATH-REFERENCED | 286 |
| HTTP-EXPOSED | 75 |
| INTERNAL | 64 |
| EVENT-WIRED | 6 |
| **HTTP-EXPOSED-INTENTIONAL** | **5** ← new in v5 |
| **DEAD** | **0** ← was 287 pre-B3 baseline |

| Gap-verdict | Count |
|---|---:|
| VELO-INTERNAL | 658 |
| WRAPPED-NO-CONSUMER | 44 |
| OK-WIRED | 29 |
| MAYBE-CFW-NAME-COLLISION | 17 |
| **OK-INTENTIONAL-ANYONE** | **5** ← new |
| OK-WIRED-VIA-DISPATCHER | 2 |
| **GAP-CFW-WANTS** | **0** |
| **UNUSED-CAN-DELETE** | **0** |

**Headline: DEAD count = 0.** cf-4x7e wave (231 methods retired, ~-54k LOC) cleared every truly-dead webMethod. v5's allowlist propagation reclassified the 5 remaining false-DEAD entries (cartSessionService.{createSession,updateCartItems}, ups-shipping.trackShipment, pinterestCatalogSync.generatePinContent, emailService.sendSwatchConfirmationEmail) into their correct `HTTP-EXPOSED-INTENTIONAL` bucket.

## Diff
**+418 / -3 LOC** across 3 files:
- `scripts/cf-dead-routes/audit.py` (+113/-3) — v4→v5 enhancements
- `scripts/cf-dead-routes/test_audit_v5.py` (+221) — new TDD suite
- `docs/audits/cf-hpwy-v5-snapshot-2026-05-15.md` (+87) — snapshot + rationale

## Test plan
- [x] 10 new v5 tests green
- [x] 35/35 full v3+v4+v5 regression green
- [x] Live detector run against cfutons + cfw produces sensible buckets (DEAD=0)
- [x] 149 non-webMethod exports inventoried; spot-checked underscore-prefix test seams
- [ ] CI: lint, hookup-assistant, CodeQL

## Reviewers (per mayor's 2026-05-15 5-agent standing order)
| Reviewer | Why chosen | Status |
|---|---|---|
| godfrey | Velo backend specialist; cross-rig caller-sweep on prior v4 | **APPROVED** 2026-05-15 (direct-experience verification on all 3 trap closures) |
| radahn | wrapped-no-consumer pattern reviewer; flagged 2 of the 3 traps | **APPROVED** 2026-05-15 (kudos on negative-case test; 2 non-blocking observations to fold) |
| miquella | 5-sub-agent CR pattern; reviewed v4 + recent cf-4x7e wave | Requested |
| rennala | audit framework co-author (cf-o5j5) | **APPROVED** 2026-05-15 (locally checked-out + 35/35 pytest green) |
| melania | bead owner; greenlit roadmap.1 | Requested |

Refs cf-5dto (closes on merge), cf-hpwy lineage v2→v3→v4→v5.

## CR fold — commit a720c6d (post miquella 5-sub-agent CR)
3 substantive findings (3-reviewer corroborated) folded:
1. `collect_non_webmethod_exports` wired into main() — was defined-but-not-called. + integration test via capsys.
2. `is_intentional_anyone` tightened on 2 axes: requires permission=='Anyone' AND allowlist; moved gap-verdict to fallback position so caller-graph signals (dispatcher / cfw_high / WRAPPED-NO-CONSUMER) surface correctly. 3 new tests pin precedence.
3. Silent OSError skip in non-WM scan now surfaces via stderr (first 10 paths + error + remainder count).

Plus 5 named-regression tests pinning each INTENTIONAL_ANYONE entry by name.

Test count: 19 v5 (10 original + 9 new). Full v3+v4+v5: 44/44 pass.

Filed as fast-follow:
- cf-5dto.fu1 (P3): regex broadening (arrow-const, cfw-style test paths)
- cf-5dto.fu2 (P3): combinatorial precedence tests for bucket interactions