### PR TITLE
feat(cf-54st.1): post_lookupOrder Velo HTTP wrapper — enable cfw /track-order

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -10,6 +10,7 @@ import { recordPriceSnapshots, checkWishlistAlerts } from 'backend/notificationS
 import { sendEmail } from 'backend/emailService.web';
 import { triggerBrowseRecovery } from 'backend/browseAbandonment.web';
 import { triggerAbandonedCartRecovery, processEmailQueue, triggerReengagement, triggerPostPurchaseSequence, getCampaignAnalytics, unsubscribeContact, triggerWelcomeSeries } from 'backend/emailAutomation.web';
+import { lookupOrder } from 'backend/orderTracking.web';
 import { scanAndTriggerWinback, runReviewRequestEmails } from 'backend/marketingSequences.web';
 import { processContentSchedule } from 'backend/contentScheduler.web';
 import { sendWeeklyBlogDigest } from 'backend/blogDigestService.web';
@@ -3786,6 +3787,59 @@ export async function post_queueCartRecovery(request) {
   });
 }
 export function options_queueCartRecovery(request) { return response(corsPreflight(request)); }
+
+// ── /_functions/lookupOrder (cf-54st / cf-fd94.fu1) ──────────────────────────
+//
+// cfw's /track-order page posts {args:[orderNumber, email]} (callVelo shape).
+// The order-tracking lookup is also a guest-flow surface, so accept the
+// raw payload shape as well: {orderNumber, email}. Returns the existing
+// orderTracking.web.js webMethod response verbatim — Wix does NOT auto-route
+// webMethods to HTTP endpoints (cf-vtx5 audit), so without this wrapper the
+// /track-order page hits 404 even though lookupOrder is defined.
+
+export async function post_lookupOrder(request) {
+  const JSON_HEADERS = corsHeaders(request, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+  let body;
+  try {
+    body = await request.body.json();
+  } catch (_) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'invalid_json' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  const payload = (Array.isArray(body?.args) && body.args.length > 0) ? body.args : null;
+  const orderNumber = payload
+    ? (typeof payload[0] === 'string' ? payload[0] : '')
+    : (typeof body?.orderNumber === 'string' ? body.orderNumber : '');
+  const email = payload
+    ? (typeof payload[1] === 'string' ? payload[1] : '')
+    : (typeof body?.email === 'string' ? body.email : '');
+  if (!orderNumber) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'orderNumber is required' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  if (!email) {
+    return badRequest({
+      body: JSON.stringify({ success: false, error: 'email is required' }),
+      headers: JSON_HEADERS,
+    });
+  }
+  try {
+    const result = await lookupOrder(orderNumber, email);
+    return ok({ body: JSON.stringify(result), headers: JSON_HEADERS });
+  } catch (err) {
+    const errorId = _veloDispatchErrorId();
+    console.error(`HTTP function error (post_lookupOrder) errorId=${errorId}:`, err);
+    return serverError({
+      body: JSON.stringify({ success: false, error: 'server_error', errorId }),
+      headers: JSON_HEADERS,
+    });
+  }
+}
+export function options_lookupOrder(request) { return response(corsPreflight(request)); }
 
 // ── /_functions/submitCommunityPhoto ─────────────────────────────────────────
 //

--- a/tests/lookupOrderWrapper.cf54st.test.js
+++ b/tests/lookupOrderWrapper.cf54st.test.js
@@ -1,0 +1,125 @@
+/**
+ * @file lookupOrderWrapper.cf54st.test.js
+ * @description cf-54st (cf-fd94.fu1) HTTP wrapper for cfw's /track-order
+ * route. cfw posts {args:[orderNumber, email]} via callVelo (or direct
+ * {orderNumber, email}) to /_functions/lookupOrder. Wix doesn't
+ * auto-route webMethods to HTTP endpoints (cf-vtx5), so this wrapper
+ * adapts the payload into the underlying lookupOrder(orderNumber, email)
+ * webMethod call.
+ *
+ * Verifies:
+ *   - validates both args (orderNumber + email) before delegating
+ *   - accepts both {args:[n, e]} (callVelo shape) and {orderNumber, email}
+ *   - invalid_json on body parse failure
+ *   - 500 server_error + errorId on unexpected throws from lookupOrder
+ *   - response shape is forwarded verbatim (success + error envelopes)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('backend/orderTracking.web', async () => {
+  const actual = await vi.importActual('backend/orderTracking.web');
+  return {
+    ...actual,
+    lookupOrder: vi.fn().mockResolvedValue({
+      success: true,
+      order: { number: '10042', status: 'Shipped' },
+    }),
+  };
+});
+
+import { post_lookupOrder, options_lookupOrder } from '../src/backend/http-functions.js';
+import { lookupOrder } from 'backend/orderTracking.web';
+
+const goodOrigin = 'https://carolina-futons-web.vercel.app';
+
+const makeReq = (body) => ({
+  body: { json: async () => body },
+  headers: { origin: goodOrigin },
+});
+
+beforeEach(() => {
+  vi.mocked(lookupOrder).mockReset();
+  vi.mocked(lookupOrder).mockResolvedValue({
+    success: true,
+    order: { number: '10042', status: 'Shipped' },
+  });
+});
+
+describe('cf-54st · post_lookupOrder', () => {
+  it('calls lookupOrder with (orderNumber, email) from callVelo {args} shape', async () => {
+    const res = await post_lookupOrder(makeReq({ args: ['10042', 'jane@example.com'] }));
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body).success).toBe(true);
+    expect(vi.mocked(lookupOrder)).toHaveBeenCalledWith('10042', 'jane@example.com');
+  });
+
+  it('accepts a direct payload body too (no callVelo wrapping)', async () => {
+    await post_lookupOrder(makeReq({ orderNumber: '10043', email: 'direct@example.com' }));
+    expect(vi.mocked(lookupOrder)).toHaveBeenCalledWith('10043', 'direct@example.com');
+  });
+
+  it('forwards the webMethod response envelope verbatim on success', async () => {
+    vi.mocked(lookupOrder).mockResolvedValueOnce({
+      success: true,
+      order: { number: '10042', status: 'In Transit' },
+      shipping: { carrier: 'UPS', trackingNumber: '1Z999' },
+    });
+    const res = await post_lookupOrder(makeReq({ args: ['10042', 'jane@example.com'] }));
+    const body = JSON.parse(res.body);
+    expect(body.shipping.trackingNumber).toBe('1Z999');
+  });
+
+  it('forwards a success:false envelope from the webMethod without rewriting it', async () => {
+    vi.mocked(lookupOrder).mockResolvedValueOnce({
+      success: false,
+      error: 'Order not found. Please check your order number.',
+    });
+    const res = await post_lookupOrder(makeReq({ args: ['10099', 'jane@example.com'] }));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it('returns 400 invalid_json when body parse fails', async () => {
+    const req = {
+      body: { json: async () => { throw new SyntaxError('bad json'); } },
+      headers: { origin: goodOrigin },
+    };
+    const res = await post_lookupOrder(req);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('invalid_json');
+    expect(vi.mocked(lookupOrder)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when orderNumber is missing', async () => {
+    const res = await post_lookupOrder(makeReq({ args: [null, 'jane@example.com'] }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/orderNumber/);
+    expect(vi.mocked(lookupOrder)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const res = await post_lookupOrder(makeReq({ args: ['10042'] }));
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/email/);
+    expect(vi.mocked(lookupOrder)).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 + errorId on unexpected throws from lookupOrder', async () => {
+    vi.mocked(lookupOrder).mockRejectedValueOnce(new Error('Wix data outage'));
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await post_lookupOrder(makeReq({ args: ['10042', 'jane@example.com'] }));
+    expect(res.status).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('server_error');
+    expect(typeof body.errorId).toBe('string');
+    consoleErr.mockRestore();
+  });
+
+  it('options preflight returns CORS response', () => {
+    const res = options_lookupOrder({ headers: { origin: goodOrigin } });
+    expect(res.status).toBeGreaterThanOrEqual(200);
+  });
+});


### PR DESCRIPTION
## Summary
Half-1 of cf-54st (cf-fd94.fu1). cfw's \`/track-order\` page (half-2, opening separately) needs to hit \`/_functions/lookupOrder\` via callVelo. **Wix doesn't auto-route webMethods to HTTP endpoints** (cf-vtx5 audit) — this wrapper adapts the payload into the underlying \`lookupOrder(orderNumber, email)\` call.

## Pattern (matches cf-uwfw)
- Accept BOTH \`{args:[orderNumber, email]}\` (callVelo shape) and direct \`{orderNumber, email}\` bodies
- 400 \`invalid_json\` on body parse failure
- 400 missing-arg on either orderNumber or email absence
- 500 \`server_error\` + errorId on unexpected throws
- Response envelope forwarded verbatim — \`orderTracking.web.js\` owns the success/error shape, wrapper just transports

## TDD
- 9 tests covering: callVelo args shape, direct payload, success envelope forwarding, success:false forwarding, invalid_json, missing orderNumber, missing email, upstream throw → 500, CORS preflight
- All pass

## Reviewers (5-agent gate)
- [ ] reviewer 1
- [ ] reviewer 2
- [ ] reviewer 3
- [ ] reviewer 4
- [ ] reviewer 5

## Sequencing
cf-54st cfw page PR opens separately and consumes this wrapper. Both should merge before cf-fd94 link points at a live destination.

Refs: cf-54st.1 (this), cf-54st (cfw page sibling), cf-fd94.fu1, cf-fd94 (G-7 link consumer), cf-vtx5 (Wix auto-route audit), cf-jqkg (cfw→Velo gaps audit pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)