### PR TITLE
feat(cf-5dto.fu1): broaden v5 regexes (arrow/fn-expr exports + cfw test paths) + carry missed-merge CR fixes

### DIFF
--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -61,6 +61,24 @@ NON_WM_FN_RE = re.compile(
     re.MULTILINE,
 )
 
+# cf-5dto.fu1: arrow + function-expression export shapes that the original
+# v5 regex missed. `export const FOO = async (x) => {...}` is the modern
+# refactor target — if anyone moves a webMethod-adjacent helper from
+# `export async function` to `export const = async () =>`, the inventory
+# must still catch it. Three separate patterns keep the kind labels
+# accurate without backtracking.
+#
+# `export const NAME = [async] (args) =>` — arrow function
+NON_WM_ARROW_RE = re.compile(
+    r"^export\s+const\s+(\w+)\s*=\s*(async\s+)?\([^)]*\)\s*=>",
+    re.MULTILINE,
+)
+# `export const NAME = [async] function` — function expression assigned to const
+NON_WM_FN_EXPR_RE = re.compile(
+    r"^export\s+const\s+(\w+)\s*=\s*(async\s+)?function\b",
+    re.MULTILINE,
+)
+
 PUBLIC_VERB_RE = re.compile(
     r"^(submit|create|track|register|capture|send|notify|subscribe|"
     r"unsubscribe|redeem|claim|generate|update|delete)",
@@ -174,19 +192,39 @@ def collect_non_webmethod_exports(backend_root: Path | None = None) -> dict[str,
                 skipped.append((str(fp), str(err)))
             continue
         text = strip_js_comments(text)
+        try:
+            file_str = str(fp.relative_to(ROOT))
+        except ValueError:
+            file_str = str(fp)
+
+        def _record(name: str, line: int, kind: str) -> None:
+            # Function-declaration takes priority over later const-rebindings
+            # (same module rebinding a function-declared name is rare and
+            # the declaration is the load-bearing entry).
+            if name not in out:
+                out[name] = {"file": file_str, "line": line, "kind": kind}
+
         for m in NON_WM_FN_RE.finditer(text):
             is_async = m.group(1) is not None
             name = m.group(2)
             line = text[: m.start()].count("\n") + 1
-            try:
-                file_str = str(fp.relative_to(ROOT))
-            except ValueError:
-                file_str = str(fp)
-            out[name] = {
-                "file": file_str,
-                "line": line,
-                "kind": "async function" if is_async else "function",
-            }
+            _record(name, line, "async function" if is_async else "function")
+        # cf-5dto.fu1: arrow shape — modern refactor target
+        for m in NON_WM_ARROW_RE.finditer(text):
+            name = m.group(1)
+            is_async = m.group(2) is not None
+            line = text[: m.start()].count("\n") + 1
+            _record(name, line, "async arrow" if is_async else "arrow")
+        # cf-5dto.fu1: function-expression assigned to const
+        for m in NON_WM_FN_EXPR_RE.finditer(text):
+            name = m.group(1)
+            is_async = m.group(2) is not None
+            line = text[: m.start()].count("\n") + 1
+            _record(
+                name,
+                line,
+                "async function expression" if is_async else "function expression",
+            )
     if skipped:
         # Surface via stderr — operator + CI both see the failure mode.
         print(
@@ -272,7 +310,14 @@ def _module_basename(file_rel: str) -> str:
 # FILESYSTEM-PATH-REFERENCED hides the asymmetry — a test-import-only
 # consumer is migrate-then-delete; a data-source consumer requires
 # refactoring the tooling FIRST.
-_FS_PATH_TEST_RE = re.compile(r"^tests/.*\.(test|spec)\.[jt]s$")
+# cf-5dto.fu1: broadened test-path regex. Matches any path with a `tests/`
+# or `__tests__/` directory segment + a test-file-extension at the leaf.
+# Covers: top-level tests/, cfw-style src/__tests__/, monorepo
+# packages/<x>/__tests__/, packages/<x>/tests/. Extensions cover
+# js/ts/tsx/jsx/mjs/cjs.
+_FS_PATH_TEST_RE = re.compile(
+    r"(?:^|/)(?:tests|__tests__)/.*\.(?:test|spec)\.(?:tsx?|jsx?|mjs|cjs)$"
+)
 _FS_PATH_SCRIPT_RE = re.compile(r"^scripts/.*\.(js|ts|mjs|cjs|py|sh)$")
 
 
@@ -284,7 +329,12 @@ def classify_fs_path_consumer(rel_path: str) -> str:
       FS-PATH-DATA-SOURCE  — `scripts/*.{js,ts,py,sh,...}` consumer (tooling)
       FS-PATH-OTHER        — any other path (operator inspects manually)
     """
-    if _FS_PATH_TEST_RE.match(rel_path):
+    # cf-5dto.fu1: search (not match) so the `(?:^|/)tests|__tests__/`
+    # pattern matches embedded test directories (cfw-style src/__tests__/,
+    # monorepo packages/<x>/__tests__/). Script paths stay top-level-only
+    # via .match — `scripts/` directories nested under packages/ aren't
+    # the tooling-data-source convention.
+    if _FS_PATH_TEST_RE.search(rel_path):
         return "FS-PATH-TEST-IMPORT"
     if _FS_PATH_SCRIPT_RE.match(rel_path):
         return "FS-PATH-DATA-SOURCE"

--- a/scripts/cf-dead-routes/audit.py
+++ b/scripts/cf-dead-routes/audit.py
@@ -159,10 +159,19 @@ def collect_non_webmethod_exports(backend_root: Path | None = None) -> dict[str,
     """
     root = backend_root if backend_root is not None else BACKEND
     out: dict[str, dict] = {}
+    skipped: list[tuple[str, str]] = []
     for fp in root.rglob("*.web.js"):
         try:
             text = fp.read_text(errors="ignore")
-        except OSError:
+        except OSError as err:
+            # cf-5dto silent-failure-hunter CR: don't silently drop the file.
+            # If we skip without logging, an operator running audit.py sees
+            # 'no non-webMethod exports here' and walks back into the B-5
+            # trap. Surface every skip + count them at the call site.
+            try:
+                skipped.append((str(fp.relative_to(ROOT)), str(err)))
+            except ValueError:
+                skipped.append((str(fp), str(err)))
             continue
         text = strip_js_comments(text)
         for m in NON_WM_FN_RE.finditer(text):
@@ -178,6 +187,16 @@ def collect_non_webmethod_exports(backend_root: Path | None = None) -> dict[str,
                 "line": line,
                 "kind": "async function" if is_async else "function",
             }
+    if skipped:
+        # Surface via stderr — operator + CI both see the failure mode.
+        print(
+            f"⚠ collect_non_webmethod_exports: skipped {len(skipped)} file(s) due to read errors:",
+            file=sys.stderr,
+        )
+        for path, err in skipped[:10]:
+            print(f"  {path}: {err}", file=sys.stderr)
+        if len(skipped) > 10:
+            print(f"  ... and {len(skipped) - 10} more", file=sys.stderr)
     return out
 
 
@@ -625,8 +644,20 @@ def classify_method(
     # through to DEAD just because no in-tree caller exists. The B-4 trap:
     # cartSessionService.createSession/updateCartItems bucketed DEAD despite
     # the allowlist + the mobile-rig caller.
+    #
+    # CR-tightening (miquella + code-reviewer + silent-failure-hunter):
+    # gate on BOTH `permission == 'Anyone'` AND allowlist membership. The
+    # allowlist's semantic is "this Anyone-permission endpoint has an
+    # out-of-tree consumer." If a method is later hardened to Admin, the
+    # allowlist entry becomes inapplicable — without the permission check
+    # we'd silently keep the OK-INTENTIONAL-ANYONE classification and mask
+    # the WRAPPED-NO-CONSUMER / GAP-CFW-WANTS signal that the hardening
+    # may have introduced.
     qualified_early = _module_qualified_name(defining_file, name)
-    is_intentional_anyone = qualified_early in INTENTIONAL_ANYONE
+    is_intentional_anyone = (
+        info["permission"] == "Anyone"
+        and qualified_early in INTENTIONAL_ANYONE
+    )
 
     buckets: list[str] = []
     if in_http:
@@ -677,15 +708,15 @@ def classify_method(
             in_dispatcher = True
             dispatcher_alias = dispatcher_modules[module_basename]
 
-    # Gap-finder verdict (cf-hpwy core deliverable)
-    if is_intentional_anyone:
-        # cf-5dto (v5): allowlisted-Anyone endpoints are kept-by-design.
-        # Out-of-tree consumers (mobile rig, third-party calls into
-        # /_functions/<name>) aren't visible to the in-tree scan; the
-        # allowlist is the operator's declaration that the surface is
-        # intentional. Don't surface as a cleanup candidate.
-        gap_verdict = "OK-INTENTIONAL-ANYONE"
-    elif in_dispatcher and not has_cfw_high:
+    # Gap-finder verdict (cf-hpwy core deliverable).
+    # cf-5dto silent-failure-hunter CR: the allowlist must NOT short-circuit
+    # the caller-graph determinations. An allowlisted-Anyone method WITH
+    # callers (cfw_high, dispatcher, frontend) should keep its OK-WIRED /
+    # OK-WIRED-VIA-DISPATCHER / GAP-CFW-WANTS verdict — those signals are
+    # load-bearing. OK-INTENTIONAL-ANYONE only fires as a fallback when
+    # the row would otherwise be UNUSED-CAN-DELETE — i.e., the out-of-tree
+    # consumer is the ONLY thing keeping the method alive.
+    if in_dispatcher and not has_cfw_high:
         # v4: dispatcher route is the WIRED path even without a direct cfw URL.
         # Distinct verdict (OK-WIRED-VIA-DISPATCHER) so the operator can see
         # the dispatch path is active and the method is alive.
@@ -698,6 +729,12 @@ def classify_method(
         gap_verdict = "WRAPPED-NO-CONSUMER"
     elif buckets == ["DEAD"] and not has_cfw_any:
         gap_verdict = "UNUSED-CAN-DELETE"
+    elif is_intentional_anyone and buckets == ["HTTP-EXPOSED-INTENTIONAL"]:
+        # cf-5dto fallback: the only thing keeping this method alive is the
+        # allowlist (no callers anywhere). Surface as OK-INTENTIONAL-ANYONE
+        # so the operator sees the out-of-tree-consumer reasoning instead of
+        # UNUSED-CAN-DELETE.
+        gap_verdict = "OK-INTENTIONAL-ANYONE"
     elif has_cfw_low:
         gap_verdict = "MAYBE-CFW-NAME-COLLISION"  # bare-word match only
     else:
@@ -793,7 +830,27 @@ def main() -> int:
         for name, info in methods.items()
     ]
 
+    # cf-5dto (v5): inventory non-webMethod function exports. The whole point
+    # of this enhancement is that operators see this list BEFORE planning a
+    # whole-file delete; defining the helper without wiring it into main()
+    # would make this PR's headline claim (149 surfaced) load-bearing on a
+    # one-off invocation rather than the production tool. CR by miquella's
+    # code-reviewer sub-agent caught this.
+    non_wm_exports = collect_non_webmethod_exports()
+    print(
+        f"\nNon-webMethod function exports in src/backend: {len(non_wm_exports)}",
+        file=sys.stderr,
+    )
+    print(
+        "  (operator action: cross-check before any whole-file delete; "
+        "underscore-prefix exports are typically test seams)",
+        file=sys.stderr,
+    )
+
     Path("/tmp/cf-dead-routes/results.json").write_text(json.dumps(rows, indent=2))
+    Path("/tmp/cf-dead-routes/non_webmethod_exports.json").write_text(
+        json.dumps(non_wm_exports, indent=2)
+    )
 
     # Single-bucket tally
     primary = Counter()

--- a/scripts/cf-dead-routes/test_audit_v5.py
+++ b/scripts/cf-dead-routes/test_audit_v5.py
@@ -186,6 +186,119 @@ def test_classify_fs_path_consumer_other_unspecified():
     assert kind == "FS-PATH-OTHER"
 
 
+# ── cf-5dto.fu1: arrow + function-expression export shapes ───────────
+
+
+def test_collect_non_webmethod_exports_finds_arrow_async_const(tmp_path):
+    """`export const FOO = async (x) => {...}` — modern arrow-async-const.
+    If anyone refactors a webMethod-adjacent helper to this shape, v5
+    must still see it. miquella silent-failure-hunter Finding 4 motivated
+    this broadening."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "arrow.web.js").write_text(textwrap.dedent("""
+        export const fetchUserData = async (id) => {
+          return { id, ok: true };
+        };
+    """))
+    out = audit.collect_non_webmethod_exports(backend)
+    assert "fetchUserData" in out
+    assert out["fetchUserData"]["kind"] == "async arrow"
+
+
+def test_collect_non_webmethod_exports_finds_arrow_sync_const(tmp_path):
+    """`export const FOO = (x) => {...}` — sync arrow-const."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "sync.web.js").write_text(textwrap.dedent("""
+        export const formatPrice = (cents) => `$${(cents/100).toFixed(2)}`;
+    """))
+    out = audit.collect_non_webmethod_exports(backend)
+    assert "formatPrice" in out
+    assert out["formatPrice"]["kind"] == "arrow"
+
+
+def test_collect_non_webmethod_exports_finds_function_expression_const(tmp_path):
+    """`export const FOO = function(x) {...}` and async variant."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "fnexpr.web.js").write_text(textwrap.dedent("""
+        export const calculate = function(x, y) {
+          return x + y;
+        };
+        export const asyncCalc = async function(x) {
+          return await x;
+        };
+    """))
+    out = audit.collect_non_webmethod_exports(backend)
+    assert "calculate" in out
+    assert out["calculate"]["kind"] == "function expression"
+    assert "asyncCalc" in out
+    assert out["asyncCalc"]["kind"] == "async function expression"
+
+
+def test_collect_non_webmethod_exports_does_not_match_value_const_or_call(tmp_path):
+    """Negative-case pin: must NOT match value-const or function-call-result.
+    Guards against the broadened regex accidentally swallowing constants."""
+    audit = _import_audit()
+    backend = tmp_path / "src" / "backend"
+    backend.mkdir(parents=True)
+    (backend / "values.web.js").write_text(textwrap.dedent("""
+        export const CONFIG = { maxRetries: 3, timeout: 5000 };
+        export const COUNT = computeCount();
+        export const ITEMS = [1, 2, 3];
+        export const result = something.method();
+        export const klass = SomeClass;
+    """))
+    out = audit.collect_non_webmethod_exports(backend)
+    assert "CONFIG" not in out
+    assert "COUNT" not in out
+    assert "ITEMS" not in out
+    assert "result" not in out
+    assert "klass" not in out
+
+
+# ── cf-5dto.fu1: FS-path test-import path broadening ─────────────────
+
+
+def test_classify_fs_path_consumer_cfw_style_underscore_tests():
+    """cfw uses `src/__tests__/foo.test.tsx` — classify as TEST-IMPORT."""
+    audit = _import_audit()
+    assert audit.classify_fs_path_consumer("src/__tests__/Header.test.tsx") == "FS-PATH-TEST-IMPORT"
+
+
+def test_classify_fs_path_consumer_test_tsx_extension():
+    """`.tsx` test files (cfw-style React component tests)."""
+    audit = _import_audit()
+    assert audit.classify_fs_path_consumer("tests/Component.test.tsx") == "FS-PATH-TEST-IMPORT"
+    assert audit.classify_fs_path_consumer("tests/Component.spec.tsx") == "FS-PATH-TEST-IMPORT"
+
+
+def test_classify_fs_path_consumer_mjs_cjs_test_files():
+    """Modern Node test runners may emit `.mjs` / `.cjs`."""
+    audit = _import_audit()
+    assert audit.classify_fs_path_consumer("tests/foo.test.mjs") == "FS-PATH-TEST-IMPORT"
+    assert audit.classify_fs_path_consumer("tests/foo.test.cjs") == "FS-PATH-TEST-IMPORT"
+
+
+def test_classify_fs_path_consumer_nested_test_roots():
+    """Monorepo / nested packages — match `__tests__/` anywhere OR
+    `tests/` under a package root."""
+    audit = _import_audit()
+    assert audit.classify_fs_path_consumer("packages/foo/__tests__/bar.test.ts") == "FS-PATH-TEST-IMPORT"
+    assert audit.classify_fs_path_consumer("packages/foo/tests/bar.test.js") == "FS-PATH-TEST-IMPORT"
+
+
+def test_classify_fs_path_consumer_other_still_fallthrough():
+    """Negative-case pin: non-test, non-script paths still OTHER."""
+    audit = _import_audit()
+    assert audit.classify_fs_path_consumer("src/components/Foo.tsx") == "FS-PATH-OTHER"
+    assert audit.classify_fs_path_consumer("docs/example.md") == "FS-PATH-OTHER"
+
+
 # ── Constant-pin: lock each trap symbol into INTENTIONAL_ANYONE ────────
 # miquella test-analyzer CR: a future refactor that removes an allowlist
 # entry silently re-introduces the trap. Pin each by name.

--- a/scripts/cf-dead-routes/test_audit_v5.py
+++ b/scripts/cf-dead-routes/test_audit_v5.py
@@ -186,6 +186,171 @@ def test_classify_fs_path_consumer_other_unspecified():
     assert kind == "FS-PATH-OTHER"
 
 
+# ── Constant-pin: lock each trap symbol into INTENTIONAL_ANYONE ────────
+# miquella test-analyzer CR: a future refactor that removes an allowlist
+# entry silently re-introduces the trap. Pin each by name.
+
+
+def test_allowlist_pins_cartSessionService_createSession():
+    audit = _import_audit()
+    assert "cartSessionService.createSession" in audit.INTENTIONAL_ANYONE
+
+
+def test_allowlist_pins_cartSessionService_updateCartItems():
+    audit = _import_audit()
+    assert "cartSessionService.updateCartItems" in audit.INTENTIONAL_ANYONE
+
+
+def test_allowlist_pins_ups_shipping_trackShipment():
+    audit = _import_audit()
+    assert "ups-shipping.trackShipment" in audit.INTENTIONAL_ANYONE
+
+
+def test_allowlist_pins_pinterestCatalogSync_generatePinContent():
+    audit = _import_audit()
+    assert "pinterestCatalogSync.generatePinContent" in audit.INTENTIONAL_ANYONE
+
+
+def test_allowlist_pins_emailService_sendSwatchConfirmationEmail():
+    audit = _import_audit()
+    assert "emailService.sendSwatchConfirmationEmail" in audit.INTENTIONAL_ANYONE
+
+
+# ── Tightened allowlist gate (CR finding 2) ────────────────────────────
+
+
+def test_admin_permission_with_allowlist_entry_is_NOT_intentional():
+    """If a method is allowlisted but its permission is Admin (not Anyone),
+    the allowlist semantic doesn't apply — the entry exists for the
+    Permissions.Anyone case. miquella code-reviewer + silent-failure-hunter
+    flagged that the gate was name-only. v5 now requires BOTH permission ==
+    'Anyone' AND allowlist membership."""
+    audit = _import_audit()
+    info = {
+        "file": "src/backend/cartSessionService.web.js",
+        "permission": "Admin",  # hardened away from Anyone
+        "line": 42,
+    }
+    row = audit.classify_method(
+        name="createSession",  # still allowlisted by name
+        info=info,
+        files=[],
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs={},
+        dispatcher_modules={},
+    )
+    # The allowlist should NOT apply — gate requires permission==Anyone.
+    assert "HTTP-EXPOSED-INTENTIONAL" not in row["bucket"]
+    assert row["gap_verdict"] != "OK-INTENTIONAL-ANYONE"
+
+
+# ── Combinatorial precedence (CR test-analyzer + code-reviewer) ────────
+
+
+def test_allowlist_does_not_short_circuit_dispatcher_signal():
+    """An allowlisted-Anyone method that's ALSO reachable via a namespace
+    dispatcher should still surface OK-WIRED-VIA-DISPATCHER (the real
+    in-tree signal), not flatten to OK-INTENTIONAL-ANYONE.
+
+    silent-failure-hunter Finding 2: the allowlist short-circuit was
+    masking caller-graph signal. v5 now makes OK-INTENTIONAL-ANYONE a
+    fallback verdict only when the row would otherwise be UNUSED-CAN-DELETE."""
+    audit = _import_audit()
+    info = {
+        "file": "src/backend/cartSessionService.web.js",
+        "permission": "Anyone",
+        "line": 42,
+    }
+    # Simulate a dispatcher mapping that hits cartSessionService.
+    row = audit.classify_method(
+        name="createSession",
+        info=info,
+        files=[],
+        cfw_files=[],
+        http_text="",
+        events_text="",
+        fs_path_refs={},
+        dispatcher_modules={"cartSessionService": "cartSessionServiceModule"},
+    )
+    # Bucket carries BOTH classifications.
+    assert "HTTP-EXPOSED-INTENTIONAL" in row["bucket"]
+    # Gap-verdict surfaces the dispatcher signal, NOT OK-INTENTIONAL-ANYONE.
+    assert row["gap_verdict"] == "OK-WIRED-VIA-DISPATCHER"
+
+
+def test_allowlist_does_not_short_circuit_cfw_high_signal():
+    """If an allowlisted method has a cfw_high reference but no in-tree
+    HTTP wrapper, the row should surface GAP-CFW-WANTS, not silently
+    flatten to OK-INTENTIONAL-ANYONE. The cfw caller is a real signal."""
+    audit = _import_audit()
+    # Build a synthetic cfw file that references the method via /_functions/<name>
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        cfw_dir = Path(td) / "src"
+        cfw_dir.mkdir()
+        (cfw_dir / "cart-fetch.ts").write_text(
+            "fetch('/_functions/createSession', { method: 'POST' });"
+        )
+        # Repoint CFW_SRC for the test.
+        audit.CFW_SRC = cfw_dir
+        info = {
+            "file": "src/backend/cartSessionService.web.js",
+            "permission": "Anyone",
+            "line": 42,
+        }
+        row = audit.classify_method(
+            name="createSession",
+            info=info,
+            files=[],
+            cfw_files=audit.collect_cfw_files(),
+            http_text="",  # no HTTP wrapper
+            events_text="",
+            fs_path_refs={},
+            dispatcher_modules={},
+        )
+    # Bucket still carries HTTP-EXPOSED-INTENTIONAL.
+    assert "HTTP-EXPOSED-INTENTIONAL" in row["bucket"]
+    # But gap-verdict surfaces the cfw signal, NOT a silent OK.
+    assert row["gap_verdict"] == "GAP-CFW-WANTS"
+
+
+# ── Main() integration smoke (CR finding 1) ────────────────────────────
+
+
+def test_main_emits_non_webmethod_inventory_to_stderr(tmp_path, capsys):
+    """The whole point of collect_non_webmethod_exports is that operators
+    SEE it via the production tool. miquella code-reviewer caught that v1
+    of the PR defined the helper but never wired it into main(). v5 now
+    invokes it from main() and prints the count to stderr."""
+    audit = _import_audit()
+
+    # Build a minimal fixture repo
+    src = tmp_path / "src" / "backend"
+    src.mkdir(parents=True)
+    (src / "sample.web.js").write_text(
+        "import { Permissions, webMethod } from 'wix-web-module';\n"
+        "export async function helperA() {}\n"
+        "export const wmB = webMethod(Permissions.Admin, async () => ({}));\n"
+    )
+    (tmp_path / "src" / "backend" / "http-functions.js").write_text("")
+    (tmp_path / "src" / "backend" / "events.js").write_text("")
+
+    # Point audit at the fixture
+    import os as _os
+    _os.environ["CFUTONS_ROOT"] = str(tmp_path)
+    Path("/tmp/cf-dead-routes").mkdir(exist_ok=True)
+    audit = _import_audit()  # reload with new ROOT
+
+    rc = audit.main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Stderr must announce the inventory + count
+    assert "Non-webMethod function exports in src/backend" in captured.err
+    assert "1" in captured.err  # the helperA count
+
+
 def test_bucket_reflects_fs_path_sub_classification(tmp_path):
     """When a defining file has both test-import and data-source consumers,
     the row should expose both sub-classifications so the operator can decide


### PR DESCRIPTION
## Summary
Two things bundled — together because they sit on the same files and would otherwise create a serialization headache:

1. **cf-5dto.fu1 regex broadening** (the headline of this PR per the bead) — arrow-const + function-expression-const export shapes; `__tests__/` + `.tsx`/`.jsx`/`.mjs`/`.cjs` test-path coverage.
2. **Missed-merge replay of commit `a720c6d`** (miquella's 3 substantive CR findings + 9 named-regression tests from cf-5dto). PR #1346 was merged at `5f86bde` BEFORE the CR-fold push reached the merge view — verified via `git merge-base --is-ancestor a720c6d origin/main` → **false**. The 3 substantive fixes need to land for the v5 claims to be operationally true.

## Why bundled
The CR-fold commit (`a720c6d`) and the fu1 changes touch the same regions of `audit.py` (NON_WM_FN_RE area + classify_fs_path_consumer). Two separate PRs would conflict; one bundled PR is cleaner. Reviewers can audit both halves by reading the file at HEAD.

## Part A — missed-merge replay (carried from `a720c6d`)

### Fix 1 — CRITICAL: wire `collect_non_webmethod_exports` into `main()`
v5 claimed "149 non-webMethod exports surfaced" but the helper was only reachable from `test_audit_v5.py`. Production-tool operators never saw the inventory; the B-5-trap-rediscovery surface was a fiction. `main()` now invokes it + emits stderr summary + writes `/tmp/cf-dead-routes/non_webmethod_exports.json`.

### Fix 2 — HIGH: tighten `is_intentional_anyone` gate
Two-axis fix:
- **Axis a — permission gate**: `is_intentional_anyone` now requires `info['permission'] == 'Anyone' AND qualified_early in INTENTIONAL_ANYONE`. Admin-hardening drops the special treatment instead of silently keeping it.
- **Axis b — caller-graph precedence**: `OK-INTENTIONAL-ANYONE` is now a fallback verdict (only fires when bucket would otherwise be UNUSED-CAN-DELETE), not a terminator. Dispatcher / cfw_high / WRAPPED-NO-CONSUMER signals surface correctly.

### Fix 3 — CRITICAL: surface `OSError` skips in non-WM scan
The `except OSError: continue` block was silent. Now appends each skip to a list + surfaces via stderr (first 10 paths + remainder count).

### Named-regression tests
5 constant-pin tests, one per INTENTIONAL_ANYONE allowlist member. Any future removal trips a failing test.

## Part B — cf-5dto.fu1 regex broadening (new in this PR)

### NON_WM_FN_RE family
v5's original regex only matched `export [async] function NAME(`. Two new patterns close modern-style refactors:
- `NON_WM_ARROW_RE`: `export const NAME = [async] (args) =>`
- `NON_WM_FN_EXPR_RE`: `export const NAME = [async] function`

`collect_non_webmethod_exports` runs all 3 with a `_record()` helper giving function-declaration priority over const rebindings.

### _FS_PATH_TEST_RE broadening
v5's pattern was `^tests/.*\.(test|spec)\.[jt]s$` — anchored at top-level `tests/` only, `j|t` extensions only. Missed:
- cfw-style `src/__tests__/foo.test.tsx`
- Monorepo `packages/<x>/__tests__/bar.test.ts`
- Modern `.mjs`/`.cjs` test runners
- `.tsx`/`.jsx` extensions

New: `(?:^|/)(?:tests|__tests__)/.*\.(?:test|spec)\.(?:tsx?|jsx?|mjs|cjs)$`, matched via `.search` so embedded directories are caught.

## Tests

9 new fu1 tests + 9 carried CR-fold tests + 10 original v5 + 16 v4 + 9 v3 = **53/53 pass**.

## Diff
+174 / -11 LOC across 2 files (audit.py + test_audit_v5.py). Detector tooling only, no production code touch.

## Reviewers (per mayor's 2026-05-15 5-agent standing order)

| Reviewer | Why chosen | Status |
|---|---|---|
| miquella | author of the missed-merge CR; verifies both halves | Requested |
| godfrey | Velo backend specialist + B-wave operator | **APPROVED** 2026-05-15 (both halves verified — regex fidelity + permission-gate AND fix) |
| radahn | wrapped-no-consumer pattern reviewer | **APPROVED** 2026-05-15 (both halves; 3 non-blocking observations — #1 folded in commit bd60fa6) |
| rennala | audit framework + local-pytest verification habit | **APPROVED** 2026-05-15 (both halves verified line-by-line; _record priority + asymmetric .search/.match callouts) |
| melania | bead owner + merge-coordinator (this PR resolves the merge gap) | **APPROVED** 2026-05-15 (PM approve + confirmed bundled approach is correct) |

## Heads-up to melania (mailed separately)
PR #1346's merge at 5f86bde missed the CR-fold commit (a720c6d). This PR is the carrier. Will not merge until you've verified the merge-gap explanation matches your recollection.

Refs cf-5dto.1 (this bead, P3), cf-5dto (parent, partially-merged via #1346).