### PR TITLE
feat(cf-6amf): wave-audit ritual — codify cf-o5j5 pattern + reachability rule

### DIFF
--- a/docs/audits/CONVENTIONS.md
+++ b/docs/audits/CONVENTIONS.md
@@ -1,0 +1,93 @@
+# Wave audit conventions
+
+**Bead:** cf-6amf (cf-roadmap.3)
+**Pattern source:** cf-o5j5 wave32 audit (2026-05-15, PR #1339)
+**Codified:** 2026-05-16
+
+This doc codifies the wave-audit ritual that emerged from cf-o5j5. Run via `scripts/wave-audit/wave-audit.sh <since-date> [<until-date>]` — the script implements every rule below.
+
+---
+
+## 1. Scope: what's audited
+
+A **wave** is the set of PRs merged into `origin/main` of a single repo within a date range. Default cadence is Monday-on-prior-week, but ad-hoc windows are fine.
+
+## 2. Reachability rule (the cf-5dto trap)
+
+**A PR is counted only if its merge commit is reachable from `origin/main`.**
+
+```bash
+git merge-base --is-ancestor <merge_commit_oid> origin/main
+```
+
+Why: GitHub's `state=MERGED` means "this PR's source branch was merged into its target branch." For **stacked PRs** the target may be a feature branch (not main), and the source can drift further before main pulls. cf-5dto / PR #1346 hit this exact trap: the CR-fold commit `a720c6d` was on the v5 detector branch but the merge to main happened from an earlier `5f86bde` head — the CR fixes never landed. The reachability check catches that asymmetry.
+
+`scripts/wave-audit/wave-audit.sh` runs the check per PR and surfaces excluded PRs in a dedicated "Excluded" section. Auditors should treat each excluded entry as a follow-up: was this an intentional non-merge, or a missed merge that needs a salvage PR?
+
+## 3. Categorization rubric
+
+Five mutually-exclusive categories. Precedence is top-down — first matching category wins. See `scripts/wave-audit/categorize.py` for the implementation and `test_categorize.py` for the pinned contract.
+
+| Category | Rule | Deep-audit applies? |
+|---|---|---|
+| `pure-docs` | All files are under `docs/` (`.md`) OR top-level docs (README, CHANGELOG, LICENSE, CONTRIBUTING, CODEOWNERS, AGENTS, CLAUDE, GEMINI) | No — no testable surface |
+| `test-only` | All files match `(?:^|/)(?:tests|__tests__|e2e)/.*\.(?:test|spec)\.(?:tsx?|jsx?|mjs|cjs)$` | No — the change *is* tests |
+| `housekeeping` | All files are config/runtime/agent-state: `.gitignore`, `.gitattributes`, `.runtime/*`, `.claude/*`, agent guide MDs | No — no production code |
+| `trivial` | Total LOC ≤ 12 OR all files are lockfile/dep-manifest | No — surface too small to host gap |
+| `substantive` | Anything else | **Yes — deep-audit target** |
+
+Threshold rationale: 12 LOC is the cf-o5j5 cut — captures aria-hidden / one-line-fix / config-tweak PRs that don't have meaningful audit surface. Lockfile-only PRs are trivial regardless of size (mechanical, dep-resolver-generated).
+
+A docs-mixed-with-source PR is **substantive**, not pure-docs — the source-code half is the audit target.
+
+## 4. Deep-audit dimensions per substantive PR
+
+For every PR in the `substantive` bucket, audit these four dimensions:
+
+### a. JSDoc / block-doc on new exports
+For each `export const NAME = ...` or `export [async] function NAME(...)` introduced, is there at least a block comment explaining intent?
+
+The cf-5dto v5 detector (`scripts/cf-dead-routes/audit.py`) tracks the export inventory; wave-audit doesn't need to re-scan from scratch — just diff the PR's added/modified exports.
+
+### b. Test coverage on new surface
+For each new public surface (route handler, async helper, component), at least one `it()` block covering happy path. Boundary cases (error, missing input, rate-limit, etc.) ideally pinned.
+
+### c. CI evidence at merge
+The merge commit's CI must show: lint + typecheck + Vitest/Playwright (whichever applies) + CodeQL green. A PR that merged on red is a real signal — file follow-up bead.
+
+### d. Spy-assertion on external SDK callsites (radahn dimension)
+For every new Server Action / async callsite wrapping an external SDK (Wix, Stripe, Twilio, fetch to a third-party API), is there a spy assertion in the corresponding `*.test.{ts,tsx}` pinning the call? This generalizes the cf-o5j5 #566 EmailCapturePopup finding: spy-on-callsite is a recurring audit dimension, not a one-off.
+
+## 5. Output deliverables
+
+Every wave-audit run produces:
+
+1. **One audit doc** under `docs/audits/cf-<bead>-<window>.md` with:
+   - Categorization table
+   - Per-PR verdict on the four dimensions for each substantive PR
+   - Gap callouts → filed as P3 follow-up beads
+2. **Zero or more P3 follow-up beads** per gap found. Naming: `cf-<wave-bead>.fu<N>` if directly attributable, or fresh bead if cross-cutting.
+3. **No code changes in the audit PR.** The audit is read-only; fixes are separate PRs.
+
+## 6. Frequency
+
+- **Weekly Monday-cadence**: prior-week merges, default cadence
+- **Ad-hoc burst**: when a merge wave > 10 PRs lands in a short window (the cf-o5j5 trigger)
+- **Pre-cutover**: before any major release / DNS cutover, audit the trailing 14-day window
+
+## 7. Tooling
+
+- **Run:** `scripts/wave-audit/wave-audit.sh <since-date> [<until-date>]`
+- **Cross-repo:** set `WAVE_AUDIT_REPO=DreadPirateRobertz/carolina-futons-web` (or any other gh-accessible repo) — defaults to the cfutons monorepo
+- **Output:** markdown to stdout — redirect to `docs/audits/cf-<bead>-<window>-WIP.md` and curate manually before committing
+
+## 8. Process integration
+
+Once the ritual has run 2-3 weeks consistently, propose to mayor as a standing process. Each wave-audit doc lands as its own PR (5-agent CR per mayor's 2026-05-15 mandate); the wave-audit script + this conventions doc are infrastructure that travels with the ritual.
+
+## 9. Refs
+
+- Source pattern PR: #1339 (cf-o5j5 wave32 cfw audit)
+- Source PR with reachability lesson: #1346 (cf-5dto v5) + #1349 (cf-5dto.fu1 missed-merge recovery)
+- Roadmap mail: cfutons/morgott → cfutons/melania 2026-05-15 cf-roadmap proposal
+- Spy-assertion dimension: cfutons/morgott ↔ cfutons/radahn mail thread on cf-o5j5 #566 follow-up

--- a/scripts/wave-audit/categorize.py
+++ b/scripts/wave-audit/categorize.py
@@ -1,0 +1,139 @@
+"""cf-6amf (cf-roadmap.3): wave-audit PR categorizer.
+
+Pure function module — takes a PR record (mirrors `gh pr list --json files,
+additions,deletions,number,title` output) and assigns a category for the
+wave-audit ritual. Five categories are mutually exclusive; check precedence
+is documented inline.
+
+Rationale: cf-o5j5 (PR #1339) shipped a one-shot 26-PR wave audit; this
+module factors the categorization rubric so future audits can run via
+`scripts/wave-audit/wave-audit.sh` and produce consistent output.
+
+Run tests: `python -m pytest scripts/wave-audit/test_categorize.py -v`
+"""
+from __future__ import annotations
+
+import re
+
+# A PR file path is "test-related" if it lives in any tests/ or __tests__/
+# directory OR has a .test.<ext> / .spec.<ext> infix. The wave-audit ritual
+# treats these uniformly — locks the contract via test_audit_v5.py-style
+# negative-case pins for paths like tests/helpers.ts that live alongside
+# tests but aren't themselves tests.
+_TEST_PATH_RE = re.compile(
+    r"(?:^|/)(?:tests|__tests__|e2e)/.*\.(?:test|spec)\.(?:tsx?|jsx?|mjs|cjs)$"
+)
+
+# Top-level docs files outside docs/ tree (README, CHANGELOG, LICENSE, etc.)
+_TOP_LEVEL_DOC_RE = re.compile(
+    r"^(README|CHANGELOG|LICENSE|CONTRIBUTING|CODEOWNERS|AGENTS|CLAUDE|GEMINI)(\.md|\.MD)?$"
+)
+
+# Housekeeping/config file patterns. .runtime/ + .claude/ are agent state;
+# .gitignore / .gitattributes are repo config; tsconfig.json etc. are
+# build config without behavior implications.
+_HOUSEKEEPING_PATH_RE = re.compile(
+    r"^(?:"
+    r"\.gitignore"
+    r"|\.gitattributes"
+    r"|\.runtime/.*"
+    r"|\.claude/.*"
+    r"|\.github/CODEOWNERS"
+    r"|CLAUDE\.md"
+    r"|AGENTS\.md"
+    r"|GEMINI\.md"
+    r")$"
+)
+
+# Threshold below which a non-lockfile PR is considered "trivial". The
+# cf-o5j5 audit used 12 LOC as the cut; it captures the typical aria-hidden
+# / one-line-fix / config-tweak shape that doesn't host meaningful gaps.
+TRIVIAL_LOC_THRESHOLD = 12
+
+# Lockfile / dep-manifest files. A diff containing ONLY these is trivial
+# regardless of LOC count — npm regenerates lockfiles in bulk on every
+# dep bump, and the diff is mechanical.
+_LOCKFILE_PATHS = frozenset({
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.lock",
+    "uv.lock",
+    "poetry.lock",
+})
+
+
+def _is_doc(path: str) -> bool:
+    """Pure-docs path: under docs/ OR top-level documentation file."""
+    if path.startswith("docs/") and path.endswith(".md"):
+        return True
+    return bool(_TOP_LEVEL_DOC_RE.match(path))
+
+
+def _is_test(path: str) -> bool:
+    return bool(_TEST_PATH_RE.search(path))
+
+
+def _is_housekeeping(path: str) -> bool:
+    return bool(_HOUSEKEEPING_PATH_RE.match(path))
+
+
+def _is_lockfile_or_manifest(path: str) -> bool:
+    return path in _LOCKFILE_PATHS or path == "package.json"
+
+
+def categorize(pr: dict) -> str:
+    """Return the wave-audit category for a PR record.
+
+    Precedence (checked top-down):
+      1. pure-docs       — ALL files are docs/ or top-level .md
+      2. test-only       — ALL files are test files
+      3. housekeeping    — ALL files are .gitignore/.runtime/.claude/etc.
+      4. trivial         — total LOC ≤ TRIVIAL_LOC_THRESHOLD,
+                           OR ALL files are lockfile/dep-manifest
+      5. substantive     — everything else (the deep-audit candidates)
+
+    Categories are computed from the file paths and LOC totals; the
+    function does NOT call out to git or gh.
+    """
+    files = [f["path"] for f in pr.get("files", [])]
+    if not files:
+        return "trivial"  # Empty PRs are vacuously trivial; defensive default.
+
+    if all(_is_doc(p) for p in files):
+        return "pure-docs"
+    if all(_is_test(p) for p in files):
+        return "test-only"
+    if all(_is_housekeeping(p) for p in files):
+        return "housekeeping"
+
+    total_loc = pr.get("additions", 0) + pr.get("deletions", 0)
+    if all(_is_lockfile_or_manifest(p) for p in files):
+        return "trivial"
+    if total_loc <= TRIVIAL_LOC_THRESHOLD and not any(_is_doc(p) for p in files):
+        # Small code-touching PR: trivial. (Docs-mixed-with-source falls through
+        # to substantive — a 5-LOC code-and-doc change still hosts surface.)
+        return "trivial"
+
+    return "substantive"
+
+
+def deep_audit_candidates(prs: list[dict]) -> list[dict]:
+    """Filter PRs to the substantive ones — the targets for JSDoc + TDD +
+    CI deep-audit per the cf-o5j5 methodology."""
+    return [pr for pr in prs if categorize(pr) == "substantive"]
+
+
+def summary_histogram(prs: list[dict]) -> dict[str, int]:
+    """Return a dict with counts per category. Keys appear even for zero
+    counts so downstream consumers can format a stable table."""
+    out = {
+        "pure-docs": 0,
+        "test-only": 0,
+        "trivial": 0,
+        "housekeeping": 0,
+        "substantive": 0,
+    }
+    for pr in prs:
+        out[categorize(pr)] += 1
+    return out

--- a/scripts/wave-audit/test_categorize.py
+++ b/scripts/wave-audit/test_categorize.py
@@ -1,0 +1,170 @@
+"""cf-6amf (cf-roadmap.3): tests for wave-audit categorizer.
+
+Codifies the categorization rubric from cf-o5j5:
+- pure-docs       — docs/ + .md files only
+- test-only       — test files only (tests/, src/__tests__/, *.test.*, *.spec.*)
+- trivial         — ≤12 LOC OR lockfile/dep-bump only
+- housekeeping    — config / runtime / agent-state files only
+- substantive     — anything else
+
+Run: `python -m pytest scripts/wave-audit/test_categorize.py -v`
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _import_cat():
+    for mod in list(sys.modules):
+        if mod == "categorize":
+            del sys.modules[mod]
+    import categorize
+    return categorize
+
+
+def _pr(number, files, additions=20, deletions=5):
+    """Build a minimal PR record mirroring `gh pr list --json files,additions,deletions,number,title`."""
+    return {
+        "number": number,
+        "title": f"PR #{number}",
+        "additions": additions,
+        "deletions": deletions,
+        "files": [{"path": p} for p in files],
+    }
+
+
+# ── Categorization ─────────────────────────────────────────────────
+
+
+def test_pure_docs_only_md_files():
+    cat = _import_cat()
+    pr = _pr(101, ["docs/runbook.md", "docs/cutover-checklist.md"], additions=200)
+    assert cat.categorize(pr) == "pure-docs"
+
+
+def test_pure_docs_template_files():
+    cat = _import_cat()
+    pr = _pr(102, ["docs/cf-3qt-day1-stability-report-TEMPLATE.md"], additions=240)
+    assert cat.categorize(pr) == "pure-docs"
+
+
+def test_test_only_top_level_tests_dir():
+    cat = _import_cat()
+    pr = _pr(103, ["tests/foo.test.js"], additions=60)
+    assert cat.categorize(pr) == "test-only"
+
+
+def test_test_only_cfw_style_underscore_tests():
+    cat = _import_cat()
+    pr = _pr(104, ["src/__tests__/Header.test.tsx"], additions=40)
+    assert cat.categorize(pr) == "test-only"
+
+
+def test_test_only_spec_file():
+    cat = _import_cat()
+    pr = _pr(105, ["e2e/auth.spec.ts"], additions=80)
+    assert cat.categorize(pr) == "test-only"
+
+
+def test_trivial_small_diff():
+    cat = _import_cat()
+    pr = _pr(106, ["src/components/Foo.tsx"], additions=8, deletions=2)
+    assert cat.categorize(pr) == "trivial"
+
+
+def test_trivial_lockfile_bump():
+    cat = _import_cat()
+    pr = _pr(107, ["package.json", "package-lock.json"], additions=41, deletions=41)
+    assert cat.categorize(pr) == "trivial"
+
+
+def test_trivial_lockfile_only_large_diff():
+    """package-lock.json can grow arbitrarily large but is still trivial — it's
+    a dep-resolution snapshot, not human-written code."""
+    cat = _import_cat()
+    pr = _pr(108, ["package-lock.json"], additions=2000, deletions=1500)
+    assert cat.categorize(pr) == "trivial"
+
+
+def test_housekeeping_gitignore_runtime_state():
+    cat = _import_cat()
+    pr = _pr(109, [".gitignore", ".runtime/agent.lock", "CLAUDE.md"], additions=9, deletions=587)
+    assert cat.categorize(pr) == "housekeeping"
+
+
+def test_substantive_feature_change():
+    cat = _import_cat()
+    pr = _pr(110, ["src/components/Header.tsx", "src/__tests__/Header.test.tsx"], additions=85, deletions=81)
+    assert cat.categorize(pr) == "substantive"
+
+
+def test_substantive_when_mixed_with_tests():
+    """A PR with both source AND test files is substantive, not test-only."""
+    cat = _import_cat()
+    pr = _pr(111, ["src/lib/seo/twitter-from-og.ts", "src/lib/seo/__tests__/twitter-from-og.test.ts"], additions=138, deletions=33)
+    assert cat.categorize(pr) == "substantive"
+
+
+def test_substantive_just_above_trivial_threshold():
+    cat = _import_cat()
+    pr = _pr(112, ["src/api/health/route.ts"], additions=13, deletions=0)
+    assert cat.categorize(pr) == "substantive"
+
+
+def test_pure_docs_with_runbook_in_top_level():
+    """Docs files outside the docs/ tree (e.g. top-level CHANGELOG.md, README.md)."""
+    cat = _import_cat()
+    pr = _pr(113, ["CHANGELOG.md", "README.md"], additions=100)
+    assert cat.categorize(pr) == "pure-docs"
+
+
+def test_substantive_when_mixed_docs_and_source():
+    """A PR with both docs and substantive code is substantive."""
+    cat = _import_cat()
+    pr = _pr(114, ["docs/api.md", "src/api/health/route.ts"], additions=80, deletions=10)
+    assert cat.categorize(pr) == "substantive"
+
+
+# ── Filter to substantive for deep audit ───────────────────────────
+
+
+def test_deep_audit_candidates_returns_only_substantive():
+    cat = _import_cat()
+    prs = [
+        _pr(1, ["docs/x.md"]),                              # pure-docs
+        _pr(2, ["tests/x.test.js"]),                        # test-only
+        _pr(3, ["package-lock.json"], additions=999),       # trivial
+        _pr(4, [".gitignore"]),                             # housekeeping
+        _pr(5, ["src/lib/foo.ts", "src/__tests__/foo.test.tsx"]),  # substantive
+        _pr(6, ["src/api/bar.ts"], additions=200),          # substantive
+    ]
+    out = cat.deep_audit_candidates(prs)
+    assert [p["number"] for p in out] == [5, 6]
+
+
+# ── Histogram for report ───────────────────────────────────────────
+
+
+def test_summary_histogram_counts_each_category():
+    cat = _import_cat()
+    prs = [
+        _pr(1, ["docs/x.md"]),
+        _pr(2, ["docs/y.md"]),
+        _pr(3, ["tests/x.test.js"]),
+        _pr(4, ["package-lock.json"], additions=999),
+        _pr(5, [".gitignore"]),
+        _pr(6, ["src/lib/foo.ts"], additions=200),
+        _pr(7, ["src/api/bar.ts"], additions=300),
+    ]
+    h = cat.summary_histogram(prs)
+    assert h == {
+        "pure-docs": 2,
+        "test-only": 1,
+        "trivial": 1,
+        "housekeeping": 1,
+        "substantive": 2,
+    }

--- a/scripts/wave-audit/wave-audit.sh
+++ b/scripts/wave-audit/wave-audit.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# cf-6amf (cf-roadmap.3): wave-audit ritual driver.
+#
+# Usage:
+#   scripts/wave-audit/wave-audit.sh <since-date> [<until-date>]
+#
+# Examples:
+#   scripts/wave-audit/wave-audit.sh 2026-05-15           # one day
+#   scripts/wave-audit/wave-audit.sh 2026-05-10 2026-05-15  # range
+#
+# Output (markdown to stdout):
+#   - Histogram of all merged PRs in the window
+#   - Categorized PR list (numbered)
+#   - Suggested deep-audit candidates (substantive bucket only)
+#   - Reachability check note for any stacked PRs that didn't land in main
+#
+# Convention: see docs/audits/CONVENTIONS.md for the categorization rubric +
+# rationale. cf-5dto v5 reachability rule (`git merge-base --is-ancestor`)
+# applies — only PRs whose merge commit is reachable from origin/main are
+# counted; stacked-PR squash-merge gaps surface in the "Excluded" section.
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <since-date> [<until-date>]" >&2
+  echo "  Dates are YYYY-MM-DD; until-date defaults to since-date." >&2
+  exit 1
+fi
+
+SINCE="$1"
+UNTIL="${2:-$1}"
+REPO="${WAVE_AUDIT_REPO:-DreadPirateRobertz/carolina-futons}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+# 1. Fetch the wave from gh.
+WAVE_JSON="$(mktemp)"
+trap 'rm -f "$WAVE_JSON"' EXIT
+
+gh pr list \
+  --repo "$REPO" \
+  --base main \
+  --state merged \
+  --search "merged:${SINCE}..${UNTIL}" \
+  --json number,title,additions,deletions,files,mergeCommit \
+  --limit 100 \
+  > "$WAVE_JSON"
+
+PR_COUNT="$(jq 'length' "$WAVE_JSON")"
+
+if [[ "$PR_COUNT" -eq 0 ]]; then
+  echo "# Wave audit: ${SINCE} → ${UNTIL}"
+  echo
+  echo "No PRs merged in this window."
+  exit 0
+fi
+
+# 2. Reachability filter — drop PRs whose merge commit isn't in origin/main.
+# This catches stacked-PR squash gaps (the cf-5dto / a720c6d trap that
+# motivated the convention).
+REACHED_JSON="$(mktemp)"
+EXCLUDED_JSON="$(mktemp)"
+trap 'rm -f "$WAVE_JSON" "$REACHED_JSON" "$EXCLUDED_JSON"' EXIT
+
+(
+  cd "$REPO_ROOT"
+  git fetch origin main --quiet 2>/dev/null || true
+  jq -c '.[]' "$WAVE_JSON" | while read -r row; do
+    SHA="$(echo "$row" | jq -r '.mergeCommit.oid // empty')"
+    if [[ -z "$SHA" ]] || git merge-base --is-ancestor "$SHA" origin/main 2>/dev/null; then
+      echo "$row"
+    else
+      echo "$row" >&2
+    fi
+  done > "$REACHED_JSON" 2>"$EXCLUDED_JSON"
+)
+
+# Wrap line-delimited JSON back into arrays for downstream tooling.
+jq -s '.' "$REACHED_JSON" > "${REACHED_JSON}.arr"
+jq -s '.' "$EXCLUDED_JSON" > "${EXCLUDED_JSON}.arr"
+mv "${REACHED_JSON}.arr" "$REACHED_JSON"
+mv "${EXCLUDED_JSON}.arr" "$EXCLUDED_JSON"
+
+REACHED_COUNT="$(jq 'length' "$REACHED_JSON")"
+EXCLUDED_COUNT="$(jq 'length' "$EXCLUDED_JSON")"
+
+# 3. Run the python categorizer.
+SUMMARY="$(python3 "$HERE/wave_audit.py" "$REACHED_JSON")"
+
+# 4. Emit the report.
+cat <<EOF
+# Wave audit: ${SINCE} → ${UNTIL}
+
+**Repo:** \`$REPO\`
+**PRs merged in window:** $PR_COUNT
+**Reachable from \`origin/main\`:** $REACHED_COUNT
+**Excluded (stacked-PR not in main):** $EXCLUDED_COUNT
+
+$SUMMARY
+EOF
+
+if [[ "$EXCLUDED_COUNT" -gt 0 ]]; then
+  echo
+  echo "## Excluded (stacked-PR squash gap)"
+  echo
+  echo "These PRs have \`state=MERGED\` but their merge commit is NOT reachable"
+  echo "from \`origin/main\` — likely a stacked PR that merged into an"
+  echo "intermediate branch which was later squash-merged from a pre-stack state."
+  echo "(cf-5dto / a720c6d traceability convention.)"
+  echo
+  jq -r '.[] | "- #\(.number) — \(.title)"' "$EXCLUDED_JSON"
+fi

--- a/scripts/wave-audit/wave_audit.py
+++ b/scripts/wave-audit/wave_audit.py
@@ -1,0 +1,90 @@
+"""cf-6amf (cf-roadmap.3): wave-audit report renderer.
+
+Reads a JSON array of PR records (output of `gh pr list --json
+number,title,additions,deletions,files,mergeCommit`) on argv[1] and emits
+a markdown summary to stdout.
+
+Tested via test_categorize.py for the underlying categorize() logic;
+this script is the thin presentation layer.
+
+Usage (called from wave-audit.sh, not directly):
+  python3 wave-audit.py <reached.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from categorize import categorize, summary_histogram, deep_audit_candidates
+
+
+def render(prs: list[dict]) -> str:
+    """Emit the markdown report body (called by the shell wrapper)."""
+    lines: list[str] = []
+
+    # Histogram table
+    histogram = summary_histogram(prs)
+    lines.append("## Histogram\n")
+    lines.append("| Category | Count |")
+    lines.append("|---|---:|")
+    for cat in ["pure-docs", "test-only", "trivial", "housekeeping", "substantive"]:
+        lines.append(f"| {cat} | {histogram[cat]} |")
+    lines.append(f"| **Total** | **{len(prs)}** |")
+    lines.append("")
+
+    # Per-PR table
+    lines.append("## All PRs (categorized)\n")
+    lines.append("| # | Cat | Diff | Title |")
+    lines.append("|---|---|---|---|")
+    for pr in sorted(prs, key=lambda p: p["number"]):
+        cat = categorize(pr)
+        diff = f"+{pr.get('additions', 0)}/-{pr.get('deletions', 0)}"
+        title = pr.get("title", "")[:70]
+        lines.append(f"| #{pr['number']} | {cat} | {diff} | {title} |")
+    lines.append("")
+
+    # Deep-audit candidates
+    candidates = deep_audit_candidates(prs)
+    lines.append(f"## Deep-audit candidates ({len(candidates)} substantive)\n")
+    if not candidates:
+        lines.append("_No substantive PRs in this window — wave was pure-docs/test-only/trivial/housekeeping._")
+    else:
+        lines.append("These PRs warrant per-file JSDoc + TDD + CI verification per the cf-o5j5 methodology:")
+        lines.append("")
+        for pr in sorted(candidates, key=lambda p: p["number"]):
+            diff = f"+{pr.get('additions', 0)}/-{pr.get('deletions', 0)}"
+            sha = (pr.get("mergeCommit") or {}).get("oid", "")[:8]
+            sha_note = f" (merge `{sha}`)" if sha else ""
+            lines.append(f"- **#{pr['number']}** {diff}{sha_note}: {pr.get('title', '')}")
+        lines.append("")
+        lines.append("### Audit dimensions per candidate")
+        lines.append("")
+        lines.append("1. **JSDoc/block-doc on new exports** — for each `export const NAME = ...` or `export [async] function NAME(...)`, is there a comment explaining intent?")
+        lines.append("2. **Test coverage on new surface** — `it()` blocks per new code path; happy + boundary cases.")
+        lines.append("3. **CI evidence at merge** — lint + typecheck + Vitest/Playwright + CodeQL green at the merge commit.")
+        lines.append("4. **Spy-assertion on external SDK callsites** (radahn dimension) — for every new Server Action / async callsite wrapping an external SDK (Wix, Stripe, Twilio, etc.), is there a spy assertion in the corresponding `*.test.ts` pinning the call?")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: wave-audit.py <reached.json>", file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"Input file not found: {path}", file=sys.stderr)
+        return 2
+    prs = json.loads(path.read_text())
+    if not isinstance(prs, list):
+        print("Expected JSON array of PR records", file=sys.stderr)
+        return 2
+    print(render(prs))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Institutionalizes the cf-o5j5 wave32 audit as a recurring ritual (cf-roadmap.3). Tooling + docs only, zero production code touched, no Vercel build risk.

- `scripts/wave-audit/wave-audit.sh` — shell driver with gh fetch + reachability filter (git merge-base --is-ancestor per cf-5dto/a720c6d lesson)
- `scripts/wave-audit/categorize.py` — pure-function categorizer (pure-docs / test-only / trivial / housekeeping / substantive)
- `scripts/wave-audit/wave_audit.py` — markdown renderer (histogram table + deep-audit candidate list)
- `scripts/wave-audit/test_categorize.py` — 16 TDD tests, all green
- `docs/audits/CONVENTIONS.md` — methodology playbook (reachability rule, rubric, radahn's spy-assertion as dimension #4)

+605 LOC across 5 files.

## Test plan

- [x] 16/16 pytest tests pass: `python -m pytest scripts/wave-audit/test_categorize.py -v`
- [x] All 5 categories covered with positive + negative cases
- [x] Reachability rule implemented + documented
- [x] Radahn spy-assertion dimension codified as audit dimension #4

Closes: cf-6amf

🤖 Generated with [Claude Code](https://claude.com/claude-code)