### PR TITLE
feat(cf-69fi): dead-code regression guard — CI-gate cf-hpwy on every PR

### DIFF
--- a/.github/workflows/cf-hpwy-guard.yml
+++ b/.github/workflows/cf-hpwy-guard.yml
@@ -1,0 +1,58 @@
+# cf-69fi (cf-roadmap.5): dead-code regression guard.
+#
+# Runs cf-hpwy v5 (scripts/cf-dead-routes/audit.py) on every PR + computes
+# the gated-verdict deltas vs scripts/cf-dead-routes/baseline.json.
+#
+# Week-1 (current): soft-fail mode — emits a markdown report as a PR
+# annotation, exit 0 even on regression so merges stay unblocked while
+# the team finishes the cf-roadmap.2 long-tail cleanup.
+#
+# Week-2+: flip --mode=soft → --mode=hard in this file (one-line edit)
+# to turn the gate into a merge blocker. cf-roadmap.5 acceptance covers
+# the soft→hard transition trigger.
+#
+# Baseline updates: a maintainer runs
+#   `python3 scripts/cf-dead-routes/check_baseline.py --update-baseline`
+# after a cleanup PR and commits scripts/cf-dead-routes/baseline.json.
+# Mirrors the vitest coverage-ratchet convention (cf-4x7e.B3/B4/B5).
+#
+# Security: this workflow does not interpolate any untrusted PR/issue
+# input into run: commands. The PR annotation step reads a file produced
+# by the trusted python script, never user-supplied text.
+
+name: cf-hpwy dead-code guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write  # for the markdown annotation comment
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run cf-hpwy v5 audit
+        run: python3 scripts/cf-dead-routes/audit.py
+
+      - name: Compare gated counts against baseline (soft-fail)
+        run: |
+          set -o pipefail
+          python3 scripts/cf-dead-routes/check_baseline.py --mode=soft \
+            | tee /tmp/cf-69fi-report.md
+
+      - name: Annotate PR with the report
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cf-69fi-dead-code-guard
+          path: /tmp/cf-69fi-report.md

--- a/scripts/cf-dead-routes/baseline.json
+++ b/scripts/cf-dead-routes/baseline.json
@@ -1,0 +1,4 @@
+{
+  "unused_can_delete": 0,
+  "dead_bucket": 0
+}

--- a/scripts/cf-dead-routes/check_baseline.py
+++ b/scripts/cf-dead-routes/check_baseline.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""cf-69fi (cf-roadmap.5): dead-code regression guard.
+
+Runs `audit.py` (cf-hpwy v5), compares the gated verdict counts against
+`scripts/cf-dead-routes/baseline.json`, and prints a markdown report
+for the GitHub Actions PR annotation.
+
+Modes:
+  --mode=soft   Week 1: print report, exit 0 even on regression
+                (annotation-only; merge stays unblocked).
+  --mode=hard   Week 2+: exit non-zero on regression so the check
+                turns red and merge is blocked.
+
+The two gated verdicts are:
+  - `UNUSED-CAN-DELETE` — the canonical 'safe to remove' signal
+  - DEAD bucket presence — captures the rare case where a row buckets
+    DEAD without UNUSED-CAN-DELETE (e.g. MAYBE-CFW-NAME-COLLISION on
+    a DEAD-bucket row).
+
+Usage (CI):
+  python3 scripts/cf-dead-routes/audit.py    # populates /tmp/cf-dead-routes/results.json
+  python3 scripts/cf-dead-routes/check_baseline.py --mode=soft
+
+Update the baseline (ratchet-down after cleanup PRs):
+  python3 scripts/cf-dead-routes/check_baseline.py --update-baseline
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_RESULTS = Path("/tmp/cf-dead-routes/results.json")
+DEFAULT_BASELINE = HERE / "baseline.json"
+
+
+def count_gated_verdicts(rows: list[dict]) -> dict[str, int]:
+    """Return per-gate counts for the comparator.
+
+    `unused_can_delete`: rows with gap_verdict == "UNUSED-CAN-DELETE"
+    `dead_bucket`: rows whose bucket array contains "DEAD"
+    """
+    unused = 0
+    dead = 0
+    for r in rows:
+        if r.get("gap_verdict") == "UNUSED-CAN-DELETE":
+            unused += 1
+        bucket = r.get("bucket") or []
+        if "DEAD" in bucket:
+            dead += 1
+    return {"unused_can_delete": unused, "dead_bucket": dead}
+
+
+def diff_against_baseline(
+    current: dict[str, int],
+    baseline: dict[str, int],
+) -> dict[str, int]:
+    """Return signed deltas per key. Missing baseline keys treated as 0
+    so first-time runs surface the full current count as the regression."""
+    keys = set(current) | set(baseline)
+    return {k: current.get(k, 0) - baseline.get(k, 0) for k in keys}
+
+
+def is_regression(delta: dict[str, int]) -> bool:
+    """Any positive delta = regression. Improvements (negative deltas)
+    are not regressions."""
+    return any(v > 0 for v in delta.values())
+
+
+def format_report(
+    current: dict[str, int],
+    baseline: dict[str, int],
+    delta: dict[str, int],
+) -> str:
+    """Markdown report for the GitHub Actions PR annotation."""
+    lines: list[str] = ["## cf-hpwy v5 — dead-code regression guard\n"]
+    lines.append("| Verdict | Baseline | Current | Delta |")
+    lines.append("|---|---:|---:|---:|")
+    for key in sorted(set(current) | set(baseline)):
+        d = delta.get(key, 0)
+        d_str = f"+{d}" if d > 0 else str(d)
+        lines.append(
+            f"| {key} | {baseline.get(key, 0)} | {current.get(key, 0)} | {d_str} |"
+        )
+    lines.append("")
+    if is_regression(delta):
+        offenders = [k for k, v in delta.items() if v > 0]
+        lines.append(
+            f"⚠ Regression: {', '.join(offenders)} count rose vs baseline."
+        )
+        lines.append(
+            "Investigate the new entries via `cat /tmp/cf-dead-routes/results.json | jq '.[] | select(.gap_verdict == \"UNUSED-CAN-DELETE\" or (.bucket | contains([\"DEAD\"])))'`."
+        )
+    else:
+        lines.append("✅ OK — no regression versus baseline.")
+    return "\n".join(lines)
+
+
+def exit_code_for_mode(delta: dict[str, int], mode: str) -> int:
+    """Pick the gate behavior:
+      mode='soft' → always 0 (annotation-only).
+      mode='hard' → non-zero on regression, 0 on clean.
+    """
+    if mode == "soft":
+        return 0
+    if mode == "hard":
+        return 1 if is_regression(delta) else 0
+    raise ValueError(f"unknown mode: {mode}")
+
+
+def _load_rows(results_path: Path) -> list[dict]:
+    if not results_path.exists():
+        sys.stderr.write(
+            f"cf-69fi: results file missing at {results_path}. "
+            "Run `python3 scripts/cf-dead-routes/audit.py` first.\n"
+        )
+        sys.exit(2)
+    return json.loads(results_path.read_text())
+
+
+def _load_baseline(baseline_path: Path) -> dict[str, int]:
+    if not baseline_path.exists():
+        # First-time bootstrap: empty baseline → current counts surface as
+        # the regression. Operator runs --update-baseline once to lock.
+        return {}
+    return json.loads(baseline_path.read_text())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="cf-69fi dead-code regression guard")
+    parser.add_argument(
+        "--mode",
+        choices=["soft", "hard"],
+        default="soft",
+        help="soft (Week 1, annotation-only) or hard (Week 2+, fail on regression)",
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=DEFAULT_RESULTS,
+        help="audit.py output JSON (default: /tmp/cf-dead-routes/results.json)",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE,
+        help="baseline JSON to compare against",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the baseline file from the current results (ratchet-down convention)",
+    )
+    args = parser.parse_args()
+
+    rows = _load_rows(args.results)
+    current = count_gated_verdicts(rows)
+
+    if args.update_baseline:
+        args.baseline.write_text(json.dumps(current, indent=2) + "\n")
+        sys.stderr.write(f"cf-69fi: baseline updated → {args.baseline}\n")
+        sys.stderr.write(json.dumps(current, indent=2) + "\n")
+        return 0
+
+    baseline = _load_baseline(args.baseline)
+    delta = diff_against_baseline(current, baseline)
+    report = format_report(current, baseline, delta)
+    print(report)
+    return exit_code_for_mode(delta, args.mode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cf-dead-routes/test_check_baseline.py
+++ b/scripts/cf-dead-routes/test_check_baseline.py
@@ -1,0 +1,190 @@
+"""cf-69fi (cf-roadmap.5): tests for the dead-code regression-guard
+comparator.
+
+The comparator reads two inputs:
+  - audit.py output (rows-by-name, e.g. /tmp/cf-dead-routes/results.json)
+  - the committed baseline (scripts/cf-dead-routes/baseline.json)
+
+It computes a diff per gated verdict and exits 0 (Week 1 soft-fail
+prints to stderr) or non-zero (Week 2+ hard-fail) when the gated
+counts rise above baseline. These tests pin the diff logic + the
+gating modes — workflow wiring is tested separately by the CI job
+itself.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _import_check():
+    for mod in list(sys.modules):
+        if mod == "check_baseline":
+            del sys.modules[mod]
+    import check_baseline  # type: ignore
+    return check_baseline
+
+
+def _row(name: str, verdict: str, bucket: list[str] | None = None) -> dict:
+    return {
+        "name": name,
+        "gap_verdict": verdict,
+        "bucket": bucket or [verdict.replace("OK-", "")],
+    }
+
+
+def test_count_gated_verdicts_returns_zero_for_clean_inventory():
+    """An audit run with zero UNUSED-CAN-DELETE + zero DEAD-bucket rows
+    must produce a clean count dict — the baseline-comparator gates on
+    these two signals."""
+    check = _import_check()
+    rows = [
+        _row("getOrders", "OK-WIRED", ["HTTP-EXPOSED"]),
+        _row("trackShipment", "OK-INTENTIONAL-ANYONE", ["HTTP-EXPOSED-INTENTIONAL"]),
+        _row("internalHelper", "VELO-INTERNAL", ["INTERNAL"]),
+    ]
+    counts = check.count_gated_verdicts(rows)
+    assert counts["unused_can_delete"] == 0
+    assert counts["dead_bucket"] == 0
+
+
+def test_count_gated_verdicts_counts_unused_can_delete():
+    """UNUSED-CAN-DELETE is the canonical 'safe to remove' verdict —
+    the count must reflect every row carrying it so the gate trips
+    when new methods slip into this state."""
+    check = _import_check()
+    rows = [
+        _row("oldHelper", "UNUSED-CAN-DELETE", ["DEAD"]),
+        _row("orphanWrap", "UNUSED-CAN-DELETE", ["DEAD"]),
+        _row("alive", "OK-WIRED", ["HTTP-EXPOSED"]),
+    ]
+    counts = check.count_gated_verdicts(rows)
+    assert counts["unused_can_delete"] == 2
+    assert counts["dead_bucket"] == 2
+
+
+def test_count_gated_verdicts_counts_dead_bucket_independently():
+    """The DEAD bucket can appear without UNUSED-CAN-DELETE (rare —
+    e.g. a method bucketed DEAD but with a cfw-low collision verdict).
+    Count it independently so a regression there surfaces too."""
+    check = _import_check()
+    rows = [
+        _row("ghostCall", "MAYBE-CFW-NAME-COLLISION", ["DEAD"]),
+        _row("alive", "OK-WIRED", ["HTTP-EXPOSED"]),
+    ]
+    counts = check.count_gated_verdicts(rows)
+    assert counts["unused_can_delete"] == 0
+    assert counts["dead_bucket"] == 1
+
+
+def test_diff_against_baseline_clean():
+    """No-delta case: current counts match baseline → no regression."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 5, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    assert delta["unused_can_delete"] == 0
+    assert delta["dead_bucket"] == 0
+    assert check.is_regression(delta) is False
+
+
+def test_diff_against_baseline_regression():
+    """Count rises → regression. is_regression flags the gate hit."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 8, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    assert delta["unused_can_delete"] == 3
+    assert delta["dead_bucket"] == 0
+    assert check.is_regression(delta) is True
+
+
+def test_diff_against_baseline_improvement_no_regression():
+    """Count drops → improvement, not regression. The operator gets
+    a 'you can ratchet down the baseline now' hint via the negative
+    delta; is_regression stays False."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 3, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    assert delta["unused_can_delete"] == -2
+    assert check.is_regression(delta) is False
+
+
+def test_diff_handles_missing_baseline_keys_as_zero():
+    """First-time CI run: baseline.json doesn't yet have a key (or has
+    just been merged with a partial schema). Treat missing keys as 0
+    so any new gated verdict reports as full regression rather than
+    KeyError-crashing the CI step."""
+    check = _import_check()
+    baseline = {}  # empty baseline
+    current = {"unused_can_delete": 3, "dead_bucket": 5}
+    delta = check.diff_against_baseline(current, baseline)
+    assert delta["unused_can_delete"] == 3
+    assert delta["dead_bucket"] == 5
+    assert check.is_regression(delta) is True
+
+
+def test_format_report_includes_per_verdict_counts(capsys):
+    """Report rendering — operator-facing markdown for the PR annotation.
+    Must include both gated counts so the operator can see at a glance
+    which dimension regressed."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 8, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    report = check.format_report(current, baseline, delta)
+    assert "unused_can_delete" in report
+    assert "dead_bucket" in report
+    # New row count visible in the report.
+    assert "+3" in report or "3" in report
+
+
+def test_format_report_no_regression_says_so():
+    """Clean case: report is brief + signals 'OK' so PR readers
+    aren't left wondering whether the gate fired silently."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 5, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    report = check.format_report(current, baseline, delta)
+    assert "OK" in report or "no regression" in report.lower()
+
+
+def test_exit_code_week_1_soft_fail():
+    """Week 1 (soft-fail) mode: exit code 0 even on regression — the
+    PR annotation is the signal, not the merge block. mode='soft' must
+    always return 0."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 8, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    code = check.exit_code_for_mode(delta, mode="soft")
+    assert code == 0
+
+
+def test_exit_code_week_2_hard_fail():
+    """Week 2+ (hard-fail) mode: exit non-zero on regression so the
+    GitHub Actions check turns red and merge is blocked."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 8, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    code = check.exit_code_for_mode(delta, mode="hard")
+    assert code != 0
+
+
+def test_exit_code_hard_mode_clean_returns_zero():
+    """Hard-fail mode must still pass when no regression — otherwise
+    every PR would fail."""
+    check = _import_check()
+    baseline = {"unused_can_delete": 5, "dead_bucket": 7}
+    current = {"unused_can_delete": 5, "dead_bucket": 7}
+    delta = check.diff_against_baseline(current, baseline)
+    code = check.exit_code_for_mode(delta, mode="hard")
+    assert code == 0


### PR DESCRIPTION
Per cf-roadmap.5. Wires cf-hpwy v5 into a per-PR GitHub Actions check + sticky markdown annotation. Week-1 soft-fail mode (exit 0 even on regression); flip --mode=soft → --mode=hard in the workflow to convert to a merge blocker. Gated verdicts: UNUSED-CAN-DELETE count + DEAD-bucket count. Baseline at 0/0 today (cf-4x7e long-tail clean). 12 TDD tests cover the comparator. Mirrors vitest coverage-ratchet pattern (cf-4x7e.B3/B4/B5). 5-agent gate per Stilgar mandate. Refs: cf-69fi, cf-roadmap.5, cf-5dto v5 (#1346).