### PR TITLE
feat(cf-69fi): dead-code regression guard — CI-gate cf-hpwy v5 on every PR

### DIFF
--- a/.github/workflows/dead-code-guard.yml
+++ b/.github/workflows/dead-code-guard.yml
@@ -6,6 +6,14 @@ name: dead-code-regression-guard
 # per cf-69fi acceptance). Week-2+ flips to --strict via a follow-up bead.
 
 on:
+  # Path-filter rationale (millicent micro-flag 2 / cf-69fi PR #1354 review):
+  # the v5 detector only finds dead webMethods in src/backend/, with callers
+  # in src/public/, src/pages/, or the detector's own scripts. Filtering to
+  # these paths skips doc-only / test-only / cfw-only PRs that can't
+  # introduce a dead-code regression. Lighter on CI minutes; broader scope
+  # would be defensible if the false-skip rate ever materializes, but the
+  # current detector coverage means new dead code MUST touch one of these
+  # paths. Re-evaluate when the detector's input surface broadens.
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/dead-code-guard.yml
+++ b/.github/workflows/dead-code-guard.yml
@@ -1,0 +1,65 @@
+name: dead-code-regression-guard
+
+# cf-69fi: run scripts/cf-dead-routes/audit.py on every PR + main push,
+# compare against the checked-in baseline (scripts/cf-dead-routes/baseline.json),
+# annotate the PR if counts rose, but DO NOT block merges yet (Week-1 soft-fail
+# per cf-69fi acceptance). Week-2+ flips to --strict via a follow-up bead.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/backend/**'
+      - 'src/public/**'
+      - 'src/pages/**'
+      - 'scripts/cf-dead-routes/**'
+      - '.github/workflows/dead-code-guard.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# cf-khqd / cf-ra41: cancel stale runs on the same branch.
+concurrency:
+  group: dead-code-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Run cf-hpwy v5 detector (audit.py)
+        # Produces /tmp/cf-dead-routes/results.json — the contract input
+        # for check-regression.py. Stderr carries the human-readable
+        # bucket tally; we tee it into the job log for visibility.
+        run: |
+          mkdir -p /tmp/cf-dead-routes
+          python3 scripts/cf-dead-routes/audit.py 2>&1 | tee /tmp/cf-dead-routes/audit-stderr.log
+
+      - name: Check regression vs baseline (soft-fail mode, Week-1)
+        # cf-69fi Week-1: annotate PR via ::warning::, do NOT block merges.
+        # The Week-2+ follow-up bead flips this to --strict.
+        run: |
+          python3 scripts/cf-dead-routes/check-regression.py \
+            --results /tmp/cf-dead-routes/results.json \
+            --baseline scripts/cf-dead-routes/baseline.json
+
+      - name: Upload audit results as PR artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cf-dead-routes-audit
+          path: |
+            /tmp/cf-dead-routes/results.json
+            /tmp/cf-dead-routes/audit-stderr.log
+          retention-days: 14

--- a/scripts/cf-dead-routes/baseline.json
+++ b/scripts/cf-dead-routes/baseline.json
@@ -1,11 +1,11 @@
 {
-  "dead": 1,
+  "dead": 0,
   "unused_can_delete": 0,
   "version": 1,
   "_meta": {
     "generated_at": "2026-05-16",
-    "by": "cf-69fi (millicent)",
-    "context": "Initial soft-fail baseline. Current DEAD=1 is wmB in src/backend/sample.web.js — an audit-test fixture, not production dead code. Ratchet this to 0 when the fixture is moved out of src/backend/ or excluded from audit.py's scan path.",
-    "ratchet_pattern": "Mirror of vitest coverage-ratchet (cf-4x7e.B3/B4/B5). When live counts drop below baseline, ratchet the baseline down in the same PR that cleared the offender. Never ratchet UP — that's the regression the guard exists to catch."
+    "by": "cf-69fi (millicent + morgott rebase)",
+    "context": "Live baseline post-cf-4x7e wave + cf-5dto v5 detector merge. Verified via fresh audit.py run: DEAD bucket = 0, UNUSED-CAN-DELETE verdict = 0. The cf-4x7e cleanup wave (231 webMethods retired, ~-54k LOC) cleared every truly-dead webMethod; v5 detector reclassified the 5 false-DEAD allowlisted-Anyone entries into their correct HTTP-EXPOSED-INTENTIONAL bucket. (millicent's draft baseline used a test-fixture dead=1; that fixture lives in tmp_path during pytest runs, not in production src/backend — so the live baseline is correctly 0.)",
+    "ratchet_pattern": "Mirror of vitest coverage-ratchet (cf-4x7e.B3/B4/B5/B5.fu). When live counts drop below baseline, ratchet the baseline down in the same PR that cleared the offender. Never ratchet UP — that's the regression the guard exists to catch. Week-1 soft-fail mode warns; Week-2+ strict mode fails the build."
   }
 }

--- a/scripts/cf-dead-routes/baseline.json
+++ b/scripts/cf-dead-routes/baseline.json
@@ -1,0 +1,11 @@
+{
+  "dead": 1,
+  "unused_can_delete": 0,
+  "version": 1,
+  "_meta": {
+    "generated_at": "2026-05-16",
+    "by": "cf-69fi (millicent)",
+    "context": "Initial soft-fail baseline. Current DEAD=1 is wmB in src/backend/sample.web.js — an audit-test fixture, not production dead code. Ratchet this to 0 when the fixture is moved out of src/backend/ or excluded from audit.py's scan path.",
+    "ratchet_pattern": "Mirror of vitest coverage-ratchet (cf-4x7e.B3/B4/B5). When live counts drop below baseline, ratchet the baseline down in the same PR that cleared the offender. Never ratchet UP — that's the regression the guard exists to catch."
+  }
+}

--- a/scripts/cf-dead-routes/check-regression.py
+++ b/scripts/cf-dead-routes/check-regression.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""cf-69fi — dead-code regression guard.
+
+Reads the JSON output of `audit.py` (`/tmp/cf-dead-routes/results.json`) plus
+a checked-in baseline (`scripts/cf-dead-routes/baseline.json`) and reports
+whether the DEAD or UNUSED-CAN-DELETE counts regressed.
+
+Modes:
+    default (soft)  annotate stderr with ::warning::, exit 0 (don't block PR)
+    --strict        also emit ::error::, exit 1 on regression (block PR)
+
+Exit codes:
+    0  no regression OR soft-mode (regression visible but not blocking)
+    1  strict-mode regression
+    2  infrastructure failure (missing file, malformed JSON, etc.)
+
+Baseline format (scripts/cf-dead-routes/baseline.json):
+    {
+        "dead": 0,
+        "unused_can_delete": 0,
+        "version": 1
+    }
+
+Usage:
+    python3 scripts/cf-dead-routes/check-regression.py \\
+        --results /tmp/cf-dead-routes/results.json \\
+        --baseline scripts/cf-dead-routes/baseline.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _exit(code: int, msg: str) -> int:
+    """Print msg to stderr and return the exit code."""
+    print(msg, file=sys.stderr)
+    return code
+
+
+def _load_json(path: Path, label: str) -> object | int:
+    """Return parsed JSON, or an exit code (int) on failure."""
+    if not path.exists():
+        return _exit(2, f"error: {label} file not found: {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return _exit(2, f"error: {label} file is not valid JSON ({e}): {path}")
+
+
+def _validate_baseline(baseline: dict) -> int | None:
+    """Return an exit code on invalid baseline, or None when valid."""
+    if not isinstance(baseline, dict):
+        return _exit(2, "error: baseline must be a JSON object")
+    if "version" not in baseline:
+        return _exit(
+            2,
+            "error: baseline missing required 'version' field — "
+            "future format migrations require an opt-in flag, not a "
+            "silent re-interpretation",
+        )
+    for field in ("dead", "unused_can_delete"):
+        if field not in baseline or not isinstance(baseline[field], int):
+            return _exit(2, f"error: baseline.{field} must be an integer")
+        if baseline[field] < 0:
+            return _exit(2, f"error: baseline.{field} must be non-negative")
+    return None
+
+
+def _count_buckets(rows: list) -> tuple[int, int, list[str], list[str]]:
+    """Return (dead_count, unused_count, dead_names, unused_names)."""
+    dead_names: list[str] = []
+    unused_names: list[str] = []
+    for r in rows:
+        buckets = r.get("bucket", [])
+        if "DEAD" in buckets:
+            dead_names.append(r.get("name", "?"))
+        if "UNUSED-CAN-DELETE" in buckets:
+            unused_names.append(r.get("name", "?"))
+    return len(dead_names), len(unused_names), dead_names, unused_names
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=Path("/tmp/cf-dead-routes/results.json"),
+        help="Path to audit.py output JSON (default: /tmp/cf-dead-routes/results.json)",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=Path(__file__).parent / "baseline.json",
+        help="Path to baseline JSON (default: scripts/cf-dead-routes/baseline.json)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on regression instead of soft-fail. Week-2+ behavior.",
+    )
+    args = parser.parse_args(argv)
+
+    results = _load_json(args.results, "results")
+    if isinstance(results, int):
+        return results
+    if not isinstance(results, list):
+        return _exit(2, "error: results.json must be a JSON array")
+
+    baseline = _load_json(args.baseline, "baseline")
+    if isinstance(baseline, int):
+        return baseline
+    err = _validate_baseline(baseline)
+    if err is not None:
+        return err
+
+    dead_count, unused_count, dead_names, unused_names = _count_buckets(results)
+
+    dead_delta = dead_count - baseline["dead"]
+    unused_delta = unused_count - baseline["unused_can_delete"]
+
+    # Healthy + improvement paths
+    if dead_delta <= 0 and unused_delta <= 0:
+        if dead_delta < 0 or unused_delta < 0:
+            print(
+                f"OK — counts below baseline (dead {baseline['dead']}→{dead_count}, "
+                f"unused-can-delete {baseline['unused_can_delete']}→{unused_count}). "
+                f"Consider ratcheting baseline.json down.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"OK — no regression (dead={dead_count}, "
+                f"unused-can-delete={unused_count}, both match baseline)",
+                file=sys.stderr,
+            )
+        return 0
+
+    # Regression path — at least one count rose.
+    print("::warning::cf-69fi dead-code regression guard found new offenders", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Dead-code regression detected:", file=sys.stderr)
+    print(
+        f"  DEAD:              {baseline['dead']} (baseline) → "
+        f"{dead_count} (current)  Δ={'+' if dead_delta > 0 else ''}{dead_delta}",
+        file=sys.stderr,
+    )
+    print(
+        f"  UNUSED-CAN-DELETE: {baseline['unused_can_delete']} (baseline) → "
+        f"{unused_count} (current)  Δ={'+' if unused_delta > 0 else ''}{unused_delta}",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+
+    if dead_delta > 0:
+        print("New DEAD offenders:", file=sys.stderr)
+        for name in dead_names[: 20]:
+            print(f"  - {name}", file=sys.stderr)
+        if len(dead_names) > 20:
+            print(f"  ... and {len(dead_names) - 20} more", file=sys.stderr)
+    if unused_delta > 0:
+        print("New UNUSED-CAN-DELETE offenders:", file=sys.stderr)
+        for name in unused_names[: 20]:
+            print(f"  - {name}", file=sys.stderr)
+        if len(unused_names) > 20:
+            print(f"  ... and {len(unused_names) - 20} more", file=sys.stderr)
+
+    if args.strict:
+        print("", file=sys.stderr)
+        print("::error::cf-69fi dead-code regression — strict mode is blocking the PR", file=sys.stderr)
+        print(
+            "If the new offenders are intentional (e.g. a new endpoint being "
+            "wired up across multiple PRs), update baseline.json and re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("", file=sys.stderr)
+    print(
+        "Soft-fail mode: PR is NOT blocked. To make this hard-fail, "
+        "pass --strict (Week-2+ behavior per cf-69fi).",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/cf-dead-routes/test_check_regression.py
+++ b/scripts/cf-dead-routes/test_check_regression.py
@@ -1,0 +1,264 @@
+"""cf-69fi — TDD tests for the dead-code regression guard.
+
+Tests pin the contract for `check-regression.py` BEFORE the wrapper script
+is implemented, per the 2026-05-15 TDD discipline standing order.
+
+The guard reads audit.py's `/tmp/cf-dead-routes/results.json` output and
+compares the DEAD + UNUSED-CAN-DELETE counts against a checked-in baseline
+(`scripts/cf-dead-routes/baseline.json`). On regression:
+
+  * default mode  — annotate stderr, exit 0 (soft-fail; PR is not blocked)
+  * --strict mode — exit 1 (hard-fail; PR is blocked)
+
+Week-1 plan ships SOFT mode. The flag flip to STRICT is a follow-up bead
+(cf-69fi.fu1) once the soft signal proves itself.
+
+Run:  python -m pytest scripts/cf-dead-routes/test_check_regression.py -v
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+GUARD = HERE / "check-regression.py"
+
+
+def run_guard(
+    *,
+    results: list[dict],
+    baseline: dict,
+    strict: bool = False,
+    tmp_path: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the guard with fixture results + baseline files; capture exit."""
+    results_path = tmp_path / "results.json"
+    baseline_path = tmp_path / "baseline.json"
+    results_path.write_text(json.dumps(results))
+    baseline_path.write_text(json.dumps(baseline))
+    cmd = [
+        sys.executable,
+        str(GUARD),
+        "--results",
+        str(results_path),
+        "--baseline",
+        str(baseline_path),
+    ]
+    if strict:
+        cmd.append("--strict")
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+def _row(name: str, *buckets: str) -> dict:
+    """Audit row shape: {name, file, line, bucket: [...]}."""
+    return {
+        "name": name,
+        "file": f"src/backend/{name}.web.js",
+        "line": 1,
+        "bucket": list(buckets) or ["DEAD"],
+    }
+
+
+BASELINE_ZERO = {"dead": 0, "unused_can_delete": 0, "version": 1}
+BASELINE_THREE = {"dead": 3, "unused_can_delete": 0, "version": 1}
+
+
+# ── Contract 1: clean run (no regression) ──────────────────────────────
+
+
+class TestNoRegression:
+    def test_zero_dead_matches_zero_baseline_exits_0(self, tmp_path):
+        """Healthy state: results match baseline exactly → exit 0."""
+        results = [_row("alive1", "HTTP-EXPOSED")]
+        cp = run_guard(results=results, baseline=BASELINE_ZERO, tmp_path=tmp_path)
+        assert cp.returncode == 0
+        assert "no regression" in cp.stderr.lower() or "ok" in cp.stderr.lower()
+
+    def test_count_decrease_exits_0(self, tmp_path):
+        """Below-baseline (improvement): exit 0 + suggest baseline ratchet."""
+        results = [_row("alive", "HTTP-EXPOSED")]  # 0 dead
+        cp = run_guard(results=results, baseline=BASELINE_THREE, tmp_path=tmp_path)
+        assert cp.returncode == 0
+        assert "ratchet" in cp.stderr.lower() or "below" in cp.stderr.lower()
+
+
+# ── Contract 2: regression detected ────────────────────────────────────
+
+
+class TestRegression:
+    def test_dead_increase_above_baseline_soft_exits_0(self, tmp_path):
+        """SOFT mode: regression visible in stderr, but exit stays 0.
+
+        Week-1 behavior — annotate the PR, don't block the merge.
+        """
+        results = [_row("regressed1"), _row("regressed2")]  # 2 dead
+        cp = run_guard(results=results, baseline=BASELINE_ZERO, tmp_path=tmp_path)
+        assert cp.returncode == 0
+        assert "regression" in cp.stderr.lower()
+        # New offenders are named.
+        assert "regressed1" in cp.stderr
+        assert "regressed2" in cp.stderr
+
+    def test_dead_increase_above_baseline_strict_exits_1(self, tmp_path):
+        """STRICT mode: regression blocks the merge."""
+        results = [_row("regressed1"), _row("regressed2")]
+        cp = run_guard(
+            results=results, baseline=BASELINE_ZERO, strict=True, tmp_path=tmp_path
+        )
+        assert cp.returncode == 1
+        assert "regression" in cp.stderr.lower()
+
+    def test_unused_can_delete_regression_also_tracked(self, tmp_path):
+        """The guard tracks UNUSED-CAN-DELETE separately from DEAD.
+
+        cf-hpwy v5 emits both buckets; a row CAN sit in both
+        (DEAD ∩ UNUSED-CAN-DELETE). Guard sums each bucket independently
+        so a regression on either flips the verdict.
+        """
+        results = [_row("orphan1", "UNUSED-CAN-DELETE")]
+        baseline = {"dead": 0, "unused_can_delete": 0, "version": 1}
+        cp = run_guard(
+            results=results, baseline=baseline, strict=True, tmp_path=tmp_path
+        )
+        assert cp.returncode == 1
+        assert "unused" in cp.stderr.lower() or "can-delete" in cp.stderr.lower()
+
+
+# ── Contract 3: degraded / missing inputs ──────────────────────────────
+
+
+class TestDegraded:
+    def test_missing_results_file_exits_2_distinct_from_regression(
+        self, tmp_path
+    ):
+        """No results.json → infrastructure failure (exit 2), not regression."""
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(json.dumps(BASELINE_ZERO))
+        cp = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD),
+                "--results",
+                str(tmp_path / "does-not-exist.json"),
+                "--baseline",
+                str(baseline_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert cp.returncode == 2
+        assert "results" in cp.stderr.lower()
+
+    def test_missing_baseline_file_exits_2(self, tmp_path):
+        """No baseline.json → infrastructure failure (exit 2)."""
+        results_path = tmp_path / "results.json"
+        results_path.write_text(json.dumps([]))
+        cp = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD),
+                "--results",
+                str(results_path),
+                "--baseline",
+                str(tmp_path / "does-not-exist.json"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert cp.returncode == 2
+        assert "baseline" in cp.stderr.lower()
+
+    def test_malformed_results_exits_2(self, tmp_path):
+        """Non-JSON results → exit 2."""
+        results_path = tmp_path / "results.json"
+        results_path.write_text("not-json {{{")
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(json.dumps(BASELINE_ZERO))
+        cp = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD),
+                "--results",
+                str(results_path),
+                "--baseline",
+                str(baseline_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert cp.returncode == 2
+
+
+# ── Contract 4: GH Actions PR annotation format ────────────────────────
+
+
+class TestAnnotation:
+    def test_regression_emits_github_actions_warning_annotation(self, tmp_path):
+        """Stderr contains a `::warning::` line GH Actions will surface.
+
+        Workflow runs with `actions/upload-artifact` + this annotation so
+        the PR check page links to the regression list.
+        """
+        results = [_row("new_dead", "DEAD")]
+        cp = run_guard(results=results, baseline=BASELINE_ZERO, tmp_path=tmp_path)
+        # Default (soft) mode still emits the warning annotation; strict adds
+        # an ::error:: line on top.
+        assert "::warning" in cp.stderr or "::warning::" in cp.stderr
+
+    def test_strict_regression_emits_github_actions_error_annotation(
+        self, tmp_path
+    ):
+        results = [_row("new_dead", "DEAD")]
+        cp = run_guard(
+            results=results, baseline=BASELINE_ZERO, strict=True, tmp_path=tmp_path
+        )
+        assert "::error" in cp.stderr or "::error::" in cp.stderr
+
+
+# ── Contract 5: baseline.json format stability ─────────────────────────
+
+
+class TestBaselineFormat:
+    def test_baseline_requires_version_field(self, tmp_path):
+        """A baseline without `version` is rejected — future format migrations
+        need an opt-in flag, not a silent re-interpretation."""
+        results_path = tmp_path / "results.json"
+        results_path.write_text(json.dumps([]))
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(json.dumps({"dead": 0, "unused_can_delete": 0}))
+        cp = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD),
+                "--results",
+                str(results_path),
+                "--baseline",
+                str(baseline_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert cp.returncode == 2
+        assert "version" in cp.stderr.lower()
+
+    def test_committed_baseline_file_is_well_formed(self):
+        """The checked-in baseline must parse and contain the 3 required
+        fields. This guards against accidental commit of a malformed file."""
+        baseline_path = HERE / "baseline.json"
+        if not baseline_path.exists():
+            pytest.skip("baseline.json not yet committed")
+        data = json.loads(baseline_path.read_text())
+        assert "dead" in data
+        assert "unused_can_delete" in data
+        assert "version" in data
+        assert isinstance(data["dead"], int)
+        assert isinstance(data["unused_can_delete"], int)
+        assert data["dead"] >= 0
+        assert data["unused_can_delete"] >= 0


### PR DESCRIPTION
cf-roadmap.5 (P3) → cf-69fi delivery. **Co-Authored-By millicent** (80% of the work was hers; I rebased + ratcheted baseline to live dead=0).

## Deliverables
- `scripts/cf-dead-routes/check-regression.py` (190 lines) — reads results.json + baseline.json, computes delta, soft-fail (Week-1) vs --strict (Week-2+), distinct exit-2 for infra failure
- `scripts/cf-dead-routes/test_check_regression.py` (264 lines, 12 cases) — pins contracts: no-regression+ratchet, soft vs strict, infra-failure exit 2, GH Actions annotation format, baseline.json version-field stability
- `scripts/cf-dead-routes/baseline.json` — live dead=0 / unused_can_delete=0 (vitest-ratchet-pattern doc inline)
- `.github/workflows/dead-code-guard.yml` — PR + push:main + workflow_dispatch, path-filtered, concurrency cancel-in-progress, uploads results.json + audit-stderr.log as 14-day PR artifact

## Why dead=0 is the right baseline
Fresh audit.py run on current main (post cf-4x7e wave + cf-5dto v5 detector merge):
```
DEAD (no caller anywhere): 0
Gap-verdict UNUSED-CAN-DELETE: 0
```
cf-4x7e cleared every truly-dead webMethod (231 retired, ~-54k LOC). v5 detector reclassified the 5 false-DEAD allowlisted-Anyone entries into their correct `HTTP-EXPOSED-INTENTIONAL` bucket. Live baseline is correctly 0.

millicent's draft baseline (dead=1 from a wmB test fixture) was conflating the pytest tmp_path fixture with production src/backend — no such file in real src/backend. Ratcheted to 0 in this PR's commit.

## TDD
12/12 tests pass on test_check_regression.py against the ratcheted baseline. Soft + strict modes both exit 0 on no-regression. Verified end-to-end via the live results.json from the audit.py run on current main.

## millicent's flagged specifics — resolved
1. **upload-artifact@v7**: verified consistent with ci.yml — no downgrade needed
2. **Path-filter scope**: keeping the filter (src/backend, src/public, src/pages, scripts/cf-dead-routes, .github/workflows/dead-code-guard.yml). Lighter on CI minutes; covers every path whose change could introduce dead-code regression
3. **cf-69fi.fu1 for fixture exclusion**: not needed — millicent's concern was about wmB in production src/backend, which doesn't exist; the tmp_path-fixture-only issue resolves itself

## Reviewers (per mayor's 2026-05-15 5-agent standing order)
| Reviewer | Why chosen | Status |
|---|---|---|
| millicent | Original author of 80% of this code | **APPROVED** 2026-05-15 (2 micro-flags — both folded: upload-artifact verified, path-filter inline doc added in 84b5f3e) |
| godfrey | Velo backend specialist | **APPROVED** 2026-05-15 (detailed exit-code design verification + lineage ack) |
| radahn | dead-code pattern reviewer | **APPROVED** 2026-05-15 (4 non-blocking observations → cf-69fi.fu1 + cf-69fi.fu2) |
| rennala | TDD verification habit (had a parallel branch — closing in favor of this PR) | **APPROVED** 2026-05-15 (65/65 local pytest verified) |
| melania | bead owner + ratchet-pattern coordinator | Requested |

## Diff
**+534 LOC across 4 files**. CI tooling only, no production code touch, no Vercel risk. Detector behavior unchanged.

Refs cf-69fi (closes on merge), cf-roadmap.5, cf-5dto v5 detector (PR #1346 + #1349).