### PR TITLE
feat(cf-wv1s): wire UR + Sentry live-API paths in dashboard.sh

### DIFF
--- a/scripts/ops/dashboard.sh
+++ b/scripts/ops/dashboard.sh
@@ -157,12 +157,33 @@ def cell_uptime_robot():
     if MODE == "fixtures":
         data = load_fixture("uptimeRobot")
     else:
-        if not os.environ.get("UPTIMEROBOT_API_KEY"):
+        key = os.environ.get("UPTIMEROBOT_API_KEY")
+        if not key:
             return _unreachable("uptimeRobot", "UPTIMEROBOT_API_KEY not set")
-        # Live impl deferred to follow-up commit once Stilgar provisions
-        # the key. The skipIf-gated live integration test will exercise
-        # the live path when the key lands.
-        return _unreachable("uptimeRobot", "live mode pending Stilgar API key + tier decision")
+        # cf-wv1s: live API wire-up. Pre-positioned so the cell goes
+        # green automatically the moment Stilgar provisions the key.
+        # The skipIf-gated integration test in dashboard.test.js
+        # exercises this path with real creds.
+        #
+        # UptimeRobot v2 is a POST-with-form-body API. urllib's default
+        # is GET, so we hand-build the form-encoded body.
+        from urllib.parse import urlencode
+        url = "https://api.uptimerobot.com/v2/getMonitors"
+        body = urlencode({
+            "api_key": key,
+            "format": "json",
+            "custom_uptime_ratios": "24",  # 24-hour ratio per monitor
+        }).encode()
+        req = urllib.request.Request(
+            url, data=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode())
+        except (urllib.error.URLError, urllib.error.HTTPError,
+                TimeoutError, ValueError):
+            return _unreachable("uptimeRobot", "live API call failed")
 
     if data is None:
         return _unreachable("uptimeRobot", "no fixture or live response")
@@ -170,7 +191,18 @@ def cell_uptime_robot():
     if not monitors:
         return _unreachable("uptimeRobot", "no monitors configured")
     active = [m for m in monitors if m.get("status") == 2]
-    uptimes = [float(m.get("custom_uptime_ratio", 0)) for m in monitors]
+    # cf-wv1s: live API returns `custom_uptime_ratios` (plural, comma-
+    # separated string of period uptimes). Fixture tests use
+    # `custom_uptime_ratio` (singular). Tolerate both — first parsable
+    # value wins.
+    uptimes = []
+    for m in monitors:
+        raw = m.get("custom_uptime_ratios") or m.get("custom_uptime_ratio") or "0"
+        first = str(raw).split(",")[0]
+        try:
+            uptimes.append(float(first))
+        except (ValueError, TypeError):
+            uptimes.append(0.0)
     min_uptime = min(uptimes) if uptimes else 0
     if min_uptime >= 99.9 and len(active) == len(monitors):
         status = GREEN
@@ -192,16 +224,49 @@ def cell_sentry():
     if MODE == "fixtures":
         data = load_fixture("sentry")
     else:
-        if not os.environ.get("SENTRY_AUTH_TOKEN"):
+        token = os.environ.get("SENTRY_AUTH_TOKEN")
+        if not token:
             return _unreachable("sentry", "SENTRY_AUTH_TOKEN not set")
-        # Live impl deferred to follow-up commit (gated on Stilgar
-        # Sentry production connection). Live test it.skipIf-gated.
-        return _unreachable("sentry", "live mode pending Stilgar Sentry connection")
+        # cf-wv1s: live API wire-up. SENTRY_ORG and SENTRY_PROJECT_SLUG
+        # come from env (Stilgar provisions alongside the token); we
+        # fall back to a sentinel if absent so the cell renders ❔
+        # instead of querying a bogus URL.
+        org = os.environ.get("SENTRY_ORG")
+        project = os.environ.get("SENTRY_PROJECT_SLUG")
+        if not org or not project:
+            return _unreachable(
+                "sentry",
+                "SENTRY_ORG and SENTRY_PROJECT_SLUG must be set alongside SENTRY_AUTH_TOKEN",
+            )
+        url = (
+            f"https://sentry.io/api/0/projects/{org}/{project}/issues/"
+            "?statsPeriod=24h&query=is:unresolved%20level:error&limit=20"
+        )
+        data_raw = _http_get(url, {"Authorization": f"Bearer {token}"})
+        if data_raw is None:
+            return _unreachable("sentry", "live API call failed")
+        # Sentry returns a flat array of issues, not the {issues, errorRatePerMin}
+        # shape the fixtures use. Normalize to the fixture shape so the rest of
+        # the cell logic works unchanged.
+        data = {"issues": data_raw if isinstance(data_raw, list) else []}
 
     if data is None:
         return _unreachable("sentry", "no fixture or live response")
-    rate = data.get("errorRatePerMin", 0)
     issues = data.get("issues", []) or []
+    # cf-wv1s: derive error_rate_per_min from issues[].count when no
+    # top-level field is present (the live API doesn't supply one).
+    # statsPeriod=24h → 24 * 60 = 1440 minutes.
+    if "errorRatePerMin" in data:
+        rate = data["errorRatePerMin"]
+    else:
+        total_events = 0
+        for i in issues:
+            c = i.get("count", 0)
+            try:
+                total_events += int(c)
+            except (ValueError, TypeError):
+                pass
+        rate = round(total_events / 1440.0, 4) if total_events else 0
     unresolved = sum(1 for i in issues if (i.get("level") in ("error", "fatal")))
     if rate < 0.5 and unresolved == 0:
         status = GREEN

--- a/tests/ops/dashboard.test.js
+++ b/tests/ops/dashboard.test.js
@@ -221,6 +221,96 @@ describe("Live-API integration (auto-skips without Stilgar tokens)", () => {
   );
 });
 
+// ─── cf-wv1s: realistic-API-shape fixture tests for UR + Sentry parse ─────
+//
+// The greenFixtures() shape was deliberately minimal. The real UR API
+// response uses `custom_uptime_ratios` (with `s`, returning a string of
+// comma-separated period uptimes). The real Sentry issues response is a
+// flat array of issues with `count` (string) + `firstSeen` / `lastSeen`
+// per issue + no top-level errorRatePerMin field. These cases pin the
+// parse logic against the actual API shapes so the live-mode wire-up
+// doesn't silently misclassify.
+
+describe("cf-wv1s — realistic UR + Sentry API shapes parse correctly", () => {
+  it("parses UptimeRobot custom_uptime_ratio (singular form) — current fixture path", async () => {
+    const fx = greenFixtures();
+    // Current parse code uses `custom_uptime_ratio` (singular). Live
+    // API returns `custom_uptime_ratios` (plural, comma-list). Cell
+    // must tolerate both — singular = single 24h ratio, plural =
+    // first value in comma-list.
+    fx.uptimeRobot.monitors = [
+      { id: 1, status: 2, friendly_name: "/", custom_uptime_ratio: "99.95" },
+    ];
+    const { exitCode } = await runDashboard(fx);
+    expect(exitCode).toBe(0);
+  });
+
+  it("parses UptimeRobot custom_uptime_ratios plural — live API shape", async () => {
+    // Live response shape uses the plural field name + comma-separated
+    // string of uptime ratios for the requested periods. With
+    // ?custom_uptime_ratios=24 you get a single value but as a string.
+    const fx = greenFixtures();
+    fx.uptimeRobot.monitors = [
+      {
+        id: 1,
+        status: 2,
+        friendly_name: "/",
+        custom_uptime_ratios: "99.95",  // single-period response
+      },
+      {
+        id: 2,
+        status: 2,
+        friendly_name: "/api/health",
+        custom_uptime_ratios: "99.99",
+      },
+    ];
+    const { stdout, exitCode } = await runDashboard(fx);
+    expect(exitCode).toBe(0);
+    // Both ratios should be parsed; min should be 99.95
+    expect(stdout).toMatch(/uptimeRobot_uptime_24h_min:\s*99\.95/);
+  });
+
+  it("computes Sentry error_rate_per_min from issues[].count when no top-level field", async () => {
+    // Live Sentry response has no `errorRatePerMin` field; cell must
+    // derive it from sum(issues[].count) / minutes-in-window. With a
+    // 24h statsPeriod, minutes = 1440.
+    //
+    // Fixture uses level=warning to isolate the rate-calc contract
+    // from the unresolved-P0/P1 verdict contract. The verdict path is
+    // pinned separately by the next test.
+    const fx = greenFixtures();
+    fx.sentry = {
+      issues: [
+        { id: "s1", count: "120", level: "warning", firstSeen: "2026-05-15T00:00:00Z" },
+        { id: "s2", count: "30", level: "warning", firstSeen: "2026-05-15T01:00:00Z" },
+      ],
+      // No top-level errorRatePerMin — cell must compute.
+    };
+    const { exitCode, stdout } = await runDashboard(fx);
+    // 120+30 = 150 events / 1440 min = ~0.104/min → GREEN threshold (<0.5);
+    // 0 unresolved error/fatal → unresolved=0 → GREEN
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/sentry_error_rate_per_min:\s*0\./);
+  });
+
+  it("Sentry unresolved P0/P1 count uses level field as primary signal", async () => {
+    // Verify the bucketing logic — only level in {error, fatal} counts.
+    const fx = greenFixtures();
+    fx.sentry = {
+      issues: [
+        { id: "s1", count: "1", level: "error" },
+        { id: "s2", count: "1", level: "fatal" },
+        { id: "s3", count: "1", level: "warning" },
+        { id: "s4", count: "1", level: "info" },
+      ],
+      errorRatePerMin: 0.1,  // explicit, override compute path
+    };
+    const { stdout } = await runDashboard(fx);
+    // 2 error+fatal → unresolved_p0p1_count=2 → YELLOW per spec
+    expect(stdout).toMatch(/sentry_unresolved_p0p1_count:\s*2/);
+  });
+});
+
 // ─── Fixtures ───────────────────────────────────────────────────────────
 
 function greenFixtures() {


### PR DESCRIPTION
Follow-up to cf-9fqc (PR #1345 merged). Pre-positions the live API code paths in dashboard.sh's UR + Sentry cells so the moment Stilgar provisions credentials (UPTIMEROBOT_API_KEY + SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT_SLUG), both cells go green automatically — zero further code change.

## TDD discipline (per 2026-05-15 mandate)

4 new tests pin realistic API shapes BEFORE the parser changes:
1. UR `custom_uptime_ratio` singular (fixture shape)
2. UR `custom_uptime_ratios` plural (live API shape, comma-separated)
3. Sentry rate-per-min computed from `sum(issues[].count)/1440` when no top-level field
4. Sentry unresolved bucketing uses level field as primary signal

RED: 2 failed (realistic shapes weren't parsed). GREEN: parser updated to tolerate both UR field-names + Sentry rate fallback.

## Verification

- `tests/ops/dashboard.test.js`: 17 passed, 2 skipped (live-API `it.skipIf` gates — auto-un-skip when Stilgar secrets land)
- Full suite: **36675/36675, zero regressions**

## When Stilgar provisions

1. Set `UPTIMEROBOT_API_KEY` in env
2. Set `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT_SLUG` in env
3. Re-run `bash scripts/ops/dashboard.sh`
4. UR + Sentry cells go from ❔ to ✅/⚠️/🔴 per real data

cfutons-only; no Vercel impact; passes cf-ukc6. 5-agent review per mayor's 2026-05-15 mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)