### PR TITLE
feat(cf-69fi.fu2): auto-ratchet bot for dead-code baseline

### DIFF
--- a/.github/workflows/dead-code-baseline-ratchet.yml
+++ b/.github/workflows/dead-code-baseline-ratchet.yml
@@ -1,0 +1,119 @@
+name: Dead-Code Baseline Ratchet
+
+# cf-69fi.fu2: when a push to main lands, re-run audit.py to compute live
+# dead-code counts. If the live counts are STRICTLY below the checked-in
+# baseline on at least one axis (and no axis rose), open a PR ratcheting
+# baseline.json down with a generated explanation. Never raises baseline;
+# never auto-merges — 5-agent CR per mayor's mandate still applies.
+#
+# Mirrors .github/workflows/coverage-ratchet.yml (the vitest analog).
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# cf-69fi base pattern: don't pile up ratchet jobs.
+concurrency:
+  group: dead-code-baseline-ratchet
+  cancel-in-progress: false
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Pass the head-commit message through env to avoid the shell-injection
+    # pattern that the GH Actions security guide flags. Used only for the
+    # loop-break check (skip the bot's own commits).
+    env:
+      HEAD_COMMIT_MSG: ${{ github.event.head_commit.message || '' }}
+
+    steps:
+      - name: Skip if this is the bot's own ratchet commit
+        id: skip
+        run: |
+          set -euo pipefail
+          # cf-69fi.fu2 commit messages start with this prefix — if we see
+          # it, bail to prevent recursive bot-PRs.
+          if [ "${HEAD_COMMIT_MSG#chore(ci): ratchet dead-code baseline}" != "$HEAD_COMMIT_MSG" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.skip.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        if: steps.skip.outputs.skip != 'true'
+        with:
+          python-version: '3.12'
+
+      - name: Run audit.py
+        if: steps.skip.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/cf-dead-routes
+          python3 scripts/cf-dead-routes/audit.py 2>/dev/null
+
+      - name: Decide ratchet
+        if: steps.skip.outputs.skip != 'true'
+        id: decide
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json, os, sys
+          sys.path.insert(0, "scripts/cf-dead-routes")
+          from auto_ratchet import live_counts, decide_ratchet, write_baseline
+          from pathlib import Path
+
+          results = Path("/tmp/cf-dead-routes/results.json")
+          baseline = Path("scripts/cf-dead-routes/baseline.json")
+
+          live = live_counts(results)
+          decision = decide_ratchet(baseline=baseline, live=live)
+
+          gh_output = Path(os.environ["GITHUB_OUTPUT"])
+          if decision is None:
+              with gh_output.open("a") as f:
+                  f.write("ratchet=false\n")
+              print(f"No ratchet needed: live={live}")
+          else:
+              # Persist new baseline + the PR body for the next step.
+              write_baseline(baseline, decision["new_baseline"])
+              Path("/tmp/cf-dead-routes/pr-body.md").write_text(decision["pr_body"])
+              new = decision["new_baseline"]
+              with gh_output.open("a") as f:
+                  f.write("ratchet=true\n")
+                  f.write(f"new_dead={new['dead']}\n")
+                  f.write(f"new_ucd={new['unused_can_delete']}\n")
+              print(f"Ratcheting: live={live} → new baseline={new}")
+          PY
+
+      - name: Open ratchet PR
+        if: steps.skip.outputs.skip != 'true' && steps.decide.outputs.ratchet == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_DEAD: ${{ steps.decide.outputs.new_dead }}
+          NEW_UCD: ${{ steps.decide.outputs.new_ucd }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/ratchet-dead-code-baseline-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "cf-69fi.fu2 auto-ratchet bot"
+          git config user.email "noreply@anthropic.com"
+          git checkout -b "$BRANCH"
+          git add scripts/cf-dead-routes/baseline.json
+          git commit -m "chore(ci): ratchet dead-code baseline (dead=$NEW_DEAD, unused_can_delete=$NEW_UCD)"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(cf-69fi.fu2): ratchet dead-code baseline (dead=$NEW_DEAD, ucd=$NEW_UCD)" \
+            --body-file /tmp/cf-dead-routes/pr-body.md \
+            --label "ci-ratchet,cf-69fi"

--- a/.github/workflows/dead-code-baseline-ratchet.yml
+++ b/.github/workflows/dead-code-baseline-ratchet.yml
@@ -57,10 +57,13 @@ jobs:
 
       - name: Run audit.py
         if: steps.skip.outputs.skip != 'true'
+        # millicent micro-obs#1 (PR #1357): tee audit.py stderr to a log so
+        # degraded-mode signals (e.g. "N files skipped due to parse errors")
+        # don't get silently dropped. Parity with dead-code-guard.yml.
         run: |
           set -euo pipefail
           mkdir -p /tmp/cf-dead-routes
-          python3 scripts/cf-dead-routes/audit.py 2>/dev/null
+          python3 scripts/cf-dead-routes/audit.py 2>&1 | tee /tmp/cf-dead-routes/audit-stderr.log
 
       - name: Decide ratchet
         if: steps.skip.outputs.skip != 'true'

--- a/scripts/cf-dead-routes/auto_ratchet.py
+++ b/scripts/cf-dead-routes/auto_ratchet.py
@@ -1,0 +1,140 @@
+"""cf-69fi.fu2: auto-ratchet helper for the dead-code regression guard.
+
+When the live audit shows DEAD or UNUSED-CAN-DELETE counts below the
+baseline, this module emits the new baseline + a PR body explaining
+the ratchet. Mirrors the vitest coverage-ratchet automation pattern
+(.github/workflows/coverage-ratchet.yml).
+
+Driven by `.github/workflows/dead-code-baseline-ratchet.yml`:
+  1. Workflow runs audit.py to produce results.json
+  2. Workflow imports this module to decide whether to ratchet
+  3. If yes — workflow writes new baseline.json + opens a PR
+
+Decisions:
+  - Live counts match baseline       → no-op (None)
+  - Live count(s) rose vs baseline   → no-op (regression guard's job, not ours)
+  - Live count strictly below        → emit ratchet decision
+  - One axis rose + another fell     → refuse (regression hiding behind progress)
+
+Pure-function design. No git/gh side-effects.
+
+Run tests: `python -m pytest scripts/cf-dead-routes/test_auto_ratchet.py -v`
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def live_counts(results_path: Path) -> dict[str, int]:
+    """Read audit.py's results.json and return the two ratchet-axis counts.
+
+    `dead` counts rows whose bucket is exactly `["DEAD"]`.
+    `unused_can_delete` counts rows whose gap_verdict is "UNUSED-CAN-DELETE"
+    (regardless of bucket — a method can be UNUSED-CAN-DELETE while
+    bucketing as something else, e.g. via the verdict-precedence chain).
+    """
+    rows = json.loads(Path(results_path).read_text())
+    dead = sum(1 for r in rows if r.get("bucket") == ["DEAD"])
+    ucd = sum(1 for r in rows if r.get("gap_verdict") == "UNUSED-CAN-DELETE")
+    return {"dead": dead, "unused_can_delete": ucd}
+
+
+def decide_ratchet(baseline: Path, live: dict[str, int]) -> dict | None:
+    """Return a ratchet decision, or None if no ratchet is warranted.
+
+    Decision shape:
+      {
+        "new_baseline": {"dead": N, "unused_can_delete": M, "version": V},
+        "pr_body":      "<markdown explaining the drop>",
+      }
+
+    Contract:
+      - If live counts match baseline on every axis: None
+      - If any axis ROSE above baseline: None (regression-guard handles it)
+      - If all axes are <= baseline AND at least one is strictly <: ratchet
+      - If one axis rose AND another fell: None (defensive — don't hide
+        the regression behind a progress)
+    """
+    base = json.loads(Path(baseline).read_text())
+    base_dead = base.get("dead", 0)
+    base_ucd = base.get("unused_can_delete", 0)
+    version = base.get("version", 1)
+
+    live_dead = live["dead"]
+    live_ucd = live["unused_can_delete"]
+
+    # Refuse if either axis is above baseline (regression — not our concern;
+    # also refuses the "one up + one down" hide-the-regression case).
+    if live_dead > base_dead or live_ucd > base_ucd:
+        return None
+
+    # No-op if both match exactly.
+    if live_dead == base_dead and live_ucd == base_ucd:
+        return None
+
+    # At this point: both axes <= baseline, at least one strictly <.
+    new_baseline = {
+        "dead": live_dead,
+        "unused_can_delete": live_ucd,
+        "version": version,
+    }
+
+    body_lines = [
+        "## Auto-ratchet (cf-69fi.fu2)",
+        "",
+        "Live dead-code audit shows count(s) below the checked-in baseline.",
+        "This PR ratchets the baseline down — same shape as the vitest",
+        "coverage-ratchet (cf-4x7e.B3/B4/B5/B5.fu).",
+        "",
+        "### Changes",
+    ]
+    if live_dead < base_dead:
+        body_lines.append(f"- `dead: {base_dead} → {live_dead}`")
+    if live_ucd < base_ucd:
+        body_lines.append(f"- `unused_can_delete: {base_ucd} → {live_ucd}`")
+    body_lines.extend([
+        "",
+        "### Why this is safe",
+        "",
+        "The dead-code regression guard (`.github/workflows/dead-code-guard.yml`)",
+        "uses this baseline as the floor — counts above it trip the guard.",
+        "Ratcheting the floor DOWN (this PR) tightens the gate; never raises it.",
+        "Cleanup wave drift gets caught on the next PR after this lands.",
+        "",
+        "**Manual merge — never auto-merge.** 5-agent review still applies per",
+        "mayor's 2026-05-15 standing order, but the diff is mechanical + the",
+        "rationale is canonical (matches `_meta.ratchet_pattern` in baseline.json).",
+    ])
+
+    return {
+        "new_baseline": new_baseline,
+        "pr_body": "\n".join(body_lines),
+    }
+
+
+def write_baseline(path: Path, new: dict) -> None:
+    """Write the new baseline JSON with a fresh _meta block referencing
+    auto-ratchet so future readers see the provenance."""
+    payload = {
+        "dead": new["dead"],
+        "unused_can_delete": new["unused_can_delete"],
+        "version": new["version"],
+        "_meta": {
+            "generated_at": "auto-ratchet",
+            "by": "cf-69fi.fu2 auto-ratchet bot",
+            "context": (
+                "Auto-ratcheted down by the cf-69fi.fu2 bot when live audit "
+                "showed counts below the previous baseline. Mirrors the "
+                "vitest coverage-ratchet pattern. See "
+                ".github/workflows/dead-code-baseline-ratchet.yml + "
+                "scripts/cf-dead-routes/auto_ratchet.py."
+            ),
+            "ratchet_pattern": (
+                "Mirror of vitest coverage-ratchet (cf-4x7e.B3/B4/B5/B5.fu). "
+                "Auto-ratchet only LOWERS — regressions trip the guard "
+                "instead."
+            ),
+        },
+    }
+    Path(path).write_text(json.dumps(payload, indent=2) + "\n")

--- a/scripts/cf-dead-routes/test_auto_ratchet.py
+++ b/scripts/cf-dead-routes/test_auto_ratchet.py
@@ -1,0 +1,192 @@
+"""cf-69fi.fu2: tests for the auto-ratchet helper that opens a bot-PR
+ratcheting baseline.json down when live dead-counts drop below it.
+
+Mirrors the vitest coverage-ratchet pattern (cf-4x7e.B3/B4/B5/B5.fu).
+Pure-function helpers — the workflow drives I/O. Tested in isolation
+via tmp files; no git/gh side-effects.
+
+Run: `python -m pytest scripts/cf-dead-routes/test_auto_ratchet.py -v`
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def _import_ar():
+    for mod in list(sys.modules):
+        if mod == "auto_ratchet":
+            del sys.modules[mod]
+    import auto_ratchet
+    return auto_ratchet
+
+
+def _write_baseline(path: Path, dead: int, ucd: int) -> None:
+    path.write_text(json.dumps({
+        "dead": dead,
+        "unused_can_delete": ucd,
+        "version": 1,
+        "_meta": {"generated_at": "2026-05-15", "by": "test"},
+    }, indent=2))
+
+
+def _write_results(path: Path, dead: int, ucd: int) -> None:
+    """Mirror audit.py's results.json structure: list of row dicts."""
+    rows = []
+    for i in range(dead):
+        rows.append({"bucket": ["DEAD"], "gap_verdict": "UNUSED-CAN-DELETE"})
+    for i in range(ucd):
+        # UNUSED-CAN-DELETE in gap_verdict with a non-DEAD bucket → still
+        # counts against the second metric. Use INTERNAL bucket as a stand-in.
+        rows.append({"bucket": ["INTERNAL"], "gap_verdict": "UNUSED-CAN-DELETE"})
+    path.write_text(json.dumps(rows))
+
+
+# ── Count helpers ────────────────────────────────────────────────
+
+
+def test_count_dead_from_results_zero(tmp_path):
+    ar = _import_ar()
+    results = tmp_path / "r.json"
+    _write_results(results, dead=0, ucd=0)
+    counts = ar.live_counts(results)
+    assert counts == {"dead": 0, "unused_can_delete": 0}
+
+
+def test_count_dead_nonzero(tmp_path):
+    ar = _import_ar()
+    results = tmp_path / "r.json"
+    _write_results(results, dead=3, ucd=5)
+    counts = ar.live_counts(results)
+    # All DEAD bucket rows also have UNUSED-CAN-DELETE gap_verdict in our
+    # fixture, plus 5 more rows with UNUSED-CAN-DELETE → total 8.
+    assert counts["dead"] == 3
+    assert counts["unused_can_delete"] == 8
+
+
+# ── Decision function ────────────────────────────────────────────
+
+
+def test_no_ratchet_when_counts_match_baseline(tmp_path):
+    """Clean state — live matches baseline. No PR needed."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=0, ucd=0)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 0, "unused_can_delete": 0})
+    assert decision is None
+
+
+def test_no_ratchet_when_live_above_baseline(tmp_path):
+    """Live counts ROSE — that's the regression-guard's job, not auto-ratchet.
+    auto-ratchet never raises baseline; it only lowers. Returns None."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=0, ucd=0)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 2, "unused_can_delete": 0})
+    assert decision is None
+
+
+def test_ratchet_when_dead_drops(tmp_path):
+    """Live dead count dropped below baseline. Open a PR with the new floor."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=10, ucd=3)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 7, "unused_can_delete": 3})
+    assert decision is not None
+    assert decision["new_baseline"]["dead"] == 7
+    assert decision["new_baseline"]["unused_can_delete"] == 3
+    assert "10" in decision["pr_body"] and "7" in decision["pr_body"]
+
+
+def test_ratchet_when_unused_can_delete_drops(tmp_path):
+    """Live UNUSED-CAN-DELETE count dropped — independent ratchet axis."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=0, ucd=20)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 0, "unused_can_delete": 15})
+    assert decision is not None
+    assert decision["new_baseline"]["dead"] == 0
+    assert decision["new_baseline"]["unused_can_delete"] == 15
+
+
+def test_ratchet_only_drops_one_axis_when_other_unchanged(tmp_path):
+    """Only ratchets the axes that actually moved — doesn't touch axes that
+    stayed equal."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=10, ucd=5)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 8, "unused_can_delete": 5})
+    assert decision is not None
+    assert decision["new_baseline"]["dead"] == 8
+    assert decision["new_baseline"]["unused_can_delete"] == 5
+
+
+def test_ratchet_preserves_version_field(tmp_path):
+    """The version field on baseline.json is part of the contract; preserve
+    it across a ratchet write."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=10, ucd=0)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 5, "unused_can_delete": 0})
+    assert decision["new_baseline"]["version"] == 1
+
+
+def test_ratchet_refuses_when_live_partially_above_baseline(tmp_path):
+    """Defensive case: if EITHER axis rose, refuse to ratchet either —
+    that's a regression to address before any ratchet. The auto-ratchet
+    bot should never let an upward drift on one axis hide behind a
+    downward drift on another."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=5, ucd=10)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 7, "unused_can_delete": 8})
+    assert decision is None
+
+
+# ── PR body content ──────────────────────────────────────────────
+
+
+def test_pr_body_includes_ratchet_summary(tmp_path):
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=10, ucd=5)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 7, "unused_can_delete": 3})
+    body = decision["pr_body"]
+    assert "dead: 10 → 7" in body
+    assert "unused_can_delete: 5 → 3" in body
+    assert "cf-69fi.fu2" in body  # bead reference
+
+
+def test_pr_body_omits_unchanged_axis(tmp_path):
+    """If only one axis moved, the PR body should only mention that axis."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=10, ucd=5)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 7, "unused_can_delete": 5})
+    body = decision["pr_body"]
+    assert "dead: 10 → 7" in body
+    assert "unused_can_delete:" not in body  # unchanged, don't mention
+
+
+# ── Write contract ───────────────────────────────────────────────
+
+
+def test_write_new_baseline(tmp_path):
+    """write_baseline produces a valid JSON file with the new counts +
+    preserves the _meta structure for human readability."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=10, ucd=0)
+    ar.write_baseline(baseline, {"dead": 5, "unused_can_delete": 0, "version": 1})
+    parsed = json.loads(baseline.read_text())
+    assert parsed["dead"] == 5
+    assert parsed["unused_can_delete"] == 0
+    assert parsed["version"] == 1
+    assert "_meta" in parsed
+    assert "auto-ratchet" in parsed["_meta"]["by"]

--- a/scripts/cf-dead-routes/test_auto_ratchet.py
+++ b/scripts/cf-dead-routes/test_auto_ratchet.py
@@ -36,14 +36,19 @@ def _write_baseline(path: Path, dead: int, ucd: int) -> None:
     }, indent=2))
 
 
-def _write_results(path: Path, dead: int, ucd: int) -> None:
-    """Mirror audit.py's results.json structure: list of row dicts."""
+def _write_results(path: Path, dead: int, extra_ucd: int) -> None:
+    """Mirror audit.py's results.json structure: list of row dicts.
+
+    `dead` controls the DEAD-bucket rows (each also carries the
+    UNUSED-CAN-DELETE verdict per audit.py's verdict chain).
+    `extra_ucd` adds rows with UNUSED-CAN-DELETE verdict but a non-DEAD
+    bucket (INTERNAL stand-in) — these are independent UCD rows beyond
+    the DEAD-bucket ones. Result: live_counts returns dead=N, ucd=N+M.
+    """
     rows = []
     for i in range(dead):
         rows.append({"bucket": ["DEAD"], "gap_verdict": "UNUSED-CAN-DELETE"})
-    for i in range(ucd):
-        # UNUSED-CAN-DELETE in gap_verdict with a non-DEAD bucket → still
-        # counts against the second metric. Use INTERNAL bucket as a stand-in.
+    for i in range(extra_ucd):
         rows.append({"bucket": ["INTERNAL"], "gap_verdict": "UNUSED-CAN-DELETE"})
     path.write_text(json.dumps(rows))
 
@@ -54,7 +59,7 @@ def _write_results(path: Path, dead: int, ucd: int) -> None:
 def test_count_dead_from_results_zero(tmp_path):
     ar = _import_ar()
     results = tmp_path / "r.json"
-    _write_results(results, dead=0, ucd=0)
+    _write_results(results, dead=0, extra_ucd=0)
     counts = ar.live_counts(results)
     assert counts == {"dead": 0, "unused_can_delete": 0}
 
@@ -62,10 +67,11 @@ def test_count_dead_from_results_zero(tmp_path):
 def test_count_dead_nonzero(tmp_path):
     ar = _import_ar()
     results = tmp_path / "r.json"
-    _write_results(results, dead=3, ucd=5)
+    _write_results(results, dead=3, extra_ucd=5)
     counts = ar.live_counts(results)
-    # All DEAD bucket rows also have UNUSED-CAN-DELETE gap_verdict in our
-    # fixture, plus 5 more rows with UNUSED-CAN-DELETE → total 8.
+    # All DEAD bucket rows also carry the UNUSED-CAN-DELETE gap_verdict
+    # per audit.py's verdict chain (the cf-5dto/cf-5dto.fu1 ordering),
+    # plus 5 extra non-DEAD UCD rows → total 8.
     assert counts["dead"] == 3
     assert counts["unused_can_delete"] == 8
 


### PR DESCRIPTION
cf-69fi.fu2 (P4) — automates the manual baseline ratchet pattern from cf-4x7e/cf-69fi.

## Three pieces (TDD-first)
- `scripts/cf-dead-routes/auto_ratchet.py` — pure-function helpers (live_counts / decide_ratchet / write_baseline)
- `scripts/cf-dead-routes/test_auto_ratchet.py` — 12 tests pinning the decision contract
- `.github/workflows/dead-code-baseline-ratchet.yml` — mirror of coverage-ratchet.yml shape

## Decision contract (pinned by tests)
- live matches baseline → no-op
- live rose on any axis → no-op (regression-guard handles it, not us)
- live partially rose + partially fell → no-op (defensive — don't hide regression behind progress)
- live strictly below on ≥1 axis, none above → ratchet decision

## Workflow shape (mirrors coverage-ratchet.yml)
- push:main + workflow_dispatch
- Loop-break skip on bot's own commits via `HEAD_COMMIT_MSG` env (GitHub Actions injection-safety pattern)
- Never auto-merges — opens PR for 5-agent CR

## Diff
+451 LOC across 3 files. CI tooling only, no production code touch, no Vercel risk.

## Test plan
- [x] 12 auto_ratchet tests green
- [x] Full pytest suite: 81/81 (incl pre-existing v3/v4/v5 + check_regression + categorize)
- [x] Workflow syntax: mirrors coverage-ratchet.yml verbatim where possible
- [ ] CI: lint, hookup-assistant, CodeQL

## Reviewers (per mayor's 2026-05-15 5-agent standing order)
| Reviewer | Why chosen | Status |
|---|---|---|
| millicent | cf-69fi co-author + ratchet-pattern expert | **APPROVED** 2026-05-15 (2 micro-obs, both folded — stderr-tee + no-action title len) |
| godfrey | Velo backend + workflow review | **APPROVED** 2026-05-15 (4-case decision contract + injection-safe env pattern verified) |
| radahn | suggested this fu2 in cf-69fi review obs#2 | **APPROVED** 2026-05-15 (3 obs: #1 param-rename folded, #3 → cf-69fi.fu3 P4 filed) |
| rennala | TDD verification habit | **APPROVED** 2026-05-15 (local 81/81 + decision-contract verified) |
| melania | bead owner + ratchet-pattern coordinator | Requested |

Refs cf-69fi.2 (closes), cf-69fi (parent #1354), pattern source coverage-ratchet.yml.