### PR TITLE
docs(cf-69fi.fu3): auto-merge opt-in design proposal — for mayor discussion

### DIFF
--- a/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
+++ b/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
@@ -76,6 +76,22 @@ The 5-agent CR mandate (Stilgar 2026-05-15) has a **human-eyes-on-merge** implic
 
 Auto-merge removes that final click. The proposal argues the merge is safe-by-construction for the narrow ratchet case, but the mayor (and the audit trail going forward) should decide whether the safety argument is strong enough to compress the human gate to zero.
 
+### Phase-flip approach (per radahn obs#1)
+
+Mirror the cf-69fi.fu1 strict-flip pattern: ship in a soft mode first (auto-merge eligibility computed + logged, but the actual `gh pr merge --auto` call is gated behind a feature flag default-off). Observe for 14 days. Flip to actual auto-merge only if the eligibility check fires 0 false-positives during the soft window.
+
+If mayor picks Option A (5-criteria gate), recommend layering Option B (time-gated, PR must be open ≥6 hours) as belt-and-suspenders for the first 14-day flip window before going to pure Option A.
+
+### Canonical log-line format (per radahn obs#2)
+
+Every eligibility decision emits a single grep-able line to GitHub Actions stdout:
+
+```
+cf-69fi.fu3 eligibility pr=<N> single-file=<bool> downward=<bool> tests=<bool> approvals=<count> request-changes=<count> verdict=<eligible|ineligible:<reason>>
+```
+
+`grep cf-69fi.fu3 eligibility` across the workflow logs reconstructs the audit trail without parsing JSON.
+
 ### Failure modes to discuss
 
 1. **Reviewer drift:** could 5 reviewers approve a non-ratchet PR by mistake? (Mitigation: criterion #2 re-runs `decide_ratchet` on the actual tree.)
@@ -89,6 +105,10 @@ Auto-merge removes that final click. The proposal argues the merge is safe-by-co
 - **Label-based:** require a `auto-merge-ratchet` label set by the bot at PR creation; auto-merge only fires if label is present. Adds a check + a recoverable bailout (operator can remove label to block).
 - **Time-gated:** require PR to be open ≥ N hours before auto-merge fires. Lets the wave-audit ritual surface anything weird.
 - **Mayor-approval:** require an explicit "auto-merge approved" label set by mayor herself. Maximally conservative.
+
+### Rollback (per radahn obs#5)
+
+If auto-merge produces a wrong merge: the wave-audit ritual (cf-6amf, `scripts/wave-audit/wave-audit.sh`) catches the regression in the next-day audit — the mechanical safety net. Manual recovery: `git revert` the offending merge commit, re-open the ratchet PR with the corrected baseline, file `cf-69fi.fu3.fu1` post-mortem documenting the failure mode.
 
 ## Recommendation
 

--- a/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
+++ b/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
@@ -32,7 +32,7 @@ Add `gh pr merge --auto --squash` to the auto-ratchet workflow IF AND ONLY IF th
 ### Safety criteria (ALL must hold)
 
 1. **Single-file diff:** only `scripts/cf-dead-routes/baseline.json` changed. No other source files, tests, workflows, or docs.
-2. **Downward only:** verified by re-running `decide_ratchet()` on the PR's tree state; result must be a ratchet decision (not None).
+2. **Downward only:** verified by re-running `decide_ratchet()` on the PR's tree state; result must be a ratchet decision (not None). **Note (rennala design-note on PR #1360):** GitHub's `--auto` re-checks branch protections at merge time, NOT arbitrary scripts. To prevent a stale verdict when baseline.json drifts between PR-open and merge-fire, the implementation must make `decide_ratchet` a **required CI status check** (so any new push to the branch re-runs it; auto-merge waits). Without this, fast-follow PRs touching baseline.json could invalidate the verdict between open + merge.
 3. **Tests still pass:** the full cf-dead-routes pytest suite runs in the same workflow + passes.
 4. **5 distinct crew APPROVED reviews:** counted by parsing review **bodies** for agent footers (`— <agent>` lines) — NOT by `reviews[].author.login`, since all crew share the `DreadPirateRobertz` GitHub account. The eligibility check must enumerate review bodies via `gh pr view --json reviews --jq '.reviews[].body'`, regex-match the `— <agent>$` footer, deduplicate, and require ≥ 5 distinct agent names. **(millicent concern #1 — load-bearing.)** Without this rewrite, criterion #4 fails on every shared-account PR.
 5. **No REQUEST-CHANGES outstanding:** any open REQUEST-CHANGES blocks auto-merge regardless of approval count.

--- a/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
+++ b/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
@@ -1,0 +1,112 @@
+# cf-69fi.fu3 — `gh pr merge --auto` opt-in for narrow ratchet PRs (proposal)
+
+**Bead:** cf-69fi.3 (P4)
+**Parent:** cf-69fi (PR #1354 — dead-code regression guard)
+**Sibling:** cf-69fi.fu2 (PR #1357 — auto-ratchet bot)
+**Status:** DESIGN PROPOSAL — **requires mayor discussion before implementation**
+
+This doc is the design artifact for cf-69fi.fu3. The bead description explicitly gates implementation on "discuss with mayor first" — this doc IS that discussion proposal. Implementation is deferred pending mayor approval of the safety-criteria + audit-trail design below.
+
+Per mayor's 2026-05-15 5-agent standing order, every PR merge (including auto-merge) requires 5 distinct crew sign-offs. This proposal does **not** bypass that mandate — it codifies the conditions under which `gh pr merge --auto` is appropriate AFTER the 5 sign-offs land.
+
+---
+
+## Problem
+
+The cf-69fi.fu2 auto-ratchet bot (PR #1357) opens PRs ratcheting `baseline.json` down when live dead-counts drop below the floor. Each such PR is:
+- Mechanically generated
+- Touches exactly one file
+- Diff is entirely downward (per the cf-69fi.fu2 decision contract — "axis rose" → no PR)
+- Provably safe by construction (the contract is pinned by 12 tests)
+
+Even so, every ratchet PR currently requires:
+1. 5-agent CR per mayor's mandate
+2. Manual `gh pr merge --admin` from an operator
+
+The operator-merge step is toil. Once 5/5 reviewers have signed off, the merge is mechanical. Auto-merge is the natural close of the loop.
+
+## Proposal
+
+Add `gh pr merge --auto --squash` to the auto-ratchet workflow IF AND ONLY IF the PR satisfies all 5 narrow criteria. Otherwise, behavior is unchanged (open PR, wait for operator).
+
+### Safety criteria (ALL must hold)
+
+1. **Single-file diff:** only `scripts/cf-dead-routes/baseline.json` changed. No other source files, tests, workflows, or docs.
+2. **Downward only:** verified by re-running `decide_ratchet()` on the PR's tree state; result must be a ratchet decision (not None).
+3. **Tests still pass:** the full cf-dead-routes pytest suite runs in the same workflow + passes.
+4. **5 distinct crew APPROVED reviews:** queried via `gh pr view --json reviewRequests,reviews` — count distinct authors with APPROVED state.
+5. **No REQUEST-CHANGES outstanding:** any open REQUEST-CHANGES blocks auto-merge regardless of approval count.
+
+If any criterion fails, the workflow stops at "open PR" — no auto-merge.
+
+### Implementation sketch
+
+```yaml
+- name: Auto-merge if eligible (cf-69fi.fu3)
+  if: steps.decide.outputs.ratchet == 'true' && steps.eligibility.outputs.eligible == 'true'
+  env:
+    GH_TOKEN: ${{ github.token }}
+    PR_NUMBER: ${{ steps.create_pr.outputs.number }}
+  run: |
+    set -euo pipefail
+    gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
+```
+
+A new step `eligibility` runs after `create_pr` and computes the 5-of-5 from `gh pr view`. It's a separate step so the eligibility logic is reviewable + testable in isolation (mirror the `auto_ratchet.decide_ratchet` factoring).
+
+### TDD-pre-write
+
+The eligibility check is the testable surface:
+
+```python
+# scripts/cf-dead-routes/test_auto_merge_eligibility.py — to be authored
+def test_eligibility_requires_single_file_diff(): ...
+def test_eligibility_requires_5_distinct_approvals(): ...
+def test_eligibility_rejects_open_request_changes(): ...
+def test_eligibility_rejects_non_ratchet_diff(): ...
+def test_eligibility_rejects_failing_tests(): ...
+def test_eligibility_passes_clean_ratchet_with_5_approves(): ...
+```
+
+These are TDD-pre-write — would land in the implementation PR, not this proposal.
+
+## Why discuss with mayor first
+
+The 5-agent CR mandate (Stilgar 2026-05-15) has a **human-eyes-on-merge** implicit assumption. Even if 5 reviewers have signed off, the merge button click is itself a gate — a moment where an operator can catch something the reviewers missed in aggregate.
+
+Auto-merge removes that final click. The proposal argues the merge is safe-by-construction for the narrow ratchet case, but the mayor (and the audit trail going forward) should decide whether the safety argument is strong enough to compress the human gate to zero.
+
+### Failure modes to discuss
+
+1. **Reviewer drift:** could 5 reviewers approve a non-ratchet PR by mistake? (Mitigation: criterion #2 re-runs `decide_ratchet` on the actual tree.)
+2. **Test-fixture pollution:** could the test suite false-pass? (Mitigation: criterion #3 runs the FULL suite, not a subset.)
+3. **Race conditions:** what if a regression lands on main between PR open + auto-merge? (Mitigation: GitHub's `--auto` flag re-checks branch protections at merge time.)
+4. **Audit trail:** can a forensic reviewer reconstruct what was auto-merged + why? (Yes — the PR description includes the live counts + the eligibility-check log line; the bot identity is in commit author.)
+
+### Alternatives
+
+- **Status quo:** operator clicks merge manually. Costs ~10-30 seconds of toil per ratchet PR.
+- **Label-based:** require a `auto-merge-ratchet` label set by the bot at PR creation; auto-merge only fires if label is present. Adds a check + a recoverable bailout (operator can remove label to block).
+- **Time-gated:** require PR to be open ≥ N hours before auto-merge fires. Lets the wave-audit ritual surface anything weird.
+- **Mayor-approval:** require an explicit "auto-merge approved" label set by mayor herself. Maximally conservative.
+
+## Recommendation
+
+If mayor approves, ship Option A (5-criteria gate). If she's hesitant, ship Option B (label-based + time-gated). The bot is the consumer either way — operator workload drops to zero in the steady state.
+
+## Open questions
+
+1. Should auto-merge fire only when DEAD axis dropped, or also when UNUSED-CAN-DELETE axis dropped? (Proposal: both — the cf-69fi.fu2 contract already verifies "no axis rose".)
+2. Should the workflow open the PR but NOT immediately auto-merge — instead set `--auto` so the merge happens when criteria are met later? (Proposal: yes — `gh pr merge --auto` is GitHub-native and handles the wait.)
+3. Should we log the auto-merge to a separate audit channel beyond the GitHub timeline? (Proposal: no — GitHub's timeline + the wave-audit ritual catches it.)
+
+## Implementation deferred
+
+This is a proposal doc only. No code changes in this PR. If mayor signs off, a follow-up PR implements the eligibility check + workflow integration + tests.
+
+## Refs
+
+- Parent: cf-69fi (PR #1354)
+- Sibling: cf-69fi.fu2 auto-ratchet bot (PR #1357)
+- Mayor's standing order: 2026-05-15 5-agent CR mandate
+- radahn obs#3 on PR #1357 (the source suggestion)

--- a/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
+++ b/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
@@ -100,7 +100,7 @@ cf-69fi.fu3 eligibility pr=<N> single-file=<bool> downward=<bool> tests=<bool> a
 4. **Audit trail:** can a forensic reviewer reconstruct what was auto-merged + why? Partially — the PR description includes the live counts + the eligibility-check log line; the bot identity is in commit author. **But** the `audit-stderr.log` + `results.json` artifacts that motivated the ratchet are retained only **14 days** per the cf-69fi `dead-code-guard.yml` setting. After that, an incident post-mortem looking back at a 3-week-old auto-merged ratchet finds the snapshot gone. **(millicent concern #3.)** Two mitigations to pick between:
    - **Option α:** bump artifact retention to **90 days** specifically for auto-ratchet artifacts (workflow conditional).
    - **Option β:** inline the **full bucket tally** (verbatim audit.py stderr) into the auto-ratchet PR description, so the snapshot survives in git history regardless of artifact retention.
-   Option β has the better forensic property (git history is forever) but bloats PR bodies. Option α is cheaper but bounded. The implementation PR should pick one; mayor's preference welcomed.
+   Option β has the better forensic property (git history is forever) but bloats PR bodies. Option α is cheaper but bounded. **godfrey CR preference (PR #1360):** Option β — git history is permanent, PR body bloat is bounded (bucket tally is ~30 lines), wave-audit ritual consumption easier inline since auditors don't need to fetch separately-stored artifacts. Default implementation: Option β unless mayor overrides.
 
 ### Alternatives
 

--- a/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
+++ b/docs/audits/cf-69fi-fu3-auto-merge-proposal.md
@@ -34,7 +34,7 @@ Add `gh pr merge --auto --squash` to the auto-ratchet workflow IF AND ONLY IF th
 1. **Single-file diff:** only `scripts/cf-dead-routes/baseline.json` changed. No other source files, tests, workflows, or docs.
 2. **Downward only:** verified by re-running `decide_ratchet()` on the PR's tree state; result must be a ratchet decision (not None).
 3. **Tests still pass:** the full cf-dead-routes pytest suite runs in the same workflow + passes.
-4. **5 distinct crew APPROVED reviews:** queried via `gh pr view --json reviewRequests,reviews` — count distinct authors with APPROVED state.
+4. **5 distinct crew APPROVED reviews:** counted by parsing review **bodies** for agent footers (`— <agent>` lines) — NOT by `reviews[].author.login`, since all crew share the `DreadPirateRobertz` GitHub account. The eligibility check must enumerate review bodies via `gh pr view --json reviews --jq '.reviews[].body'`, regex-match the `— <agent>$` footer, deduplicate, and require ≥ 5 distinct agent names. **(millicent concern #1 — load-bearing.)** Without this rewrite, criterion #4 fails on every shared-account PR.
 5. **No REQUEST-CHANGES outstanding:** any open REQUEST-CHANGES blocks auto-merge regardless of approval count.
 
 If any criterion fails, the workflow stops at "open PR" — no auto-merge.
@@ -96,8 +96,11 @@ cf-69fi.fu3 eligibility pr=<N> single-file=<bool> downward=<bool> tests=<bool> a
 
 1. **Reviewer drift:** could 5 reviewers approve a non-ratchet PR by mistake? (Mitigation: criterion #2 re-runs `decide_ratchet` on the actual tree.)
 2. **Test-fixture pollution:** could the test suite false-pass? (Mitigation: criterion #3 runs the FULL suite, not a subset.)
-3. **Race conditions:** what if a regression lands on main between PR open + auto-merge? (Mitigation: GitHub's `--auto` flag re-checks branch protections at merge time.)
-4. **Audit trail:** can a forensic reviewer reconstruct what was auto-merged + why? (Yes — the PR description includes the live counts + the eligibility-check log line; the bot identity is in commit author.)
+3. **Race conditions:** what if a regression lands on main between PR open + auto-merge? GitHub's `--auto` flag re-checks branch protections at merge time, but this assumes `required_status_checks.strict=true` is configured in cfutons branch-protection rules. **(millicent concern #2.)** The implementation PR must verify this setting via `gh api repos/.../branches/main/protection` and refuse to enable auto-merge if `strict` is false — otherwise `--auto` could fire before required checks turn green on the latest SHA.
+4. **Audit trail:** can a forensic reviewer reconstruct what was auto-merged + why? Partially — the PR description includes the live counts + the eligibility-check log line; the bot identity is in commit author. **But** the `audit-stderr.log` + `results.json` artifacts that motivated the ratchet are retained only **14 days** per the cf-69fi `dead-code-guard.yml` setting. After that, an incident post-mortem looking back at a 3-week-old auto-merged ratchet finds the snapshot gone. **(millicent concern #3.)** Two mitigations to pick between:
+   - **Option α:** bump artifact retention to **90 days** specifically for auto-ratchet artifacts (workflow conditional).
+   - **Option β:** inline the **full bucket tally** (verbatim audit.py stderr) into the auto-ratchet PR description, so the snapshot survives in git history regardless of artifact retention.
+   Option β has the better forensic property (git history is forever) but bloats PR bodies. Option α is cheaper but bounded. The implementation PR should pick one; mayor's preference welcomed.
 
 ### Alternatives
 


### PR DESCRIPTION
## Summary

cf-69fi.3 (P4) — design-only PR. The bead description explicitly gates implementation on "discuss with mayor first." This doc IS that discussion artifact, not the implementation.

## What's here

`docs/audits/cf-69fi-fu3-auto-merge-proposal.md` (+112 LOC):
- Problem statement (auto-ratchet PRs are toil after 5/5 lands)
- 5-criteria safety gate (single-file diff + downward only + tests pass + 5 distinct APPROVED + no open REQUEST-CHANGES)
- Implementation sketch (workflow YAML + new eligibility step)
- TDD-pre-write skeleton (6 test cases — to author if/when implementation PR follows)
- Failure modes to discuss with mayor (reviewer drift, fixture pollution, race conditions, audit trail)
- 4 alternatives (status quo / label-based / time-gated / mayor-approval)

## Why doc-only

The 5-agent CR mandate has an implicit human-eyes-on-merge assumption. Auto-merge would remove the final operator click. The mayor should decide whether the safety-by-construction argument for the narrow ratchet case is strong enough to compress that human gate to zero — that's a process decision, not a code decision.

## Diff

+112 LOC, 1 file (markdown). Docs only, no Vercel risk, no production code, no behavior change.

## Reviewers (per mayor's 2026-05-15 5-agent standing order)

| Reviewer | Why chosen | Status |
|---|---|---|
| melania | PRIMARY — mayor-discussion path; her decision determines next step | Requested |
| radahn | original suggester (cf-69fi.fu2 obs#3) | **APPROVED** 2026-05-15 (5 obs: #1+#2+#5 folded; #3+#4 implicit) |
| godfrey | Velo backend + workflow security review | **APPROVED** 2026-05-15 (mayor-deferred; preference for Option β audit-trail inlining over Option α retention bump — folded) |
| millicent | ratchet-pattern co-author; ships #1357 sibling | **APPROVED** 2026-05-15 (3 substantive concerns — all folded incl. shared-account counting fix) |
| rennala | TDD verification habit | **APPROVED** 2026-05-15 (criterion #2 timing bug surfaced — `decide_ratchet` must be required CI check, folded) |

Refs cf-69fi.3 (closes on merge or pivots to implementation PR per mayor decision), cf-69fi (PR #1354), cf-69fi.fu2 (PR #1357), mayor's 5-agent standing order 2026-05-15.