### PR TITLE
feat(cf-6amf.1): sub-classify substantive bucket by commit prefix

### DIFF
--- a/scripts/wave-audit/categorize.py
+++ b/scripts/wave-audit/categorize.py
@@ -124,6 +124,90 @@ def deep_audit_candidates(prs: list[dict]) -> list[dict]:
     return [pr for pr in prs if categorize(pr) == "substantive"]
 
 
+# cf-6amf.1 (cf-6amf.fu1): sub-classify the substantive bucket by
+# conventional-commit prefix so deep-audit can prioritize feat-touching-
+# external-SDK PRs ahead of chore/refactor. Pilot wave (2026-05-15) had a
+# 71% substantive ratio; a flat sub-bucket of 24 PRs is too coarse to
+# guide attention.
+
+# Conventional-commit prefix tokens we recognize. Anything else maps to
+# "other" (e.g. WIP, Merge, free-form titles). The trailing `(scope)`,
+# optional `!` for breaking change, and `:` are all stripped before the
+# prefix token is read.
+_CONVENTIONAL_PREFIXES = frozenset({
+    "feat", "fix", "refactor", "chore", "test", "perf", "docs", "style",
+})
+
+# Match `prefix`, `prefix(scope)`, `prefix!`, or `prefix(scope)!` followed
+# by `:` at the start of the title. Case-insensitive on the prefix token.
+_COMMIT_PREFIX_RE = re.compile(
+    r"^([A-Za-z]+)(?:\([^)]*\))?!?:\s",
+)
+
+# Paths whose new feat-prefixed PRs likely introduce external-SDK call
+# sites — flagged for the radahn dimension-#4 spy-assertion check.
+_HIGH_VALUE_PATH_RE = re.compile(
+    r"^(?:"
+    r"src/lib/wix(?:/|$)"
+    r"|src/lib/stripe(?:/|$)"
+    r"|src/api/[^/]+/route\.ts$"
+    r")"
+)
+
+
+def commit_prefix(title: str) -> str:
+    """Extract the conventional-commit prefix from a PR title.
+
+    Returns the lowercased prefix token (feat/fix/refactor/chore/test/perf/
+    docs/style) when the title matches `prefix(...)?!?: ...`. Returns
+    "other" for unrecognized prefixes, freeform titles, merge commits,
+    and empty strings.
+    """
+    if not title:
+        return "other"
+    m = _COMMIT_PREFIX_RE.match(title)
+    if not m:
+        return "other"
+    token = m.group(1).lower()
+    return token if token in _CONVENTIONAL_PREFIXES else "other"
+
+
+def substantive_subhistogram(prs: list[dict]) -> dict[str, int]:
+    """Return a dict with substantive-bucket counts keyed by commit prefix.
+
+    Only PRs that categorize as "substantive" are counted; pure-docs/test-
+    only/trivial/housekeeping PRs are excluded entirely (even if their
+    title carries a conventional-commit prefix). The full key set always
+    appears so downstream tables render with stable columns.
+    """
+    out = {p: 0 for p in _CONVENTIONAL_PREFIXES}
+    out["other"] = 0
+    for pr in prs:
+        if categorize(pr) != "substantive":
+            continue
+        out[commit_prefix(pr.get("title", ""))] += 1
+    return out
+
+
+def is_high_value_audit_target(pr: dict) -> bool:
+    """True when a substantive PR carries `feat:` AND touches a path that
+    typically introduces an external-SDK call site (src/lib/wix, src/lib/
+    stripe, src/api/<name>/route.ts).
+
+    These are the deep-audit candidates that most likely need a spy-
+    assertion per radahn obs#3 — a missing spy on a new Wix/Stripe
+    callsite is the kind of gap cf-o5j5/cf-6amf was designed to surface.
+    """
+    if categorize(pr) != "substantive":
+        return False
+    if commit_prefix(pr.get("title", "")) != "feat":
+        return False
+    return any(
+        _HIGH_VALUE_PATH_RE.match(f["path"])
+        for f in pr.get("files", [])
+    )
+
+
 def summary_histogram(prs: list[dict]) -> dict[str, int]:
     """Return a dict with counts per category. Keys appear even for zero
     counts so downstream consumers can format a stable table."""

--- a/scripts/wave-audit/test_categorize.py
+++ b/scripts/wave-audit/test_categorize.py
@@ -168,3 +168,170 @@ def test_summary_histogram_counts_each_category():
         "housekeeping": 1,
         "substantive": 2,
     }
+
+
+# ── cf-6amf.1: substantive sub-classification by commit prefix ─────
+
+
+def _pr_titled(number, title, files, additions=200, deletions=10):
+    return {
+        "number": number,
+        "title": title,
+        "additions": additions,
+        "deletions": deletions,
+        "files": [{"path": p} for p in files],
+    }
+
+
+def test_commit_prefix_feat_with_scope():
+    cat = _import_cat()
+    assert cat.commit_prefix("feat(cf-9fqc): observability dashboard GREEN") == "feat"
+
+
+def test_commit_prefix_fix_no_scope():
+    cat = _import_cat()
+    assert cat.commit_prefix("fix: align UptimeRobot keyword to /api/health") == "fix"
+
+
+def test_commit_prefix_chore_with_scope():
+    cat = _import_cat()
+    assert cat.commit_prefix("chore(cf-4x7e.B5): surgical drop dead modules") == "chore"
+
+
+def test_commit_prefix_recognizes_refactor_test_perf_docs_style():
+    cat = _import_cat()
+    assert cat.commit_prefix("refactor(foo): extract helper") == "refactor"
+    assert cat.commit_prefix("test(cf-5dto.2): combinatorial tests") == "test"
+    assert cat.commit_prefix("perf(cf-gsca): React.cache wrap") == "perf"
+    assert cat.commit_prefix("docs(cf-zn5b): parity audit") == "docs"
+    assert cat.commit_prefix("style: prettier sweep") == "style"
+
+
+def test_commit_prefix_breaking_change_marker():
+    """`feat!: ...` and `feat(scope)!: ...` are conventional-commits BREAKING markers."""
+    cat = _import_cat()
+    assert cat.commit_prefix("feat!: drop legacy API") == "feat"
+    assert cat.commit_prefix("feat(api)!: drop legacy v1") == "feat"
+
+
+def test_commit_prefix_unknown_returns_other():
+    cat = _import_cat()
+    assert cat.commit_prefix("WIP: in-progress thing") == "other"
+    assert cat.commit_prefix("Merge branch 'main'") == "other"
+    assert cat.commit_prefix("just a sentence with no prefix") == "other"
+    assert cat.commit_prefix("") == "other"
+
+
+def test_commit_prefix_is_case_insensitive_on_prefix_token():
+    """GitHub UI doesn't lowercase titles — accept FEAT/Fix gracefully."""
+    cat = _import_cat()
+    assert cat.commit_prefix("Fix(scope): something") == "fix"
+    assert cat.commit_prefix("FEAT: big thing") == "feat"
+
+
+def test_substantive_subhistogram_only_counts_substantive_prs():
+    """Sub-classification applies ONLY to the substantive bucket.
+    A docs-only PR with a `feat:` prefix is still pure-docs and should be excluded."""
+    cat = _import_cat()
+    prs = [
+        # substantive
+        _pr_titled(1, "feat(cf-9fqc): obs dashboard", ["src/lib/foo.ts"], additions=300),
+        _pr_titled(2, "feat(cf-54st): track-order page", ["src/app/track-order/page.tsx"], additions=200),
+        _pr_titled(3, "fix(cf-ewnw): redact emails", ["src/backend/util.js"], additions=80),
+        _pr_titled(4, "chore(cf-4x7e): retire dead modules", ["src/backend/x.web.js"], additions=2, deletions=8054),
+        _pr_titled(5, "test(cf-5dto.2): precedence tests", ["scripts/x.py", "scripts/y.py"], additions=167),
+        _pr_titled(6, "refactor: extract helper", ["src/lib/foo.ts"], additions=90),
+        _pr_titled(7, "WIP: experimental thing", ["src/lib/bar.ts"], additions=200),  # other
+        # not substantive (excluded entirely)
+        _pr_titled(8, "feat(cf-zn5b): parity audit", ["docs/audit.md"], additions=111),  # pure-docs
+        _pr_titled(9, "test(cf-x): only tests", ["tests/x.test.js"], additions=60),       # test-only
+    ]
+    h = cat.substantive_subhistogram(prs)
+    assert h == {
+        "feat": 2,
+        "fix": 1,
+        "refactor": 1,
+        "chore": 1,
+        "test": 1,
+        "perf": 0,
+        "docs": 0,
+        "style": 0,
+        "other": 1,
+    }
+
+
+def test_substantive_subhistogram_keys_stable_with_all_zeros():
+    """Empty PR list still returns the full key set for stable table rendering."""
+    cat = _import_cat()
+    h = cat.substantive_subhistogram([])
+    assert set(h.keys()) == {"feat", "fix", "refactor", "chore", "test", "perf", "docs", "style", "other"}
+    assert all(v == 0 for v in h.values())
+
+
+# ── cf-6amf.1 + radahn obs#3: high-value audit target flag ─────────
+
+
+def test_high_value_audit_target_feat_touching_wix_lib():
+    cat = _import_cat()
+    pr = _pr_titled(
+        1, "feat(cf-gsca): wrap getCollectionBySlug",
+        ["src/lib/wix/products.ts", "src/__tests__/get-collection-by-slug-cache.test.ts"],
+        additions=120,
+    )
+    assert cat.is_high_value_audit_target(pr) is True
+
+
+def test_high_value_audit_target_feat_touching_api_route():
+    cat = _import_cat()
+    pr = _pr_titled(
+        2, "feat(cf-54st.1): post_lookupOrder HTTP wrapper",
+        ["src/api/track-order/route.ts"],
+        additions=179,
+    )
+    assert cat.is_high_value_audit_target(pr) is True
+
+
+def test_high_value_audit_target_feat_touching_stripe_lib():
+    cat = _import_cat()
+    pr = _pr_titled(
+        3, "feat(payments): stripe webhook handler",
+        ["src/lib/stripe/webhook.ts"],
+        additions=140,
+    )
+    assert cat.is_high_value_audit_target(pr) is True
+
+
+def test_high_value_audit_target_false_for_feat_outside_sdk_paths():
+    cat = _import_cat()
+    pr = _pr_titled(
+        4, "feat(ui): new button component",
+        ["src/components/ui/Button.tsx"],
+        additions=80,
+    )
+    assert cat.is_high_value_audit_target(pr) is False
+
+
+def test_high_value_audit_target_false_for_non_feat_prefix_in_sdk_paths():
+    """`chore` retiring dead Wix modules isn't a spy-assertion candidate
+    (no new external SDK callsite); fix/refactor are also out per the
+    bead — feat is the surface-introducing prefix."""
+    cat = _import_cat()
+    pr = _pr_titled(
+        5, "chore(cf-4x7e): retire dead wix module",
+        ["src/lib/wix/dead-module.ts"],
+        additions=0, deletions=400,
+    )
+    assert cat.is_high_value_audit_target(pr) is False
+
+
+def test_high_value_audit_target_false_for_non_substantive_pr():
+    """A 5-LOC fix to src/lib/wix is trivial → not a deep-audit target,
+    even though it touches a flagged path."""
+    cat = _import_cat()
+    pr = _pr_titled(
+        6, "feat(cf-x): tiny wix tweak",
+        ["src/lib/wix/products.ts"],
+        additions=3, deletions=2,
+    )
+    # Trivial PR (≤12 LOC), so it shouldn't surface as a deep-audit target.
+    assert cat.is_high_value_audit_target(pr) is False

--- a/scripts/wave-audit/wave_audit.py
+++ b/scripts/wave-audit/wave_audit.py
@@ -19,7 +19,18 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
-from categorize import categorize, summary_histogram, deep_audit_candidates
+from categorize import (
+    categorize,
+    summary_histogram,
+    deep_audit_candidates,
+    substantive_subhistogram,
+    is_high_value_audit_target,
+)
+
+# cf-6amf.1 (cf-6amf.fu1): prefix display order — feat first (highest
+# audit value), then fix/refactor/perf, then chore/test/style, then docs
+# and "other" trailing. Stable across runs so wave-over-wave diffs read.
+_SUB_BUCKET_ORDER = ("feat", "fix", "refactor", "perf", "chore", "test", "style", "docs", "other")
 
 
 def render(prs: list[dict]) -> str:
@@ -35,6 +46,17 @@ def render(prs: list[dict]) -> str:
         lines.append(f"| {cat} | {histogram[cat]} |")
     lines.append(f"| **Total** | **{len(prs)}** |")
     lines.append("")
+
+    # cf-6amf.1: substantive sub-bucket by conventional-commit prefix.
+    sub = substantive_subhistogram(prs)
+    if histogram["substantive"] > 0:
+        lines.append("### Substantive sub-bucket (by commit prefix)\n")
+        lines.append("| Prefix | Count |")
+        lines.append("|---|---:|")
+        for prefix in _SUB_BUCKET_ORDER:
+            if sub[prefix] > 0:
+                lines.append(f"| {prefix} | {sub[prefix]} |")
+        lines.append("")
 
     # Per-PR table
     lines.append("## All PRs (categorized)\n")
@@ -59,8 +81,15 @@ def render(prs: list[dict]) -> str:
             diff = f"+{pr.get('additions', 0)}/-{pr.get('deletions', 0)}"
             sha = (pr.get("mergeCommit") or {}).get("oid", "")[:8]
             sha_note = f" (merge `{sha}`)" if sha else ""
-            lines.append(f"- **#{pr['number']}** {diff}{sha_note}: {pr.get('title', '')}")
+            # cf-6amf.1 + radahn obs#3: surface high-value targets so reviewers
+            # can prioritize feat+(wix|stripe|api-route) PRs for the spy-assertion
+            # dimension check.
+            priority = " 🎯" if is_high_value_audit_target(pr) else ""
+            lines.append(f"- **#{pr['number']}**{priority} {diff}{sha_note}: {pr.get('title', '')}")
         lines.append("")
+        if any(is_high_value_audit_target(pr) for pr in candidates):
+            lines.append("> 🎯 = priority-1 deep audit (radahn obs#3): `feat:` PR touching `src/lib/wix`, `src/lib/stripe`, or `src/api/*/route.ts` — likely introduces a new external-SDK callsite that needs a spy assertion in tests.")
+            lines.append("")
         lines.append("### Audit dimensions per candidate")
         lines.append("")
         lines.append("1. **JSDoc/block-doc on new exports** — for each `export const NAME = ...` or `export [async] function NAME(...)`, is there a comment explaining intent?")


### PR DESCRIPTION
## Summary
- Extends the cf-6amf wave-audit ritual (cf-6amf.fu1): adds a sub-classification axis to the substantive bucket using conventional-commit prefixes.
- Surfaces a 🎯 priority marker on `feat:` PRs touching external-SDK paths (`src/lib/wix`, `src/lib/stripe`, `src/api/*/route.ts`) — radahn obs#3 spy-assertion candidates.
- Closes bd cf-6amf.1.

## Motivation
Pilot wave (2026-05-15, PR #1359) hit a 71% substantive ratio (24/34). A flat bucket of 24 PRs is too coarse to guide deep-audit attention — godfrey + radahn both endorsed adding signal within the substantive set.

## API additions (categorize.py)
- `commit_prefix(title)` — case-insensitive prefix extraction; handles scope + `!` breaking-change marker; "other" fallback.
- `substantive_subhistogram(prs)` — per-prefix counts among substantive PRs (excludes pure-docs/test-only/trivial/housekeeping even if their title carries a known prefix).
- `is_high_value_audit_target(pr)` — `feat:` ∧ touches `src/lib/wix|src/lib/stripe|src/api/*/route.ts` ∧ substantive.

## Renderer additions (wave_audit.py)
- New `### Substantive sub-bucket (by commit prefix)` table after the main histogram (only emitted when substantive > 0).
- 🎯 marker on per-PR rows in the deep-audit candidates list + legend.

## Test plan
- [x] `python3 -m pytest scripts/wave-audit/ -v` — **31 passed** in 0.05s (16 baseline + 15 new).
- [x] Smoke-rendered against a hand-crafted 4-PR sample → sub-histogram correctly shows feat/perf/chore and excludes the docs PR.
- [x] Smoke-rendered against a 2-PR feat-into-wix/stripe sample → both rows show 🎯 + legend appears.
- [ ] 5-agent review per Stilgar 2026-05-15 standing order.

## 5-Agent Review Gate
Per Stilgar 2026-05-15 standing order: 5 agent approvals required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)