### PR TITLE
fix(test)(P1): add brand/business/shippingConfig to public/sharedTokens vi.mock — unblocks 43 tests

### DIFF
--- a/tests/blogRssFeedEdgeCases.test.js
+++ b/tests/blogRssFeedEdgeCases.test.js
@@ -42,7 +42,12 @@ vi.mock('backend/seoHelpers.web', () => ({
 vi.mock('wix-data', () => ({
   default: { query: vi.fn(() => ({ find: vi.fn(() => Promise.resolve({ items: [], totalCount: 0 })) })) },
 }));
-vi.mock('public/sharedTokens', () => ({ colors: {} }));
+vi.mock('public/sharedTokens', () => ({
+  colors: {},
+  brand: { name: 'Carolina Futons' },
+  business: { phoneDigits: '0000000000', address: { street: '1 Test St', city: 'Test', state: 'TS', zip: '00000' } },
+  shippingConfig: { freeThreshold: 0 },
+}));
 vi.mock('backend/utils/sanitize', () => ({ sanitize: vi.fn((s) => s), validateEmail: vi.fn(() => true) }));
 vi.mock('backend/facebookCatalog.web', () => ({
   getEnhancedCatalogFields: vi.fn(), exportCustomerAudienceData: vi.fn(),

--- a/tests/topicClusterEndpoint.test.js
+++ b/tests/topicClusterEndpoint.test.js
@@ -39,7 +39,12 @@ vi.mock('backend/seoHelpers.web', () => ({
 vi.mock('wix-data', () => ({
   default: { query: vi.fn(() => ({ find: vi.fn(() => Promise.resolve({ items: [], totalCount: 0 })) })) },
 }));
-vi.mock('public/sharedTokens', () => ({ colors: {} }));
+vi.mock('public/sharedTokens', () => ({
+  colors: {},
+  brand: { name: 'Carolina Futons' },
+  business: { phoneDigits: '0000000000', address: { street: '1 Test St', city: 'Test', state: 'TS', zip: '00000' } },
+  shippingConfig: { freeThreshold: 0 },
+}));
 vi.mock('backend/facebookCatalog.web', () => ({
   getEnhancedCatalogFields: vi.fn(), exportCustomerAudienceData: vi.fn(),
 }));

--- a/tests/topicClusterEndpointUrlEncoding.test.js
+++ b/tests/topicClusterEndpointUrlEncoding.test.js
@@ -43,7 +43,12 @@ vi.mock('backend/seoHelpers.web', () => ({
 vi.mock('wix-data', () => ({
   default: { query: vi.fn(() => ({ find: vi.fn(() => Promise.resolve({ items: [], totalCount: 0 })) })) },
 }));
-vi.mock('public/sharedTokens', () => ({ colors: {} }));
+vi.mock('public/sharedTokens', () => ({
+  colors: {},
+  brand: { name: 'Carolina Futons' },
+  business: { phoneDigits: '0000000000', address: { street: '1 Test St', city: 'Test', state: 'TS', zip: '00000' } },
+  shippingConfig: { freeThreshold: 0 },
+}));
 vi.mock('backend/facebookCatalog.web', () => ({
   getEnhancedCatalogFields: vi.fn(), exportCustomerAudienceData: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
P1 fix for the pre-existing test failure melania flagged when PM-merging cf-69fi.fu1/fu2 (PRs #1357 + #1358) at 2026-05-15 23:09. Three tests fail with `Error: [vitest] No "brand" export is defined on the "public/sharedTokens" mock`:
- `tests/blogRssFeedEdgeCases.test.js`
- `tests/topicClusterEndpoint.test.js`
- `tests/topicClusterEndpointUrlEncoding.test.js`

## Diagnosis (moment-of-truth drift pattern)

Each test mocks `public/sharedTokens` with `{ colors: {} }` only. Each then imports a backend HTTP function (`get_blogRssFeed`, `post_topicCluster`) which transitively pulls in `orderTracking.web.js → ups-shipping.web.js`. ups-shipping reads at module-load:

```js
import { brand, business, shippingConfig } from 'public/sharedTokens.js';
const ORIGIN_ADDRESS = {
  Name: brand.name,                    // ← undefined
  AddressLine: [business.address.street],
  ...
};
```

Module-init throws TypeError on `brand.name` → vitest never runs the test bodies.

## Fix

Add the full sharedTokens surface ups-shipping needs (`brand.name`, `business.{phoneDigits,address.*}`, `shippingConfig.freeThreshold`) to each of the three mocks.

## Verification

- 3/3 failing files: **all green post-fix** (43 tests pass total)
- Adjacent tests (`sharedTokens.test.js` + `brandPalette.test.js` + `conversionOptimization.test.js`): 121 tests still green
- Diff: 3 files, +18/-3 LOC

## Centralization deferred

22 other test files also mock `public/sharedTokens` with brand-missing shapes but don't transitively load `ups-shipping.web.js`, so they don't trip the brand-reader. Centralizing into `tests/__mocks__/` would be cleaner long-term — happy to file as fu1 if reviewers prefer that path.

## Reviewers (per mayor's 2026-05-15 5-agent standing order)
| Reviewer | Why chosen | Status |
|---|---|---|
| melania | flagged the failure on PM merge | Requested |
| rennala | TDD verification habit | **APPROVED** 2026-05-15 (verified stub shape against real exports + ups-shipping module-init deref chain) |
| godfrey | Velo backend (orderTracking + ups-shipping are Velo) | **APPROVED** 2026-05-15 (mock-shape expansion bounded; module-init destructure diagnosis verified) |
| miquella | 5-sub-agent CR pattern | Requested |
| radahn | dead-code/test pattern reviewer | **APPROVED** 2026-05-15 (4 non-blocking obs incl. centralization-after-4th + CONVENTIONS one-liner) |

No production code touched; no Vercel risk; 18-LOC test-fixture fix. CI tooling for clean merges resumes once this lands.

## Bead linkage
melania filed **cf-t8k1** (P2 BUG) for this exact issue post-PM-merge of #1357/#1358. PR #1363 closes cf-t8k1 — bead claimed + status set to in_progress for tracking; will close on merge.