### PR TITLE
fix(cf-r6q7)(P2): lazy-init internationalShipping.web.js — close sibling-module trap

### DIFF
--- a/src/backend/internationalShipping.web.js
+++ b/src/backend/internationalShipping.web.js
@@ -7,7 +7,40 @@ import { Permissions, webMethod } from 'wix-web-module';
 import { sanitize } from 'backend/utils/sanitize';
 import { internationalShippingConfig, business } from 'public/sharedTokens.js';
 
-const { zones, restrictedCountries, freeInternationalThreshold } = internationalShippingConfig;
+// cf-r6q7 (cf-t8k1.fu2): lazy-init the internationalShippingConfig
+// destructure. Previously this was a top-level
+//   `const { zones, restrictedCountries, freeInternationalThreshold } = internationalShippingConfig;`
+// which threw TypeError during module import if a test mocked
+// public/sharedTokens with a partial shape (missing
+// internationalShippingConfig). Mirrors the cf-t8k1.fu1 fix that
+// PR #1364 shipped for ups-shipping.web.js. Deferring computation
+// into getters decouples module-init from mock shape — tests that
+// don't exercise zone / restriction / threshold surfaces don't need
+// to mock internationalShippingConfig.
+let _zonesCache = null;
+let _restrictedCountriesCache = null;
+let _freeInternationalThresholdCache = null;
+
+export function getInternationalZones() {
+  if (_zonesCache === null) {
+    _zonesCache = internationalShippingConfig.zones;
+  }
+  return _zonesCache;
+}
+
+export function getRestrictedCountries() {
+  if (_restrictedCountriesCache === null) {
+    _restrictedCountriesCache = internationalShippingConfig.restrictedCountries;
+  }
+  return _restrictedCountriesCache;
+}
+
+export function getFreeInternationalThreshold() {
+  if (_freeInternationalThresholdCache === null) {
+    _freeInternationalThresholdCache = internationalShippingConfig.freeInternationalThreshold;
+  }
+  return _freeInternationalThresholdCache;
+}
 
 /**
  * Validate and normalize a 2-letter ISO country code.
@@ -39,18 +72,18 @@ export const getShippingZone = webMethod(
         return { success: false, error: 'US is a domestic destination — use standard shipping' };
       }
 
-      if (restrictedCountries.includes(code)) {
+      if (getRestrictedCountries().includes(code)) {
         return { success: false, error: `Cannot ship to restricted country: ${code}` };
       }
 
-      for (const [zoneName, zoneConfig] of Object.entries(zones)) {
+      for (const [zoneName, zoneConfig] of Object.entries(getInternationalZones())) {
         if (zoneConfig.countries.includes(code)) {
           return { success: true, zone: zoneName, zoneName: zoneConfig.name };
         }
       }
 
       // Not in any named zone — falls to "other"
-      return { success: true, zone: 'other', zoneName: zones.other.name };
+      return { success: true, zone: 'other', zoneName: getInternationalZones().other.name };
     } catch (err) {
       console.error('getShippingZone error:', err);
       return { success: false, error: 'Failed to determine shipping zone' };
@@ -72,7 +105,7 @@ export const isShippableCountry = webMethod(
         return { success: false, error: 'Invalid country code' };
       }
 
-      const shippable = !restrictedCountries.includes(code);
+      const shippable = !getRestrictedCountries().includes(code);
       return { success: true, shippable };
     } catch (err) {
       console.error('isShippableCountry error:', err);
@@ -101,7 +134,7 @@ export const getInternationalShippingEstimate = webMethod(
         return { success: false, error: 'Use domestic shipping for US destinations' };
       }
 
-      if (restrictedCountries.includes(code)) {
+      if (getRestrictedCountries().includes(code)) {
         return { success: false, error: `Cannot ship to restricted country: ${code}` };
       }
 
@@ -109,8 +142,8 @@ export const getInternationalShippingEstimate = webMethod(
       const subtotal = Math.max(0, Number(orderSubtotal) || 0);
 
       // Determine zone
-      let zoneConfig = zones.other;
-      for (const [, config] of Object.entries(zones)) {
+      let zoneConfig = getInternationalZones().other;
+      for (const [, config] of Object.entries(getInternationalZones())) {
         if (config.countries.includes(code)) {
           zoneConfig = config;
           break;
@@ -118,7 +151,7 @@ export const getInternationalShippingEstimate = webMethod(
       }
 
       // Check free shipping threshold
-      if (subtotal >= freeInternationalThreshold) {
+      if (subtotal >= getFreeInternationalThreshold()) {
         return {
           success: true,
           estimate: {
@@ -172,7 +205,7 @@ export const getInternationalShippingRates = webMethod(
         return { success: false, error: 'Invalid destination country' };
       }
 
-      if (restrictedCountries.includes(country)) {
+      if (getRestrictedCountries().includes(country)) {
         return { success: false, error: `Cannot ship to restricted country: ${country}` };
       }
 
@@ -181,9 +214,9 @@ export const getInternationalShippingRates = webMethod(
       const totalWeight = pkgs.reduce((sum, p) => sum + (Number(p?.weight) || 0), 0);
 
       // Determine zone
-      let zoneConfig = zones.other;
+      let zoneConfig = getInternationalZones().other;
       let zoneName = 'other';
-      for (const [name, config] of Object.entries(zones)) {
+      for (const [name, config] of Object.entries(getInternationalZones())) {
         if (config.countries.includes(country)) {
           zoneConfig = config;
           zoneName = name;
@@ -192,7 +225,7 @@ export const getInternationalShippingRates = webMethod(
       }
 
       // Free shipping check
-      const freeShipping = subtotal >= freeInternationalThreshold;
+      const freeShipping = subtotal >= getFreeInternationalThreshold();
 
       // Build zone-based estimated rates
       const weightCharge = Math.max(0, totalWeight) * zoneConfig.perPoundRate;

--- a/tests/internationalShippingLazyInit.test.js
+++ b/tests/internationalShippingLazyInit.test.js
@@ -1,0 +1,114 @@
+/**
+ * cf-r6q7 (cf-t8k1.fu2) — Pins the lazy-init contract for
+ * internationalShipping.web.js module-init reads.
+ *
+ * Pre-fix shape: top-level
+ *   `const { zones, restrictedCountries, freeInternationalThreshold } = internationalShippingConfig;`
+ * threw TypeError during module import if the public/sharedTokens mock
+ * didn't return `internationalShippingConfig`. Blocked the entire test
+ * file's collection before any test body ran — sibling of the cf-t8k1
+ * trap that PR #1363 / PR #1364 closed for ups-shipping.web.js.
+ *
+ * Post-fix shape: 3 lazy-init getters
+ *   - getInternationalZones()
+ *   - getRestrictedCountries()
+ *   - getFreeInternationalThreshold()
+ * each cached via module-level `let _cache = null`.
+ *
+ * Contracts pinned:
+ *  1. Module imports cleanly with EMPTY public/sharedTokens mock
+ *  2. Getters throw at CALL-TIME (not module-init) when fields are missing
+ *  3. Getters return correct values when mock IS shaped
+ *  4. Getters are memoized — repeat calls return identical references
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Deliberately empty mock — pre-fix this would throw on import below.
+vi.mock('public/sharedTokens.js', () => ({}));
+
+// Stub the rest so the import path runs to completion.
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+describe('cf-r6q7 — internationalShipping lazy-init contract', () => {
+  it('imports cleanly with EMPTY public/sharedTokens mock (no module-init deref)', async () => {
+    // Pre-fix: this import throws TypeError ("Cannot destructure property
+    // 'zones' of undefined") because internationalShippingConfig is
+    // destructured at module top-level.
+    //
+    // Post-fix: import succeeds because the destructure is deferred into
+    // getter functions called only when zone / restriction / threshold
+    // lookups actually fire.
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    expect(mod).toBeDefined();
+    expect(typeof mod.getInternationalZones).toBe('function');
+    expect(typeof mod.getRestrictedCountries).toBe('function');
+    expect(typeof mod.getFreeInternationalThreshold).toBe('function');
+  });
+
+  it('getInternationalZones throws clearly when sharedTokens fields are missing', async () => {
+    // Calling the getter when the mock is empty is still expected to
+    // throw — but it throws at CALL TIME from a specific operation, not
+    // at module-init blocking unrelated tests.
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    expect(() => mod.getInternationalZones()).toThrow();
+  });
+});
+
+describe('cf-r6q7 — internationalShipping lazy-init with proper mock', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock('public/sharedTokens.js', () => ({
+      internationalShippingConfig: {
+        zones: {
+          canada: { name: 'Canada', countries: ['CA'], rates: { ground: 50 } },
+          other: { name: 'Other', countries: [], rates: { ground: 200 } },
+        },
+        restrictedCountries: ['XX', 'YY'],
+        freeInternationalThreshold: 5000,
+      },
+      business: { name: 'Test Co' },
+    }));
+    vi.doMock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+    vi.doMock('wix-web-module', () => ({
+      Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+      webMethod: (_perm, fn) => fn,
+    }));
+  });
+
+  it('getInternationalZones returns the zones object shape', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    const zones = mod.getInternationalZones();
+    expect(zones).toHaveProperty('canada');
+    expect(zones.canada.name).toBe('Canada');
+    expect(zones.canada.countries).toEqual(['CA']);
+  });
+
+  it('getRestrictedCountries returns the restriction list', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    expect(mod.getRestrictedCountries()).toEqual(['XX', 'YY']);
+  });
+
+  it('getFreeInternationalThreshold returns the threshold dollars', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    expect(mod.getFreeInternationalThreshold()).toBe(5000);
+  });
+
+  it('getInternationalZones is memoized — repeat calls return identical reference', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    const a = mod.getInternationalZones();
+    const b = mod.getInternationalZones();
+    expect(a).toBe(b);
+  });
+
+  it('getRestrictedCountries is memoized — repeat calls return identical reference', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    const a = mod.getRestrictedCountries();
+    const b = mod.getRestrictedCountries();
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes the cf-t8k1 trap's last domino: `src/backend/internationalShipping.web.js:10` was destructuring `internationalShippingConfig` at module-init, same failure shape as `ups-shipping.web.js` before PR #1364.
- Mirrors the cf-t8k1.fu1 pattern: 3 lazy-init getters replace the top-level destructure.
- Closes bd cf-r6q7.

## Sibling-module sweep
Per miquella's cf-t8k1.fu1 review note: of 6 backend `.web.js` modules importing from `public/sharedTokens`, only `ups-shipping` (fixed in #1364) and `internationalShipping` (this PR) had the module-init destructure trap. **No further dominos.**

## Internal callers updated
- 3× `restrictedCountries.includes(...)` → `getRestrictedCountries().includes(...)`
- 3× `Object.entries(zones)` → `Object.entries(getInternationalZones())`
- 3× `zones.other` → `getInternationalZones().other`
- 2× `freeInternationalThreshold` comparison → `getFreeInternationalThreshold()`

## Test plan
- [x] `npx vitest run tests/internationalShippingLazyInit.test.js` — 7/7 green (RED→GREEN; 7/7 failed pre-fix)
- [x] `npx vitest run tests/internationalShipping.test.js tests/internationalShippingDeep.test.js` — 43/43 still green
- [x] Total: 50/50 international-shipping suite green
- [ ] 5-agent review per Stilgar 2026-05-15 standing order

## TDD contracts pinned (mirrors `upsShippingLazyInit.test.js`)
1. Module imports cleanly with EMPTY public/sharedTokens mock
2. Getters throw at CALL-TIME (not module-init) when fields missing — locality of failure
3. Getters return correct values when mock IS shaped
4. Reference-equality memoization on repeat calls

## Branch naming note
Branch is `-v2` because the unsuffixed name was clobbered by a parallel rennala instance's force-push to a different repo's branch sharing the same name. 3rd cfw collision tonight — recovery via cherry-pick from reflog. Flagged to melania.

## 5-Agent Review Gate
Per Stilgar 2026-05-15 standing order: 5 agent approvals required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)