### PR TITLE
fix(cf-44qt)(P2): internationalShipping silent-failure cleanup — drop $199.99 fabrication, wire logError

### DIFF
--- a/src/backend/internationalShipping.web.js
+++ b/src/backend/internationalShipping.web.js
@@ -5,7 +5,8 @@
 
 import { Permissions, webMethod } from 'wix-web-module';
 import { sanitize } from 'backend/utils/sanitize';
-import { internationalShippingConfig } from 'public/sharedTokens.js';
+import { logError } from 'backend/utils/errorHandler';
+import { internationalShippingConfig, business } from 'public/sharedTokens.js';
 
 // cf-t8k1.fu2: lazy-init internationalShippingConfig destructure. The
 // pre-fix shape was `const { zones, restrictedCountries,
@@ -94,7 +95,7 @@ export const getShippingZone = webMethod(
       // Not in any named zone — falls to "other"
       return { success: true, zone: 'other', zoneName: zones.other.name };
     } catch (err) {
-      console.error('getShippingZone error:', err);
+      logError('internationalShipping:getShippingZone', err);
       return { success: false, error: 'Failed to determine shipping zone' };
     }
   }
@@ -119,7 +120,7 @@ export const isShippableCountry = webMethod(
       const shippable = !restrictedCountries.includes(code);
       return { success: true, shippable };
     } catch (err) {
-      console.error('isShippableCountry error:', err);
+      logError('internationalShipping:isShippableCountry', err);
       return { success: false, error: 'Failed to check shipping eligibility' };
     }
   }
@@ -197,7 +198,7 @@ export const getInternationalShippingEstimate = webMethod(
         },
       };
     } catch (err) {
-      console.error('getInternationalShippingEstimate error:', err);
+      logError('internationalShipping:getInternationalShippingEstimate', err);
       return { success: false, error: 'Failed to estimate international shipping' };
     }
   }
@@ -272,21 +273,17 @@ export const getInternationalShippingRates = webMethod(
 
       return { success: true, rates, estimated: true };
     } catch (err) {
-      console.error('getInternationalShippingRates error:', err);
-
-      // Fallback rates
+      // cf-44qt: previously this catch returned `success: true` with a
+      // fabricated $199.99 rate, which silently shipped a guessed
+      // price to /checkout on ANY misconfig — and the error went only
+      // to `console.error` (no Sentry). Now: structured failure +
+      // logError so the caller decides whether to surface fallback
+      // pricing, and Sentry traces the root cause.
+      logError('internationalShipping:getInternationalShippingRates', err);
       return {
-        success: true,
-        rates: [
-          {
-            code: 'intl-flat-standard',
-            title: 'International Shipping (Estimated)',
-            cost: 199.99,
-            currency: 'USD',
-            estimatedDays: '14-28',
-          },
-        ],
-        estimated: true,
+        success: false,
+        error: 'Failed to calculate international shipping rates',
+        code: 'INTERNATIONAL_RATE_ERROR',
       };
     }
   }

--- a/tests/internationalShippingSilentFailureCleanup.test.js
+++ b/tests/internationalShippingSilentFailureCleanup.test.js
@@ -1,0 +1,110 @@
+/**
+ * cf-44qt (cf-r6q7.fu1) — Pins the silent-failure cleanup contract:
+ *
+ *   1. catch blocks return { success: false, error, code } — no more
+ *      `success: true` with fabricated $199.99 rates.
+ *   2. catch blocks invoke `logError` (errorHandler) — not raw
+ *      `console.error` — so Sentry sees the misconfig.
+ *
+ * Origin: cf-r6q7 / PR #1366 silent-failure-hunter dim flagged that
+ * `getInternationalShippingRates` returned `success: true` with a
+ * fabricated $199.99 rate on ANY thrown error. Post-cf-r6q7 lazy-init,
+ * that catch path is reachable at runtime (not just at deploy) when
+ * any subset of internationalShippingConfig is missing.
+ *
+ * Test strategy: mock `internationalShippingConfig` so a getter call
+ * inside the webMethod synchronously throws TypeError; assert the
+ * webMethod returns the structured error shape and that `logError`
+ * was called.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Spy on logError so we can assert the catch wired it correctly.
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+// Sharded mock: zones is undefined → getInternationalZones throws on
+// first deref. The other config fields are populated so non-throwing
+// webMethods still work.
+vi.mock('public/sharedTokens.js', () => ({
+  internationalShippingConfig: {
+    // zones intentionally absent — causes `internationalShippingConfig.zones`
+    // to return undefined; downstream `Object.entries(undefined)` throws.
+    restrictedCountries: ['CU', 'IR', 'KP'],
+    freeInternationalThreshold: 1500,
+  },
+  business: { address: {} },
+}));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+describe('cf-44qt — internationalShipping silent-failure cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    vi.resetModules();
+  });
+
+  it('getInternationalShippingRates returns success:false with INTERNATIONAL_RATE_ERROR code on throw', async () => {
+    // Pre-fix: this returned `{ success: true, rates: [{ cost: 199.99 }], estimated: true }` —
+    // a fabricated rate that customers would actually be charged.
+    // Post-fix: structured error response, customer-side fallback explicit.
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    const result = await mod.getInternationalShippingRates(
+      { country: 'CA', postalCode: 'M5V', city: 'Toronto', state: 'ON' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('INTERNATIONAL_RATE_ERROR');
+    expect(result.error).toBeTruthy();
+    // No fabricated rates leak through.
+    expect(result.rates).toBeUndefined();
+  });
+
+  it('getInternationalShippingRates wires logError on catch (Sentry surface)', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    await mod.getInternationalShippingRates(
+      { country: 'CA', postalCode: 'M5V' },
+      [{ weight: 50 }],
+      500,
+    );
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toContain('internationalShipping');
+  });
+
+  it('getShippingZone wires logError on catch (no raw console.error)', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    // 'CA' would normally succeed, but with zones missing the
+    // Object.entries call inside throws.
+    const result = await mod.getShippingZone('CA');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+  });
+
+  it('getInternationalShippingEstimate wires logError on catch', async () => {
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    const result = await mod.getInternationalShippingEstimate('CA', 50, 500);
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+  });
+
+  it('isShippableCountry still wires logError when restricted check itself fails', async () => {
+    // isShippableCountry doesn't touch zones — happy path here.
+    // To force its catch, we'd need restrictedCountries to throw,
+    // which requires a different mock shape. Instead pin the happy
+    // path doesn't log spuriously, and the existing
+    // `internationalShipping.test.js` covers the wider success/failure
+    // matrix.
+    const mod = await import('../src/backend/internationalShipping.web.js');
+    const result = await mod.isShippableCountry('CA');
+    expect(result.success).toBe(true);
+    expect(result.shippable).toBe(true);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Origin

Filed by godfrey from cf-r6q7 / PR #1366 silent-failure-hunter dim. The lazy-init sibling-sweep (cf-r6q7) made these catch-block pathologies reachable at runtime, not just at deploy. Melania assigned via direct nudge.

## Two silent failures fixed

**1. `$199.99` fabrication in `getInternationalShippingRates` catch block.**

Pre-fix:
\`\`\`js
} catch (err) {
  console.error('getInternationalShippingRates error:', err);
  return {
    success: true,
    rates: [{ code: 'intl-flat-standard', title: '...', cost: 199.99, ... }],
    estimated: true,
  };
}
\`\`\`

On ANY thrown error, returned `success: true` with a fabricated $199.99 rate — /checkout would charge customers a guessed price for a real misconfig with no operator signal. Post-fix: structured `{ success: false, error, code: 'INTERNATIONAL_RATE_ERROR' }`.

**2. No Sentry trace on misconfigs.**

All 4 catch blocks used `console.error` (Velo console only) instead of `logError` from `backend/utils/errorHandler` (Sentry convention used by 12+ other backend modules: challengeService, swatchAttribution, gamificationWidgets, tradeInService, bundleService, etc.). Post-fix: `logError('internationalShipping:<fnName>', err)` across all 4 catch blocks.

## TDD (5 cases, mirrors logError convention from sibling modules)

| # | Test |
|---|---|
| 1 | `getInternationalShippingRates` returns `success:false` + `INTERNATIONAL_RATE_ERROR` code on throw |
| 2 | `getInternationalShippingRates` wires `logError` with `internationalShipping:` tag |
| 3 | `getShippingZone` wires `logError` on catch |
| 4 | `getInternationalShippingEstimate` wires `logError` on catch |
| 5 | `isShippableCountry` happy path doesn't log spuriously (negative pin) |

## Verification

- 5/5 new tests pass ✅
- 43 existing internationalShipping suite green (28 + 15) ✅
- Total **48/48 across 3 files**

## Caller note (NOT in scope)

`shipping-rates-plugin.js:139-146` has its own caller-side `$199.99` fallback when `intlResult.success === false`. That's a /checkout UX policy decision (different file, different ownership). Customer-facing behavior remains the same — still defaults to $199.99 estimate — but now Sentry sees the inner-module root-cause trace via `logError`. Filing follow-up if mayor wants the caller-side fabrication also removed.

## Pre-flight

- [x] vitest 5/5 new + 43/43 existing
- [x] `node --check` clean
- [ ] CI green
- [ ] 5-agent crew sign-offs per mayor 2026-05-15

5-agent review dispatching.

Refs cf-44qt (this), cf-r6q7 (PR #1366), cf-t8k1.fu1 (PR #1364)

🤖 Generated with [Claude Code](https://claude.com/claude-code)