### PR TITLE
fix(cf-uydr)(P3): emailAutomation.web.js — console.error → logError ×19

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -175,7 +175,7 @@ export function wixMembers_onMemberCreated(event) {
   if (!email) return;
 
   return triggerWelcomeSequence(contactId, email, firstName)
-    .catch(err => console.error('Error triggering welcome sequence:', err));
+    .catch(err => logError('emailAutomation:welcomeSequence-trigger', err));
 }
 
 /**
@@ -205,12 +205,12 @@ export function wixEcom_onOrderCreated(event) {
     orderNumber: String(orderNumber),
     total: typeof total === 'number' ? `$${total.toFixed(2)}` : String(total),
     itemSummary: lineItems.map(i => `${i.quantity}× ${i.name}`).join(', '),
-  }).catch(err => console.error('Error sending order confirmation:', err));
+  }).catch(err => logError('emailAutomation:orderConfirmation-send', err));
 
   // CF-fzsd: Queue post-purchase care sequence at order creation so slug
   // extraction from lineItems is available (Day 7 review URL uses product slug).
   return triggerPostPurchaseSequence(contactId, email, firstName, String(orderNumber), total, lineItems)
-    .catch(err => console.error('[CF-fzsd] Error queuing post-purchase sequence on order created:', err));
+    .catch(err => logError('emailAutomation:postPurchase-queue-onOrderCreated', err));
 }
 
 /**
@@ -261,7 +261,7 @@ export function handleFulfillmentShippingNotification(event) {
       proNumber: payload.proNumber,
       trackingUrl: payload.trackingUrl || '',
       carrier: payload.displayCarrier,
-    }).catch(err => console.error('Error sending fulfillment notification:', err));
+    }).catch(err => logError('emailAutomation:shippingNotification-send-freight', err));
   } else {
     sendShippingNotification({
       contactId,
@@ -271,7 +271,7 @@ export function handleFulfillmentShippingNotification(event) {
       trackingNumber: tracking.trackingNumber || '',
       trackingUrl: tracking.trackingLink || '',
       carrier: tracking.shippingProvider || '',
-    }).catch(err => console.error('Error sending fulfillment notification:', err));
+    }).catch(err => logError('emailAutomation:shippingNotification-send-parcel', err));
   }
 }
 
@@ -351,7 +351,7 @@ export function wixEcom_onOrderCanceled(event) {
   if (!email) return;
 
   cancelSequenceForOrder(email, orderNumber)
-    .catch(err => console.error('Error cancelling care sequence:', err));
+    .catch(err => logError('emailAutomation:careSequence-cancel', err));
 }
 
 // ── Public Web Methods ────────────────────────────────────────────────
@@ -455,7 +455,7 @@ export const triggerWelcomeSequence = webMethod(
 
       return { success: true, queued };
     } catch (err) {
-      console.error('Error queuing welcome sequence:', err);
+      logError('emailAutomation:triggerWelcomeSequence-queue', err);
       return { success: false, queued: 0 };
     }
   }
@@ -543,7 +543,7 @@ export const triggerWelcomeSeries = webMethod(
 
       return { success: true, queued };
     } catch (err) {
-      console.error('Error queuing welcome series:', err);
+      logError('emailAutomation:triggerWelcomeSeries-queue', err);
       return { success: false, queued: 0 };
     }
   }
@@ -655,7 +655,7 @@ export const triggerPostPurchaseSequence = webMethod(
                 variables.referralCode = refData.referralCode;
               }
             } catch (refErr) {
-              console.error('[emailAutomation] Referral link generation failed (non-blocking):', refErr);
+              logError('emailAutomation:referralLink-nonblocking', refErr);
             }
           }
           // Sentinel defaults — template should handle gracefully
@@ -677,7 +677,7 @@ export const triggerPostPurchaseSequence = webMethod(
 
       return { success: true, queued };
     } catch (err) {
-      console.error('Error queuing post-purchase sequence:', err);
+      logError('emailAutomation:triggerPostPurchaseSequence-queue', err);
       return { success: false, queued: 0 };
     }
   }
@@ -944,8 +944,10 @@ export const triggerAbandonedCartRecovery = webMethod(
                 discountAvailable = true;
               }
             } catch (e) {
-              console.error('[emailAutomation] createCartRecoveryCoupon failed for cart', cart.checkoutId,
-                '— email:', cartEmail, '— step 3 will send without discount. Error:', e.message);
+              logError(
+                `emailAutomation:cartRecoveryCoupon-create cart=${cart.checkoutId} email=${redactEmail(cartEmail)} step3WillSendWithoutDiscount`,
+                e,
+              );
             }
           }
 
@@ -1001,7 +1003,7 @@ export const triggerAbandonedCartRecovery = webMethod(
 
       return { success: true, cartsProcessed };
     } catch (err) {
-      console.error('Error processing cart recovery:', err);
+      logError('emailAutomation:triggerAbandonedCartRecovery', err);
       return { success: false, cartsProcessed: 0 };
     }
   }
@@ -1118,7 +1120,7 @@ export const triggerReengagement = webMethod(
 
       return { success: true, contacted };
     } catch (err) {
-      console.error('Error processing reengagement:', err);
+      logError('emailAutomation:triggerReengagement', err);
       return { success: false, contacted: 0 };
     }
   }
@@ -1228,7 +1230,7 @@ export const processEmailQueue = webMethod(
 
       return { sent, failed, cancelled, deferred };
     } catch (err) {
-      console.error('Error processing email queue:', err);
+      logError('emailAutomation:processEmailQueue', err);
       return { sent: 0, failed: 0, cancelled: 0, deferred: 0 };
     }
   }
@@ -1284,7 +1286,7 @@ export const unsubscribeContact = webMethod(
       logAuditEvent('Unsubscribes', 'unsubscribe', cleanEmail, { sequenceType: cleanType });
       return { success: true };
     } catch (err) {
-      console.error('Error processing unsubscribe:', err);
+      logError('emailAutomation:unsubscribeContact', err);
       return { success: false };
     }
   }
@@ -1326,7 +1328,7 @@ export const recordEmailEvent = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('Error recording email event:', err);
+      logError('emailAutomation:recordEmailEvent', err);
       return { success: false };
     }
   }
@@ -1507,7 +1509,7 @@ export const triggerRestockNotifications = webMethod(
 
       return { success: true, notified, failed };
     } catch (err) {
-      console.error('[emailAutomation] Error triggering restock notifications:', err);
+      logError('emailAutomation:triggerRestockNotifications', err);
       return { success: false, notified: 0, failed: 0, error: err.message };
     }
   }
@@ -1570,7 +1572,7 @@ export const getAbTestResults = webMethod(
         })),
       };
     } catch (err) {
-      console.error('[emailAutomation] Error getting A/B test results:', err);
+      logError('emailAutomation:getAbTestResults', err);
       return { tests: [], error: err.message };
     }
   }
@@ -1722,7 +1724,7 @@ export const getCampaignAnalytics = webMethod(
         abTestSummary,
       };
     } catch (err) {
-      console.error('[emailAutomation] Error fetching campaign analytics:', err);
+      logError('emailAutomation:getCampaignAnalytics', err);
       return {
         success: false,
         error: err.message,

--- a/tests/cartRecoveryActivation.test.js
+++ b/tests/cartRecoveryActivation.test.js
@@ -20,6 +20,7 @@ vi.mock('backend/utils/sanitize', () => ({
     return str.replace(/<[^>]*>/g, '').trim().slice(0, maxLen);
   },
   validateEmail: (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email),
+  redactEmail: (str) => str,
 }));
 
 // Intercept createCartRecoveryCoupon so we control its output
@@ -217,17 +218,15 @@ describe('triggerAbandonedCartRecovery — coupon failure fallback', () => {
   });
 
   it('logs an error when createCartRecoveryCoupon throws', async () => {
+    // logError emits console.error('[context]', message) — 2 args.
+    // The context tag encodes cart id; message is the thrown error string.
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockCreateCoupon.mockRejectedValueOnce(new Error('network timeout'));
     seedAbandonedCart({ buyerEmail: 'test@example.com', checkoutId: 'co-test' });
     await triggerAbandonedCartRecovery();
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[emailAutomation]'),
-      expect.stringContaining('co-test'),
-      expect.anything(),
-      expect.stringContaining('test@example.com'),
-      expect.anything(),
-      expect.anything()
+      expect.stringContaining('[emailAutomation:cartRecoveryCoupon-create cart=co-test'),
+      expect.stringContaining('network timeout'),
     );
     errorSpy.mockRestore();
   });

--- a/tests/emailAutomationLogErrorMigration.test.js
+++ b/tests/emailAutomationLogErrorMigration.test.js
@@ -1,0 +1,76 @@
+/**
+ * cf-uydr (cf-44qt.fu1) — pins the console.error → logError migration in
+ * src/backend/emailAutomation.web.js. 19 catch sites converted to use the
+ * `logError(tag, err)` shape from `backend/utils/errorHandler` so Sentry
+ * sees all email-automation failures (previously `console.error` only hit
+ * Velo console).
+ *
+ * Strategy: static-string assertions on the source file. This proves the
+ * swap is complete + the tag list is consistent. Behavioral regression
+ * coverage comes from the existing emailAutomation.test.js +
+ * emailAutomationErrorHandling.test.js + emailAutomationDeepen.test.js
+ * suites which exercise the catch paths.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/emailAutomation.web.js'),
+  'utf-8',
+);
+
+// Each expected logError tag — one per swapped site. Order matches the
+// file's top-to-bottom layout for ease of forensic review.
+const EXPECTED_TAGS = [
+  'emailAutomation:welcomeSequence-trigger',
+  'emailAutomation:orderConfirmation-send',
+  'emailAutomation:postPurchase-queue-onOrderCreated',
+  'emailAutomation:shippingNotification-send-freight',
+  'emailAutomation:shippingNotification-send-parcel',
+  'emailAutomation:careSequence-cancel',
+  'emailAutomation:triggerWelcomeSequence-queue',
+  'emailAutomation:triggerWelcomeSeries-queue',
+  'emailAutomation:referralLink-nonblocking',
+  'emailAutomation:triggerPostPurchaseSequence-queue',
+  'emailAutomation:cartRecoveryCoupon-create',
+  'emailAutomation:triggerAbandonedCartRecovery',
+  'emailAutomation:triggerReengagement',
+  'emailAutomation:processEmailQueue',
+  'emailAutomation:unsubscribeContact',
+  'emailAutomation:recordEmailEvent',
+  'emailAutomation:triggerRestockNotifications',
+  'emailAutomation:getAbTestResults',
+  'emailAutomation:getCampaignAnalytics',
+];
+
+describe('cf-uydr — emailAutomation.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls (all 19 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    // Accept either single-quoted ('tag') or template-literal (`tag ...`)
+    // forms — `cartRecoveryCoupon-create` uses a template literal to
+    // include the cart.checkoutId + redactEmail context in the tag.
+    expect(SRC).toMatch(new RegExp(`logError\\([\\s\\n]*['\`]${tag.replace(/[.*+?^${}()|[\\\]\\\\]/g, '\\\\$&')}`));
+  });
+
+  it('logError call count is at least 25 (the 19 migrated sites + 6 pre-existing)', () => {
+    // Pre-cf-uydr: 6 logError calls (handleOrderDelivered :confirmation /
+    // :postPurchaseCare / :survey + triggerConsultationFollowup +
+    // triggerSwatchFollowupSequence + checkAndTriggerTierMilestone).
+    // Post-cf-uydr: + 19 new = 25 total minimum.
+    const matches = SRC.match(/\blogError\s*\(/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(25);
+  });
+});


### PR DESCRIPTION
## Origin

Continuation of cf-44qt (PR #1368, internationalShipping silent-failure cleanup). \`emailAutomation.web.js\` already imported \`logError\` from \`backend/utils/errorHandler\` (line 43) but still used \`console.error\` in 19 catch sites — partial migration. Production misconfigs in any of these paths hit only Velo console, never Sentry.

## What changed

- **19 catch sites** in \`src/backend/emailAutomation.web.js\` converted to \`logError('emailAutomation:<fn>-<reason>', err)\`.
- **\`cartRecoveryCoupon-create\` tag** uses a template literal with dynamic context (cart id + redacted email) — most actionable trace for the checkout-coupon-failure incident class.
- All other tags are static strings for grep-ability.

## TDD (22 cases in \`tests/emailAutomationLogErrorMigration.test.js\`)

| # | Pin |
|---|---|
| 1 | Zero \`console.error\` remaining in source |
| 2 | \`logError\` imported from \`backend/utils/errorHandler\` |
| 3-21 | Each of the 19 expected tags appears (regex admits single-quoted + template-literal forms) |
| 22 | Total \`logError\` count ≥ 25 (19 new + 6 pre-existing) |

## Verification

- New migration test: **22/22** ✅
- Full \`emailAutomation/\` suite (8 files): **265/265** ✅ — no behavioral regression
- \`node --check\` clean

## Net effect

Sentry now sees every email-automation failure path with a structured tag (\`emailAutomation:<fn>-<reason>\`). On-call investigators can grep the channel for \`emailAutomation:\` to find the surface; the reason suffix identifies which catch fired.

## Pre-flight

- [x] vitest 22 new + 265 existing
- [x] cf-ukc6 not applicable (cfutons, not cfw)
- [ ] CI green
- [ ] 5-agent crew sign-offs per mayor 2026-05-15

5-agent review dispatching.

Refs cf-uydr (this), cf-44qt (sibling pattern, PR #1368)

🤖 Generated with [Claude Code](https://claude.com/claude-code)