### PR TITLE
fix(cf-qyjw)(P3): npm override d3-color@^3.1.0 — close Dependabot HIGH (ReDoS)

### DIFF
--- a/packages/hookup-assistant/package-lock.json
+++ b/packages/hookup-assistant/package-lock.json
@@ -2834,11 +2834,14 @@
       "optional": true
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-dispatch": {
       "version": "2.0.0",

--- a/packages/hookup-assistant/package.json
+++ b/packages/hookup-assistant/package.json
@@ -15,6 +15,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
+  "overrides": {
+    "d3-color": "^3.1.0"
+  },
   "optionalDependencies": {
     "@wix/design-system": "^1.260.0",
     "@wix/editor": "^1.451.0",


### PR DESCRIPTION
## Summary
- Closes the 1 HIGH Dependabot alert (d3-color ReDoS, GHSA-36jr-mh4h-2g58) flagged on \`packages/hookup-assistant/package-lock.json\`.
- Adds \`"overrides": { "d3-color": "^3.1.0" }\` to packages/hookup-assistant/package.json + regenerates lockfile.
- Closes bd cf-qyjw (cf-dbw9.fu1).

## Verification
- \`npm ls d3-color\` shows \`d3-color@3.1.0 overridden\` on the d3-transition branch + \`d3-color@3.1.0 deduped\` on the d3-scale branch. Both resolve to the patched version.
- \`npm audit\` returns **0 vulnerabilities**.
- Pre-existing TypeScript build errors (Wix SDK \`components\` property + tests/hookupPanel.test.tsx type drift) verified unchanged from main via stash+rebuild. Not caused by this PR; tracked separately.

## Why npm override (radahn's recommended option 1)
- **Smallest blast radius** — touches only the hookup-assistant subpackage.
- **Deterministic** — doesn't depend on Wix shipping cadence (option 2 per radahn's triage is "indefinite timeline").
- **Honest** — option 3 (suppress as "won't fix - upstream") leaves the vulnerable code in the lockfile even though the threat model (server-side ReDoS) is irrelevant to a static Wix Studio editor tool. Override fixes the actual artifact.
- **API-compatible** — d3-color 3.x is backward-compatible at the API level for the consumers in the d3-* tree (d3-scale, d3-interpolate, d3-transition all consume it via the same surface).

## Test plan
- [x] \`npm install\` regenerated lockfile cleanly (468 packages, 0 vulns)
- [x] \`npm ls d3-color\` confirms 3.1.0 resolution on both branches
- [x] \`npm audit\` 0 vulnerabilities
- [x] Pre-existing TS build errors verified unchanged from main
- [ ] 5-agent review per Stilgar 2026-05-15 standing order

## 5-Agent Review Gate
Per Stilgar 2026-05-15 standing order: 5 agent approvals required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)