### PR TITLE
fix(cf-g79m)(P4): emailAutomation logError tag normalization — 6 sites prefixed

### DIFF
--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -310,12 +310,12 @@ export function handleOrderDelivered(event) {
     email,
     firstName,
     orderNumber: String(orderNumber),
-  }).catch(err => logError('handleOrderDelivered:confirmation', err));
+  }).catch(err => logError('emailAutomation:handleOrderDelivered:confirmation', err));
 
   // CF-nkau: Queue post-purchase care sequence starting from delivery date
   // Day 3: care guide, Day 7: review request, Day 30: cross-sell recommendations
   triggerPostPurchaseSequence(contactId, email, firstName, String(orderNumber), total, lineItems)
-    .catch(err => logError('handleOrderDelivered:postPurchaseCare', err));
+    .catch(err => logError('emailAutomation:handleOrderDelivered:postPurchaseCare', err));
 
   // CF-qy79 review-reward prompt removed alongside triggerReviewRewardPrompt
   // (cf-namd Pass 3 chunk B — webMethod was unreachable; the post-purchase
@@ -328,7 +328,7 @@ export function handleOrderDelivered(event) {
     orderId: order._id || String(orderNumber),
     email,
     deliveredAt: new Date(),
-  }).catch(err => logError('handleOrderDelivered:survey', err));
+  }).catch(err => logError('emailAutomation:handleOrderDelivered:survey', err));
 }
 
 /**
@@ -753,7 +753,7 @@ export const triggerConsultationFollowup = webMethod(
 
       return { success: true, queued: 1 };
     } catch (err) {
-      logError('triggerConsultationFollowup', err);
+      logError('emailAutomation:triggerConsultationFollowup', err);
       return { success: false, queued: 0 };
     }
   }
@@ -839,7 +839,7 @@ export const triggerSwatchFollowupSequence = webMethod(
 
       return { success: true, queued };
     } catch (err) {
-      logError('triggerSwatchFollowupSequence', err);
+      logError('emailAutomation:triggerSwatchFollowupSequence', err);
       return { success: false, queued: 0 };
     }
   }
@@ -1822,7 +1822,7 @@ export async function checkAndTriggerTierMilestone(memberId, email, firstName, n
           sentAt: now,
         });
       } catch (err) {
-        logError(`checkAndTriggerTierMilestone:${milestone.milestoneKey}`, err);
+        logError(`emailAutomation:checkAndTriggerTierMilestone:${milestone.milestoneKey}`, err);
       }
     }
   }

--- a/tests/emailAutomationTagNormalization.test.js
+++ b/tests/emailAutomationTagNormalization.test.js
@@ -1,0 +1,71 @@
+/**
+ * cf-g79m (cf-uydr.fu1) — pins the logError tag normalization in
+ * src/backend/emailAutomation.web.js. cf-uydr migrated 19 console.error
+ * sites with `emailAutomation:<fn>-<reason>` tags; this PR brings the
+ * 6 pre-existing (non-prefixed) logError calls under the same naming
+ * convention so Sentry can group all email-automation surfaces by a
+ * single `emailAutomation:*` prefix.
+ *
+ * Strategy: static-string assertion on the source file. Same shape as
+ * the cf-uydr migration test. Behavioral coverage for the underlying
+ * functions lives in their respective test files (cf-fzsd review email,
+ * cf-tcj5 consultation, cf-jm5t swatch, cf-nkau post-purchase,
+ * cf-8onx tier-milestone, etc.) — those already exercise the catch
+ * paths; this test only pins the tag-string shape.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/emailAutomation.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_PREFIXED_TAGS = [
+  'emailAutomation:handleOrderDelivered:confirmation',
+  'emailAutomation:handleOrderDelivered:postPurchaseCare',
+  'emailAutomation:handleOrderDelivered:survey',
+  'emailAutomation:triggerConsultationFollowup',
+  'emailAutomation:triggerSwatchFollowupSequence',
+  'emailAutomation:checkAndTriggerTierMilestone',
+];
+
+const FORBIDDEN_LEGACY_TAGS = [
+  "logError('handleOrderDelivered:confirmation'",
+  "logError('handleOrderDelivered:postPurchaseCare'",
+  "logError('handleOrderDelivered:survey'",
+  "logError('triggerConsultationFollowup'",
+  "logError('triggerSwatchFollowupSequence'",
+  // checkAndTriggerTierMilestone uses a template literal with milestoneKey
+  // suffix — match the bare prefix without the colon-suffix.
+  'logError(`checkAndTriggerTierMilestone:',
+];
+
+describe('cf-g79m — emailAutomation.web.js logError tag normalization', () => {
+  it.each(EXPECTED_PREFIXED_TAGS)('uses logError tag prefix %s', (tag) => {
+    expect(SRC).toContain(tag);
+  });
+
+  it.each(FORBIDDEN_LEGACY_TAGS)('does NOT use legacy non-prefixed form %s', (legacy) => {
+    expect(SRC).not.toContain(legacy);
+  });
+
+  it('every logError call uses the emailAutomation: prefix', () => {
+    // Match all `logError(<tag>, ...)` call sites and verify each tag
+    // starts with 'emailAutomation:'. Catches future drift where a new
+    // catch site forgets the prefix.
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    // Sanity floor: at least 25 logError calls present (19 cf-uydr +
+    // 6 cf-g79m). The exact count may drift up as new code lands.
+    expect(tags.length).toBeGreaterThanOrEqual(25);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('emailAutomation:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without emailAutomation: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Origin

cf-uydr.fu1 follow-up to PR #1373 (merged earlier this session). cf-uydr migrated 19 \`console.error\` sites to \`logError('emailAutomation:<fn>-<reason>', err)\` but 6 pre-existing logError calls used un-prefixed tags. A Sentry grep on \`emailAutomation:*\` would miss them. Normalizing for grep-symmetry.

## Swaps (6)

| Site | Pre | Post |
|---|---|---|
| handleOrderDelivered confirmation | \`handleOrderDelivered:confirmation\` | \`emailAutomation:handleOrderDelivered:confirmation\` |
| handleOrderDelivered postPurchaseCare | \`handleOrderDelivered:postPurchaseCare\` | \`emailAutomation:handleOrderDelivered:postPurchaseCare\` |
| handleOrderDelivered survey | \`handleOrderDelivered:survey\` | \`emailAutomation:handleOrderDelivered:survey\` |
| triggerConsultationFollowup | \`triggerConsultationFollowup\` | \`emailAutomation:triggerConsultationFollowup\` |
| triggerSwatchFollowupSequence | \`triggerSwatchFollowupSequence\` | \`emailAutomation:triggerSwatchFollowupSequence\` |
| checkAndTriggerTierMilestone | template literal | template literal with \`emailAutomation:\` prefix |

## TDD (13 cases)

| # | Pin |
|---|---|
| 1-6 | Each expected prefixed tag appears in source |
| 7-12 | Each legacy non-prefixed form is absent |
| 13 | **Drift guard:** every logError call uses \`emailAutomation:\` prefix (catches future regressions where a new catch site forgets the prefix) |

## Verification

- New tag-normalization test: **13/13** ✅
- Broader emailAutomation-touching regression sweep (18 files): **407/407** ✅
- redactEmail tests already exist in \`tests/sanitize.test.js\` (cf-ewnw work) — not duplicated per melania directive

## Why P4

No functional change, no Sentry data loss prior to this PR (the 6 sites already logged via \`logError\`). This is naming-consistency hygiene so an on-call grep on \`emailAutomation:\` returns the complete surface.

## Pre-flight

- [x] vitest 13 new + 407 existing
- [x] cf-ukc6 N/A (cfutons, not cfw)
- [ ] CI green
- [ ] 5-agent crew sign-offs per mayor 2026-05-15

5-agent review dispatching.

Refs cf-g79m (this), cf-uydr (PR #1373 — merged sibling pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)