### PR TITLE
chore(cf-b8n8): allowlist 5 non-bead cf-* tokens — clears doc-drift baseline

### DIFF
--- a/scripts/check-doc-bead-refs.allowlist
+++ b/scripts/check-doc-bead-refs.allowlist
@@ -41,3 +41,28 @@ cf-dead
 cf-current
 cf-cutover
 cf-cya
+
+# ── Roadmap / workstream area names (not beads) ──────────────────
+# Roadmap is the cf-3qt epic's published-to-stakeholders presentation
+# layer; .3/.4/.5 etc. are roadmap sections (cleanup, observability,
+# notification, etc.) referenced in CONVENTIONS + go-live runbooks,
+# distinct from any bead's sub-ID.
+cf-roadmap
+cf-roadmap.3
+cf-roadmap.4
+
+# ── Security / secrets workstream area name (not a bead) ─────────
+# `cf-secrets` is the operational vocabulary for the
+# cutover-night secrets-management workstream (referenced in
+# CONVENTIONS + wave-audit pilot). Individual operational tasks
+# get their own real beads (e.g. cf-secrets.F1, cf-secrets.F2 if
+# present in bd; the bare `cf-secrets` is the umbrella term).
+cf-secrets
+
+# ── Historical stale aliases preserved in doc text ────────────────
+# `cf-fp19` was a stale alias dropped from cf-094q's triage title by
+# PR #1335 (docs(cf-zb6j)). The wave-audit pilot doc quotes that PR
+# title verbatim as part of its categorization table — preserving
+# the historical record is intentional. Allowlist the alias here
+# rather than editing audit-doc PR-title quotations.
+cf-fp19


### PR DESCRIPTION
## Summary

cf-b8n8 (P4) — extend `scripts/check-doc-bead-refs.allowlist` with 5 non-bead `cf-*` tokens that surfaced as NEW drift on the most recent scan. Brings the baseline back to clean (exit 0, "No NEW drift").

## What was flagged

`python3 scripts/check-doc-bead-refs.py` (no args) against current `docs/` surfaced 5 NEW unknown bead-reference drifts vs baseline. All 5 are non-bead tokens that bleed into prose from adjacent vocabulary — exactly the case the allowlist exists for:

| Token | Location | Why it's not a bead |
|---|---|---|
| `cf-roadmap` | CONVENTIONS.md:92 | Roadmap workstream area name (umbrella term) |
| `cf-roadmap.3` | CONVENTIONS.md:3 | Roadmap cleanup-wave section |
| `cf-roadmap.4` | notification-go-live-runbook.md:3 | Roadmap observability-wave section |
| `cf-secrets` | wave-audit-pilot.md:25 | Cutover-night secrets-management umbrella |
| `cf-fp19` | wave-audit-pilot.md:37 | Stale alias dropped by PR #1335; pilot doc quotes that PR title verbatim — historical preservation, allowlist rather than edit |

## State after

`python3 scripts/check-doc-bead-refs.py` → exit 0, **No NEW drift**, 875 known beads + 20 allowlist entries + 68 baselined refs.

## Test plan

- [x] Scanner exits 0 against current docs/
- [ ] CI green
- [ ] No Vercel risk (scripts/ + docs/ only)

## Refs

- Bead: cf-b8n8 (P4 in_progress; this PR ships the maintenance update)
- Sibling: cf-ad9y `scripts/check-doc-links.py`
- Stale-alias precedent: PR #1335 (docs(cf-zb6j))

## Follow-on (not gating)

CI wiring is now unblocked per the bead's "Could be wired into lint workflow after baseline is clean" note. Worth a P4 follow-on: `.github/workflows/` step that runs the scanner on PRs touching `docs/**/*.md`. File as cf-b8n8.fu1 if you want it gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
