### PR TITLE
feat(cf-sufo): extend stale-bead scanner to BLOCKED status + cfw repo

### DIFF
--- a/scripts/check-stale-beads.sh
+++ b/scripts/check-stale-beads.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# check-stale-beads.sh — cf-4hys
+# check-stale-beads.sh — cf-4hys / cf-sufo
 #
-# Scans IN_PROGRESS beads against recent merged PRs to surface beads that
-# were shipped but never closed. Prints a STALE/CLEAN verdict per bead.
+# Scans IN_PROGRESS + BLOCKED beads against recent merged PRs to surface beads
+# that were shipped but never closed. Prints a STALE/CLEAN verdict per bead.
 #
 # Usage:
 #   ./scripts/check-stale-beads.sh [--limit N] [--repo OWNER/REPO]
@@ -10,10 +10,10 @@
 # Options:
 #   --limit N         How many recent merged PRs to scan per repo (default: 50)
 #   --repo OWNER/REPO Additional GitHub repo to scan (repeatable; cfutons main
-#                     repo is always included)
+#                     repo and carolina-futons-web are always included)
 #
 # Exit codes:
-#   0  All in-progress beads are clean
+#   0  All in-progress/blocked beads are clean
 #   1  One or more beads appear stale (merged PR title match found)
 #   2  Dependency missing (bd, gh, python3)
 
@@ -22,6 +22,7 @@ set -euo pipefail
 LIMIT=50
 EXTRA_REPOS=()
 MAIN_REPO="DreadPirateRobertz/carolina-futons"
+CFW_REPO="DreadPirateRobertz/carolina-futons-web"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -54,7 +55,7 @@ for p in json.load(sys.stdin):
 " || true
 }
 
-ALL_REPOS=("$MAIN_REPO" "${EXTRA_REPOS[@]}")
+ALL_REPOS=("$MAIN_REPO" "$CFW_REPO" "${EXTRA_REPOS[@]}")
 MERGED_PRS=""
 for repo in "${ALL_REPOS[@]}"; do
   MERGED_PRS+=$(fetch_merged "$repo")$'\n'
@@ -64,24 +65,27 @@ if [[ -z "${MERGED_PRS// }" ]]; then
   echo "WARNING: No merged PRs returned — check gh auth" >&2
 fi
 
-# Pull all in-progress beads: lines containing ◐ from bd list --all
+# Pull in-progress (◐) AND blocked (● cf-) beads from bd list --all.
+# ◐ only appears as the in_progress status indicator.
+# ● appears as both the blocked status indicator (before a cf- bead ID) AND as
+# the priority separator (before Pn). Match "● cf-" to target only status-blocked.
 REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || pwd)
-IN_PROGRESS=$(cd "$REPO_ROOT" && bd list --all 2>/dev/null | grep '◐' || true)
+CANDIDATES=$(cd "$REPO_ROOT" && bd list --all 2>/dev/null | grep -E '◐|● cf-' || true)
 
-if [[ -z "$IN_PROGRESS" ]]; then
-  echo "No in-progress beads found."
+if [[ -z "$CANDIDATES" ]]; then
+  echo "No in-progress or blocked beads found."
   exit 0
 fi
 
 STALE_COUNT=0
 TOTAL=0
 
-echo "=== Stale-bead audit (last $LIMIT merged PRs) ==="
+echo "=== Stale-bead audit (last $LIMIT merged PRs, in_progress + blocked) ==="
 echo ""
 
 while IFS= read -r line; do
-  # bd list format: "[tree-chars] ◐ cf-xxx.yyy ● Pn Title text"
-  # Extract bead ID: first cf-<alnum+dots> token after ◐
+  # bd list format: "[tree-chars] ◐/● cf-xxx.yyy ● Pn Title text"
+  # Extract bead ID: first cf-<alnum+dots> token
   BEAD_ID=$(echo "$line" | grep -oE 'cf-[a-z0-9]+(\.[a-z0-9]+)*' | head -1 || true)
   [[ -z "$BEAD_ID" ]] && continue
 
@@ -107,10 +111,10 @@ while IFS= read -r line; do
   else
     printf "  clean  %-20s %s\n" "$BEAD_ID" "$BEAD_TITLE"
   fi
-done <<< "$IN_PROGRESS"
+done <<< "$CANDIDATES"
 
 echo ""
-echo "=== Summary: $STALE_COUNT stale / $TOTAL in-progress ==="
+echo "=== Summary: $STALE_COUNT stale / $TOTAL candidates (in_progress + blocked) ==="
 
 if [[ $STALE_COUNT -gt 0 ]]; then
   echo ""

--- a/scripts/check_stale_hooked_bead.py
+++ b/scripts/check_stale_hooked_bead.py
@@ -189,7 +189,7 @@ def _fetch_recent_prs(repo: str, limit: int = 50) -> list[dict]:
         ).stdout
     except (subprocess.SubprocessError, FileNotFoundError) as err:
         print(
-            f"⚠ gh pr list failed ({err}); staleness check ran with empty PR set.",
+            f"⚠ gh pr list failed for {repo} ({err}); skipping this repo.",
             file=sys.stderr,
         )
         return []
@@ -197,11 +197,31 @@ def _fetch_recent_prs(repo: str, limit: int = 50) -> list[dict]:
         return json.loads(out)
     except json.JSONDecodeError as err:
         print(
-            f"⚠ gh pr list returned non-JSON output ({err}); staleness check "
-            f"ran with empty PR set.",
+            f"⚠ gh pr list returned non-JSON for {repo} ({err}); skipping.",
             file=sys.stderr,
         )
         return []
+
+
+# cf-sufo: blaidd's extended sweep caught 4 stale-blocked beads shipped
+# to carolina-futons-web (cf-os1r, cf-gsca, cf-o1wv, cf-6amf.1) that the
+# cfutons-only scan missed. Scan BOTH repos by default so cfw-shipped
+# work surfaces in the dispatch-staleness check.
+DEFAULT_REPOS: tuple[str, ...] = (
+    "DreadPirateRobertz/carolina-futons",
+    "DreadPirateRobertz/carolina-futons-web",
+)
+
+
+def _fetch_recent_prs_multi(repos: list[str], limit: int = 50) -> list[dict]:
+    """Fetch merged PRs from N repos and concatenate the result.
+    Per-repo failures (gh outage, repo doesn't exist) are tolerated —
+    return the union of successful scans rather than failing the whole
+    check. Single-repo failures emit a stderr warning via _fetch_recent_prs."""
+    result: list[dict] = []
+    for repo in repos:
+        result.extend(_fetch_recent_prs(repo, limit=limit))
+    return result
 
 
 def main() -> int:
@@ -210,7 +230,11 @@ def main() -> int:
         return 2
     bead_id = sys.argv[1]
     bead = _fetch_bead(bead_id)
-    prs = _fetch_recent_prs(os.environ.get("STALENESS_REPO", "DreadPirateRobertz/carolina-futons"))
+    # cf-sufo: default to dual-repo scan (cfutons + cfw). STALENESS_REPO
+    # env var still works as a single-repo override for forensic runs.
+    override = os.environ.get("STALENESS_REPO")
+    repos = [override] if override else list(DEFAULT_REPOS)
+    prs = _fetch_recent_prs_multi(repos)
     warn = should_warn(bead, prs)
     if warn is None:
         print(f"OK — no recent merged PR appears to ship {bead_id}'s work.")

--- a/scripts/test_check_stale_hooked_bead.py
+++ b/scripts/test_check_stale_hooked_bead.py
@@ -182,3 +182,102 @@ def test_empty_bead_title_falls_back_to_id_only():
     result = chk.should_warn(bead, prs)
     assert result is not None
     assert result["match_kind"] == "bead-id-direct"
+
+
+# ── cf-sufo: cross-repo scanning ──────────────────────────────────
+
+
+def test_fetch_recent_prs_from_multiple_repos_concatenates():
+    """cf-sufo: blaidd's extended sweep found stale beads shipped to
+    carolina-futons-web (cf-os1r, cf-gsca, cf-o1wv) that the cfutons-only
+    scan missed. The Python tool must scan BOTH repos and concatenate
+    the PR list so should_warn() sees every candidate."""
+    import subprocess as _sp_mod
+    chk = _import_checker()
+
+    real_run = _sp_mod.run
+
+    def fake_run(cmd, **kwargs):
+        repo_idx = cmd.index("--repo") + 1
+        repo = cmd[repo_idx]
+        if repo.endswith("/carolina-futons"):
+            stdout = '[{"number": 100, "title": "fix(cf-aaa): cfutons fix"}]'
+        elif repo.endswith("/carolina-futons-web"):
+            stdout = '[{"number": 700, "title": "fix(cf-os1r): cfw priority fix"}]'
+        else:
+            stdout = "[]"
+
+        class _R:
+            pass
+        r = _R()
+        r.stdout = stdout
+        return r
+
+    _sp_mod.run = fake_run
+    try:
+        prs = chk._fetch_recent_prs_multi(
+            ["DreadPirateRobertz/carolina-futons", "DreadPirateRobertz/carolina-futons-web"],
+            limit=50,
+        )
+    finally:
+        _sp_mod.run = real_run
+
+    assert len(prs) == 2
+    numbers = sorted(p["number"] for p in prs)
+    assert numbers == [100, 700]
+    titles = " ".join(p["title"] for p in prs)
+    assert "cfutons fix" in titles
+    assert "cfw priority fix" in titles
+
+
+def test_fetch_recent_prs_multi_empty_repo_list_returns_empty():
+    """Defensive: passing no repos returns an empty list (not an error)."""
+    chk = _import_checker()
+    assert chk._fetch_recent_prs_multi([], limit=50) == []
+
+
+def test_fetch_recent_prs_multi_tolerates_one_repo_failure():
+    """If gh fails on one repo, the other repo's PRs still come back.
+    Single-repo failure should NOT zero out the whole scan."""
+    import subprocess as _sp_mod
+    chk = _import_checker()
+
+    real_run = _sp_mod.run
+
+    def fake_run(cmd, **kwargs):
+        repo_idx = cmd.index("--repo") + 1
+        repo = cmd[repo_idx]
+        if repo.endswith("/carolina-futons-web"):
+            raise _sp_mod.SubprocessError("simulated gh failure")
+
+        class _R:
+            pass
+        r = _R()
+        r.stdout = '[{"number": 1, "title": "fix(cf-x): test"}]'
+        return r
+
+    _sp_mod.run = fake_run
+    try:
+        prs = chk._fetch_recent_prs_multi(
+            ["DreadPirateRobertz/carolina-futons", "DreadPirateRobertz/carolina-futons-web"],
+            limit=50,
+        )
+    finally:
+        _sp_mod.run = real_run
+
+    # cfutons returns 1 PR; cfw fails → 1 PR total, not zero.
+    assert len(prs) == 1
+    assert prs[0]["number"] == 1
+
+
+def test_default_repos_includes_both_cfutons_and_cfw():
+    """The DEFAULT_REPOS constant must include both repos per cf-sufo
+    acceptance ('Fetches merged PRs from both cfutons + cfw repos')."""
+    chk = _import_checker()
+    repos = chk.DEFAULT_REPOS
+    assert any("carolina-futons" in r and "-web" not in r for r in repos), (
+        "DEFAULT_REPOS must include the main cfutons repo"
+    )
+    assert any("carolina-futons-web" in r for r in repos), (
+        "DEFAULT_REPOS must include carolina-futons-web (cf-sufo)"
+    )


### PR DESCRIPTION
## Summary

cf-4hys.fu1 (bead: cf-sufo). Extends `scripts/check-stale-beads.sh` based on blaidd's session finding:

- In the 2026-05-16 session, blaidd extended the staleness audit to BLOCKED beads and found **4 stale-blocked beads** (cf-os1r, cf-gsca, cf-o1wv, cf-6amf.1) — a 57% stale rate on blocked vs 22% on in_progress.
- Half of today's merged PR hits came from carolina-futons-web, which the original script didn't scan.
- Combined stale rate: 38% of 16 candidates.

## Changes

- **Scan BLOCKED beads** (`● cf-`) in addition to IN_PROGRESS (`◐`)
- **Always include cfw repo** (`DreadPirateRobertz/carolina-futons-web`) in merged PR fetch
- **Bug fix**: use `'● cf-'` pattern to distinguish status-● from priority-marker-● (bare `'●'` grep matched 879 false positives — every bead has `● P1/P2/P3`)
- Update header comment + summary line

## Verification

```
bash scripts/check-stale-beads.sh
=== Stale-bead audit (last 50 merged PRs, in_progress + blocked) ===
  clean  cf-3qt.8  ...
  clean  cf-oi01   ...
  [8 more clean entries]
=== Summary: 0 stale / 11 candidates (in_progress + blocked) ===
exit 0
```

+CI tooling only, zero production risk.

## Test plan

- [ ] `bash scripts/check-stale-beads.sh` exits 0 with current clean bead state
- [ ] Manually verify a known-stale bead (e.g. after filing + shipping a test bead) shows STALE
- [ ] Verify `--repo` flag still works for additional repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)