### PR TITLE
fix(cf-6amf.fu1): wave-audit cross-repo reachability — false 0/N when WAVE_AUDIT_REPO differs from local clone

### DIFF
--- a/docs/audits/CONVENTIONS.md
+++ b/docs/audits/CONVENTIONS.md
@@ -78,7 +78,7 @@ Every wave-audit run produces:
 ## 7. Tooling
 
 - **Run:** `scripts/wave-audit/wave-audit.sh <since-date> [<until-date>]`
-- **Cross-repo:** set `WAVE_AUDIT_REPO=DreadPirateRobertz/carolina-futons-web` (or any other gh-accessible repo) — defaults to the cfutons monorepo
+- **Cross-repo:** set `WAVE_AUDIT_REPO=DreadPirateRobertz/carolina-futons-web` (or any other gh-accessible repo). When `WAVE_AUDIT_REPO` differs from the local clone the script lives in, **also set `WAVE_AUDIT_REPO_ROOT=/path/to/local/clone`** (cf-6amf.fu1) — without it the reachability `git merge-base` runs against the wrong object DB and silently false-excludes every PR. The script hard-fails with a remediation hint if the cross-repo case is detected without `WAVE_AUDIT_REPO_ROOT`.
 - **Output:** markdown to stdout — redirect to `docs/audits/cf-<bead>-<window>-WIP.md` and curate manually before committing
 
 ## 8. Process integration

--- a/scripts/wave-audit/wave-audit.sh
+++ b/scripts/wave-audit/wave-audit.sh
@@ -18,6 +18,13 @@
 # rationale. cf-5dto v5 reachability rule (`git merge-base --is-ancestor`)
 # applies — only PRs whose merge commit is reachable from origin/main are
 # counted; stacked-PR squash-merge gaps surface in the "Excluded" section.
+#
+# Cross-repo (cf-6amf.fu1): when WAVE_AUDIT_REPO points to a different repo
+# than the local clone hosting this script, set WAVE_AUDIT_REPO_ROOT to a
+# local clone of that repo so the reachability `git merge-base` runs in the
+# correct repo. Without this, a cross-repo run silently false-excludes 100%
+# of PRs (the merge SHAs aren't present in the script-hosting repo's
+# object DB).
 
 set -euo pipefail
 
@@ -33,6 +40,25 @@ REPO="${WAVE_AUDIT_REPO:-DreadPirateRobertz/carolina-futons}"
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+# Resolve the local clone we should run reachability checks against.
+# Default: REPO_ROOT (the cfutons monorepo containing this script).
+# Override: WAVE_AUDIT_REPO_ROOT (for cross-repo runs against cfw etc.).
+# Detection: compare the local repo's gh `nameWithOwner` against $REPO.
+# If they differ and no override was given, hard-fail rather than emit a
+# false 0/100 reachable count.
+LOCAL_NWO="$(cd "$REPO_ROOT" && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")"
+if [[ -n "${WAVE_AUDIT_REPO_ROOT:-}" ]]; then
+  REACHABILITY_ROOT="$WAVE_AUDIT_REPO_ROOT"
+elif [[ -n "$LOCAL_NWO" && "$LOCAL_NWO" != "$REPO" ]]; then
+  echo "ERROR: cross-repo run detected (WAVE_AUDIT_REPO=$REPO, local=$LOCAL_NWO)" >&2
+  echo "       but WAVE_AUDIT_REPO_ROOT is unset. Without a local clone of" >&2
+  echo "       $REPO, the reachability check would false-exclude every PR." >&2
+  echo "       Fix: WAVE_AUDIT_REPO_ROOT=/path/to/local/clone $0 $*" >&2
+  exit 2
+else
+  REACHABILITY_ROOT="$REPO_ROOT"
+fi
 
 # 1. Fetch the wave from gh.
 WAVE_JSON="$(mktemp)"
@@ -64,7 +90,7 @@ EXCLUDED_JSON="$(mktemp)"
 trap 'rm -f "$WAVE_JSON" "$REACHED_JSON" "$EXCLUDED_JSON"' EXIT
 
 (
-  cd "$REPO_ROOT"
+  cd "$REACHABILITY_ROOT"
   git fetch origin main --quiet 2>/dev/null || true
   jq -c '.[]' "$WAVE_JSON" | while read -r row; do
     SHA="$(echo "$row" | jq -r '.mergeCommit.oid // empty')"


### PR DESCRIPTION
## Summary
- **Bug:** `scripts/wave-audit/wave-audit.sh` always ran `git merge-base --is-ancestor` inside its own `REPO_ROOT` (the cfutons monorepo). When `WAVE_AUDIT_REPO` pointed to a different repo (e.g. `carolina-futons-web`), the merge SHAs from that repo weren't in cfutons's object DB, so every check returned false. **Silent 100% false-exclusion** — the script reported `Reachable from origin/main: 0` while the wave actually contained N substantive PRs.
- **Discovery:** running `WAVE_AUDIT_REPO=DreadPirateRobertz/carolina-futons-web scripts/wave-audit/wave-audit.sh 2026-05-09 2026-05-16` produced `Reachable from origin/main: 0 · Excluded: 100`. All 100 PRs were verified reachable in the cfw repo's own `origin/main`.
- **Fix:**
  - New `WAVE_AUDIT_REPO_ROOT` env var: operator sets it to a local clone of the target repo; reachability check `cd`s there.
  - Cross-repo auto-detection: compare local `gh repo view nameWithOwner` vs `WAVE_AUDIT_REPO`. If they differ and `WAVE_AUDIT_REPO_ROOT` is unset, hard-fail (exit 2) with a remediation hint. Better to fail loud than emit a misleading 0/N count.
- **Docs:** CONVENTIONS.md §7 updated.

## Verification (3 cases run from the fix branch)
| Case | Expected | Actual |
|---|---|---|
| Cross-repo, no override | exit 2 + remediation message | ✅ exits 2, prints "ERROR: cross-repo run detected ... but WAVE_AUDIT_REPO_ROOT is unset" |
| Cross-repo with override (cfw, `WAVE_AUDIT_REPO_ROOT=/Users/hal/gt/carolina-futons-web`) | `Reachable: 100/100` | ✅ 100/100 reachable (was 0/100 before fix) |
| Default cfutons (no env vars) | no regression, `Reachable: 51/51` for 2026-05-15→05-16 | ✅ 51/51 reachable |

## Why this matters (reachable → observable → honest framing)
- **Reachable:** the check fired every cross-repo run, just always returned false.
- **Observable:** zero signal — the script printed a clean `0/100 reachable` count with no hint that the comparison was structurally wrong. An auditor reading the report would assume "100 stacked PRs failed to land in main," not "the reachability check is broken."
- **Honest:** post-fix, the script either succeeds with a real count OR exits 2 with a remediation hint. No silent fabrication.

This matches the rennala-articulated 3-stage silent-failure framing (see `feedback_reachable_observable_honest.md` precedent on cf-44qt/cf-uydr).

## Test plan
- [x] Cross-repo without override hard-fails with exit 2
- [x] Cross-repo with override yields correct reachable count
- [x] Default cfutons run unchanged (51/51)
- [ ] 5-agent CR per mayor's 2026-05-15 mandate
- [ ] Melania PM approval

## Bead
Filed as cf-6amf.fu1 follow-up to cf-6amf (wave-audit ritual). Melania pending bead-row creation; this PR references the planned ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)