### PR TITLE
fix(cf-44qt sibling): abTesting.web.js console.error → logError ×5 (P3 observability cleanup)

### DIFF
--- a/src/backend/abTesting.web.js
+++ b/src/backend/abTesting.web.js
@@ -23,6 +23,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 
 // Z-score for 95% confidence (p < 0.05, two-tailed)
 const Z_95 = 1.96;
@@ -87,7 +88,7 @@ export const getVariant = webMethod(
 
       return { success: true, variant: { id: variant.id, name: variant.name }, testActive: true };
     } catch (err) {
-      console.error('[AbTesting] Error getting variant:', err);
+      logError('abTesting.getVariant', err);
       return { success: false, error: 'Unable to get variant' };
     }
   }
@@ -135,8 +136,10 @@ export const trackEvent = webMethod(
 
       return { success: true };
     } catch (err) {
-      // Silent — tracking failures should not affect user experience
-      console.error('[AbTesting] Event tracking error:', err?.message);
+      // Tracking failures must not break the user flow; the catch is intentional.
+      // logError still fires so operators see the rate (silently dropping
+      // analytics is the textbook fabricated-success anti-pattern).
+      logError('abTesting.trackEvent', err);
       return { success: false };
     }
   }
@@ -230,7 +233,7 @@ export const getTestResults = webMethod(
         },
       };
     } catch (err) {
-      console.error('[AbTesting] Error getting results:', err);
+      logError('abTesting.getTestResults', err);
       return { success: false, error: 'Unable to get test results' };
     }
   }
@@ -274,7 +277,7 @@ export const concludeTest = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[AbTesting] Error concluding test:', err);
+      logError('abTesting.concludeTest', err);
       return { success: false, error: 'Unable to conclude test' };
     }
   }
@@ -331,7 +334,7 @@ export const createTest = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[AbTesting] Error creating test:', err);
+      logError('abTesting.createTest', err);
       return { success: false, error: 'Unable to create test' };
     }
   }

--- a/tests/abTestingSilentFailureCleanup.test.js
+++ b/tests/abTestingSilentFailureCleanup.test.js
@@ -1,0 +1,100 @@
+/**
+ * cf-44qt sibling — abTesting.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch in abTesting.web.js
+ * calls `logError(context, err)` with a structured context label,
+ * not raw `console.error`. The webMethod return shape stays the same
+ * (`success: false` was already honest pre-migration — this PR only
+ * upgrades the "observable" stage of the reachable→observable→honest
+ * framing per feedback_reachable_observable_honest.md).
+ *
+ * Pattern source: cf-44qt PR #1366 internationalShippingSilentFailureCleanup.test.js.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — abTesting.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    __reset();
+  });
+
+  it('getVariant wires logError on catch with abTesting.getVariant context', async () => {
+    __setQueryError('AbTests', new Error('wixData failure'));
+    const mod = await import('../src/backend/abTesting.web.js');
+    const result = await mod.getVariant('myTest', 'visitor-1');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/^abTesting\.getVariant/);
+  });
+
+  it('trackEvent wires logError on catch with abTesting.trackEvent context', async () => {
+    __setInsertError('AbEvents', new Error('wixData insert failure'));
+    const mod = await import('../src/backend/abTesting.web.js');
+    const result = await mod.trackEvent('myTest', 'control', 'visitor-1', 'impression');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/^abTesting\.trackEvent/);
+  });
+
+  it('getTestResults wires logError on catch with abTesting.getTestResults context', async () => {
+    __setQueryError('AbTests', new Error('wixData failure'));
+    const mod = await import('../src/backend/abTesting.web.js');
+    const result = await mod.getTestResults('myTest');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/^abTesting\.getTestResults/);
+  });
+
+  it('concludeTest wires logError on catch with abTesting.concludeTest context', async () => {
+    __setQueryError('AbTests', new Error('wixData failure'));
+    const mod = await import('../src/backend/abTesting.web.js');
+    const result = await mod.concludeTest('myTest', 'winner-id');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/^abTesting\.concludeTest/);
+  });
+
+  it('createTest wires logError on catch with abTesting.createTest context', async () => {
+    __setInsertError('AbTests', new Error('wixData insert failure'));
+    const mod = await import('../src/backend/abTesting.web.js');
+    const result = await mod.createTest({
+      testName: 'myTest',
+      variants: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
+    });
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/^abTesting\.createTest/);
+  });
+
+  it('early-return guard does NOT call logError (no spurious noise on missing inputs)', async () => {
+    const mod = await import('../src/backend/abTesting.web.js');
+    const result = await mod.getVariant('', '');
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **5 catch sites** in \`src/backend/abTesting.web.js\` migrated from raw \`console.error('[AbTesting] X', err)\` → \`logError('abTesting.<fn>', err)\`.
- Matches the cf-44qt (#1366/#1368) and cf-uydr (#1373) pattern. The sibling \`abTestDashboard.web.js\` already migrated 2 of its catches; this PR closes the gap for the missed parallel module.
- **Doc-light** — 9 LOC src delta + 103 LOC new test file.

## Reachable → observable → honest framing
| Stage | Pre-fix | Post-fix |
|---|---|---|
| Reachable | ✅ catches fire on wixData throws | ✅ no change |
| Observable | ⚠ \`console.error\` with ad-hoc prefix, only in raw Velo console | ✅ structured \`logError\` with greppable \`abTesting.<fn>\` context — routes to errorHandler aggregation; future-proof for Sentry / ErrorLogs CMS persistence |
| Honest | ✅ all catches return \`success: false\` with structured error message | ✅ no change (no fabrication to remove, unlike cf-44qt's \$199.99 case) |

## Test contract (6 new, all green)
\`tests/abTestingSilentFailureCleanup.test.js\` pins:
- 5 catch-path tests asserting \`logError\` invocation with the right \`abTesting.<fn>\` context tag (regex-matched so future renames stay flexible)
- 1 early-return-guard test pinning "no spurious logError noise on validation-not-error inputs"

## Verification
- [x] New tests: **6/6 green** (TDD-red verified pre-fix, green post-fix)
- [x] Existing \`abTesting.test.js\` + \`abTestingDeep.test.js\`: **117/117 green** (no regression)
- [x] Coverage on \`abTesting.web.js\`: 97.2/90.5/100/97.8 (statements/branches/functions/lines)
- [x] Overall coverage: 90.53/84.9/88.76/91.71 — no threshold breached, **no ratchet needed**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR per mayor's 2026-05-15 mandate (silent-failure-hunter natural primary lens)

## Why P3 honest
This is **observability cleanup, not silent-failure remediation**. The catches were already honest; the upgrade is from ad-hoc prefix to structured \`logError\`. Worth shipping for consistency + future-proofing the route to Sentry, but doesn't unblock a P0/P1. Surfaced while scanning for actionable work after \`bd ready\` returned no unowned P0/P1.

## Bead
TBD — recommend filing as cf-44qt.fu2 or cf-44qt sibling. Did not file a new row to avoid melania queue churn for a P3 cleanup. PR can be re-titled / bead-linked at melania's discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)