### PR TITLE
fix(cf-44qt sibling): notificationService.web.js console.error → logError ×9 (P3 observability cleanup)

### DIFF
--- a/src/backend/notificationService.web.js
+++ b/src/backend/notificationService.web.js
@@ -80,7 +80,7 @@ export const recordPriceSnapshots = webMethod(
 
       return { recorded };
     } catch (err) {
-      console.error('[notificationService] Error recording price snapshots:', err);
+      logError('[notificationService] recordPriceSnapshots failed', err);
       return { recorded: 0, error: 'Failed to record price snapshots' };
     }
   }
@@ -158,7 +158,7 @@ export const checkWishlistAlerts = webMethod(
 
       return { priceDropAlerts, backInStockAlerts };
     } catch (err) {
-      console.error('[notificationService] Error checking wishlist alerts:', err);
+      logError('[notificationService] checkWishlistAlerts failed', err);
       return { priceDropAlerts: 0, backInStockAlerts: 0, error: 'Failed to check alerts' };
     }
   }
@@ -230,11 +230,11 @@ async function notifyWishlistMembers(product, alertType, alertData) {
           sent++;
         }
       } catch (memberErr) {
-        console.error(`[notificationService] Error notifying member ${entry.memberId}:`, memberErr);
+        logError(`[notificationService] notifyWishlistMembers member-${entry.memberId} failed`, memberErr);
       }
     }
   } catch (err) {
-    console.error('[notificationService] Error in notifyWishlistMembers:', err);
+    logError('[notificationService] notifyWishlistMembers failed', err);
   }
 
   return sent;
@@ -294,7 +294,7 @@ async function sendAlert(memberId, product, alertType, alertData) {
 
     return true;
   } catch (err) {
-    console.error(`[notificationService] Error sending ${alertType} alert:`, err);
+    logError(`[notificationService] sendAlert-${alertType} failed`, err);
     return false;
   }
 }
@@ -327,7 +327,7 @@ export const toggleProductAlerts = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[notificationService] Error toggling product alerts:', err);
+      logError('[notificationService] toggleProductAlerts failed', err);
       return { success: false };
     }
   }
@@ -403,7 +403,7 @@ async function writeNotification(memberId, type, message, extra = {}) {
         .find({ suppressAuth: true });
       if (existing.items.length > 0) return;
     } catch (err) {
-      console.error('[notificationService] writeNotification dedup check failed:', err);
+      logError('[notificationService] writeNotification milestone-dedup failed', err);
     }
   }
 
@@ -418,7 +418,7 @@ async function writeNotification(memberId, type, message, extra = {}) {
         .find({ suppressAuth: true });
       if (existing.items.length > 0) return;
     } catch (err) {
-      console.error('[notificationService] writeNotification dedup check failed:', err);
+      logError('[notificationService] writeNotification streak-dedup failed', err);
     }
   }
 
@@ -429,7 +429,7 @@ async function writeNotification(memberId, type, message, extra = {}) {
     const queued = await enqueueNotification({ userId: memberId, type, payload: { memberId, type, message, extra } });
     queuedId = queued._id;
   } catch (err) {
-    console.error('[notificationService] writeNotification enqueue failed:', err);
+    logError('[notificationService] writeNotification enqueue failed', err);
     // If we cannot queue, fall through to best-effort direct insert
   }
 

--- a/tests/notificationServiceSilentFailureCleanup.test.js
+++ b/tests/notificationServiceSilentFailureCleanup.test.js
@@ -1,0 +1,95 @@
+/**
+ * cf-44qt sibling — notificationService.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every error-path catch in
+ * notificationService.web.js calls `logError(context, err)` instead of
+ * raw `console.error`. The notifyOwner console.error fallback (L368)
+ * is INTENTIONAL (last-resort alert channel, documented in JSDoc)
+ * and is NOT in scope.
+ *
+ * Pattern source: cf-44qt PR #1366 + cf-uydr PR #1373 +
+ * cf-44qt-sibling-abTesting PR #1382.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => null) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — notificationService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('recordPriceSnapshots wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/notificationService.web.js');
+    const result = await mod.recordPriceSnapshots();
+    // recordPriceSnapshots returns { recorded, error } shape (not success:bool).
+    expect(result.recorded).toBe(0);
+    expect(result.error).toBeTruthy();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/notificationService/);
+    expect(tag).toMatch(/recordPriceSnapshots/);
+  });
+
+  it('checkWishlistAlerts wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/notificationService.web.js');
+    const result = await mod.checkWishlistAlerts();
+    // checkWishlistAlerts returns { priceDropAlerts, backInStockAlerts, error } shape.
+    expect(result.priceDropAlerts).toBe(0);
+    expect(result.backInStockAlerts).toBe(0);
+    expect(result.error).toBeTruthy();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/notificationService/);
+    expect(tag).toMatch(/checkWishlistAlerts/);
+  });
+
+  it('toggleProductAlerts wires logError on ProductAlertPreferences query throw', async () => {
+    __setQueryError('ProductAlertPreferences', new Error('wixData query failure'));
+    const mod = await import('../src/backend/notificationService.web.js');
+    const result = await mod.toggleProductAlerts('prod-1', true);
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/notificationService/);
+    expect(tag).toMatch(/toggleProductAlerts/);
+  });
+
+  it('notifyOwner intentional console.error fallback does NOT call logError (per JSDoc contract)', async () => {
+    // notifyOwner is the documented "last-resort console alert channel" — its
+    // L368 console.error is intentional and MUST NOT be migrated to logError.
+    // This test pins that contract so future cleanup sweeps don't accidentally
+    // break the fallback.
+    const mod = await import('../src/backend/notificationService.web.js');
+    // With no SITE_OWNER_CONTACT_ID secret set, notifyOwner falls through to
+    // the console fallback path. Returns success:true,method:'console' by design.
+    const result = await mod.notifyOwner('test', 'message');
+    expect(result.success).toBe(true);
+    expect(result.method).toBe('console');
+    // The fallback path uses console.error directly — NOT logError. So the
+    // spy must NOT have been called for the fallback emission.
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **9 catch sites** in \`src/backend/notificationService.web.js\` migrated from raw \`console.error('[notificationService] X', err)\` → structured \`logError(context, err)\` calls.
- Third in the cf-44qt / cf-uydr / cf-44qt-abTesting series. \`notificationService.web.js\` already imported \`logError\` (used in 5 sites) but had 9 raw \`console.error\` catches remaining — same partial-migration shape as PR #1373 (emailAutomation) and PR #1382 (abTesting).
- **1 intentional console.error preserved at L368** — \`notifyOwner\`'s last-resort fallback channel (documented in JSDoc L337-339). Pinned by a dedicated test so future cleanup sweeps don't accidentally break it.

## Reachable → observable → honest
| Stage | Pre-fix | Post-fix |
|---|---|---|
| Reachable | ✅ catches fire on wixData throws | ✅ no change |
| Observable | ⚠ ad-hoc \`console.error\` with raw string prefix, only in Velo console | ✅ structured \`logError\` joins 5 existing sites for file-level consistency; greppable \`[notificationService] <fn>\` tags route to errorHandler aggregation |
| Honest | ✅ catches return \`success: false\` OR \`{ recorded: 0, error: ... }\` shape | ✅ no change (no fabrication to remove) |

## Test contract (4 new, all green)
\`tests/notificationServiceSilentFailureCleanup.test.js\`:
- 3 catch-path tests pin logError invocation with the right \`[notificationService] <fn>\` tag for representative sites (recordPriceSnapshots, checkWishlistAlerts, toggleProductAlerts)
- 1 contract-pin: \`notifyOwner\` intentional console fallback does NOT call logError — protects the last-resort alert channel from future cleanup-sweep regression

## Verification
- [x] New tests: **4/4 green** (TDD-red verified pre-fix on 3 catch paths)
- [x] Existing notification suite: **123/123 green** (notificationService + notificationQueueCron + notificationPreferences)
- [x] Combined: **127/127**
- [x] Coverage: overall 90.53/84.9/88.78/91.7 — no threshold breached, no ratchet needed
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR per mayor's 2026-05-15 mandate (silent-failure-hunter natural primary lens)

## Why P3 honest
Observability cleanup, not silent-failure remediation. Catches were already honest; the upgrade is ad-hoc-prefix → structured \`logError\`. Third in the partial-migration cleanup wave. \`bd ready\` continues to show no unowned P0/P1 work; surfacing this from the wider \`for f in src/backend/*.js; do grep console.error\` scan.

## Bead
TBD — same recommendation as PR #1382, file as cf-44qt.fu3 or generic cf-obs-cleanup if melania wants a tracking row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)