### PR TITLE
fix(cf-44qt sibling): giftCards.web.js console.error → logError ×9 (P3 observability cleanup)

### DIFF
--- a/src/backend/giftCards.web.js
+++ b/src/backend/giftCards.web.js
@@ -21,6 +21,7 @@ import { triggeredEmails } from 'wix-crm-backend';
 import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const GIFT_CARD_AMOUNTS = [25, 50, 100, 150, 200, 500];
 const EXPIRATION_DAYS = 365;
@@ -83,7 +84,7 @@ export const purchaseGiftCard = webMethod(
         recipientName: sanitize(data.recipientName || '', 200),
         message: sanitize(data.message || '', 500),
         expirationDate: expirationDate.toISOString(),
-      }).catch(err => console.error('Gift card email delivery failed:', err));
+      }).catch(err => logError('[giftCards] purchaseGiftCard email-delivery failed', err));
 
       return {
         success: true,
@@ -93,7 +94,7 @@ export const purchaseGiftCard = webMethod(
         expirationDate: expirationDate.toISOString(),
       };
     } catch (err) {
-      console.error('Error purchasing gift card:', err);
+      logError('[giftCards] purchaseGiftCard failed', err);
       return { success: false, message: 'Failed to create gift card' };
     }
   }
@@ -145,7 +146,7 @@ export const checkBalance = webMethod(
         initialAmount: card.initialAmount,
       };
     } catch (err) {
-      console.error('Error checking gift card balance:', err);
+      logError('[giftCards] checkBalance failed', err);
       return { found: false };
     }
   }
@@ -224,7 +225,7 @@ export const redeemGiftCard = webMethod(
         remainingBalance: newBalance,
       };
     } catch (err) {
-      console.error('Error redeeming gift card:', err);
+      logError('[giftCards] redeemGiftCard failed', err);
       return { success: false, message: 'Failed to redeem gift card' };
     }
   }
@@ -293,7 +294,7 @@ async function sendGiftCardEmails(data) {
     );
     purchaserSent = true;
   } catch (err) {
-    console.error('Error sending purchaser gift card email:', err);
+    logError('[giftCards] sendPurchaserEmail failed', err);
   }
 
   // Send recipient notification — independent of purchaser
@@ -317,7 +318,7 @@ async function sendGiftCardEmails(data) {
     );
     recipientSent = true;
   } catch (err) {
-    console.error('Error sending recipient gift card email:', err);
+    logError('[giftCards] sendRecipientEmail failed', err);
   }
 
   return { success: purchaserSent || recipientSent, purchaserSent, recipientSent };
@@ -361,7 +362,7 @@ export const getMyPurchasedCards = webMethod(
         })),
       };
     } catch (err) {
-      console.error('[giftCards] getMyPurchasedCards error:', err);
+      logError('[giftCards] getMyPurchasedCards failed', err);
       return { success: false, reason: 'fetch_failed' };
     }
   }
@@ -399,7 +400,7 @@ export const getMyReceivedCards = webMethod(
         cards: result.items.map(card => sanitizeCardForFrontend(card)),
       };
     } catch (err) {
-      console.error('[giftCards] getMyReceivedCards error:', err);
+      logError('[giftCards] getMyReceivedCards failed', err);
       return { success: false, reason: 'fetch_failed' };
     }
   }
@@ -441,7 +442,7 @@ export const getMyGiftCards = webMethod(
         received: receivedResult.items.map(sanitizeCardForFrontend),
       };
     } catch (err) {
-      console.error('Error fetching gift cards:', err);
+      logError('[giftCards] listAllGiftCards failed', err);
       return { success: false, message: 'Failed to fetch gift cards' };
     }
   }

--- a/tests/giftCardsSilentFailureCleanup.test.js
+++ b/tests/giftCardsSilentFailureCleanup.test.js
@@ -1,0 +1,106 @@
+/**
+ * cf-44qt sibling — giftCards.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch in giftCards.web.js
+ * calls `logError(context, err)` with a structured `[giftCards] <fn>`
+ * tag instead of raw `console.error`.
+ *
+ * Pattern source: cf-44qt PR #1366 + cf-uydr PR #1373 +
+ * cf-44qt-sibling-abTesting PR #1382 + notificationService PR #1383.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateEmail: (s) => s,
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('backend/utils/auditLog', () => ({
+  logAuditEvent: vi.fn(),
+}));
+vi.mock('backend/contacts/contactResolver.web', () => ({
+  _resolveContactIdInternal: vi.fn(async () => 'contact-1'),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-crm-backend', () => ({
+  triggeredEmails: { emailContact: vi.fn(async () => undefined) },
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ loginEmail: 'buyer@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — giftCards.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('checkBalance wires logError on GiftCards query throw', async () => {
+    __setQueryError('GiftCards', new Error('wixData failure'));
+    const mod = await import('../src/backend/giftCards.web.js');
+    // checkBalance returns { found: false } shape on throw, not { success: false }.
+    const result = await mod.checkBalance('CODE-1');
+    expect(result.found).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/giftCards/);
+    expect(tag).toMatch(/checkBalance/);
+  });
+
+  it('redeemGiftCard wires logError on GiftCards query throw', async () => {
+    __setQueryError('GiftCards', new Error('wixData failure'));
+    const mod = await import('../src/backend/giftCards.web.js');
+    const result = await mod.redeemGiftCard('CODE-1', 50);
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/giftCards/);
+    expect(tag).toMatch(/redeemGiftCard/);
+  });
+
+  it('getMyPurchasedCards wires logError on GiftCards query throw', async () => {
+    __setQueryError('GiftCards', new Error('wixData failure'));
+    const mod = await import('../src/backend/giftCards.web.js');
+    const result = await mod.getMyPurchasedCards();
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/giftCards/);
+    expect(tag).toMatch(/getMyPurchasedCards/);
+  });
+
+  it('getMyReceivedCards wires logError on GiftCards query throw', async () => {
+    __setQueryError('GiftCards', new Error('wixData failure'));
+    const mod = await import('../src/backend/giftCards.web.js');
+    const result = await mod.getMyReceivedCards();
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/giftCards/);
+    expect(tag).toMatch(/getMyReceivedCards/);
+  });
+
+  it('early-return guards do NOT call logError', async () => {
+    const mod = await import('../src/backend/giftCards.web.js');
+    // checkBalance with empty code returns { found: false } via early-return,
+    // never entering the wixData branch. logError must not fire.
+    const result = await mod.checkBalance('');
+    expect(result.found).toBe(false);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **9 catch sites** in \`src/backend/giftCards.web.js\` migrated from raw \`console.error\` (mix of \`[giftCards]\`-prefixed and bare-prefix) → structured \`logError('[giftCards] <fn> failed', err)\` calls.
- Fourth in the cf-44qt / cf-uydr / cf-44qt-abTesting (#1382) / cf-44qt-notificationService (#1383) series. Full first-time migration (file didn't import logError previously).
- Includes 1 inline \`.catch(err => ...)\` arrow form on L87 (the fire-and-forget post-purchase email delivery).

## Reachable → observable → honest
| Stage | Pre-fix | Post-fix |
|---|---|---|
| Reachable | ✅ catches fire on wixData/triggeredEmail throws | ✅ no change |
| Observable | ⚠ inconsistent (3 \`[giftCards]\` prefix, 6 bare \`'Error X:'\`), Velo console only | ✅ all 9 use structured \`logError('[giftCards] <fn> failed', err)\` — file-level consistency, future Sentry/ErrorLogs CMS routing-ready |
| Honest | ✅ catches return \`{ success: false }\`, \`{ found: false }\`, or \`{ reason: 'fetch_failed' }\` | ✅ no change (no fabrication to remove) |

## Test contract (5 new, all green)
\`tests/giftCardsSilentFailureCleanup.test.js\`:
- 4 catch-path tests for checkBalance / redeemGiftCard / getMyPurchasedCards / getMyReceivedCards
- 1 early-return-guard test pinning no-spurious-logError on \`checkBalance('')\`

## Verification
- [x] New tests: **5/5 green**
- [x] Existing giftCards suite: **125/125 green** (4 files)
- [x] Combined: **130/130**
- [x] Coverage on giftCards.web.js: 90.96/90.82/93.75/94.36
- [x] Overall coverage: 90.56/84.9/88.8/91.74 — no ratchet needed
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR per mayor's 2026-05-15 mandate

🤖 Generated with [Claude Code](https://claude.com/claude-code)