### PR TITLE
fix(cf-44qt sibling): subscriptionService.web.js console.error → logError ×10 (P3 obs cleanup)

### DIFF
--- a/src/backend/subscriptionService.web.js
+++ b/src/backend/subscriptionService.web.js
@@ -19,6 +19,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'Subscriptions';
 
@@ -194,7 +195,7 @@ export const createSubscription = webMethod(
 
       return { success: true, subscription };
     } catch (err) {
-      console.error('Error creating subscription:', err);
+      logError('[subscriptionService] createSubscription failed', err);
       return { success: false, message: 'Failed to create subscription' };
     }
   }
@@ -223,7 +224,7 @@ export const getMySubscriptions = webMethod(
 
       return { success: true, subscriptions: result.items };
     } catch (err) {
-      console.error('Error getting subscriptions:', err);
+      logError('[subscriptionService] getSubscriptions failed', err);
       return { success: false, message: 'Failed to load subscriptions', subscriptions: [] };
     }
   }
@@ -253,7 +254,7 @@ export const getSubscriptionDetails = webMethod(
 
       return { success: true, subscription: sub };
     } catch (err) {
-      console.error('Error getting subscription details:', err);
+      logError('[subscriptionService] getSubscriptionDetails failed', err);
       return { success: false, message: 'Failed to load subscription' };
     }
   }
@@ -296,7 +297,7 @@ export const updateFrequency = webMethod(
 
       return { success: true, subscription: updated };
     } catch (err) {
-      console.error('Error updating frequency:', err);
+      logError('[subscriptionService] updateFrequency failed', err);
       return { success: false, message: 'Failed to update frequency' };
     }
   }
@@ -337,7 +338,7 @@ export const pauseSubscription = webMethod(
 
       return { success: true, subscription: updated };
     } catch (err) {
-      console.error('Error pausing subscription:', err);
+      logError('[subscriptionService] pauseSubscription failed', err);
       return { success: false, message: 'Failed to pause subscription' };
     }
   }
@@ -376,7 +377,7 @@ export const resumeSubscription = webMethod(
 
       return { success: true, subscription: updated };
     } catch (err) {
-      console.error('Error resuming subscription:', err);
+      logError('[subscriptionService] resumeSubscription failed', err);
       return { success: false, message: 'Failed to resume subscription' };
     }
   }
@@ -421,7 +422,7 @@ export const skipNextDelivery = webMethod(
 
       return { success: true, subscription: updated };
     } catch (err) {
-      console.error('Error skipping delivery:', err);
+      logError('[subscriptionService] skipDelivery failed', err);
       return { success: false, message: 'Failed to skip delivery' };
     }
   }
@@ -461,7 +462,7 @@ export const cancelSubscription = webMethod(
 
       return { success: true, subscription: updated };
     } catch (err) {
-      console.error('Error cancelling subscription:', err);
+      logError('[subscriptionService] cancelSubscription failed', err);
       return { success: false, message: 'Failed to cancel subscription' };
     }
   }
@@ -499,7 +500,7 @@ export const getSubscriberDiscount = webMethod(
 
       return { success: true, discount, activeCount };
     } catch (err) {
-      console.error('Error getting subscriber discount:', err);
+      logError('[subscriptionService] getSubscriberDiscount failed', err);
       return { success: false, message: 'Failed to get discount', discount: 0, activeCount: 0 };
     }
   }
@@ -542,7 +543,7 @@ export const isProductSubscribable = webMethod(
 
       return { subscribable: eligible, discount: eligible ? BASE_DISCOUNT : 0 };
     } catch (err) {
-      console.error('Error checking subscription eligibility:', err);
+      logError('[subscriptionService] checkSubscriptionEligibility failed', err);
       return { subscribable: false, discount: 0 };
     }
   }

--- a/tests/subscriptionServiceSilentFailureCleanup.test.js
+++ b/tests/subscriptionServiceSilentFailureCleanup.test.js
@@ -1,0 +1,94 @@
+/**
+ * cf-44qt sibling — subscriptionService.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch in
+ * subscriptionService.web.js calls `logError('[subscriptionService] <fn>
+ * failed', err)` instead of raw `console.error`.
+ *
+ * Pattern source: cf-44qt PR #1366 + cf-uydr PR #1373 +
+ * abTesting #1382 + notificationService #1383 + giftCards #1384.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'sub@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — subscriptionService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getMySubscriptions wires logError on Subscriptions query throw', async () => {
+    __setQueryError('Subscriptions', new Error('wixData failure'));
+    const mod = await import('../src/backend/subscriptionService.web.js');
+    const result = await mod.getMySubscriptions();
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/subscriptionService/);
+    expect(tag).toMatch(/getSubscriptions/);
+  });
+
+  it('pauseSubscription wires logError on Subscriptions query throw', async () => {
+    __setQueryError('Subscriptions', new Error('wixData failure'));
+    const mod = await import('../src/backend/subscriptionService.web.js');
+    const result = await mod.pauseSubscription('sub-1');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/subscriptionService/);
+    expect(tag).toMatch(/pauseSubscription/);
+  });
+
+  it('cancelSubscription wires logError on Subscriptions query throw', async () => {
+    __setQueryError('Subscriptions', new Error('wixData failure'));
+    const mod = await import('../src/backend/subscriptionService.web.js');
+    const result = await mod.cancelSubscription('sub-1');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/subscriptionService/);
+    expect(tag).toMatch(/cancelSubscription/);
+  });
+
+  it('getSubscriberDiscount wires logError on Subscriptions query throw', async () => {
+    __setQueryError('Subscriptions', new Error('wixData failure'));
+    const mod = await import('../src/backend/subscriptionService.web.js');
+    const result = await mod.getSubscriberDiscount();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/subscriptionService/);
+    expect(tag).toMatch(/getSubscriberDiscount/);
+  });
+
+  it('isProductSubscribable wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/subscriptionService.web.js');
+    const result = await mod.isProductSubscribable('prod-1');
+    expect(result.subscribable).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/subscriptionService/);
+    expect(tag).toMatch(/checkSubscriptionEligibility/);
+  });
+});


### PR DESCRIPTION
## Summary
- **10 catch sites** in \`src/backend/subscriptionService.web.js\` migrated to structured \`logError\` calls. Full first-time migration (file did not import logError previously).
- Fifth in the cf-44qt sibling series (#1373 → #1382 → #1383 → #1384 → this), per melania's 06:00 MT directive after the giftCards wave merged.
- Subscription/billing-adjacent surface — failed pauseSubscription/cancelSubscription silently going only to Velo console (pre-fix) is a real operational risk for recurring charges.

## Test contract (5 new, all green)
Representative spy assertions on getMySubscriptions, pauseSubscription, cancelSubscription, getSubscriberDiscount, isProductSubscribable.

## Verification
- [x] New tests: **5/5 green**
- [x] Existing suite: 176/176 (subscriptionService + subscriptionServiceDeep)
- [x] Combined: **181/181**
- [x] No coverage threshold breach
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)