### PR TITLE
fix(cf-44qt sibling): smsService.web.js console.error → logError ×14 (P3 obs cleanup)

### DIFF
--- a/src/backend/smsService.web.js
+++ b/src/backend/smsService.web.js
@@ -28,6 +28,7 @@ import { getSecret } from 'wix-secrets-backend';
 import { fetch } from 'wix-fetch';
 import wixData from 'wix-data';
 import { sanitize, validatePhone, formatPhoneE164 } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SMS_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SITE_URL = 'https://www.carolinafutons.com';
@@ -66,14 +67,14 @@ async function sendViaTwilio(to, body) {
 
     if (!response.ok) {
       const err = await response.json();
-      console.error('[smsService] Twilio error:', err);
+      logError('[smsService] twilioRequest failed', err);
       return { success: false };
     }
 
     const data = await response.json();
     return { success: true, sid: data.sid };
   } catch (err) {
-    console.error('[smsService] Error sending SMS:', err);
+    logError('[smsService] sendSMS failed', err);
     return { success: false };
   }
 }
@@ -146,7 +147,7 @@ async function logSMS(logData) {
       sentAt: new Date(),
     });
   } catch (err) {
-    console.error('[smsService] Error logging SMS:', err);
+    logError('[smsService] logSMS failed', err);
   }
 }
 
@@ -187,7 +188,7 @@ export const sendOrderConfirmationSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendOrderConfirmationSMS:', err);
+      logError('[smsService] sendOrderConfirmationSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -236,7 +237,7 @@ export const sendShippingUpdateSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendShippingUpdateSMS:', err);
+      logError('[smsService] sendShippingUpdateSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -283,7 +284,7 @@ export const sendDeliveryReminderSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendDeliveryReminderSMS:', err);
+      logError('[smsService] sendDeliveryReminderSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -331,7 +332,7 @@ export const sendBackInStockSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendBackInStockSMS:', err);
+      logError('[smsService] sendBackInStockSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -388,7 +389,7 @@ export const updateSMSPreferences = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in updateSMSPreferences:', err);
+      logError('[smsService] updateSMSPreferences failed', err);
       return { success: false, error: 'Failed to update preferences' };
     }
   }
@@ -437,7 +438,7 @@ export const sendOrderShippedSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendOrderShippedSMS:', err);
+      logError('[smsService] sendOrderShippedSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -488,7 +489,7 @@ export const getSMSPreferences = webMethod(
         },
       };
     } catch (err) {
-      console.error('[smsService] Error in getSMSPreferences:', err);
+      logError('[smsService] getSMSPreferences failed', err);
       return { success: false };
     }
   }
@@ -553,7 +554,7 @@ export const sendWhiteGloveConfirmationSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendWhiteGloveConfirmationSMS:', err);
+      logError('[smsService] sendWhiteGloveConfirmationSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -599,7 +600,7 @@ export const sendWhiteGloveReminderSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendWhiteGloveReminderSMS:', err);
+      logError('[smsService] sendWhiteGloveReminderSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -641,7 +642,7 @@ export const sendWhiteGloveDayOfSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendWhiteGloveDayOfSMS:', err);
+      logError('[smsService] sendWhiteGloveDayOfSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }
@@ -687,7 +688,7 @@ export const sendChallengeAlertSMS = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[smsService] Error in sendChallengeAlertSMS:', err);
+      logError('[smsService] sendChallengeAlertSMS failed', err);
       return { success: false, reason: 'error' };
     }
   }

--- a/tests/smsServiceSilentFailureCleanup.test.js
+++ b/tests/smsServiceSilentFailureCleanup.test.js
@@ -1,0 +1,100 @@
+/**
+ * cf-44qt sibling — smsService.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch calls
+ * `logError('[smsService] <fn> failed', err)` instead of raw
+ * `console.error`. Per melania directive 2026-05-16 06:00 MT.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validatePhone: (s) => true,
+  formatPhoneE164: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-secrets-backend', () => ({
+  getSecret: vi.fn(async (k) => {
+    if (k === 'TWILIO_ACCOUNT_SID') return 'AC_test';
+    if (k === 'TWILIO_AUTH_TOKEN') return 'token_test';
+    if (k === 'TWILIO_PHONE_NUMBER') return '+15555550100';
+    return '';
+  }),
+}));
+vi.mock('wix-fetch', () => ({
+  fetch: vi.fn(async () => ({ ok: false, status: 500, text: async () => 'twilio error' })),
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — smsService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('updateSMSPreferences wires logError on SMSPreferences query throw', async () => {
+    __setQueryError('SMSPreferences', new Error('wixData failure'));
+    const mod = await import('../src/backend/smsService.web.js');
+    const result = await mod.updateSMSPreferences({ phone: '+15555550100', smsEnabled: true });
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/smsService/);
+    expect(tag).toMatch(/updateSMSPreferences/);
+  });
+
+  it('getSMSPreferences wires logError on SMSPreferences query throw', async () => {
+    __setQueryError('SMSPreferences', new Error('wixData failure'));
+    const mod = await import('../src/backend/smsService.web.js');
+    await mod.getSMSPreferences();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/smsService/);
+    expect(tag).toMatch(/getSMSPreferences/);
+  });
+
+  it('sendOrderConfirmationSMS wires logError on SMSPreferences query throw', async () => {
+    __setQueryError('SMSPreferences', new Error('wixData failure'));
+    const mod = await import('../src/backend/smsService.web.js');
+    await mod.sendOrderConfirmationSMS({ memberId: 'member-1', orderNumber: 'ord-1', orderTotal: 99 });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/smsService/);
+    expect(tag).toMatch(/sendOrderConfirmationSMS/);
+  });
+
+  it('sendBackInStockSMS wires logError on SMSPreferences query throw', async () => {
+    __setQueryError('SMSPreferences', new Error('wixData failure'));
+    const mod = await import('../src/backend/smsService.web.js');
+    await mod.sendBackInStockSMS({ memberId: 'member-1', productName: 'Test' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/smsService/);
+    expect(tag).toMatch(/sendBackInStockSMS/);
+  });
+
+  it('sendChallengeAlertSMS wires logError on SMSPreferences query throw', async () => {
+    __setQueryError('SMSPreferences', new Error('wixData failure'));
+    const mod = await import('../src/backend/smsService.web.js');
+    await mod.sendChallengeAlertSMS({ memberId: 'member-1', message: 'Challenge alert' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/smsService/);
+    expect(tag).toMatch(/sendChallengeAlertSMS/);
+  });
+});


### PR DESCRIPTION
## Summary
- **14 catch sites** in \`src/backend/smsService.web.js\` migrated to structured \`logError\` calls. Full first-time migration (file did not import logError previously).
- Sixth in the cf-44qt sibling series; second target on melania's priority list (smsService → events → http-functions).
- 3 internal helpers (twilioRequest, sendSMS, logSMS) + 11 public webMethods. Customer-touchpoint surface with Twilio paid-per-message billing.

## Test contract (5 new, all green)
Representative spy assertions covering the 3 distinct destructure-arg patterns: \`{ phone, ... }\` (updateSMSPreferences), no-args (getSMSPreferences), \`{ memberId, ... }\` (sendOrderConfirmationSMS / sendBackInStockSMS / sendChallengeAlertSMS).

## Verification
- [x] New tests: **5/5 green**
- [x] Existing suite: 66/66 (smsService + smsServiceDeep)
- [x] Combined: **71/71**
- [x] No coverage threshold breach
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)