### PR TITLE
fix(cf-44qt sibling): emailService.web.js console.error → logError ×10 (P3 obs cleanup)

### DIFF
--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -26,6 +26,7 @@ import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 import { validateSchema } from 'backend/utils/validateSchema';
 import { resolveTemplateId } from 'backend/emailTemplates.web';
 
@@ -235,7 +236,7 @@ export const sendEmail = webMethod(
       logAuditEvent('ContactSubmissions', 'send_email', cleanEmail, { subject: cleanSubject });
       return { success: true };
     } catch (err) {
-      console.error('Error sending contact email:', err);
+      logError('[emailService] sendEmail failed', err);
       return { success: false, message: 'Failed to send message. Please try calling us at (828) 252-9449.' };
     }
   }
@@ -387,13 +388,13 @@ export const submitSwatchRequest = webMethod(
           );
         }
       } catch (confirmErr) {
-        console.error('Swatch confirmation email failed (non-blocking):', confirmErr);
+        logError('[emailService] submitSwatchRequest confirmation-email non-blocking', confirmErr);
       }
 
       logAuditEvent('ContactSubmissions', 'swatch_request', cleanEmail, { product: cleanProductName });
       return { success: true };
     } catch (err) {
-      console.error('Error submitting swatch request:', err);
+      logError('[emailService] submitSwatchRequest failed', err);
       return { success: false, message: 'Failed to submit swatch request. Please try calling us at (828) 252-9449.' };
     }
   }
@@ -459,7 +460,7 @@ export const sendSwatchConfirmationEmail = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('Error sending swatch confirmation email:', err);
+      logError('[emailService] sendSwatchConfirmationEmail failed', err);
       return { success: false, message: 'Failed to send confirmation email.' };
     }
   }
@@ -504,7 +505,7 @@ export const sendOrderNotification = webMethod(
       );
       return { success: true };
     } catch (err) {
-      console.error('Error sending order notification:', err);
+      logError('[emailService] sendOrderNotification failed', err);
       return { success: false };
     }
   }
@@ -548,7 +549,7 @@ export const sendOrderConfirmation = webMethod(
       );
       return { success: true };
     } catch (err) {
-      console.error('[emailService] Error sending order confirmation:', err);
+      logError('[emailService] sendOrderConfirmation failed', err);
       return { success: false };
     }
   }
@@ -594,7 +595,7 @@ export const sendShippingNotification = webMethod(
       );
       return { success: true };
     } catch (err) {
-      console.error('[emailService] Error sending shipping notification:', err);
+      logError('[emailService] sendShippingNotification failed', err);
       return { success: false };
     }
   }
@@ -640,7 +641,7 @@ export const sendFreightShippingNotification = webMethod(
       );
       return { success: true };
     } catch (err) {
-      console.error('[emailService] Error sending freight shipping notification:', err);
+      logError('[emailService] sendFreightShippingNotification failed', err);
       return { success: false };
     }
   }
@@ -678,7 +679,7 @@ export const sendDeliveryConfirmation = webMethod(
       );
       return { success: true };
     } catch (err) {
-      console.error('[emailService] Error sending delivery confirmation:', err);
+      logError('[emailService] sendDeliveryConfirmation failed', err);
       return { success: false };
     }
   }
@@ -737,7 +738,7 @@ export const sendABEmail = webMethod(
 
       return { sent: true, variant: effectiveVariant };
     } catch (err) {
-      console.error('[emailService] sendABEmail error:', err);
+      logError('[emailService] sendABEmail failed', err);
       return { sent: false, reason: 'send_failed' };
     }
   }

--- a/tests/emailServiceSilentFailureCleanup.test.js
+++ b/tests/emailServiceSilentFailureCleanup.test.js
@@ -1,0 +1,109 @@
+/**
+ * cf-44qt sibling — emailService.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch calls
+ * `logError('[emailService] <fn> failed', err)` instead of raw
+ * `console.error`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateEmail: (s) => true,
+}));
+vi.mock('backend/utils/auditLog', () => ({
+  logAuditEvent: vi.fn(),
+}));
+vi.mock('backend/utils/validateSchema', () => ({
+  validateSchema: vi.fn((schema, data) => ({ valid: true, data })),
+}));
+vi.mock('backend/emailTemplates.web', () => ({
+  resolveTemplateId: vi.fn((k) => `tpl_${k}`),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-secrets-backend', () => ({
+  getSecret: vi.fn(async () => ''),
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+vi.mock('backend/emailABService.web', () => ({
+  assignVariant: vi.fn(() => 'A'),
+  logABSend: vi.fn(async () => undefined),
+}));
+
+let emailContactFn;
+vi.mock('wix-crm-backend', () => {
+  emailContactFn = vi.fn(async () => { throw new Error('triggeredEmail failure'); });
+  return {
+    triggeredEmails: { emailContact: emailContactFn },
+    contacts: { queryContacts: vi.fn(() => ({ eq: () => ({ find: async () => ({ items: [{ _id: 'c-1' }] }) }) })) },
+  };
+});
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — emailService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('sendOrderConfirmation wires logError on triggeredEmail throw', async () => {
+    const mod = await import('../src/backend/emailService.web.js');
+    await mod.sendOrderConfirmation({ contactId: 'c-1', email: 'buyer@example.com', orderNumber: 'ord-1', orderTotal: 99 });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/emailService/);
+    expect(tag).toMatch(/sendOrderConfirmation/);
+  });
+
+  it('sendShippingNotification wires logError on triggeredEmail throw', async () => {
+    const mod = await import('../src/backend/emailService.web.js');
+    await mod.sendShippingNotification({ contactId: 'c-1', email: 'buyer@example.com', orderNumber: 'ord-1', trackingNumber: 'T-1' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/emailService/);
+    expect(tag).toMatch(/sendShippingNotification/);
+  });
+
+  it('sendFreightShippingNotification wires logError on triggeredEmail throw', async () => {
+    const mod = await import('../src/backend/emailService.web.js');
+    await mod.sendFreightShippingNotification({ contactId: 'c-1', email: 'buyer@example.com', orderNumber: 'ord-1' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/emailService/);
+    expect(tag).toMatch(/sendFreightShippingNotification/);
+  });
+
+  it('sendDeliveryConfirmation wires logError on triggeredEmail throw', async () => {
+    const mod = await import('../src/backend/emailService.web.js');
+    await mod.sendDeliveryConfirmation({ contactId: 'c-1', email: 'buyer@example.com', orderNumber: 'ord-1' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/emailService/);
+    expect(tag).toMatch(/sendDeliveryConfirmation/);
+  });
+
+  it('sendABEmail wires logError on triggeredEmail throw', async () => {
+    const mod = await import('../src/backend/emailService.web.js');
+    await mod.sendABEmail('member-1', 'campaign-1', 'buyer@example.com', [
+      { variant: 'A', templateId: 'tpl_A', variables: {} },
+      { variant: 'B', templateId: 'tpl_B', variables: {} },
+    ]);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/emailService/);
+    expect(tag).toMatch(/sendABEmail/);
+  });
+});


### PR DESCRIPTION
## Summary
- **10 catch sites** in \`src/backend/emailService.web.js\` migrated to structured \`logError\` calls. Full first-time migration.
- Seventh in the cf-44qt sibling series. Customer-touchpoint surface (transactional comms — order confirmations, shipping notices, swatch requests).

## Test contract (5 new, all green)
sendOrderConfirmation, sendShippingNotification, sendFreightShippingNotification, sendDeliveryConfirmation, sendABEmail. Covers both 1-arg-object and positional-args signatures.

## Verification
- [x] New tests: **5/5 green**
- [x] Existing suite (5 test files): 121/121 green
- [x] Combined: **126/126**
- [x] No coverage threshold breach
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)