### PR TITLE
fix(cf-44qt sibling): deliveryScheduling.web.js console.error → logError ×10 (P3 obs cleanup)

### DIFF
--- a/src/backend/deliveryScheduling.web.js
+++ b/src/backend/deliveryScheduling.web.js
@@ -34,6 +34,7 @@ import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { checkRateLimit, hashRateLimitKey } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 import { validateSchema } from 'backend/utils/validateSchema';
 import { sendDeliveryBookingConfirmationSms } from 'backend/deliveryNotifications.web';
 
@@ -137,7 +138,7 @@ export const getAvailableDeliveryWindows = webMethod(
 
       return slots;
     } catch (err) {
-      console.error('Error getting delivery windows:', err);
+      logError('[deliveryScheduling] getAvailableDeliveryWindows failed', err);
       return [];
     }
   }
@@ -245,7 +246,7 @@ export const reserveDeliveryWindow = webMethod(
         },
       };
     } catch (err) {
-      console.error('Error reserving delivery window:', err);
+      logError('[deliveryScheduling] reserveDeliveryWindow failed', err);
       return { success: false, message: 'Failed to reserve delivery window' };
     }
   }
@@ -298,7 +299,7 @@ export const getAvailableDeliverySlots = webMethod(
 
       return slots;
     } catch (err) {
-      console.error('Error getting delivery slots:', err);
+      logError('[deliveryScheduling] getAvailableDeliverySlots failed', err);
       return [];
     }
   }
@@ -408,12 +409,12 @@ export const scheduleDelivery = webMethod(
           orderId,
           date,
           timeWindow,
-        }).catch(err => console.error('[deliveryScheduling] SMS confirmation fire failed:', err?.message));
+        }).catch(err => logError('[deliveryScheduling] scheduleDelivery SMS-confirmation fire failed', err));
       }
 
       return { success: true, scheduleId: schedule._id };
     } catch (err) {
-      console.error('Error scheduling delivery:', err);
+      logError('[deliveryScheduling] scheduleDelivery failed', err);
       return { success: false, message: 'Failed to schedule delivery' };
     }
   }
@@ -451,7 +452,7 @@ export const getMyDeliverySchedule = webMethod(
         status: s.status,
       }));
     } catch (err) {
-      console.error('Error getting delivery schedule:', err);
+      logError('[deliveryScheduling] getMyDeliverySchedule failed', err);
       return [];
     }
   }
@@ -579,7 +580,7 @@ export const getAvailableAppointmentSlots = webMethod(
 
       return slots;
     } catch (err) {
-      console.error('Error getting appointment slots:', err);
+      logError('[deliveryScheduling] getAvailableAppointmentSlots failed', err);
       return [];
     }
   }
@@ -709,7 +710,7 @@ export const bookAppointment = webMethod(
         },
       };
     } catch (err) {
-      console.error('Error booking appointment:', err);
+      logError('[deliveryScheduling] bookAppointment failed', err);
       return { success: false, message: 'Failed to book appointment' };
     }
   }
@@ -762,7 +763,7 @@ export const cancelAppointment = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('Error cancelling appointment:', err);
+      logError('[deliveryScheduling] cancelAppointment failed', err);
       return { success: false, message: 'Failed to cancel appointment' };
     }
   }
@@ -804,7 +805,7 @@ export const getUpcomingAppointments = webMethod(
         notes: a.notes,
       }));
     } catch (err) {
-      console.error('Error getting upcoming appointments:', err);
+      logError('[deliveryScheduling] getUpcomingAppointments failed', err);
       return [];
     }
   }

--- a/tests/deliverySchedulingSilentFailureCleanup.test.js
+++ b/tests/deliverySchedulingSilentFailureCleanup.test.js
@@ -1,0 +1,95 @@
+/**
+ * cf-44qt sibling — deliveryScheduling.web.js observability cleanup.
+ *
+ * Pins post-migration contract: catches call logError('[deliveryScheduling] <fn> failed', err).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateEmail: () => true,
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+  hashRateLimitKey: (s) => s,
+}));
+vi.mock('backend/utils/auditLog', () => ({ logAuditEvent: vi.fn() }));
+vi.mock('backend/utils/validateSchema', () => ({
+  validateSchema: vi.fn((schema, data) => ({ valid: true, data })),
+}));
+vi.mock('backend/deliveryNotifications.web', () => ({
+  sendDeliveryBookingConfirmationSms: vi.fn(async () => ({ success: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — deliveryScheduling.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getAvailableDeliveryWindows wires logError on DeliverySchedule query throw', async () => {
+    __setQueryError('DeliverySchedule', new Error('wixData failure'));
+    const mod = await import('../src/backend/deliveryScheduling.web.js');
+    await mod.getAvailableDeliveryWindows();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/deliveryScheduling/);
+    expect(tag).toMatch(/getAvailableDeliveryWindows/);
+  });
+
+  it('getAvailableDeliverySlots wires logError on DeliverySchedule query throw', async () => {
+    __setQueryError('DeliverySchedule', new Error('wixData failure'));
+    const mod = await import('../src/backend/deliveryScheduling.web.js');
+    await mod.getAvailableDeliverySlots('2026-06-01', '2026-06-30');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/deliveryScheduling/);
+    expect(tag).toMatch(/getAvailableDeliverySlots/);
+  });
+
+  it('getMyDeliverySchedule wires logError on DeliverySchedule query throw', async () => {
+    __setQueryError('DeliverySchedule', new Error('wixData failure'));
+    const mod = await import('../src/backend/deliveryScheduling.web.js');
+    await mod.getMyDeliverySchedule('cust@example.com');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/deliveryScheduling/);
+    expect(tag).toMatch(/getMyDeliverySchedule/);
+  });
+
+  it('getAvailableAppointmentSlots wires logError on ShowroomAppointments query throw', async () => {
+    __setQueryError('ShowroomAppointments', new Error('wixData failure'));
+    const mod = await import('../src/backend/deliveryScheduling.web.js');
+    await mod.getAvailableAppointmentSlots('browse');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/deliveryScheduling/);
+    expect(tag).toMatch(/getAvailableAppointmentSlots/);
+  });
+
+  it('getUpcomingAppointments wires logError on ShowroomAppointments query throw', async () => {
+    __setQueryError('ShowroomAppointments', new Error('wixData failure'));
+    const mod = await import('../src/backend/deliveryScheduling.web.js');
+    await mod.getUpcomingAppointments('cust@example.com');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const [tag] = logErrorSpy.mock.calls[0];
+    expect(tag).toMatch(/deliveryScheduling/);
+    expect(tag).toMatch(/getUpcomingAppointments/);
+  });
+});


### PR DESCRIPTION
## Summary
- **10 catch sites** in \`src/backend/deliveryScheduling.web.js\` migrated to structured \`logError\` calls. Full first-time migration.
- Eighth in the cf-44qt sibling series. Delivery + showroom-appointment scheduling — silent fails could cause double-booking / lost reservations / customer-visible scheduling chaos.
- Includes 1 inline \`.catch(err => ...)\` arrow form on the scheduleDelivery post-schedule SMS-confirmation fire.

## Test contract (5 new, all green)
getAvailableDeliveryWindows, getAvailableDeliverySlots, getMyDeliverySchedule, getAvailableAppointmentSlots, getUpcomingAppointments. Covers both delivery-side and appointment-side surfaces.

## Verification
- [x] New tests: **5/5 green**
- [x] Existing suite: 111/111 (3 test files)
- [x] Combined: **116/116**
- [x] No threshold breach
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)