### PR TITLE
fix(cf-44qt sibling): ups-shipping.web.js console.error → logError ×10 (P3 obs cleanup)

### DIFF
--- a/src/backend/ups-shipping.web.js
+++ b/src/backend/ups-shipping.web.js
@@ -33,6 +33,7 @@ import { getSecret } from 'wix-secrets-backend';
 import { fetch } from 'wix-fetch';
 import { brand, business, shippingConfig } from 'public/sharedTokens.js';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Configuration ───────────────────────────────────────────────────
 
@@ -153,7 +154,7 @@ async function getUPSToken() {
 
   if (!response.ok) {
     const error = await response.text();
-    console.error('UPS OAuth error:', error);
+    logError('[ups-shipping] getOAuthToken failed', error);
     throw new Error('Failed to authenticate with UPS');
   }
 
@@ -172,7 +173,7 @@ async function getBaseUrl() {
   let sandbox = false;
   try {
     sandbox = (await getSecret('UPS_SANDBOX')) === 'true';
-  } catch (e) { console.error('[ups-shipping] Failed to retrieve UPS_SANDBOX setting:', e.message); }
+  } catch (e) { logError('[ups-shipping] UPS_SANDBOX-secret-read failed', e); }
   return sandbox
     ? 'https://wwwcie.ups.com/api'
     : 'https://onlinetools.ups.com/api';
@@ -298,7 +299,7 @@ export const getUPSRates = webMethod(
 
       if (!response.ok) {
         const errorText = await response.text();
-        console.error('UPS Rate API error:', response.status, errorText);
+        logError('[ups-shipping] getShippingRates UPS-Rate-API non-2xx', new Error(`status=${response.status} body=${errorText}`));
         return getUPSFallbackRates(destinationAddress.postalCode);
       }
 
@@ -324,7 +325,7 @@ export const getUPSRates = webMethod(
       }).sort((a, b) => a.cost - b.cost);
 
     } catch (err) {
-      console.error('Error getting UPS rates:', err);
+      logError('[ups-shipping] getShippingRates failed', err);
       return getUPSFallbackRates(destinationAddress?.postalCode);
     }
   }
@@ -497,7 +498,7 @@ export const createShipment = webMethod(
 
       if (!response.ok) {
         const errorText = await response.text();
-        console.error('UPS Shipment API error:', response.status, errorText);
+        logError('[ups-shipping] createShipment UPS-Shipment-API non-2xx', new Error(`status=${response.status} body=${errorText}`));
         throw new Error(`UPS shipment creation failed: ${response.status}`);
       }
 
@@ -533,7 +534,7 @@ export const createShipment = webMethod(
         billingWeight: shipmentResult.BillingWeight?.Weight,
       };
     } catch (err) {
-      console.error('Error creating UPS shipment:', err);
+      logError('[ups-shipping] createShipment failed', err);
       return {
         success: false,
         error: 'Unable to create shipment. Please try again or contact support.',
@@ -579,7 +580,7 @@ export const trackShipment = webMethod(
       );
 
       if (!response.ok) {
-        console.error('UPS Tracking API error:', response.status);
+        logError('[ups-shipping] trackShipment UPS-Tracking-API non-2xx', new Error(`status=${response.status}`));
         return {
           success: false,
           error: 'Unable to retrieve tracking information',
@@ -619,7 +620,7 @@ export const trackShipment = webMethod(
         })),
       };
     } catch (err) {
-      console.error('Error tracking UPS shipment:', err);
+      logError('[ups-shipping] trackShipment failed', err);
       return {
         success: false,
         error: 'Unable to retrieve tracking information',
@@ -677,7 +678,7 @@ export const validateAddress = webMethod(
       });
 
       if (!response.ok) {
-        console.error('UPS address validation API returned', response.status);
+        logError('[ups-shipping] validateAddress UPS-AddressValidation-API non-2xx', new Error(`status=${response.status}`));
         return { valid: false, candidates: [], unavailable: true, error: 'validation unavailable' };
       }
 
@@ -704,7 +705,7 @@ export const validateAddress = webMethod(
 
       return { valid: false, candidates: [], unavailable: true, error: 'validation unavailable' };
     } catch (err) {
-      console.error('Address validation error:', err);
+      logError('[ups-shipping] validateAddress failed', err);
       return { valid: false, candidates: [], unavailable: true, error: 'validation unavailable' };
     }
   }

--- a/tests/upsShippingSilentFailureCleanup.test.js
+++ b/tests/upsShippingSilentFailureCleanup.test.js
@@ -1,0 +1,85 @@
+/**
+ * cf-44qt sibling — ups-shipping.web.js observability cleanup.
+ *
+ * Pins post-migration contract: catches call logError instead of raw
+ * console.error. UPS shipping is the carrier-pricing surface — silent
+ * fails (OAuth blip, rate-API outage) silently strand orders.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-secrets-backend', () => ({
+  getSecret: vi.fn(async (k) => {
+    if (k === 'UPS_CLIENT_ID') return 'client_test';
+    if (k === 'UPS_CLIENT_SECRET') return 'secret_test';
+    return '';
+  }),
+}));
+vi.mock('public/sharedTokens.js', () => ({
+  brand: { name: 'Carolina Futons' },
+  business: { address: { street: '824 Locust', city: 'Hendersonville', state: 'NC', zip: '28792' } },
+  shippingConfig: { freeThreshold: 999999 },
+}));
+
+vi.mock('wix-fetch', () => ({
+  fetch: vi.fn(async () => ({ ok: false, status: 500, text: async () => 'ups api error' })),
+}));
+
+describe('cf-44qt sibling — ups-shipping.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+  });
+
+  it('getUPSRates wires logError on UPS API failure', async () => {
+    const mod = await import('../src/backend/ups-shipping.web.js');
+    await mod.getUPSRates(
+      { street: '1 Test', city: 'Asheville', state: 'NC', zip: '28801', country: 'US' },
+      [{ weight: 10 }],
+    );
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ups-shipping/);
+  });
+
+  it('createShipment wires logError on UPS Shipment API failure', async () => {
+    const mod = await import('../src/backend/ups-shipping.web.js');
+    await mod.createShipment(
+      { street: '1 Test', city: 'Asheville', state: 'NC', zip: '28801', country: 'US' },
+      [{ weight: 10 }],
+      '03', // GROUND
+    );
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ups-shipping/);
+  });
+
+  it('trackShipment wires logError on UPS Tracking API failure', async () => {
+    const mod = await import('../src/backend/ups-shipping.web.js');
+    await mod.trackShipment('1Z9999999999999999');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ups-shipping/);
+  });
+
+  it('validateAddress wires logError on UPS Address Validation API failure', async () => {
+    const mod = await import('../src/backend/ups-shipping.web.js');
+    await mod.validateAddress({
+      street: '1 Test',
+      city: 'Asheville',
+      state: 'NC',
+      zip: '28801',
+      country: 'US',
+    });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ups-shipping/);
+  });
+});


### PR DESCRIPTION
## Summary
- **10 catch sites** in \`src/backend/ups-shipping.web.js\` migrated. Carrier-pricing surface across OAuth, Rate, Shipment, Tracking, AddressValidation APIs.
- Non-2xx responses now wrap status/body in real \`new Error(...)\` so the structured log carries response shape (vs prior variadic-spread \`console.error\` that wasn't introspectable).
- Tenth in the cf-44qt sibling series.

## Test contract (4 new, all green)
4 outer-catch boundaries: getUPSRates, createShipment, trackShipment, validateAddress.

## Verification
- [x] New tests: **4/4 green**
- [x] Existing ups-shipping suite (4 files incl. lazy-init contract): **129/129 green**
- [x] Combined: **133/133**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)