### PR TITLE
fix(cf-44qt sibling): reviewsService.web.js console.error → logError ×12 (P3 obs cleanup)

### DIFF
--- a/src/backend/reviewsService.web.js
+++ b/src/backend/reviewsService.web.js
@@ -28,6 +28,7 @@ import { currentMember } from 'wix-members-backend';
 import { mediaManager } from 'wix-media-backend';
 import { sanitize, validateId, isWixMediaUrl } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 import { receiveGamificationEvent } from 'backend/gamificationEventReceiver.web';
 import { recordEmailEvent } from 'backend/emailAutomation.web'; // CF-fzsd: conversion tracking
 
@@ -232,7 +233,7 @@ export const submitReview = webMethod(
 
       return { success: true, reviewId: saved._id };
     } catch (err) {
-      console.error('[reviewsService] Submit error:', err);
+      logError('[reviewsService] submitReview failed', err);
       return { success: false, error: 'Unable to submit review. Please try again.' };
     }
   }
@@ -259,7 +260,7 @@ export const markHelpful = webMethod(
       await wixData.update(COLLECTION, review);
       return { success: true, helpful: review.helpful };
     } catch (err) {
-      console.error('[reviewsService] markHelpful error:', err);
+      logError('[reviewsService] markHelpful failed', err);
       return { success: false };
     }
   }
@@ -304,7 +305,7 @@ export const flagReview = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[reviewsService] flagReview error:', err);
+      logError('[reviewsService] flagReview failed', err);
       return { success: false, error: 'Failed to flag review' };
     }
   }
@@ -333,7 +334,7 @@ export const getPendingReviews = webMethod(
         total: result.totalCount,
       };
     } catch (err) {
-      console.error('[reviewsService] getPendingReviews error:', err);
+      logError('[reviewsService] getPendingReviews failed', err);
       return { success: false, reviews: [], total: 0 };
     }
   }
@@ -389,7 +390,7 @@ export const moderateReview = webMethod(
       logAuditEvent(COLLECTION, `moderate_${action}`, rid, { previousStatus, newStatus });
       return { success: true, previousStatus, newStatus };
     } catch (err) {
-      console.error('[reviewsService] moderateReview error:', err);
+      logError('[reviewsService] moderateReview failed', err);
       return { success: false, error: 'Failed to moderate review.' };
     }
   }
@@ -447,7 +448,7 @@ export const getCategoryReviewSummaries = webMethod(
 
       return summaries;
     } catch (err) {
-      console.error('[reviewsService] getCategoryReviewSummaries error:', err);
+      logError('[reviewsService] getCategoryReviewSummaries failed', err);
       return {};
     }
   }
@@ -475,7 +476,7 @@ async function checkVerifiedPurchase(memberId, productId) {
     }
     return false;
   } catch (err) {
-    console.error('[reviewsService] Verified purchase check error:', err);
+    logError('[reviewsService] verifiedPurchaseCheck failed', err);
     return false;
   }
 }
@@ -572,7 +573,7 @@ export const submitVideoReview = webMethod(
 
       return { success: true, reviewId: inserted._id };
     } catch (err) {
-      console.error('[reviewsService] submitVideoReview error:', err);
+      logError('[reviewsService] submitVideoReview failed', err);
       return { success: false, error: 'Failed to submit video review.' };
     }
   }
@@ -614,7 +615,7 @@ export const getVideoReviews = webMethod(
 
       return { success: true, reviews, totalCount: result.totalCount };
     } catch (err) {
-      console.error('[reviewsService] getVideoReviews error:', err);
+      logError('[reviewsService] getVideoReviews failed', err);
       return { success: false, error: 'Failed to load video reviews.', reviews: [] };
     }
   }
@@ -653,13 +654,13 @@ export const moderateVideoReview = webMethod(
         try {
           await receiveGamificationEvent('video_review_approved', { memberId: review.memberId });
         } catch (e) {
-          console.error('[reviewsService] moderateVideoReview gamification trigger failed:', e?.message);
+          logError('[reviewsService] moderateVideoReview gamification-trigger failed', e);
         }
       }
 
       return { success: true };
     } catch (err) {
-      console.error('[reviewsService] moderateVideoReview error:', err);
+      logError('[reviewsService] moderateVideoReview failed', err);
       return { success: false, error: 'Failed to moderate video review.' };
     }
   }
@@ -743,7 +744,7 @@ export const getFeaturedReviews = webMethod(
 
       return { success: true, reviews };
     } catch (err) {
-      console.error('[reviewsService] getFeaturedReviews error:', err);
+      logError('[reviewsService] getFeaturedReviews failed', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }

--- a/tests/reviewsServiceSilentFailureCleanup.test.js
+++ b/tests/reviewsServiceSilentFailureCleanup.test.js
@@ -1,0 +1,83 @@
+/**
+ * cf-44qt sibling — reviewsService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+  isWixMediaUrl: () => true,
+}));
+vi.mock('backend/utils/auditLog', () => ({ logAuditEvent: vi.fn() }));
+vi.mock('backend/gamificationEventReceiver.web', () => ({
+  receiveGamificationEvent: vi.fn(async () => ({ success: true })),
+}));
+vi.mock('backend/emailAutomation.web', () => ({
+  recordEmailEvent: vi.fn(async () => ({})),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+vi.mock('wix-media-backend', () => ({
+  mediaManager: { getFileInfo: vi.fn(async () => ({})) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — reviewsService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getPendingReviews wires logError on Reviews query throw', async () => {
+    __setQueryError('Reviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/reviewsService.web.js');
+    await mod.getPendingReviews();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/reviewsService/);
+    expect(allTags).toMatch(/getPendingReviews/);
+  });
+
+  it('getCategoryReviewSummaries wires logError on query throw', async () => {
+    __setQueryError('Reviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/reviewsService.web.js');
+    await mod.getCategoryReviewSummaries(['prod-1', 'prod-2']);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/reviewsService/);
+    expect(allTags).toMatch(/getCategoryReviewSummaries/);
+  });
+
+  it('getVideoReviews wires logError on VideoReviews query throw', async () => {
+    __setQueryError('VideoReviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/reviewsService.web.js');
+    await mod.getVideoReviews('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/reviewsService/);
+    expect(allTags).toMatch(/getVideoReviews/);
+  });
+
+  it('getFeaturedReviews wires logError on Reviews query throw', async () => {
+    __setQueryError('Reviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/reviewsService.web.js');
+    await mod.getFeaturedReviews();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/reviewsService/);
+    expect(allTags).toMatch(/getFeaturedReviews/);
+  });
+});


### PR DESCRIPTION
## Summary
- **12 catch sites** migrated. 10 public webMethods + 2 internal helpers.
- Eleventh in the cf-44qt sibling series. UGC moderation flow — silent fails risk inappropriate content publishing OR legitimate reviews getting blocked.

## Test contract (4 new, all green)
getPendingReviews, getCategoryReviewSummaries, getVideoReviews (both Reviews + VideoReviews collections), getFeaturedReviews.

## Verification
- [x] New tests: **4/4 green**
- [x] Existing reviewsService suite (6 files): **236/236 green**
- [x] Combined: **240/240**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)