### PR TITLE
fix(cf-44qt sibling): warrantyService.web.js console.error → logError ×7 (P3 obs cleanup)

### DIFF
--- a/src/backend/warrantyService.web.js
+++ b/src/backend/warrantyService.web.js
@@ -58,6 +58,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId, validateEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const VALID_ISSUE_TYPES = ['structural', 'fabric', 'mechanism', 'accidental', 'stain', 'other'];
 const MIN_DESCRIPTION_LENGTH = 10;
@@ -102,7 +103,7 @@ async function queueEmail(templateId, recipientEmail, variables) {
       createdAt: new Date(),
     });
   } catch (err) {
-    console.error(`[warrantyService] Email queue insert failed (${templateId}):`, err);
+    logError(`[warrantyService] queueEmail-${templateId} insert failed`, err);
   }
 }
 
@@ -174,7 +175,7 @@ export const registerWarranty = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[warrantyService] Error registering warranty:', err);
+      logError('[warrantyService] registerWarranty failed', err);
       return { success: false, error: 'Failed to register warranty.' };
     }
   }
@@ -224,7 +225,7 @@ export const getMyWarranties = webMethod(
 
       return { success: true, warranties };
     } catch (err) {
-      console.error('[warrantyService] Error getting warranties:', err);
+      logError('[warrantyService] getMyWarranties failed', err);
       return { success: false, error: 'Failed to load warranties.', warranties: [] };
     }
   }
@@ -299,7 +300,7 @@ export const getWarrantyDetails = webMethod(
         },
       };
     } catch (err) {
-      console.error('[warrantyService] Error getting warranty details:', err);
+      logError('[warrantyService] getWarrantyDetails failed', err);
       return { success: false, error: 'Failed to load warranty details.' };
     }
   }
@@ -387,7 +388,7 @@ export const submitClaim = webMethod(
         },
       };
     } catch (err) {
-      console.error('[warrantyService] Error submitting claim:', err);
+      logError('[warrantyService] submitClaim failed', err);
       return { success: false, error: 'Failed to submit warranty claim.' };
     }
   }
@@ -437,7 +438,7 @@ export const getClaimStatus = webMethod(
         },
       };
     } catch (err) {
-      console.error('[warrantyService] Error getting claim status:', err);
+      logError('[warrantyService] getClaimStatus failed', err);
       return { success: false, error: 'Failed to load claim status.' };
     }
   }
@@ -473,7 +474,7 @@ export const getMyClaims = webMethod(
 
       return { success: true, claims };
     } catch (err) {
-      console.error('[warrantyService] Error getting claims:', err);
+      logError('[warrantyService] getMyClaims failed', err);
       return { success: false, error: 'Failed to load claims.', claims: [] };
     }
   }

--- a/tests/warrantyServiceSilentFailureCleanup.test.js
+++ b/tests/warrantyServiceSilentFailureCleanup.test.js
@@ -1,0 +1,73 @@
+/**
+ * cf-44qt sibling — warrantyService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+  validateEmail: () => true,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — warrantyService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getMyWarranties wires logError on Warranties query throw', async () => {
+    __setQueryError('WarrantyRegistrations', new Error('wixData failure'));
+    const mod = await import('../src/backend/warrantyService.web.js');
+    await mod.getMyWarranties();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/warrantyService/);
+    expect(allTags).toMatch(/getMyWarranties/);
+  });
+
+  it('getWarrantyDetails wires logError on Warranties query throw', async () => {
+    __setQueryError('WarrantyRegistrations', new Error('wixData failure'));
+    const mod = await import('../src/backend/warrantyService.web.js');
+    await mod.getWarrantyDetails('warranty-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/warrantyService/);
+    expect(allTags).toMatch(/getWarrantyDetails/);
+  });
+
+  it('getMyClaims wires logError on WarrantyClaims query throw', async () => {
+    __setQueryError('WarrantyClaims', new Error('wixData failure'));
+    const mod = await import('../src/backend/warrantyService.web.js');
+    await mod.getMyClaims();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/warrantyService/);
+    expect(allTags).toMatch(/getMyClaims/);
+  });
+
+  it('getClaimStatus wires logError on WarrantyClaims query throw', async () => {
+    __setQueryError('WarrantyClaims', new Error('wixData failure'));
+    const mod = await import('../src/backend/warrantyService.web.js');
+    await mod.getClaimStatus('claim-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/warrantyService/);
+    expect(allTags).toMatch(/getClaimStatus/);
+  });
+});


### PR DESCRIPTION
## Summary
- **7 catch sites** migrated. 6 webMethods + 1 internal queueEmail helper.
- Twelfth in the cf-44qt sibling series.

## Test contract (4 new, all green)
getMyWarranties, getWarrantyDetails, getMyClaims, getClaimStatus (covers both WarrantyRegistrations + WarrantyClaims collections).

## Verification
- [x] New tests: **4/4 green**
- [x] Existing warranty suite: **73/73 green**
- [x] Combined: **77/77**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)