### PR TITLE
fix(cf-44qt sibling): promotionsEngine.web.js console.error → logError ×8 (P3 obs cleanup)

### DIFF
--- a/src/backend/promotionsEngine.web.js
+++ b/src/backend/promotionsEngine.web.js
@@ -48,6 +48,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -142,7 +143,7 @@ export const validatePromoCode = webMethod(
         },
       };
     } catch (err) {
-      console.error('[promotionsEngine] Error validating promo code:', err);
+      logError('[promotionsEngine] validatePromoCode failed', err);
       return { success: false, error: 'Failed to validate promo code' };
     }
   }
@@ -259,7 +260,7 @@ export const applyPromoCode = webMethod(
         code: promo.code,
       };
     } catch (err) {
-      console.error('[promotionsEngine] Error applying promo code:', err);
+      logError('[promotionsEngine] applyPromoCode failed', err);
       return { success: false, error: 'Failed to apply promo code' };
     }
   }
@@ -298,7 +299,7 @@ export const getActiveFlashSales = webMethod(
 
       return { success: true, sales };
     } catch (err) {
-      console.error('[promotionsEngine] Error fetching flash sales:', err);
+      logError('[promotionsEngine] getActiveFlashSales failed', err);
       return { success: true, sales: [] };
     }
   }
@@ -335,7 +336,7 @@ export const getActiveBOGODeals = webMethod(
 
       return { success: true, deals };
     } catch (err) {
-      console.error('[promotionsEngine] Error fetching BOGO deals:', err);
+      logError('[promotionsEngine] getActiveBOGODeals failed', err);
       return { success: true, deals: [] };
     }
   }
@@ -412,7 +413,7 @@ export const calculateBOGOSavings = webMethod(
         appliedDeals,
       };
     } catch (err) {
-      console.error('[promotionsEngine] Error calculating BOGO savings:', err);
+      logError('[promotionsEngine] calculateBOGOSavings failed', err);
       return { success: true, totalSavings: 0, appliedDeals: [] };
     }
   }
@@ -466,7 +467,7 @@ export const createFlashSale = webMethod(
 
       return { success: true, sale };
     } catch (err) {
-      console.error('[promotionsEngine] Error creating flash sale:', err);
+      logError('[promotionsEngine] createFlashSale failed', err);
       return { success: false, error: 'Failed to create flash sale' };
     }
   }
@@ -545,7 +546,7 @@ export const createPromoCode = webMethod(
 
       return { success: true, promo };
     } catch (err) {
-      console.error('[promotionsEngine] Error creating promo code:', err);
+      logError('[promotionsEngine] createPromoCode failed', err);
       return { success: false, error: 'Failed to create promo code' };
     }
   }
@@ -567,7 +568,7 @@ async function incrementUsage(code) {
       await wixData.update('PromoCodes', promo);
     }
   } catch (err) {
-    console.error('[promotionsEngine] Error incrementing usage:', err);
+    logError('[promotionsEngine] incrementUsage failed', err);
   }
 }
 

--- a/tests/promotionsEngineSilentFailureCleanup.test.js
+++ b/tests/promotionsEngineSilentFailureCleanup.test.js
@@ -1,0 +1,73 @@
+/**
+ * cf-44qt sibling — promotionsEngine.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — promotionsEngine.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('validatePromoCode wires logError on PromoCodes query throw', async () => {
+    __setQueryError('PromoCodes', new Error('wixData failure'));
+    const mod = await import('../src/backend/promotionsEngine.web.js');
+    await mod.validatePromoCode('CODE-1', 100);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/promotionsEngine/);
+    expect(allTags).toMatch(/validatePromoCode/);
+  });
+
+  it('getActiveFlashSales wires logError on FlashSales query throw', async () => {
+    __setQueryError('FlashSales', new Error('wixData failure'));
+    const mod = await import('../src/backend/promotionsEngine.web.js');
+    await mod.getActiveFlashSales();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/promotionsEngine/);
+    expect(allTags).toMatch(/getActiveFlashSales/);
+  });
+
+  it('getActiveBOGODeals wires logError on BOGODeals query throw', async () => {
+    __setQueryError('BOGODeals', new Error('wixData failure'));
+    const mod = await import('../src/backend/promotionsEngine.web.js');
+    await mod.getActiveBOGODeals();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/promotionsEngine/);
+    expect(allTags).toMatch(/getActiveBOGODeals/);
+  });
+
+  it('applyPromoCode propagates logError on inner PromoCodes query throw', async () => {
+    __setQueryError('PromoCodes', new Error('wixData failure'));
+    const mod = await import('../src/backend/promotionsEngine.web.js');
+    await mod.applyPromoCode(
+      'CODE-1',
+      [{ _id: 'p1', price: 50, quantity: 1 }],
+      { rateLimitKey: 'member-1' },
+    );
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/promotionsEngine/);
+    expect(allTags).toMatch(/(applyPromoCode|validatePromoCode)/);
+  });
+});


### PR DESCRIPTION
## Summary
- **8 catch sites** migrated. 7 webMethods + 1 internal incrementUsage helper.
- Thirteenth in the cf-44qt sibling series. Promo / flash sale / BOGO surface — silent fail risks lost conversions on customer side + revenue-ops blockers on admin side.

## Test contract (4 new, all green)
validatePromoCode, getActiveFlashSales, getActiveBOGODeals, applyPromoCode (propagates inner validatePromoCode catch).

## Verification
- [x] New tests: **4/4 green**
- [x] Existing suite (7 files): **259/259 green**
- [x] Combined: **263/263**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)