### PR TITLE
fix(cf-44qt sibling): mediaGallery.web.js console.error → logError ×8 (P3 obs cleanup)

### DIFF
--- a/src/backend/mediaGallery.web.js
+++ b/src/backend/mediaGallery.web.js
@@ -33,6 +33,7 @@ import wixData from 'wix-data';
 import { mediaManager } from 'wix-media-backend';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const MEDIA_SYNC_COLLECTION = 'MediaSync';
 const PRODUCTS_COLLECTION = 'Stores/Products';
@@ -204,7 +205,7 @@ export const getProductMedia = webMethod(
         lastSynced: null,
       };
     } catch (err) {
-      console.error('getProductMedia error:', err);
+      logError('[mediaGallery] getProductMedia failed', err);
       return { success: false, error: 'Unable to fetch product media' };
     }
   }
@@ -269,7 +270,7 @@ export const getBatchProductThumbnails = webMethod(
 
       return { success: true, thumbnails };
     } catch (err) {
-      console.error('getBatchProductThumbnails error:', err);
+      logError('[mediaGallery] getBatchProductThumbnails failed', err);
       return { success: false, error: 'Unable to fetch thumbnails' };
     }
   }
@@ -329,7 +330,7 @@ export const listMediaFolder = webMethod(
         totalCount: files.length,
       };
     } catch (err) {
-      console.error('listMediaFolder error:', err);
+      logError('[mediaGallery] listMediaFolder failed', err);
       return { success: false, error: 'Failed to list media folder' };
     }
   }
@@ -359,7 +360,7 @@ export const listMediaFolders = webMethod(
 
       return { success: true, folders };
     } catch (err) {
-      console.error('listMediaFolders error:', err);
+      logError('[mediaGallery] listMediaFolders failed', err);
       return { success: false, error: 'Failed to list media folders' };
     }
   }
@@ -441,7 +442,7 @@ export const syncProductMedia = webMethod(
         lastSynced: now,
       };
     } catch (err) {
-      console.error('syncProductMedia error:', err);
+      logError('[mediaGallery] syncProductMedia failed', err);
       return { success: false, error: 'Failed to sync product media' };
     }
   }
@@ -515,7 +516,7 @@ export const batchSyncMedia = webMethod(
 
       return { success: true, synced, totalProducts: products.items.length };
     } catch (err) {
-      console.error('batchSyncMedia error:', err);
+      logError('[mediaGallery] batchSyncMedia failed', err);
       return { success: false, error: 'Failed to batch sync media' };
     }
   }
@@ -561,7 +562,7 @@ export const getImageUrl = webMethod(
         originalUrl: cleanUrl,
       };
     } catch (err) {
-      console.error('getImageUrl error:', err);
+      logError('[mediaGallery] getImageUrl failed', err);
       return { success: false, error: 'Unable to process image URL' };
     }
   }
@@ -605,7 +606,7 @@ export const getMediaStats = webMethod(
         },
       };
     } catch (err) {
-      console.error('getMediaStats error:', err);
+      logError('[mediaGallery] getMediaStats failed', err);
       return { success: false, error: 'Failed to load media stats' };
     }
   }

--- a/tests/mediaGallerySilentFailureCleanup.test.js
+++ b/tests/mediaGallerySilentFailureCleanup.test.js
@@ -1,0 +1,74 @@
+/**
+ * cf-44qt sibling — mediaGallery.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+vi.mock('wix-media-backend', () => ({
+  mediaManager: {
+    listFiles: vi.fn(async () => { throw new Error('mediaManager failure'); }),
+    listFolders: vi.fn(async () => { throw new Error('mediaManager failure'); }),
+    getFileInfo: vi.fn(async () => { throw new Error('mediaManager failure'); }),
+  },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — mediaGallery.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('listMediaFolder wires logError on mediaManager failure', async () => {
+    const mod = await import('../src/backend/mediaGallery.web.js');
+    await mod.listMediaFolder('test-folder');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/mediaGallery/);
+    expect(allTags).toMatch(/listMediaFolder/);
+  });
+
+  it('listMediaFolders wires logError on mediaManager failure', async () => {
+    const mod = await import('../src/backend/mediaGallery.web.js');
+    await mod.listMediaFolders();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/mediaGallery/);
+    expect(allTags).toMatch(/listMediaFolders/);
+  });
+
+  it('getProductMedia wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/mediaGallery.web.js');
+    await mod.getProductMedia('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/mediaGallery/);
+    expect(allTags).toMatch(/getProductMedia/);
+  });
+
+  it('getBatchProductThumbnails wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/mediaGallery.web.js');
+    await mod.getBatchProductThumbnails(['p1', 'p2']);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/mediaGallery/);
+    expect(allTags).toMatch(/getBatchProductThumbnails/);
+  });
+});


### PR DESCRIPTION
## Summary
- **8 catch sites** migrated. All public webMethods.
- 14th in the cf-44qt sibling series. Media Manager integration surface.

## Test contract (4 new, all green)
Covers both wixData throws (getProductMedia, getBatchProductThumbnails) AND mediaManager throws (listMediaFolder, listMediaFolders).

## Verification
- [x] **4/4** new + **190/190** existing = **194/194 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)