### PR TITLE
fix(cf-44qt sibling): ugcService.web.js console.error → logError ×8 (P3 obs cleanup)

### DIFF
--- a/src/backend/ugcService.web.js
+++ b/src/backend/ugcService.web.js
@@ -40,6 +40,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId, isWixMediaUrl } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const VALID_ROOM_TYPES = ['living-room', 'bedroom', 'office', 'dorm', 'porch'];
 const VALID_MODERATION_ACTIONS = ['approve', 'reject', 'feature'];
@@ -123,7 +124,7 @@ export const submitUGCPhoto = webMethod(
       const inserted = await wixData.insert('UGCPhotos', record);
       return { success: true, data: inserted };
     } catch (err) {
-      console.error('[ugcService] Error submitting UGC photo:', err);
+      logError('[ugcService] submitUGCPhoto failed', err);
       return { success: false, error: 'Failed to submit photo.' };
     }
   }
@@ -174,7 +175,7 @@ export const getApprovedPhotos = webMethod(
         totalCount: result.totalCount,
       };
     } catch (err) {
-      console.error('[ugcService] Error getting approved photos:', err);
+      logError('[ugcService] getApprovedPhotos failed', err);
       return { success: false, error: 'Failed to load photos.', photos: [], totalCount: 0 };
     }
   }
@@ -231,7 +232,7 @@ export const getBeforeAfterPairs = webMethod(
 
       return { success: true, pairs };
     } catch (err) {
-      console.error('[ugcService] Error getting before/after pairs:', err);
+      logError('[ugcService] getBeforeAfterPairs failed', err);
       return { success: false, error: 'Failed to load before/after pairs.', pairs: [] };
     }
   }
@@ -304,7 +305,7 @@ export const voteForPhoto = webMethod(
 
       return { success: true, voted, voteCount };
     } catch (err) {
-      console.error('[ugcService] Error voting for photo:', err);
+      logError('[ugcService] voteForPhoto failed', err);
       return { success: false, error: 'Failed to process vote.' };
     }
   }
@@ -346,7 +347,7 @@ export const reportPhoto = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[ugcService] Error reporting photo:', err);
+      logError('[ugcService] reportPhoto failed', err);
       return { success: false, error: 'Failed to report photo.' };
     }
   }
@@ -398,7 +399,7 @@ export const moderatePhoto = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[ugcService] Error moderating photo:', err);
+      logError('[ugcService] moderatePhoto failed', err);
       return { success: false, error: 'Failed to moderate photo.' };
     }
   }
@@ -444,7 +445,7 @@ export const getProductUGCPhotos = webMethod(
         totalCount: result.totalCount,
       };
     } catch (err) {
-      console.error('[ugcService] Error getting product UGC photos:', err);
+      logError('[ugcService] getProductUGCPhotos failed', err);
       return { success: false, error: 'Failed to load photos.', photos: [], totalCount: 0 };
     }
   }
@@ -487,7 +488,7 @@ export const getUGCStats = webMethod(
         stats: { total, featured, byRoomType },
       };
     } catch (err) {
-      console.error('[ugcService] Error getting UGC stats:', err);
+      logError('[ugcService] getUGCStats failed', err);
       return {
         success: false,
         error: 'Failed to load stats.',

--- a/tests/ugcServiceCoverage.test.js
+++ b/tests/ugcServiceCoverage.test.js
@@ -65,9 +65,11 @@ describe('moderatePhoto — error catch block', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Failed to moderate photo.');
+    // cf-44qt sibling migration: logError wraps the context in another bracket
+    // pair when delegating to console.error — assert the new module-prefix shape.
     expect(consoleSpy).toHaveBeenCalledWith(
-      '[ugcService] Error moderating photo:',
-      expect.any(Error)
+      expect.stringContaining('[ugcService] moderatePhoto failed'),
+      expect.any(String),
     );
   });
 
@@ -84,8 +86,8 @@ describe('moderatePhoto — error catch block', () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe('Failed to moderate photo.');
     expect(consoleSpy).toHaveBeenCalledWith(
-      '[ugcService] Error moderating photo:',
-      expect.any(Error)
+      expect.stringContaining('[ugcService] moderatePhoto failed'),
+      expect.any(String),
     );
   });
 });
@@ -160,8 +162,8 @@ describe('getUGCStats — error catch block', () => {
     expect(result.error).toBe('Failed to load stats.');
     expect(result.stats).toEqual({ total: 0, featured: 0, byRoomType: {} });
     expect(consoleSpy).toHaveBeenCalledWith(
-      '[ugcService] Error getting UGC stats:',
-      expect.any(Error)
+      expect.stringContaining('[ugcService] getUGCStats failed'),
+      expect.any(String),
     );
   });
 });

--- a/tests/ugcServiceSilentFailureCleanup.test.js
+++ b/tests/ugcServiceSilentFailureCleanup.test.js
@@ -1,0 +1,73 @@
+/**
+ * cf-44qt sibling — ugcService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+  isWixMediaUrl: () => true,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — ugcService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getApprovedPhotos wires logError on UGCPhotos query throw', async () => {
+    __setQueryError('UGCPhotos', new Error('wixData failure'));
+    const mod = await import('../src/backend/ugcService.web.js');
+    await mod.getApprovedPhotos();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ugcService/);
+    expect(allTags).toMatch(/getApprovedPhotos/);
+  });
+
+  it('getBeforeAfterPairs wires logError on UGCPhotos query throw', async () => {
+    __setQueryError('UGCPhotos', new Error('wixData failure'));
+    const mod = await import('../src/backend/ugcService.web.js');
+    await mod.getBeforeAfterPairs();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ugcService/);
+    expect(allTags).toMatch(/getBeforeAfterPairs/);
+  });
+
+  it('getProductUGCPhotos wires logError on UGCPhotos query throw', async () => {
+    __setQueryError('UGCPhotos', new Error('wixData failure'));
+    const mod = await import('../src/backend/ugcService.web.js');
+    await mod.getProductUGCPhotos('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ugcService/);
+    expect(allTags).toMatch(/getProductUGCPhotos/);
+  });
+
+  it('getUGCStats wires logError on UGCPhotos query throw', async () => {
+    __setQueryError('UGCPhotos', new Error('wixData failure'));
+    const mod = await import('../src/backend/ugcService.web.js');
+    await mod.getUGCStats();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/ugcService/);
+    expect(allTags).toMatch(/getUGCStats/);
+  });
+});


### PR DESCRIPTION
## Summary
- **8 catch sites** migrated. All public webMethods.
- 15th in the cf-44qt sibling series. UGC photo gallery + moderation surface.

## Existing-test update
\`tests/ugcServiceCoverage.test.js\` had 3 tests pinning the OLD \`console.error('[ugcService] Error X:', err)\` argument shape. Updated to assert the new logError-wrapped output via \`stringContaining('[ugcService] <fn> failed')\` — forward-compatible with future tag renames.

## Test contract (4 new, all green)
getApprovedPhotos, getBeforeAfterPairs, getProductUGCPhotos, getUGCStats.

## Verification
- [x] **4/4** new + **218/218** existing = **222/222 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)