### PR TITLE
fix(cf-44qt sibling): productRecommendations.web.js console.error → logError ×13 (P3 obs cleanup)

### DIFF
--- a/src/backend/productRecommendations.web.js
+++ b/src/backend/productRecommendations.web.js
@@ -16,6 +16,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateSlug, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const RECENTLY_VIEWED_COLLECTION = 'RecentlyViewed';
 /** Call-for-price products use $0 or $1.00 placeholder prices. Exclude from recommendations.
@@ -70,7 +71,7 @@ export const getRelatedProducts = webMethod(
         ribbon: item.ribbon,
       }));
     } catch (err) {
-      console.error('Error fetching related products:', err);
+      logError('[productRecommendations] getRelatedProducts failed', err);
       return [];
     }
   }
@@ -184,7 +185,7 @@ export const getCompletionSuggestions = webMethod(
 
       return suggestions;
     } catch (err) {
-      console.error('Error fetching completion suggestions:', err);
+      logError('[productRecommendations] getCompletionSuggestions failed', err);
       return [];
     }
   }
@@ -214,7 +215,7 @@ export const getSameCollection = webMethod(
 
       return results.items.map(formatProduct);
     } catch (err) {
-      console.error('Error fetching same collection:', err);
+      logError('[productRecommendations] getSameCollection failed', err);
       return [];
     }
   }
@@ -249,7 +250,7 @@ export const getFeaturedProducts = webMethod(
 
       return results.items.map(formatProduct);
     } catch (err) {
-      console.error('Error fetching featured products:', err);
+      logError('[productRecommendations] getFeaturedProducts failed', err);
       return [];
     }
   }
@@ -281,7 +282,7 @@ export const getSaleProducts = webMethod(
           return discountB - discountA;
         });
     } catch (err) {
-      console.error('Error fetching sale products:', err);
+      logError('[productRecommendations] getSaleProducts failed', err);
       return [];
     }
   }
@@ -358,7 +359,7 @@ export const getBundleSuggestion = webMethod(
         savings: discount,
       };
     } catch (err) {
-      console.error('Error fetching bundle suggestion:', err);
+      logError('[productRecommendations] getBundleSuggestion failed', err);
       return null;
     }
   }
@@ -401,7 +402,7 @@ export const getRecentlyViewed = webMethod(
 
       return { success: true, products: ordered };
     } catch (err) {
-      console.error('[productRecommendations] getRecentlyViewed error:', err);
+      logError('[productRecommendations] getRecentlyViewed failed', err);
       return { success: false, products: [] };
     }
   }
@@ -456,7 +457,7 @@ export const getSimilarProducts = webMethod(
         products: results.items.map(formatProduct),
       };
     } catch (err) {
-      console.error('[productRecommendations] getSimilarProducts error:', err);
+      logError('[productRecommendations] getSimilarProducts failed', err);
       return { success: false, products: [] };
     }
   }
@@ -546,7 +547,7 @@ export const getCustomersAlsoBought = webMethod(
 
       return { success: true, products: ordered };
     } catch (err) {
-      console.error('[productRecommendations] getCustomersAlsoBought error:', err);
+      logError('[productRecommendations] getCustomersAlsoBought failed', err);
       return { success: false, products: [] };
     }
   }
@@ -586,7 +587,7 @@ export const getBatchCurrentPrices = webMethod(
       }
       return { success: true, prices };
     } catch (err) {
-      console.error('[productRecommendations] getBatchCurrentPrices error:', err?.message);
+      logError('[productRecommendations] getBatchCurrentPrices failed', err);
       return { success: false, prices: {} };
     }
   }
@@ -685,7 +686,7 @@ export const getRecommendations = webMethod(
 
       return { success: true, products: ranked.slice(0, safeLimit) };
     } catch (err) {
-      console.error('[productRecommendations] getRecommendations error:', err);
+      logError('[productRecommendations] getRecommendations failed', err);
       return { success: false, products: [] };
     }
   }
@@ -722,7 +723,7 @@ export const getFreightComplementProducts = webMethod(
 
       return { success: true, products: results.items.map(formatProduct) };
     } catch (err) {
-      console.error('[productRecommendations] getFreightComplementProducts error:', err);
+      logError('[productRecommendations] getFreightComplementProducts failed', err);
       return { success: false, products: [] };
     }
   }
@@ -879,7 +880,7 @@ export const getProductRecommendations = webMethod(
 
       return { success: true, products: categoryProducts, source: 'category' };
     } catch (err) {
-      console.error('[productRecommendations] getProductRecommendations error:', err);
+      logError('[productRecommendations] getProductRecommendations failed', err);
       return { success: false, products: [], source: 'category' };
     }
   }

--- a/tests/productRecommendationsSilentFailureCleanup.test.js
+++ b/tests/productRecommendationsSilentFailureCleanup.test.js
@@ -1,0 +1,73 @@
+/**
+ * cf-44qt sibling — productRecommendations.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateSlug: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — productRecommendations.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getRelatedProducts wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/productRecommendations.web.js');
+    await mod.getRelatedProducts('prod-1', 'futon-frames');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productRecommendations/);
+    expect(allTags).toMatch(/getRelatedProducts/);
+  });
+
+  it('getFeaturedProducts wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/productRecommendations.web.js');
+    await mod.getFeaturedProducts();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productRecommendations/);
+    expect(allTags).toMatch(/getFeaturedProducts/);
+  });
+
+  it('getSaleProducts wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/productRecommendations.web.js');
+    await mod.getSaleProducts();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productRecommendations/);
+    expect(allTags).toMatch(/getSaleProducts/);
+  });
+
+  it('getRecentlyViewed wires logError on RecentlyViewed query throw', async () => {
+    __setQueryError('RecentlyViewed', new Error('wixData failure'));
+    const mod = await import('../src/backend/productRecommendations.web.js');
+    await mod.getRecentlyViewed();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productRecommendations/);
+    expect(allTags).toMatch(/getRecentlyViewed/);
+  });
+});


### PR DESCRIPTION
## Summary
- **13 catch sites** migrated. All 13 public webMethods.
- 16th in the cf-44qt sibling series.

## Test contract (4 new, all green)
getRelatedProducts, getFeaturedProducts, getSaleProducts, getRecentlyViewed.

## Verification
- [x] **4/4** new + **156/156** existing = **160/160 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)