### PR TITLE
fix(cf-44qt sibling): batch2 — assemblyGuides/birthdayMigration/blogService/communityGallery/contactSubmissions console.error → logError ×9 (P3 obs cleanup)

### DIFF
--- a/src/backend/assemblyGuides.web.js
+++ b/src/backend/assemblyGuides.web.js
@@ -17,6 +17,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Get assembly guide for a product by SKU.
@@ -52,7 +53,7 @@ export const getAssemblyGuide = webMethod(
         category: guide.category || '',
       };
     } catch (err) {
-      console.error('Error getting assembly guide:', err);
+      logError('[assemblyGuides] getAssemblyGuide failed', err);
       return null;
     }
   }
@@ -101,7 +102,7 @@ export const getCareTips = webMethod(
 
       return tips[cleanCategory] || getDefaultCareTips();
     } catch (err) {
-      console.error('Error getting care tips:', err);
+      logError('[assemblyGuides] getCareTips failed', err);
       return getDefaultCareTips();
     }
   }
@@ -133,7 +134,7 @@ export const listAssemblyGuides = webMethod(
         hasVideo: !!g.videoUrl,
       }));
     } catch (err) {
-      console.error('Error listing assembly guides:', err);
+      logError('[assemblyGuides] listAssemblyGuides failed', err);
       return [];
     }
   }

--- a/src/backend/birthdayMigration.web.js
+++ b/src/backend/birthdayMigration.web.js
@@ -14,6 +14,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { _parseBirthdayMonthDay } from 'backend/events';
+import { logError } from 'backend/utils/errorHandler';
 
 const MEMBERS_COLLECTION = 'Members/PrivateMembersData';
 const PAGE_SIZE = 100;
@@ -78,7 +79,7 @@ export const backfillBirthdayFields = webMethod(
           });
           updated++;
         } catch (err) {
-          console.error('[birthdayMigration] Failed to update member', member._id, ':', err?.message ?? err);
+          logError('[birthdayMigration] Failed to update member', err);
           errors++;
         }
       }

--- a/src/backend/blogService.web.js
+++ b/src/backend/blogService.web.js
@@ -19,6 +19,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { posts as blogPosts } from 'wix-blog-backend';
 import { getAllBlogPosts } from 'backend/blogContent';
+import { logError } from 'backend/utils/errorHandler';
 
 const DEFAULT_PER_PAGE = 9;
 const FALLBACK_AUTHOR = 'Carolina Futons Team';
@@ -73,7 +74,7 @@ export const getPublishedBlogPosts = webMethod(
         hasPrevPage: safePage > 1,
       };
     } catch (err) {
-      console.error('[blogService] getPublishedBlogPosts failed:', err?.message);
+      logError('[blogService] getPublishedBlogPosts failed', err);
       return {
         posts: [],
         total: 0,
@@ -108,7 +109,7 @@ export const getRecentPosts = webMethod(
       });
       return (response.posts ?? []).map(normalizePost);
     } catch (err) {
-      console.error('[blogService] getRecentPosts failed:', err?.message);
+      logError('[blogService] getRecentPosts failed', err);
       return [];
     }
   }
@@ -137,7 +138,7 @@ export const getCategories = webMethod(
       }
       return [...seen].sort();
     } catch (err) {
-      console.error('[blogService] getCategories failed:', err?.message);
+      logError('[blogService] getCategories failed', err);
       return [];
     }
   }

--- a/src/backend/communityGalleryService.web.js
+++ b/src/backend/communityGalleryService.web.js
@@ -20,6 +20,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, generateUUIDFilename } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 export const GALLERY_ROOM_TYPES = ['living-room', 'bedroom', 'studio', 'office', 'dorm'];
 const GALLERY_PAGE_SIZE = 12;
@@ -224,7 +225,7 @@ export const getGalleryPhotos = webMethod(
         page: safePage,
       };
     } catch (err) {
-      console.error('[communityGalleryService] Error loading gallery photos:', err.message);
+      logError('[communityGalleryService] getGalleryPhotos failed', err);
       return { success: false, error: 'Failed to load gallery photos.', photos: [], hasMore: false, total: 0 };
     }
   }

--- a/src/backend/contactSubmissions.web.js
+++ b/src/backend/contactSubmissions.web.js
@@ -23,6 +23,7 @@ import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { validateSchema } from 'backend/utils/validateSchema';
+import { logError } from 'backend/utils/errorHandler';
 
 // Rate limiting for submitContactForm — prevents contact form spam flood.
 // CMS collection `ContactRateLimits`: key (Text), count (Number), windowStart (DateTime).
@@ -116,7 +117,7 @@ export const submitContactForm = webMethod(
       logAuditEvent('ContactSubmissions', 'submit', email, { source });
       return { success: true };
     } catch (err) {
-      console.error('Error submitting contact form:', err);
+      logError('[contactSubmissions] submitContactForm failed', err);
       return { success: false };
     }
   }

--- a/tests/cf-44qt-logError-batch2.test.js
+++ b/tests/cf-44qt-logError-batch2.test.js
@@ -1,0 +1,195 @@
+/**
+ * cf-44qt wave — batch 2: console.error → logError
+ * Modules: birthdayMigration, assemblyGuides, blogService,
+ *           communityGalleryService, contactSubmissions
+ *
+ * Pins logError call site + tag for each catch block migrated in this wave.
+ * Uses stringContaining so tag-format changes don't break the suite.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (hoisted before any imports) ──────────────────────────────────────
+
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
+vi.mock('backend/events', () => ({ _parseBirthdayMonthDay: vi.fn() }));
+
+vi.mock('backend/blogContent', () => ({
+  getBlogPost: vi.fn(),
+  getAllBlogPosts: vi.fn(() => []),
+}));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: vi.fn((s, max) => String(s ?? '').slice(0, max ?? 200)),
+  validateEmail: vi.fn((e) => /^[^@]+@[^@]+\.[^@]+$/.test(e)),
+  generateUUIDFilename: vi.fn((n) => `uuid-${n}`),
+}));
+
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock('backend/utils/auditLog', () => ({ logAuditEvent: vi.fn() }));
+
+vi.mock('backend/utils/validateSchema', () => ({
+  validateSchema: vi.fn().mockReturnValue([]),
+}));
+
+// ── Module imports (after vi.mock) ──────────────────────────────────────────
+
+import {
+  __seed,
+  __setUpdateError,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+import {
+  __setListError as __setBlogListError,
+} from './__mocks__/wix-blog-backend.js';
+
+import { backfillBirthdayFields } from '../src/backend/birthdayMigration.web.js';
+import {
+  getAssemblyGuide,
+  getCareTips,
+  listAssemblyGuides,
+} from '../src/backend/assemblyGuides.web.js';
+import {
+  getPublishedBlogPosts,
+  getRecentPosts,
+  getCategories,
+} from '../src/backend/blogService.web.js';
+import { getGalleryPhotos } from '../src/backend/communityGalleryService.web.js';
+import { submitContactForm } from '../src/backend/contactSubmissions.web.js';
+
+let logError;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ logError } = await import('backend/utils/errorHandler'));
+  // Restore defaults cleared by clearAllMocks
+  const { validateSchema } = await import('backend/utils/validateSchema');
+  vi.mocked(validateSchema).mockReturnValue([]);
+  const { validateEmail, sanitize } = await import('backend/utils/sanitize');
+  vi.mocked(validateEmail).mockImplementation((e) => /^[^@]+@[^@]+\.[^@]+$/.test(e));
+  vi.mocked(sanitize).mockImplementation((s, max) => String(s ?? '').slice(0, max ?? 200));
+  const { checkRateLimit } = await import('backend/utils/rateLimit');
+  vi.mocked(checkRateLimit).mockResolvedValue({ allowed: true });
+});
+
+// ── birthdayMigration ────────────────────────────────────────────────────────
+
+describe('birthdayMigration — logError on update failure', () => {
+  it('calls logError when wixData.update throws during backfill', async () => {
+    const { _parseBirthdayMonthDay } = await import('backend/events');
+    vi.mocked(_parseBirthdayMonthDay).mockReturnValue({ month: 4, day: 12 });
+
+    __seed('Members/PrivateMembersData', [
+      { _id: 'm-1', birthday: '1990-04-12', birthday_month: null, birthday_day: null },
+    ]);
+    __setUpdateError('Members/PrivateMembersData', new Error('Wix data update failed'));
+
+    const result = await backfillBirthdayFields();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[birthdayMigration]'),
+      expect.any(Error),
+    );
+    expect(result.errors).toBe(1);
+  });
+});
+
+// ── assemblyGuides ───────────────────────────────────────────────────────────
+
+describe('assemblyGuides — logError on query failures', () => {
+  it('calls logError and returns null when getAssemblyGuide query throws', async () => {
+    __setQueryError('AssemblyGuides', new Error('DB down'));
+    const result = await getAssemblyGuide('some-sku');
+    expect(result).toBeNull();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[assemblyGuides]'),
+      expect.any(Error),
+    );
+  });
+
+  it('calls logError and returns defaults when sanitize throws in getCareTips', async () => {
+    const { sanitize } = await import('backend/utils/sanitize');
+    vi.mocked(sanitize).mockImplementationOnce(() => { throw new Error('sanitize failed'); });
+    const result = await getCareTips('futon-frames');
+    expect(Array.isArray(result)).toBe(true);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[assemblyGuides]'),
+      expect.any(Error),
+    );
+  });
+
+  it('calls logError and returns [] when listAssemblyGuides query throws', async () => {
+    __setQueryError('AssemblyGuides', new Error('DB down'));
+    const result = await listAssemblyGuides();
+    expect(result).toEqual([]);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[assemblyGuides]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── blogService ──────────────────────────────────────────────────────────────
+
+describe('blogService — logError on Wix Blog API failures', () => {
+  it('calls logError when getPublishedBlogPosts throws', async () => {
+    __setBlogListError(new Error('Blog API down'));
+    const result = await getPublishedBlogPosts();
+    expect(result.error).toBe(true);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[blogService]'),
+      expect.any(Error),
+    );
+  });
+
+  it('calls logError when getRecentPosts throws', async () => {
+    __setBlogListError(new Error('Blog API down'));
+    const result = await getRecentPosts();
+    expect(result).toEqual([]);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[blogService]'),
+      expect.any(Error),
+    );
+  });
+
+  it('calls logError when getCategories throws', async () => {
+    __setBlogListError(new Error('Blog API down'));
+    const result = await getCategories();
+    expect(result).toEqual([]);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[blogService]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── communityGalleryService ──────────────────────────────────────────────────
+
+describe('communityGalleryService — logError on query failure', () => {
+  it('calls logError when PhotoReviews query throws', async () => {
+    __setQueryError('PhotoReviews', new Error('DB down'));
+    const result = await getGalleryPhotos(null);
+    expect(result.success).toBe(false);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[communityGalleryService]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── contactSubmissions ───────────────────────────────────────────────────────
+
+describe('contactSubmissions — logError on insert failure', () => {
+  it('calls logError when wixData.insert throws during form submit', async () => {
+    __setInsertError('ContactSubmissions', new Error('DB insert failed'));
+    const result = await submitContactForm({ email: 'test@example.com', name: 'Test' });
+    expect(result.success).toBe(false);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[contactSubmissions]'),
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **9 catch sites** migrated across 5 backend web modules.
- Part of the cf-44qt/cf-r6q7 silent-failure cleanup wave — wires Sentry to all catch blocks.

## Files changed
| File | Sites |
|------|-------|
| assemblyGuides.web.js | 3 (getAssemblyGuide, getCareTips, listAssemblyGuides) |
| birthdayMigration.web.js | 1 (backfillBirthdayFields update catch) |
| blogService.web.js | 3 (getPublishedBlogPosts, getRecentPosts, getCategories) |
| communityGalleryService.web.js | 1 (getGalleryPhotos) |
| contactSubmissions.web.js | 1 (submitContactForm) |

## Pre-existing test check
- CLEAR — no pre-existing `console.error` assertions found in test files for any of these modules.

## Test contract (9 new tests, all green)
- birthdayMigration: logError on wixData.update failure during backfill
- assemblyGuides: logError on query failure (getAssemblyGuide, listAssemblyGuides), logError on sanitize throw (getCareTips dead-code path)
- blogService: logError on Blog API failure (getPublishedBlogPosts, getRecentPosts, getCategories)
- communityGalleryService: logError on PhotoReviews query failure
- contactSubmissions: logError on wixData.insert failure during form submit

## Verification
- [x] 9 new tests all green
- [x] Full suite: 1085 files / 36779 tests passing
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

Closes bead cf-v6zk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)