### PR TITLE
fix(cf-44qt sibling): whiteGloveScheduling.web.js console.error → logError ×13 (P3 obs cleanup)

### DIFF
--- a/src/backend/whiteGloveScheduling.web.js
+++ b/src/backend/whiteGloveScheduling.web.js
@@ -39,6 +39,7 @@ import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId, validatePhone } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 import { validateSchema } from 'backend/utils/validateSchema';
 import {
   sendWhiteGloveConfirmationSMS,
@@ -148,7 +149,7 @@ export const getWhiteGloveSlots = webMethod(Permissions.Anyone, async (_orderId)
 
     return { success: true, slots };
   } catch (err) {
-    console.error('[whiteGloveScheduling] getWhiteGloveSlots error:', err);
+    logError('[whiteGloveScheduling] getWhiteGloveSlots failed', err);
     return { success: false, slots: [], error: 'Could not load available slots.' };
   }
 });
@@ -275,7 +276,7 @@ export const bookWhiteGloveDelivery = webMethod(Permissions.SiteMember, async (d
         windowLabel: DELIVERY_WINDOWS[windowKey].label,
         address: sanitize(data.address || '', 200),
         appointmentId: appointment._id,
-      }).catch(err => console.error('[whiteGloveScheduling] SMS confirmation error:', err));
+      }).catch(err => logError('[whiteGloveScheduling] bookWhiteGloveDelivery SMS-confirmation failed', err));
     }
 
     return {
@@ -288,7 +289,7 @@ export const bookWhiteGloveDelivery = webMethod(Permissions.SiteMember, async (d
       },
     };
   } catch (err) {
-    console.error('[whiteGloveScheduling] bookWhiteGloveDelivery error:', err);
+    logError('[whiteGloveScheduling] bookWhiteGloveDelivery failed', err);
     return { success: false, error: 'Failed to book appointment' };
   }
 });
@@ -331,7 +332,7 @@ export const getMyWhiteGloveAppointment = webMethod(Permissions.SiteMember, asyn
       },
     };
   } catch (err) {
-    console.error('[whiteGloveScheduling] getMyWhiteGloveAppointment error:', err);
+    logError('[whiteGloveScheduling] getMyWhiteGloveAppointment failed', err);
     return { success: false, error: 'Could not load appointment' };
   }
 });
@@ -411,7 +412,7 @@ export const rescheduleWhiteGlove = webMethod(Permissions.SiteMember, async (app
       },
     };
   } catch (err) {
-    console.error('[whiteGloveScheduling] rescheduleWhiteGlove error:', err);
+    logError('[whiteGloveScheduling] rescheduleWhiteGlove failed', err);
     return { success: false, error: 'Failed to reschedule appointment' };
   }
 });
@@ -450,7 +451,7 @@ export const blockDeliveryDate = webMethod(Permissions.Admin, async (date, reaso
     logAuditEvent('BlockedDeliveryDates', 'block', dateStr, { reason });
     return { success: true, data: { blockedDate: dateStr } };
   } catch (err) {
-    console.error('[whiteGloveScheduling] blockDeliveryDate error:', err);
+    logError('[whiteGloveScheduling] blockDeliveryDate failed', err);
     return { success: false, error: 'Failed to block date' };
   }
 });
@@ -480,7 +481,7 @@ export const unblockDeliveryDate = webMethod(Permissions.Admin, async (date) => 
     logAuditEvent('BlockedDeliveryDates', 'unblock', dateStr, {});
     return { success: true };
   } catch (err) {
-    console.error('[whiteGloveScheduling] unblockDeliveryDate error:', err);
+    logError('[whiteGloveScheduling] unblockDeliveryDate failed', err);
     return { success: false, error: 'Failed to unblock date' };
   }
 });
@@ -509,7 +510,7 @@ export const getBlockedDates = webMethod(Permissions.Admin, async () => {
       })),
     };
   } catch (err) {
-    console.error('[whiteGloveScheduling] getBlockedDates error:', err);
+    logError('[whiteGloveScheduling] getBlockedDates failed', err);
     return { success: false, data: [], error: 'Could not load blocked dates' };
   }
 });
@@ -555,7 +556,7 @@ export const getAdminCalendar = webMethod(Permissions.Admin, async (startDate, e
       })),
     };
   } catch (err) {
-    console.error('[whiteGloveScheduling] getAdminCalendar error:', err);
+    logError('[whiteGloveScheduling] getAdminCalendar failed', err);
     return { success: false, data: [], error: 'Could not load calendar' };
   }
 });
@@ -632,13 +633,13 @@ export const runWhiteGlove48hReminders = webMethod(
           sent++;
         } else {
           skipped++;
-          console.error('[whiteGloveScheduling] 48h SMS failed for appt', appt._id, smsResult.reason);
+          logError(`[whiteGloveScheduling] runWhiteGlove48hReminders SMS-send failed appt=${appt._id}`, new Error(String(smsResult.reason || 'unknown')));
         }
       }
 
       return { success: true, sent, skipped };
     } catch (err) {
-      console.error('[whiteGloveScheduling] runWhiteGlove48hReminders error:', err);
+      logError('[whiteGloveScheduling] runWhiteGlove48hReminders failed', err);
       return { success: false, sent: 0, skipped: 0 };
     }
   }
@@ -682,13 +683,13 @@ export const runWhiteGloveDayOfReminders = webMethod(
           sent++;
         } else {
           skipped++;
-          console.error('[whiteGloveScheduling] day-of SMS failed for appt', appt._id, smsResult.reason);
+          logError(`[whiteGloveScheduling] runWhiteGloveDayOfReminders SMS-send failed appt=${appt._id}`, new Error(String(smsResult.reason || 'unknown')));
         }
       }
 
       return { success: true, sent, skipped };
     } catch (err) {
-      console.error('[whiteGloveScheduling] runWhiteGloveDayOfReminders error:', err);
+      logError('[whiteGloveScheduling] runWhiteGloveDayOfReminders failed', err);
       return { success: false, sent: 0, skipped: 0 };
     }
   }

--- a/tests/whiteGloveSchedulingSilentFailureCleanup.test.js
+++ b/tests/whiteGloveSchedulingSilentFailureCleanup.test.js
@@ -1,0 +1,85 @@
+/**
+ * cf-44qt sibling — whiteGloveScheduling.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+  validatePhone: () => true,
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('backend/utils/auditLog', () => ({ logAuditEvent: vi.fn() }));
+vi.mock('backend/utils/validateSchema', () => ({
+  validateSchema: vi.fn(() => []),
+}));
+vi.mock('backend/smsService.web', () => ({
+  sendWhiteGloveConfirmationSMS: vi.fn(async () => ({ success: true })),
+  sendWhiteGloveReminderSMS: vi.fn(async () => ({ success: true })),
+  sendWhiteGloveDayOfSMS: vi.fn(async () => ({ success: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — whiteGloveScheduling.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getWhiteGloveSlots wires logError on BlockedDeliveryDates query throw', async () => {
+    __setQueryError('BlockedDeliveryDates', new Error('wixData failure'));
+    const mod = await import('../src/backend/whiteGloveScheduling.web.js');
+    await mod.getWhiteGloveSlots();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/whiteGloveScheduling/);
+    expect(allTags).toMatch(/getWhiteGloveSlots/);
+  });
+
+  it('getBlockedDates wires logError on BlockedDeliveryDates query throw', async () => {
+    __setQueryError('BlockedDeliveryDates', new Error('wixData failure'));
+    const mod = await import('../src/backend/whiteGloveScheduling.web.js');
+    await mod.getBlockedDates();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/whiteGloveScheduling/);
+    expect(allTags).toMatch(/getBlockedDates/);
+  });
+
+  it('getAdminCalendar wires logError on WhiteGloveAppointments query throw', async () => {
+    __setQueryError('WhiteGloveAppointments', new Error('wixData failure'));
+    const mod = await import('../src/backend/whiteGloveScheduling.web.js');
+    await mod.getAdminCalendar('2026-06-01', '2026-06-30');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/whiteGloveScheduling/);
+    expect(allTags).toMatch(/getAdminCalendar/);
+  });
+
+  it('getMyWhiteGloveAppointment wires logError on query throw', async () => {
+    __setQueryError('WhiteGloveAppointments', new Error('wixData failure'));
+    const mod = await import('../src/backend/whiteGloveScheduling.web.js');
+    await mod.getMyWhiteGloveAppointment('order-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/whiteGloveScheduling/);
+    expect(allTags).toMatch(/getMyWhiteGloveAppointment/);
+  });
+});


### PR DESCRIPTION
## Summary
- **13 catch sites** migrated. 10 public webMethods + 3 inline non-blocking sites (SMS confirmation fire-and-forget + 48h + day-of reminder loops).
- 18th in the cf-44qt sibling series.

## Inline SMS-failure pattern
The 48h + day-of reminder loops emit per-appointment SMS-failure signals (not catches — they check \`smsResult.success\`). Wrapped \`smsResult.reason\` strings into real \`Error\` objects so logError captures structured context (was previously variadic-spread, not introspectable).

## Test contract (4 new, all green)
getWhiteGloveSlots, getBlockedDates, getAdminCalendar, getMyWhiteGloveAppointment.

## Verification
- [x] **4/4** new + **116/116** existing = **120/120 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)