### PR TITLE
fix(cf-44qt batch4): console.error → logError in 5 backend modules

### DIFF
--- a/src/backend/abTestDashboard.web.js
+++ b/src/backend/abTestDashboard.web.js
@@ -78,7 +78,7 @@ export const listExperiments = webMethod(
 
       return { success: true, tests, total: result.totalCount };
     } catch (err) {
-      console.error('[abTestDashboard] listExperiments error:', err);
+      logError('[abTestDashboard] listExperiments failed', err);
       return { success: false, tests: [], total: 0 };
     }
   }
@@ -148,7 +148,7 @@ export const getExperimentDetail = webMethod(
         },
       };
     } catch (err) {
-      console.error('[abTestDashboard] getExperimentDetail error:', err);
+      logError('[abTestDashboard] getExperimentDetail failed', err);
       return { success: false, experiment: null };
     }
   }
@@ -197,7 +197,7 @@ export const getDashboardSummary = webMethod(
         },
       };
     } catch (err) {
-      console.error('[abTestDashboard] getDashboardSummary error:', err);
+      logError('[abTestDashboard] getDashboardSummary failed', err);
       return { success: false, summary: null };
     }
   }

--- a/src/backend/analyticsDigest.web.js
+++ b/src/backend/analyticsDigest.web.js
@@ -12,6 +12,7 @@ import { logAuditEvent } from 'backend/utils/auditLog';
 import { CUSTOM_EVENTS } from 'backend/customEvents.web';
 import { ANALYTICS_EVENTS_COLLECTION } from 'backend/utils/analyticsEvents';
 import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
+import { logError } from 'backend/utils/errorHandler';
 
 const ORDERS_COLLECTION = 'Stores/Orders';
 const TOP_PRODUCTS_LIMIT = 5;
@@ -121,7 +122,7 @@ export const generateWeeklyDigest = webMethod(
 
       return { success: true, digest };
     } catch (err) {
-      console.error('[analyticsDigest] Error generating digest:', err);
+      logError('[analyticsDigest] generateWeeklyDigest failed', err);
       return { success: false, error: 'Failed to generate analytics digest' };
     }
   }
@@ -165,7 +166,7 @@ export const sendWeeklyDigestEmail = webMethod(
       // resolve so processQueue doesn't reject the row at dispatch time.
       const digestContactId = await _resolveContactIdInternal(recipient);
       if (!digestContactId) {
-        console.error('[analyticsDigest] sendWeeklyDigestEmail: resolveContactId returned null for', recipient);
+        logError('[analyticsDigest] sendWeeklyDigestEmail: resolveContactId returned null', new Error(String(recipient)));
         return { success: false, error: 'Failed to resolve CRM contact for digest email' };
       }
 
@@ -188,7 +189,7 @@ export const sendWeeklyDigestEmail = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[analyticsDigest] sendWeeklyDigestEmail error:', err);
+      logError('[analyticsDigest] sendWeeklyDigestEmail failed', err);
       return { success: false, error: 'Failed to send digest email' };
     }
   }
@@ -247,7 +248,7 @@ export async function fetchOrderMetrics(since) {
 
     return { orderCount, totalRevenue: Math.round(totalRevenue * 100) / 100, avgOrderValue, topProducts };
   } catch (err) {
-    console.error('[analyticsDigest] fetchOrderMetrics error:', err);
+    logError('[analyticsDigest] fetchOrderMetrics failed', err);
     return { orderCount: 0, totalRevenue: 0, avgOrderValue: 0, topProducts: [] };
   }
 }

--- a/src/backend/badgeService.web.js
+++ b/src/backend/badgeService.web.js
@@ -27,6 +27,7 @@ import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { colors } from 'public/sharedTokens.js';
 import { _WHITE_GLOVE_CATEGORIES } from 'backend/deliveryOptions.web';
+import { logError } from 'backend/utils/errorHandler';
 
 const BADGES_COLLECTION = 'ProductBadges';
 const LOW_STOCK_THRESHOLD = 5;
@@ -151,7 +152,7 @@ export const getProductBadges = webMethod(
 
       return { success: true, badge, source };
     } catch (err) {
-      console.error('getProductBadges error:', err);
+      logError('[badgeService] getProductBadges failed', err);
       return { success: false, error: 'Unable to fetch product badges' };
     }
   }
@@ -218,7 +219,7 @@ export const getBatchProductBadges = webMethod(
 
       return { success: true, badges };
     } catch (err) {
-      console.error('getBatchProductBadges error:', err);
+      logError('[badgeService] getBatchProductBadges failed', err);
       return { success: false, error: 'Unable to fetch product badges' };
     }
   }
@@ -259,7 +260,7 @@ export const getWhiteGloveBadge = webMethod(
         },
       };
     } catch (err) {
-      console.error('getWhiteGloveBadge error:', err);
+      logError('[badgeService] getWhiteGloveBadge failed', err);
       return { success: false, error: 'Unable to determine white glove eligibility' };
     }
   }

--- a/src/backend/bundleBuilder.web.js
+++ b/src/backend/bundleBuilder.web.js
@@ -32,6 +32,7 @@ import wixData from 'wix-data';
 import { cart as ecomCart } from 'wix-ecom-backend';
 import { sanitize } from 'backend/utils/sanitize';
 import { colors } from 'public/sharedTokens';
+import { logError } from 'backend/utils/errorHandler';
 
 // Tier definitions for upselling — used by calculateBundlePrice via getTierForPrice.
 const TIERS = {
@@ -102,7 +103,7 @@ export const calculateBundlePrice = webMethod(
         tier: tier.label,
       };
     } catch (err) {
-      console.error('Error calculating bundle price:', err);
+      logError('[bundleBuilder] calculateBundlePrice failed', err);
       return { basePrice: 0, bundlePrice: 0, savings: 0, discountPercent: 0, tier: '' };
     }
   }
@@ -139,7 +140,7 @@ export const getBundlePageProducts = webMethod(
 
       return { success: true, products };
     } catch (e) {
-      console.error('[bundleBuilder] getBundlePageProducts failed:', e);
+      logError('[bundleBuilder] getBundlePageProducts failed', e);
       return { success: false, error: 'Failed to load products', products: [] };
     }
   }
@@ -182,7 +183,7 @@ export const addBundleToCart = webMethod(
       await ecomCart.addToCurrentCart({ lineItems });
       return { success: true };
     } catch (e) {
-      console.error('[bundleBuilder] addBundleToCart failed:', e);
+      logError('[bundleBuilder] addBundleToCart failed', e);
       return { success: false, error: 'Failed to add bundle to cart' };
     }
   }

--- a/src/backend/buyingGuideOgCards.web.js
+++ b/src/backend/buyingGuideOgCards.web.js
@@ -20,6 +20,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { getBuyingGuide, getBuyingGuideSlugs } from 'backend/buyingGuides.web';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Design constants ──────────────────────────────────────────────────��───────
 
@@ -275,7 +276,7 @@ export const getOgCardSpec = webMethod(
         },
       };
     } catch (err) {
-      console.error('[buyingGuideOgCards] getOgCardSpec error:', err);
+      logError('[buyingGuideOgCards] getOgCardSpec failed', err);
       return { success: false, error: 'Failed to generate OG card spec.' };
     }
   }
@@ -308,7 +309,7 @@ export const getAllOgCardSpecs = webMethod(
 
       return { success: true, specs };
     } catch (err) {
-      console.error('[buyingGuideOgCards] getAllOgCardSpecs error:', err);
+      logError('[buyingGuideOgCards] getAllOgCardSpecs failed', err);
       return { success: false, error: 'Failed to generate OG card specs.' };
     }
   }

--- a/tests/badgeService.test.js
+++ b/tests/badgeService.test.js
@@ -382,8 +382,8 @@ describe('getWhiteGloveBadge', () => {
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/white glove/i);
     expect(errorSpy).toHaveBeenCalledWith(
-      'getWhiteGloveBadge error:',
-      expect.any(Error),
+      expect.stringContaining('[badgeService]'),
+      expect.any(String),
     );
   });
 });

--- a/tests/cf-44qt-logError-batch4.test.js
+++ b/tests/cf-44qt-logError-batch4.test.js
@@ -1,0 +1,116 @@
+/**
+ * @file cf-44qt-logError-batch4.test.js
+ * @description TDD red → green for cf-44qt batch4: verify console.error sites
+ * in abTestDashboard, analyticsDigest, badgeService, bundleBuilder, and
+ * buyingGuideOgCards are migrated to canonical logError.
+ *
+ * All tests RED until source migration applied.
+ * cf-1f5t (cf-44qt wave batch4)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  __reset as resetData,
+  __seed,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+vi.mock('backend/buyingGuides.web', () => ({
+  getBuyingGuide: vi.fn(),
+  getBuyingGuideSlugs: vi.fn(),
+}));
+
+import { logError } from '../src/backend/utils/errorHandler.js';
+import { getBuyingGuide } from '../src/backend/buyingGuides.web.js';
+import { listExperiments } from '../src/backend/abTestDashboard.web.js';
+import { fetchOrderMetrics } from '../src/backend/analyticsDigest.web.js';
+import { getProductBadges } from '../src/backend/badgeService.web.js';
+import { getBundlePageProducts } from '../src/backend/bundleBuilder.web.js';
+import { getOgCardSpec } from '../src/backend/buyingGuideOgCards.web.js';
+
+beforeEach(() => {
+  resetData();
+  vi.mocked(logError).mockClear();
+  vi.mocked(getBuyingGuide).mockResolvedValue({ success: true, guide: null });
+});
+
+// ── abTestDashboard ───────────────────────────────────────────────────────────
+
+describe('abTestDashboard.listExperiments', () => {
+  it('calls canonical logError when AbTests query fails', async () => {
+    __setQueryError('AbTests', new Error('DB offline'));
+
+    const result = await listExperiments();
+
+    expect(result).toEqual({ success: false, tests: [], total: 0 });
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[abTestDashboard]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── analyticsDigest ───────────────────────────────────────────────────────────
+
+describe('analyticsDigest.fetchOrderMetrics', () => {
+  it('calls canonical logError when Stores/Orders query fails', async () => {
+    __setQueryError('Stores/Orders', new Error('query failed'));
+
+    const result = await fetchOrderMetrics(new Date('2026-01-01'));
+
+    expect(result).toEqual({ orderCount: 0, totalRevenue: 0, avgOrderValue: 0, topProducts: [] });
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[analyticsDigest]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── badgeService ──────────────────────────────────────────────────────────────
+
+describe('badgeService.getProductBadges', () => {
+  it('calls canonical logError when ProductBadges query fails', async () => {
+    __seed('ProductBadges', []);
+    __setQueryError('ProductBadges', new Error('CMS unavailable'));
+
+    const result = await getProductBadges('prod-123', {});
+
+    expect(result.success).toBe(false);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[badgeService]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── bundleBuilder ─────────────────────────────────────────────────────────────
+
+describe('bundleBuilder.getBundlePageProducts', () => {
+  it('calls canonical logError when Stores/Products query fails', async () => {
+    __setQueryError('Stores/Products', new Error('products query failed'));
+
+    const result = await getBundlePageProducts();
+
+    expect(result).toEqual(expect.objectContaining({ success: false }));
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[bundleBuilder]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── buyingGuideOgCards ────────────────────────────────────────────────────────
+
+describe('buyingGuideOgCards.getOgCardSpec', () => {
+  it('calls canonical logError when getBuyingGuide throws', async () => {
+    vi.mocked(getBuyingGuide).mockRejectedValueOnce(new Error('guide service down'));
+
+    const result = await getOgCardSpec('futon-frames');
+
+    expect(result).toEqual({ success: false, error: 'Failed to generate OG card spec.' });
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[buyingGuideOgCards]'),
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Migrates 15 `console.error` sites to canonical `logError(context, err)` across 5 modules
- `abTestDashboard` already had logError imported — replaced 3 console.error calls
- `analyticsDigest` 4 sites; resolveContactId null-guard wrapped with `new Error(String(recipient))`
- `badgeService` 3 sites — added `[badgeService]` prefix (were previously unprefixed)
- `bundleBuilder` 3 sites — calculateBundlePrice was unprefixed
- `buyingGuideOgCards` 2 sites

## Test plan
- [x] 5 TDD tests added (`tests/cf-44qt-logError-batch4.test.js`) — one per module
- [x] Tests red before source changes, green after
- [x] Updated `badgeService.test.js` console.error pin to match new logError format
- [x] Full suite: 1100 files / 36848 tests passing

cf-1f5t (cf-44qt wave batch4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)