### PR TITLE
fix(cf-44qt sibling): loyaltyService.web.js console.error → logError ×7 (P3 obs cleanup)

### DIFF
--- a/src/backend/loyaltyService.web.js
+++ b/src/backend/loyaltyService.web.js
@@ -76,7 +76,7 @@ export const getMyLoyaltyAccount = webMethod(
         accountId: account._id,
       };
     } catch (err) {
-      console.error('Error getting loyalty account:', err);
+      logError('[loyaltyService] getMyLoyaltyAccount failed', err);
       return { points: 0, tier: 'Bronze', nextTier: 'Silver', progress: 0, pointsToNext: 500 };
     }
   }
@@ -106,7 +106,7 @@ export const getAvailableRewards = webMethod(
           type: r.type || 'discount',
         }));
     } catch (err) {
-      console.error('Error getting rewards:', err);
+      logError('[loyaltyService] getAvailableRewards failed', err);
       return [];
     }
   }
@@ -158,7 +158,7 @@ export const redeemReward = webMethod(
         message: `Redeemed: ${reward.name}`,
       };
     } catch (err) {
-      console.error('Error redeeming reward:', err);
+      logError('[loyaltyService] redeemReward failed', err);
       return { success: false, message: 'Failed to redeem reward' };
     }
   }
@@ -292,7 +292,7 @@ export const getLeaderboard = webMethod(
 
       return { entries };
     } catch (err) {
-      console.error('Error getting leaderboard:', err);
+      logError('[loyaltyService] getLeaderboard failed', err);
       return { entries: [] };
     }
   }
@@ -585,7 +585,7 @@ export async function checkStreakAchievements(memberId, currentStreakDays) {
     const earned = new Set(existing.items.map(r => r.milestone));
     return reached.filter(m => !earned.has(m));
   } catch (err) {
-    console.error('Error checking streak achievements:', err);
+    logError('[loyaltyService] _checkStreakAchievements failed', err);
     return [];
   }
 }
@@ -619,7 +619,7 @@ export async function insertStreakAchievement(memberId, milestone, streakDays) {
     }, { suppressAuth: true });
   } catch (err) {
     if (isDuplicateKeyError(err)) return; // concurrent insert — already recorded
-    console.error('Error inserting streak achievement:', err);
+    logError('[loyaltyService] _insertStreakAchievement failed', err);
     throw err;
   }
 }
@@ -656,7 +656,7 @@ export const getMyAchievements = webMethod(
       return { achievements };
     } catch (err) {
       // Fail-open: return empty list rather than surface errors to the client
-      console.error('Error getting achievements:', err);
+      logError('[loyaltyService] getMyAchievements failed', err);
       return defaults;
     }
   }

--- a/tests/loyaltyServiceSilentFailureCleanup.test.js
+++ b/tests/loyaltyServiceSilentFailureCleanup.test.js
@@ -1,0 +1,89 @@
+/**
+ * cf-44qt sibling — loyaltyService.web.js observability cleanup.
+ * Partial-migration finisher: file already imported logError; this PR migrates
+ * the remaining 7 raw console.error sites.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('backend/memberGamePreferences.web', () => ({
+  getGamePrefsForMember: vi.fn(async () => ({ optedIn: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+vi.mock('wix-loyalty.v2', () => ({
+  accounts: {
+    getAccount: vi.fn(async () => { throw new Error('loyalty api failure'); }),
+    queryLoyaltyAccounts: vi.fn(() => ({
+      eq: () => ({ find: async () => { throw new Error('loyalty api failure'); } }),
+    })),
+  },
+  rewards: {
+    listRewards: vi.fn(async () => { throw new Error('loyalty api failure'); }),
+    redeemPoints: vi.fn(async () => { throw new Error('loyalty api failure'); }),
+  },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — loyaltyService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getMyLoyaltyAccount wires logError on loyalty API throw', async () => {
+    const mod = await import('../src/backend/loyaltyService.web.js');
+    await mod.getMyLoyaltyAccount();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/loyaltyService/);
+    expect(allTags).toMatch(/getMyLoyaltyAccount/);
+  });
+
+  it('getAvailableRewards wires logError on rewards.listRewards throw', async () => {
+    const mod = await import('../src/backend/loyaltyService.web.js');
+    await mod.getAvailableRewards();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/loyaltyService/);
+    expect(allTags).toMatch(/getAvailableRewards/);
+  });
+
+  it('getLeaderboard wires logError on LoyaltyAccounts query throw', async () => {
+    __setQueryError('LoyaltyAccounts', new Error('wixData failure'));
+    const mod = await import('../src/backend/loyaltyService.web.js');
+    await mod.getLeaderboard();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/loyaltyService/);
+  });
+
+  it('getMyAchievements wires logError on Achievements query throw', async () => {
+    __setQueryError('StreakAchievements', new Error('wixData failure'));
+    const mod = await import('../src/backend/loyaltyService.web.js');
+    await mod.getMyAchievements();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/loyaltyService/);
+    expect(allTags).toMatch(/getMyAchievements/);
+  });
+});


### PR DESCRIPTION
## Summary
- **7 catch sites** migrated (partial-migration finisher; file already imported logError but had 7 raw console.error sites remaining).
- 5 webMethods + 2 internal helpers.
- 19th in the cf-44qt sibling series.

## Test contract (4 new, all green)
getMyLoyaltyAccount, getAvailableRewards, getLeaderboard, getMyAchievements.

## Verification
- [x] **4/4** new + **124/124** existing = **128/128 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)