### PR TITLE
fix(cf-sizeguide-logerror): sizeGuide.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/sizeGuide.web.js
+++ b/src/backend/sizeGuide.web.js
@@ -10,6 +10,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 const CM_PER_INCH = 2.54;
 const TIGHT_FIT_THRESHOLD = 2; // inches — warn when clearance < 2"
@@ -72,7 +73,7 @@ export const getProductDimensions = webMethod(
         mattressSize: dims.mattressSize ?? null,
       };
     } catch (err) {
-      console.error('Error fetching product dimensions:', err);
+      logError('sizeGuide:getProductDimensions', err);
       return null;
     }
   }
@@ -185,7 +186,7 @@ export const checkRoomFit = webMethod(
         checks,
       };
     } catch (err) {
-      console.error('Error checking room fit:', err);
+      logError('sizeGuide:checkRoomFit', err);
       return { success: false, error: 'Failed to check room fit' };
     }
   }
@@ -241,7 +242,7 @@ export const getDimensionsByCategory = webMethod(
         };
       });
     } catch (err) {
-      console.error('Error fetching category dimensions:', err);
+      logError('sizeGuide:getDimensionsByCategory', err);
       return [];
     }
   }
@@ -351,7 +352,7 @@ export const getComparisonTable = webMethod(
         products: entries,
       };
     } catch (err) {
-      console.error('Error building comparison table:', err);
+      logError('sizeGuide:getComparisonTable', err);
       return { success: false, error: 'Failed to build comparison table' };
     }
   }

--- a/tests/sizeGuideLogErrorMigration.test.js
+++ b/tests/sizeGuideLogErrorMigration.test.js
@@ -1,0 +1,56 @@
+/**
+ * cf-sizeguide-logerror — pins the console.error → logError migration
+ * in src/backend/sizeGuide.web.js. Same shape as cf-44qt /
+ * cf-uydr / cf-g79m / batch-3 PR #1400 — all errors now flow to Sentry
+ * via `logError('sizeGuide:<fn>', err)` instead of Velo-console-only
+ * `console.error(...)`.
+ *
+ * Strategy: static-string assertion on the source file. Behavioral
+ * coverage for the catch paths lives in the existing sizeGuide test
+ * files; this test pins the tag-shape contract + drift guard.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/sizeGuide.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'sizeGuide:getProductDimensions',
+  'sizeGuide:checkRoomFit',
+  'sizeGuide:getDimensionsByCategory',
+  'sizeGuide:getComparisonTable',
+];
+
+describe('cf-sizeguide-logerror — sizeGuide.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 4 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the sizeGuide: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('sizeGuide:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without sizeGuide: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Per mayor STILGAR PACE ALERT 08:59 + small-class greenlight 06:46

Sibling pattern PR following cf-44qt / cf-uydr / cf-g79m / batch-3 PR #1400. sizeGuide.web.js `console.error` → `logError('sizeGuide:<fn>', err)`.

## Swaps (4)

| Site | Tag |
|---|---|
| getProductDimensions | `sizeGuide:getProductDimensions` |
| checkRoomFit | `sizeGuide:checkRoomFit` |
| getDimensionsByCategory | `sizeGuide:getDimensionsByCategory` |
| getComparisonTable | `sizeGuide:getComparisonTable` |

## TDD (7 cases in tests/sizeGuideLogErrorMigration.test.js)

- zero `console.error` remaining
- `logError` imported from `backend/utils/errorHandler`
- each of the 4 expected tags appears
- drift guard — every `logError` uses `sizeGuide:` prefix (catches future regressions)

## Verification

- New migration test: **7/7** ✅
- Full sizeGuide-touching suite (6 files): **174/174** ✅
- `node --check` clean

## Pre-flight

- [x] vitest 7 new + 167 existing
- [x] cf-ukc6 N/A (cfutons, not cfw)
- [ ] CI green → auto-merge eligible per Stilgar small-class greenlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
