### PR TITLE
fix(cf-stampedio-logerror): stampedIoService.web.js — 3 console.error → logError

### DIFF
--- a/src/backend/stampedIoService.web.js
+++ b/src/backend/stampedIoService.web.js
@@ -20,6 +20,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { getSecret } from 'wix-secrets-backend';
 import { fetch } from 'wix-fetch';
+import { logError } from 'backend/utils/errorHandler';
 
 const STAMPED_API_BASE = 'https://stamped.io/api/v2';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -103,7 +104,7 @@ export const getStampedRating = webMethod(
       _aggregateCache.set(productId, { data: result, ts: Date.now() });
       return result;
     } catch (err) {
-      console.error('[stampedIo] getStampedRating failed:', err?.message);
+      logError('stampedIoService:getStampedRating', err);
       return { average: 0, total: 0, distribution: {} };
     }
   }
@@ -154,7 +155,7 @@ export const getStampedReviews = webMethod(
         page: Number(data.page) || 1,
       };
     } catch (err) {
-      console.error('[stampedIo] getStampedReviews failed:', err?.message);
+      logError('stampedIoService:getStampedReviews', err);
       return { reviews: [], total: 0, page: 1 };
     }
   }
@@ -226,7 +227,7 @@ export const getStampedWidgetConfig = webMethod(
       const { apiKey, storeHash } = await getCredentials();
       return { storeHash, apiKey };
     } catch (err) {
-      console.error('[stampedIo] getStampedWidgetConfig failed:', err?.message);
+      logError('stampedIoService:getStampedWidgetConfig', err);
       return { storeHash: '', apiKey: '' };
     }
   }

--- a/tests/stampedIoServiceLogErrorMigration.test.js
+++ b/tests/stampedIoServiceLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-stampedio-logerror — pins console.error → logError migration in
+ * src/backend/stampedIoService.web.js. Same shape as cf-44qt / cf-uydr /
+ * cf-g79m / batch-3 / cf-sizeguide.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/stampedIoService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'stampedIoService:getStampedRating',
+  'stampedIoService:getStampedReviews',
+  'stampedIoService:getStampedWidgetConfig',
+];
+
+describe('cf-stampedio-logerror — stampedIoService.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 3 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the stampedIoService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(3);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('stampedIoService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without stampedIoService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT 08:59 small-class greenlight. Sibling pattern PR following cf-sizeguide-logerror PR #1403.

## Swaps (3 sites in stampedIoService.web.js)

- `getStampedRating` → `stampedIoService:getStampedRating`
- `getStampedReviews` → `stampedIoService:getStampedReviews`
- `getStampedWidgetConfig` → `stampedIoService:getStampedWidgetConfig`

## TDD (6 cases)

- zero `console.error` remaining
- `logError` imported
- 3 tag presence pins
- drift guard — every `logError` uses `stampedIoService:` prefix

## Verification

- New migration test: **6/6** ✅
- stamped suite: **17/17** ✅

Auto-merge eligible on CI green.
