### PR TITLE
fix(cf-tok3): wishlistShare console.error → logError migration

### DIFF
--- a/src/backend/wishlistShare.web.js
+++ b/src/backend/wishlistShare.web.js
@@ -19,6 +19,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── addShareToken ─────────────────────────────────────────────────────────────
 
@@ -61,7 +62,7 @@ export const addShareToken = webMethod(
     try {
       member = await currentMember.getMember();
     } catch (err) {
-      console.error('[wishlistShare] getMember error:', err);
+      logError('wishlistShare.addShareToken.getMember', err);
       return { error: 'auth_failed' };
     }
 
@@ -92,7 +93,7 @@ export const addShareToken = webMethod(
         createdAt: now,
       });
     } catch (err) {
-      console.error('[wishlistShare] insert error:', err);
+      logError('wishlistShare.addShareToken.insert', err);
       return { error: 'db_failed' };
     }
 
@@ -152,7 +153,7 @@ export const resolveShareToken = webMethod(
           addedDate: i.addedDate || null,
         }));
       } catch (itemErr) {
-        console.error('[wishlistShare] Failed to fetch wishlist items:', itemErr);
+        logError('wishlistShare.resolveShareToken.fetchItems', itemErr);
         // Return valid with empty items rather than failing the whole request
       }
 
@@ -163,7 +164,7 @@ export const resolveShareToken = webMethod(
         items,
       };
     } catch (err) {
-      console.error('[wishlistShare] resolveShareToken error:', err);
+      logError('wishlistShare.resolveShareToken', err);
       return { valid: false, reason: 'not_found' };
     }
   }

--- a/tests/cf-tok3-wishlistshare-logError.test.js
+++ b/tests/cf-tok3-wishlistshare-logError.test.js
@@ -1,0 +1,80 @@
+/**
+ * @file cf-tok3-wishlistshare-logError.test.js
+ * @description TDD red → green for cf-tok3 wishlistShare batch: verify the
+ * 4 console.error sites in src/backend/wishlistShare.web.js migrate to the
+ * canonical logError from backend/utils/errorHandler.
+ *
+ * Mayor PACE ALERT 08:59 — small-class logError migration, auto-merge eligible
+ * on CI green. Pattern matches cf-44qt batch3 (tests/cf-44qt-logError-batch3.test.js).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  __reset as resetData,
+  __setInsertError,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+import { __reset as resetMembers, __setMember, currentMember } from './__mocks__/wix-members-backend.js';
+
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
+import { logError } from '../src/backend/utils/errorHandler.js';
+import { addShareToken, resolveShareToken } from '../src/backend/wishlistShare.web.js';
+
+beforeEach(() => {
+  resetData();
+  resetMembers();
+  logError.mockReset();
+});
+
+describe('cf-tok3 wishlistShare — console.error → logError migration', () => {
+  describe('addShareToken', () => {
+    it('routes getMember failure through logError with wishlistShare.addShareToken.getMember context', async () => {
+      currentMember.getMember.mockRejectedValueOnce(new Error('member-svc-down'));
+      const result = await addShareToken({});
+      expect(result).toEqual({ error: 'auth_failed' });
+      expect(logError).toHaveBeenCalledTimes(1);
+      const [context, err] = logError.mock.calls[0];
+      expect(context).toMatch(/wishlistShare\.addShareToken/);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('member-svc-down');
+    });
+
+    it('routes wixData.insert failure through logError', async () => {
+      __setMember({ _id: 'm1', loginEmail: 'a@b.c', profile: {}, contactDetails: {} });
+      __setInsertError('WishlistShareTokens', new Error('insert-failed'));
+      const result = await addShareToken({});
+      expect(result).toEqual({ error: 'db_failed' });
+      expect(logError).toHaveBeenCalledTimes(1);
+      const [context, err] = logError.mock.calls[0];
+      expect(context).toMatch(/wishlistShare\.addShareToken/);
+      expect(err.message).toBe('insert-failed');
+    });
+  });
+
+  describe('resolveShareToken', () => {
+    it('routes outer query throw through logError', async () => {
+      __setQueryError('WishlistShareTokens', new Error('query-blew-up'));
+      const result = await resolveShareToken('some-token');
+      expect(result).toEqual({ valid: false, reason: 'not_found' });
+      expect(logError).toHaveBeenCalledTimes(1);
+      const [context, err] = logError.mock.calls[0];
+      expect(context).toMatch(/wishlistShare\.resolveShareToken/);
+      expect(err.message).toBe('query-blew-up');
+    });
+  });
+
+  describe('console.error elimination (regression guard)', () => {
+    it('source file contains zero raw console.error calls (canonical logError only)', async () => {
+      const { readFile } = await import('node:fs/promises');
+      const src = await readFile(
+        new URL('../src/backend/wishlistShare.web.js', import.meta.url),
+        'utf8',
+      );
+      // Strip line comments so the pattern's documentation references
+      // (e.g. "// console.error replaced by logError") don't fail the
+      // regression guard.
+      const stripped = src.replace(/\/\/.*$/gm, '');
+      expect(stripped).not.toMatch(/console\.error/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 4 console.error sites in `src/backend/wishlistShare.web.js` migrate to canonical `logError` from `backend/utils/errorHandler`
- 4 new TDD tests pin the contract
- 92/92 wishlistShare regression suite passes (no functional change)

## Why

Mayor PACE ALERT 08:59 — small-class logError migration under Stilgar's 06:46 small-class greenlight. Pattern matches cf-44qt batch3 (PR #1400).

Without this, wishlist-share failures (auth-svc down, CMS insert collision, query 5xx) emit raw console.error strings that don't aggregate properly in Wix runtime logs. Canonical `logError` adds structured context labels + ISO timestamp + stack so Sentry-ingest parsers can route by tag.

## Context tag map

| Old                                                  | New                                          |
|------------------------------------------------------|----------------------------------------------|
| `[wishlistShare] getMember error:`                   | `wishlistShare.addShareToken.getMember`      |
| `[wishlistShare] insert error:`                      | `wishlistShare.addShareToken.insert`         |
| `[wishlistShare] Failed to fetch wishlist items:`    | `wishlistShare.resolveShareToken.fetchItems` |
| `[wishlistShare] resolveShareToken error:`           | `wishlistShare.resolveShareToken`            |

## Tests

1. `getMember` rejection routes through `logError` with `wishlistShare.addShareToken.getMember` context
2. `wixData.insert` rejection routes through `logError` (`wishlistShare.addShareToken.insert`)
3. `resolveShareToken` outer query throw routes through `logError`
4. Source-scan regression guard: zero raw `console.error` remain

## Test plan

- [x] 4/4 new tests pass
- [x] 92/92 wishlistShare existing tests pass (regression check)
- [ ] CI green
- [ ] Auto-merge under Stilgar small-class greenlight

Refs cf-tok3 (mayor PACE ALERT 08:59), cf-44qt batch3 (PR #1400 pattern reference), cf-ukc6 (build conservation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)