### PR TITLE
fix(cf-pushtokenregistry-logerror): pushTokenRegistry.web.js — 3 console.error → logError

### DIFF
--- a/src/backend/pushTokenRegistry.web.js
+++ b/src/backend/pushTokenRegistry.web.js
@@ -12,6 +12,7 @@
  */
 
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 export const PUSH_TOKENS_COLLECTION = 'PushTokens';
 const VALID_PLATFORMS = ['ios', 'android', 'web'];
@@ -38,7 +39,7 @@ export async function registerToken(memberId, token, platform) {
     );
     return { success: true };
   } catch (err) {
-    console.error('[pushTokenRegistry] registerToken error:', err);
+    logError('pushTokenRegistry:registerToken', err);
     return { success: false, error: err.message };
   }
 }
@@ -59,7 +60,7 @@ export async function getActiveTokensForMember(memberId) {
       .find({ suppressAuth: true });
     return result.items;
   } catch (err) {
-    console.error('[pushTokenRegistry] getActiveTokensForMember error:', err);
+    logError('pushTokenRegistry:getActiveTokensForMember', err);
     return [];
   }
 }
@@ -85,7 +86,7 @@ export async function deactivateToken(memberId, token) {
     await wixData.update(PUSH_TOKENS_COLLECTION, item, { suppressAuth: true });
     return { success: true };
   } catch (err) {
-    console.error('[pushTokenRegistry] deactivateToken error:', err);
+    logError('pushTokenRegistry:deactivateToken', err);
     return { success: false, error: err.message };
   }
 }

--- a/tests/pushTokenRegistryLogErrorMigration.test.js
+++ b/tests/pushTokenRegistryLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-pushtokenregistry-logerror — pins console.error → logError in
+ * src/backend/pushTokenRegistry.web.js. Same shape as cf-sizeguide /
+ * cf-stampedio.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/pushTokenRegistry.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'pushTokenRegistry:registerToken',
+  'pushTokenRegistry:getActiveTokensForMember',
+  'pushTokenRegistry:deactivateToken',
+];
+
+describe('cf-pushtokenregistry-logerror — pushTokenRegistry.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 3 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the pushTokenRegistry: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(3);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('pushTokenRegistry:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without pushTokenRegistry: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT 08:59 small-class greenlight. Sibling pattern after cf-sizeguide-logerror PR #1403 + cf-stampedio-logerror PR #1405.

## Swaps (3 sites in pushTokenRegistry.web.js)

- `registerToken` → `pushTokenRegistry:registerToken`
- `getActiveTokensForMember` → `pushTokenRegistry:getActiveTokensForMember`
- `deactivateToken` → `pushTokenRegistry:deactivateToken`

## Verification

- New migration test: **6/6** ✅
- Full pushToken suite: **23/23** ✅

Auto-merge eligible on CI green.
