### PR TITLE
fix(cf-paymentoptions-logerror): paymentOptions.web.js — 5 console.error → logError

### DIFF
--- a/src/backend/paymentOptions.web.js
+++ b/src/backend/paymentOptions.web.js
@@ -22,6 +22,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { colors } from 'public/sharedTokens.js';
+import { logError } from 'backend/utils/errorHandler';
 
 // Afterpay configuration
 const AFTERPAY_CONFIG = {
@@ -68,7 +69,7 @@ export const getPaymentOptions = webMethod(
 
       return { success: true, price: numPrice, ...options };
     } catch (err) {
-      console.error('getPaymentOptions error:', err);
+      logError('paymentOptions:getPaymentOptions', err);
       return { success: false, error: 'Unable to calculate payment options' };
     }
   }
@@ -88,7 +89,7 @@ export const getAfterpayMessage = webMethod(
       const info = getAfterpayInfo(numPrice);
       return { success: true, ...info };
     } catch (err) {
-      console.error('getAfterpayMessage error:', err);
+      logError('paymentOptions:getAfterpayMessage', err);
       return { success: false, error: 'Unable to calculate Afterpay message' };
     }
   }
@@ -143,7 +144,7 @@ export const getBatchPaymentBadges = webMethod(
 
       return { success: true, badges };
     } catch (err) {
-      console.error('getBatchPaymentBadges error:', err);
+      logError('paymentOptions:getBatchPaymentBadges', err);
       return { success: false, error: 'Unable to calculate payment badges' };
     }
   }
@@ -202,7 +203,7 @@ export const getCheckoutPaymentSummary = webMethod(
 
       return { success: true, summary };
     } catch (err) {
-      console.error('getCheckoutPaymentSummary error:', err);
+      logError('paymentOptions:getCheckoutPaymentSummary', err);
       return { success: false, error: 'Unable to calculate payment summary' };
     }
   }
@@ -267,7 +268,7 @@ export const getInstallmentCalculation = webMethod(
         tierLabel: tier.label,
       };
     } catch (err) {
-      console.error('getInstallmentCalculation error:', err);
+      logError('paymentOptions:getInstallmentCalculation', err);
       return { success: false, error: 'Unable to calculate installments' };
     }
   }

--- a/tests/paymentOptionsLogErrorMigration.test.js
+++ b/tests/paymentOptionsLogErrorMigration.test.js
@@ -1,0 +1,52 @@
+/**
+ * cf-paymentoptions-logerror — pins console.error → logError migration
+ * in src/backend/paymentOptions.web.js. Same shape as cf-sizeguide /
+ * cf-stampedio / cf-pushtokenregistry / cf-44qt / cf-uydr / cf-g79m /
+ * batch-3.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/paymentOptions.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'paymentOptions:getPaymentOptions',
+  'paymentOptions:getAfterpayMessage',
+  'paymentOptions:getBatchPaymentBadges',
+  'paymentOptions:getCheckoutPaymentSummary',
+  'paymentOptions:getInstallmentCalculation',
+];
+
+describe('cf-paymentoptions-logerror — paymentOptions.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 5 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the paymentOptions: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(5);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('paymentOptions:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without paymentOptions: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. Sibling pattern PR.

## Swaps (5 sites in paymentOptions.web.js)

- `getPaymentOptions` → `paymentOptions:getPaymentOptions`
- `getAfterpayMessage` → `paymentOptions:getAfterpayMessage`
- `getBatchPaymentBadges` → `paymentOptions:getBatchPaymentBadges`
- `getCheckoutPaymentSummary` → `paymentOptions:getCheckoutPaymentSummary`
- `getInstallmentCalculation` → `paymentOptions:getInstallmentCalculation`

## Verification

- New migration test: **8/8** ✅
- Full paymentOptions suite: **120/120** ✅

Auto-merge eligible on CI green.
