### PR TITLE
fix(cf-buyingguides-logerror): buyingGuides.web.js — 7 console.error → logError

### DIFF
--- a/src/backend/buyingGuides.web.js
+++ b/src/backend/buyingGuides.web.js
@@ -11,6 +11,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 const PUBLISHER = { name: 'Carolina Futons', logo: `${SITE_URL}/logo.png` };
@@ -692,7 +693,7 @@ export const getBuyingGuide = webMethod(
           }));
         }
       } catch (e) {
-        console.error('getBuyingGuide: related products fetch failed:', e);
+        logError('buyingGuides:getBuyingGuide-relatedProducts', e);
       }
 
       return {
@@ -704,7 +705,7 @@ export const getBuyingGuide = webMethod(
         },
       };
     } catch (err) {
-      console.error('getBuyingGuide error:', err);
+      logError('buyingGuides:getBuyingGuide', err);
       return { success: false, error: 'Unable to load buying guide' };
     }
   }
@@ -749,7 +750,7 @@ export const getAllBuyingGuides = webMethod(
         }),
       };
     } catch (err) {
-      console.error('getAllBuyingGuides error:', err);
+      logError('buyingGuides:getAllBuyingGuides', err);
       return { success: false, error: 'Unable to load buying guides' };
     }
   }
@@ -830,7 +831,7 @@ export const getBuyingGuideSchema = webMethod(
 
       return { success: true, articleSchema, faqSchema };
     } catch (err) {
-      console.error('getBuyingGuideSchema error:', err);
+      logError('buyingGuides:getBuyingGuideSchema', err);
       return { success: false, error: 'Unable to generate schema' };
     }
   }
@@ -864,7 +865,7 @@ export const getGuideComparisonTable = webMethod(
         table: guide.comparisonTable,
       };
     } catch (err) {
-      console.error('getGuideComparisonTable error:', err);
+      logError('buyingGuides:getGuideComparisonTable', err);
       return { success: false, error: 'Unable to load comparison table' };
     }
   }
@@ -896,7 +897,7 @@ export const getGuideFaqs = webMethod(
         faqs: guide.faqs,
       };
     } catch (err) {
-      console.error('getGuideFaqs error:', err);
+      logError('buyingGuides:getGuideFaqs', err);
       return { success: false, error: 'Unable to load FAQs' };
     }
   }
@@ -938,7 +939,7 @@ export const getSocialShareLinks = webMethod(
         },
       };
     } catch (err) {
-      console.error('getSocialShareLinks error:', err);
+      logError('buyingGuides:getSocialShareLinks', err);
       return { success: false, error: 'Unable to generate share links' };
     }
   }

--- a/tests/buyingGuidesLogErrorMigration.test.js
+++ b/tests/buyingGuidesLogErrorMigration.test.js
@@ -1,0 +1,52 @@
+/**
+ * cf-buyingguides-logerror — pins console.error → logError migration in
+ * src/backend/buyingGuides.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/buyingGuides.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'buyingGuides:getBuyingGuide-relatedProducts',
+  'buyingGuides:getBuyingGuide',
+  'buyingGuides:getAllBuyingGuides',
+  'buyingGuides:getBuyingGuideSchema',
+  'buyingGuides:getGuideComparisonTable',
+  'buyingGuides:getGuideFaqs',
+  'buyingGuides:getSocialShareLinks',
+];
+
+describe('cf-buyingguides-logerror — buyingGuides.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 7 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the buyingGuides: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(7);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('buyingGuides:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without buyingGuides: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 6th PR in the pace-alert burst, largest at 7 sites.

## Swaps (7 sites in buyingGuides.web.js)

- `getBuyingGuide` relatedProducts inner catch → `buyingGuides:getBuyingGuide-relatedProducts`
- `getBuyingGuide` outer catch → `buyingGuides:getBuyingGuide`
- `getAllBuyingGuides` → `buyingGuides:getAllBuyingGuides`
- `getBuyingGuideSchema` → `buyingGuides:getBuyingGuideSchema`
- `getGuideComparisonTable` → `buyingGuides:getGuideComparisonTable`
- `getGuideFaqs` → `buyingGuides:getGuideFaqs`
- `getSocialShareLinks` → `buyingGuides:getSocialShareLinks`

## Verification

- New migration test: **10/10** ✅
- Full buyingGuide-touching suite (11 files): **819/819** ✅

Auto-merge eligible on CI green.
