### PR TITLE
fix(cf-44qt sibling): couponsService.web.js console.error → logError ×7 (P3 obs cleanup)

### DIFF
--- a/src/backend/couponsService.web.js
+++ b/src/backend/couponsService.web.js
@@ -13,6 +13,7 @@ import { coupons } from 'wix-marketing-backend';
 import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Create a welcome coupon for a new member (10% off first order).
@@ -64,7 +65,7 @@ export const createWelcomeCoupon = webMethod(
           active: true,
         });
       } catch (insertErr) {
-        console.error('[couponsService] MemberCoupons insert failed for welcome coupon:', cleanEmail, ':', insertErr.message);
+        logError(`[couponsService] createWelcomeCoupon MemberCoupons-insert failed email=${cleanEmail}`, insertErr);
       }
 
       return {
@@ -74,7 +75,7 @@ export const createWelcomeCoupon = webMethod(
         expiresIn: '30 days',
       };
     } catch (err) {
-      console.error('Error creating welcome coupon:', err);
+      logError('[couponsService] createWelcomeCoupon failed', err);
       return { success: false, message: 'Failed to create coupon' };
     }
   }
@@ -124,7 +125,7 @@ export const getActiveCoupons = webMethod(
         active: c.active,
       }));
     } catch (err) {
-      console.error('Error getting coupons:', err);
+      logError('[couponsService] getActiveCoupons failed', err);
       return [];
     }
   }
@@ -193,7 +194,7 @@ export const createBirthdayCoupon = webMethod(
         expiresIn: '7 days',
       };
     } catch (err) {
-      console.error('Error creating birthday coupon:', err);
+      logError('[couponsService] createBirthdayCoupon failed', err);
       return { success: false, message: 'Failed to create coupon' };
     }
   }
@@ -259,7 +260,7 @@ export const createTierUpgradeCoupon = webMethod(
         expiresIn: '14 days',
       };
     } catch (err) {
-      console.error('Error creating tier upgrade coupon:', err);
+      logError('[couponsService] createTierUpgradeCoupon failed', err);
       return { success: false, message: 'Failed to create coupon' };
     }
   }
@@ -367,7 +368,7 @@ export const generateRecoveryCoupon = webMethod(
         expiresAt: expiresAtISO,
       };
     } catch (err) {
-      console.error('[couponsService] generateRecoveryCoupon failed for cartId:', cartId, '— error:', err.message);
+      logError(`[couponsService] generateRecoveryCoupon failed cartId=${cartId}`, err);
       return { success: false, message: 'Failed to generate recovery coupon' };
     }
   }
@@ -434,7 +435,7 @@ export const createCartRecoveryCoupon = webMethod(
         expiresIn: '48 hours',
       };
     } catch (err) {
-      console.error('Error creating cart recovery coupon:', err);
+      logError('[couponsService] createCartRecoveryCoupon failed', err);
       return { success: false, message: 'Failed to create coupon' };
     }
   }

--- a/tests/couponsServiceIdor.test.js
+++ b/tests/couponsServiceIdor.test.js
@@ -255,10 +255,10 @@ describe('MemberCoupons insert failure is non-blocking', () => {
 
     expect(result.success).toBe(true);
     expect(result.code).toBe('TEST-ABCDEF');
+    // cf-44qt sibling: console.error now routes through logError which
+    // delegates to console.error with a bracketed [context] + message shape.
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('MemberCoupons insert failed'),
-      expect.anything(),
-      expect.stringContaining(':'),
+      expect.stringContaining('[couponsService] createWelcomeCoupon MemberCoupons-insert failed'),
       expect.stringContaining('DB down'),
     );
     errorSpy.mockRestore();

--- a/tests/couponsServiceSilentFailureCleanup.test.js
+++ b/tests/couponsServiceSilentFailureCleanup.test.js
@@ -1,0 +1,74 @@
+/**
+ * cf-44qt sibling — couponsService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateEmail: () => true,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+vi.mock('wix-marketing-backend', () => ({
+  coupons: {
+    createCoupon: vi.fn(async () => { throw new Error('coupons API failure'); }),
+  },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — couponsService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('createWelcomeCoupon wires logError on coupons.createCoupon throw', async () => {
+    const mod = await import('../src/backend/couponsService.web.js');
+    await mod.createWelcomeCoupon('welcome@example.com');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/couponsService/);
+    expect(allTags).toMatch(/createWelcomeCoupon/);
+  });
+
+  it('getActiveCoupons wires logError on MemberCoupons query throw', async () => {
+    __setQueryError('MemberCoupons', new Error('wixData failure'));
+    const mod = await import('../src/backend/couponsService.web.js');
+    await mod.getActiveCoupons();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/couponsService/);
+    expect(allTags).toMatch(/getActiveCoupons/);
+  });
+
+  it('createBirthdayCoupon wires logError on coupons.createCoupon throw', async () => {
+    const mod = await import('../src/backend/couponsService.web.js');
+    await mod.createBirthdayCoupon('bday@example.com');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/couponsService/);
+    expect(allTags).toMatch(/createBirthdayCoupon/);
+  });
+
+  it('createTierUpgradeCoupon wires logError on coupons.createCoupon throw', async () => {
+    const mod = await import('../src/backend/couponsService.web.js');
+    await mod.createTierUpgradeCoupon('tier@example.com', 'Gold');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/couponsService/);
+    expect(allTags).toMatch(/createTierUpgradeCoupon/);
+  });
+});


### PR DESCRIPTION
## Summary
- **7 catch sites** migrated. 6 webMethods + 1 inline MemberCoupons-insert non-blocking catch.
- 20th in the cf-44qt sibling series.

## Existing-test update
\`tests/couponsServiceIdor.test.js\` pinned the OLD 4-arg \`console.error\` signature. Migrated to the new logError-wrapped 2-arg shape via \`stringContaining\` matchers.

## Test contract (4 new, all green)
createWelcomeCoupon, getActiveCoupons, createBirthdayCoupon, createTierUpgradeCoupon.

## Verification
- [x] **4/4** new + **123/123** existing = **127/127 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)