### PR TITLE
fix(cf-pricematch-logerror): priceMatchService.web.js — 5 console.error → logError

### DIFF
--- a/src/backend/priceMatchService.web.js
+++ b/src/backend/priceMatchService.web.js
@@ -33,6 +33,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'PriceMatches';
 const MAX_NOTES_LEN = 2000;
@@ -251,7 +252,7 @@ export const submitPriceMatchRequest = webMethod(
         },
       };
     } catch (err) {
-      console.error('Error submitting price match request:', err);
+      logError('priceMatchService:submitPriceMatchRequest', err);
       return { success: false, message: 'Failed to submit price match request' };
     }
   }
@@ -291,7 +292,7 @@ export const getMyPriceMatches = webMethod(
         })),
       };
     } catch (err) {
-      console.error('Error fetching price matches:', err);
+      logError('priceMatchService:getMyPriceMatches', err);
       return { requests: [] };
     }
   }
@@ -336,7 +337,7 @@ export const getPriceMatchById = webMethod(
         },
       };
     } catch (err) {
-      console.error('Error fetching price match:', err);
+      logError('priceMatchService:getPriceMatchById', err);
       return { success: false, message: 'Failed to fetch price match request' };
     }
   }
@@ -394,7 +395,7 @@ export const reviewPriceMatchRequest = webMethod(
         },
       };
     } catch (err) {
-      console.error('Error reviewing price match request:', err);
+      logError('priceMatchService:reviewPriceMatchRequest', err);
       return { success: false, message: 'Failed to review price match request' };
     }
   }
@@ -444,7 +445,7 @@ export const getPriceMatchStats = webMethod(
 
       return { stats };
     } catch (err) {
-      console.error('Error fetching price match stats:', err);
+      logError('priceMatchService:getPriceMatchStats', err);
       return {
         stats: {
           total: 0,

--- a/tests/priceMatchServiceLogErrorMigration.test.js
+++ b/tests/priceMatchServiceLogErrorMigration.test.js
@@ -1,0 +1,50 @@
+/**
+ * cf-pricematch-logerror — pins console.error → logError migration in
+ * src/backend/priceMatchService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/priceMatchService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'priceMatchService:submitPriceMatchRequest',
+  'priceMatchService:getMyPriceMatches',
+  'priceMatchService:getPriceMatchById',
+  'priceMatchService:reviewPriceMatchRequest',
+  'priceMatchService:getPriceMatchStats',
+];
+
+describe('cf-pricematch-logerror — priceMatchService.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 5 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the priceMatchService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(5);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('priceMatchService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without priceMatchService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 7th PR in burst.

## Swaps (5 sites in priceMatchService.web.js)

- `submitPriceMatchRequest` → `priceMatchService:submitPriceMatchRequest`
- `getMyPriceMatches` → `priceMatchService:getMyPriceMatches`
- `getPriceMatchById` → `priceMatchService:getPriceMatchById`
- `reviewPriceMatchRequest` → `priceMatchService:reviewPriceMatchRequest`
- `getPriceMatchStats` → `priceMatchService:getPriceMatchStats`

## Verification

- New migration test: **8/8** ✅
- Full priceMatch suite: **208/208** ✅

Auto-merge eligible on CI green.
