### PR TITLE
fix(cf-m7yg)(cf-44qt wave): reviewsService console.warn → logError ×6

### DIFF
--- a/src/backend/reviewsService.web.js
+++ b/src/backend/reviewsService.web.js
@@ -122,7 +122,7 @@ export const getAggregateRating = webMethod(
     let validCount = 0;
     for (const r of reviews) {
       if (r.rating == null || isNaN(Number(r.rating))) {
-        console.warn(`[reviewsService] Skipping review ${r._id}: invalid rating (${r.rating})`);
+        logError(`reviewsService:getAggregateRating-skipInvalidRating review=${r._id} rating=${r.rating}`, null);
         continue;
       }
       const rating = Math.min(5, Math.max(1, Math.round(Number(r.rating))));
@@ -221,14 +221,14 @@ export const submitReview = webMethod(
         'gamification_submit_review',
         { has_photo: photos.length > 0 },
         memberId,
-      ).catch(err => console.warn('[reviewsService] gamification event failed:', err));
+      ).catch(err => logError('reviewsService:submitReview-gamificationEvent', err));
 
       // CF-fzsd: record email conversion when review came from a review-request email
       const emailQueueId = data.emailQueueId ? sanitize(data.emailQueueId, 50) : '';
       if (emailQueueId) {
         recordEmailEvent({ emailQueueId, eventType: 'conversion' })
-          .then(res => { if (!res?.success) console.warn('[reviewsService] email conversion not recorded for queue', emailQueueId); })
-          .catch(err => console.warn('[reviewsService] email conversion record failed:', err));
+          .then(res => { if (!res?.success) logError(`reviewsService:submitReview-emailConversionNotRecorded queue=${emailQueueId}`, null); })
+          .catch(err => logError('reviewsService:submitReview-emailConversionRecord', err));
       }
 
       return { success: true, reviewId: saved._id };
@@ -375,7 +375,7 @@ export const moderateReview = webMethod(
       const allowed = REVIEW_STATUS_TRANSITIONS[currentStatus];
 
       if (!allowed || !allowed.includes(newStatus)) {
-        console.warn(`[reviewsService] Blocked transition: ${rid} ${currentStatus} → ${newStatus}`);
+        logError(`reviewsService:moderateReview-blockedTransition review=${rid} from=${currentStatus} to=${newStatus}`, null);
         return {
           success: false,
           error: `Cannot ${action} a review with status '${currentStatus}'.`,
@@ -431,7 +431,7 @@ export const getCategoryReviewSummaries = webMethod(
         const pid = review.productId;
         if (!summaries[pid]) continue;
         if (review.rating == null || isNaN(Number(review.rating))) {
-          console.warn(`[reviewsService] Skipping review ${review._id}: invalid rating (${review.rating})`);
+          logError(`reviewsService:getCategoryReviewSummaries-skipInvalidRating review=${review._id} rating=${review.rating}`, null);
           continue;
         }
         const raw = Number(review.rating);

--- a/tests/reviewsServiceLogErrorMigration.test.js
+++ b/tests/reviewsServiceLogErrorMigration.test.js
@@ -1,0 +1,68 @@
+/**
+ * cf-m7yg (cf-44qt wave): pins the remaining console.warn → logError
+ * migration in src/backend/reviewsService.web.js. 6 sites converted to
+ * the `logError(tag, err)` shape so Sentry sees every reviews-service
+ * non-fatal path (previously `console.warn` only hit Velo console).
+ *
+ * Pre-existing logError calls (4 in submitReview/markHelpful/flagReview/
+ * getPendingReviews) keep their original "[reviewsService] X failed"
+ * bracket-style message — out of scope for this batch; a separate
+ * cf-44qt.tagstyle.fu1 follow-up could normalize them all to
+ * "reviewsService:fn-reason" if melania signals that's desired.
+ *
+ * Same shape as cf-mrcm PR #1404 + cf-uydr PR #1373. Tag regex accepts
+ * single/double/backtick quoting (cf-mrcm's learning folded forward).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/reviewsService.web.js'),
+  'utf-8',
+);
+
+// Order matches file's top-to-bottom layout.
+const EXPECTED_TAGS = [
+  'reviewsService:getAggregateRating-skipInvalidRating',
+  'reviewsService:submitReview-gamificationEvent',
+  'reviewsService:submitReview-emailConversionNotRecorded',
+  'reviewsService:submitReview-emailConversionRecord',
+  'reviewsService:moderateReview-blockedTransition',
+  'reviewsService:getCategoryReviewSummaries-skipInvalidRating',
+];
+
+describe('cf-m7yg: reviewsService.web.js logError migration', () => {
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{\s*logError\s*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('contains zero remaining console.error|warn|log|debug|info calls', () => {
+    const consoleCalls = SRC.match(/console\.(error|warn|log|debug|info)\s*\(/g) || [];
+    expect(consoleCalls).toEqual([]);
+  });
+
+  describe('each expected logError tag is present', () => {
+    for (const tag of EXPECTED_TAGS) {
+      it(`tag "${tag}" appears in the source`, () => {
+        const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const pattern = new RegExp(
+          `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+        );
+        expect(SRC).toMatch(pattern);
+      });
+    }
+  });
+
+  it(`total logError call count is at least ${EXPECTED_TAGS.length + 4} (6 migrated + 4 pre-existing)`, () => {
+    // Floor: the 4 pre-existing logError calls (submitReview / markHelpful /
+    // flagReview / getPendingReviews error catches) are out-of-scope for this
+    // batch but still must persist. 6 new + 4 pre-existing = 10 minimum.
+    const calls = SRC.match(/logError\s*\(/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(EXPECTED_TAGS.length + 4);
+  });
+});


### PR DESCRIPTION
cf-44qt logger sweep convoy. Single-file batch, 6 console.warn sites in reviewsService.web.js.

## Scope correction during scout

Initial grep showed 18 sites but 12 were the file's pre-existing `logError('[reviewsService] X failed', err)` calls (4 from a prior partial migration — bracket-message style instead of canonical `module:fn-reason` namespace). Real scope was 6 console.warn sites.

**This PR migrates the 6 console.warn sites** to the canonical tag namespace. The 4 pre-existing bracket-style logError calls are **left in place** — out of scope. A separate cf-44qt.tagstyle.fu1 follow-up could normalize all 10 if desired.

## Sites migrated

| Tag | Site |
|---|---|
| `reviewsService:getAggregateRating-skipInvalidRating` | dynamic-context (review id + rating) |
| `reviewsService:submitReview-gamificationEvent` | static |
| `reviewsService:submitReview-emailConversionNotRecorded` | dynamic-context (queue id) |
| `reviewsService:submitReview-emailConversionRecord` | static |
| `reviewsService:moderateReview-blockedTransition` | dynamic-context (review id + from/to status) |
| `reviewsService:getCategoryReviewSummaries-skipInvalidRating` | dynamic-context |

Non-error contexts pass `null` as the err arg — convoy convention for non-throw observability events (matches cf-mrcm's runWhiteGlove48hReminders-smsPerAppt pattern).

## TDD per 2026-05-15 mandate

- RED: 7 of 9 assertions fail at start
- GREEN: 9/9 pass
- Regex extended to accept `'`, `"`, AND backtick (cf-mrcm's folded learning)

## Verification

- `reviewsServiceLogErrorMigration.test.js`: **9/9**
- `reviewsService*.test.js` (8 files, 249 cases) — no behavioral regression
- Full suite: **36859/36859, zero regressions**

5-agent review per mayor mandate. Auto-merge class per convoy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)