### PR TITLE
fix(cf-postpurchase-logerror): postPurchaseCare.web.js — 6 console.error → logError

### DIFF
--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -56,6 +56,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -107,7 +108,7 @@ export const getProductGuides = webMethod(
 
       return { success: true, guides };
     } catch (err) {
-      console.error('[postPurchaseCare] Error getting product guides:', err);
+      logError('postPurchaseCare:getProductGuides', err);
       return { success: false, error: 'Failed to load care guides.', guides: [] };
     }
   }
@@ -172,7 +173,7 @@ export const deliverGuidesForOrder = webMethod(
 
       return { success: true, guidesByCategory };
     } catch (err) {
-      console.error('[postPurchaseCare] Error delivering guides for order:', err);
+      logError('postPurchaseCare:deliverGuidesForOrder', err);
       return { success: false, error: 'Failed to load order guides.', guidesByCategory: {} };
     }
   }
@@ -238,7 +239,7 @@ export const getUpsellRecommendations = webMethod(
         recommendations: filtered.map(formatRecommendation),
       };
     } catch (err) {
-      console.error('[postPurchaseCare] Error getting upsell recommendations:', err);
+      logError('postPurchaseCare:getUpsellRecommendations', err);
       return { success: false, error: 'Failed to load recommendations.', recommendations: [] };
     }
   }
@@ -285,7 +286,7 @@ export const trackGuideEngagement = webMethod(
       await wixData.insert('GuideEngagement', record);
       return { success: true };
     } catch (err) {
-      console.error('[postPurchaseCare] Error tracking guide engagement:', err);
+      logError('postPurchaseCare:trackGuideEngagement', err);
       return { success: false, error: 'Failed to track engagement.' };
     }
   }
@@ -332,7 +333,7 @@ export const logUpsellConversion = webMethod(
       await wixData.insert('UpsellConversions', record);
       return { success: true };
     } catch (err) {
-      console.error('[postPurchaseCare] Error logging upsell conversion:', err);
+      logError('postPurchaseCare:logUpsellConversion', err);
       return { success: false, error: 'Failed to log conversion.' };
     }
   }
@@ -373,7 +374,7 @@ export const getReviewSolicitationData = webMethod(
 
       return { success: true, reviewUrl, customerName: cleanName, products: productList };
     } catch (err) {
-      console.error('[postPurchaseCare] Error getting review solicitation data:', err);
+      logError('postPurchaseCare:getReviewSolicitationData', err);
       return { success: false, error: 'Failed to load review data.', reviewUrl: '', customerName: '', products: [] };
     }
   }

--- a/tests/postPurchaseCareLogErrorMigration.test.js
+++ b/tests/postPurchaseCareLogErrorMigration.test.js
@@ -1,0 +1,51 @@
+/**
+ * cf-postpurchase-logerror — pins console.error → logError migration
+ * in src/backend/postPurchaseCare.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/postPurchaseCare.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'postPurchaseCare:getProductGuides',
+  'postPurchaseCare:deliverGuidesForOrder',
+  'postPurchaseCare:getUpsellRecommendations',
+  'postPurchaseCare:trackGuideEngagement',
+  'postPurchaseCare:logUpsellConversion',
+  'postPurchaseCare:getReviewSolicitationData',
+];
+
+describe('cf-postpurchase-logerror — postPurchaseCare.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 6 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the postPurchaseCare: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('postPurchaseCare:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without postPurchaseCare: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 8th PR in burst.

## Swaps (6 sites in postPurchaseCare.web.js)

- `getProductGuides`, `deliverGuidesForOrder`, `getUpsellRecommendations`, `trackGuideEngagement`, `logUpsellConversion`, `getReviewSolicitationData` → all under `postPurchaseCare:<fn>`

## Verification

- New migration test: **9/9** ✅
- Full postPurchase suite: **206/206** ✅

Auto-merge eligible on CI green.
