### PR TITLE
fix(cf-44qt sibling): testimonialService.web.js console.error → logError ×7 (P3)

### DIFF
--- a/src/backend/testimonialService.web.js
+++ b/src/backend/testimonialService.web.js
@@ -19,6 +19,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -77,7 +78,7 @@ export const submitTestimonial = webMethod(
       const inserted = await wixData.insert('Testimonials', record);
       return { success: true, id: inserted._id };
     } catch (err) {
-      console.error('[testimonialService] Error submitting testimonial:', err);
+      logError('[testimonialService] submitTestimonial failed', err);
       return { success: false, error: 'Failed to submit testimonial.' };
     }
   }
@@ -114,7 +115,7 @@ export const getFeaturedTestimonials = webMethod(
       const rotated = rotateSelection(pool, safeLimit);
       return { items: rotated, success: true };
     } catch (err) {
-      console.error('[testimonialService] Error getting featured testimonials:', err);
+      logError('[testimonialService] getFeaturedTestimonials failed', err);
       return { items: [], success: false, error: 'Failed to load featured testimonials.' };
     }
   }
@@ -169,7 +170,7 @@ export const getTestimonialsByCategory = webMethod(
       const result = await query.find();
       return { items: result.items, success: true };
     } catch (err) {
-      console.error('[testimonialService] Error getting testimonials by category:', err);
+      logError('[testimonialService] getTestimonialsByCategory failed', err);
       return { items: [], success: false };
     }
   }
@@ -193,7 +194,7 @@ export const getMyTestimonials = webMethod(
 
       return { items: result.items, success: true };
     } catch (err) {
-      console.error('[testimonialService] Error getting my testimonials:', err);
+      logError('[testimonialService] getMyTestimonials failed', err);
       return { items: [], success: false };
     }
   }
@@ -248,7 +249,7 @@ export const getTestimonialSchema = webMethod(
 
       return JSON.stringify(schema);
     } catch (err) {
-      console.error('[testimonialService] Error building schema:', err);
+      logError('[testimonialService] getTestimonialSchema failed', err);
       return '';
     }
   }
@@ -305,7 +306,7 @@ export const updateTestimonialStatus = webMethod(
       await wixData.update('Testimonials', update);
       return { success: true };
     } catch (err) {
-      console.error('[testimonialService] Error updating status:', err);
+      logError('[testimonialService] updateTestimonialStatus failed', err);
       return { success: false, error: 'Failed to update testimonial status.' };
     }
   }
@@ -329,7 +330,7 @@ export const getPendingTestimonials = webMethod(
 
       return { items: result.items, success: true };
     } catch (err) {
-      console.error('[testimonialService] Error getting pending testimonials:', err);
+      logError('[testimonialService] getPendingTestimonials failed', err);
       return { items: [], success: false };
     }
   }

--- a/tests/testimonialServiceSilentFailureCleanup.test.js
+++ b/tests/testimonialServiceSilentFailureCleanup.test.js
@@ -1,0 +1,72 @@
+/**
+ * cf-44qt sibling — testimonialService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — testimonialService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getFeaturedTestimonials wires logError on Testimonials query throw', async () => {
+    __setQueryError('Testimonials', new Error('wixData failure'));
+    const mod = await import('../src/backend/testimonialService.web.js');
+    await mod.getFeaturedTestimonials();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/testimonialService/);
+    expect(allTags).toMatch(/getFeaturedTestimonials/);
+  });
+
+  it('getTestimonialsByCategory wires logError on Testimonials query throw', async () => {
+    __setQueryError('Testimonials', new Error('wixData failure'));
+    const mod = await import('../src/backend/testimonialService.web.js');
+    await mod.getTestimonialsByCategory('futons');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/testimonialService/);
+    expect(allTags).toMatch(/getTestimonialsByCategory/);
+  });
+
+  it('getMyTestimonials wires logError on Testimonials query throw', async () => {
+    __setQueryError('Testimonials', new Error('wixData failure'));
+    const mod = await import('../src/backend/testimonialService.web.js');
+    await mod.getMyTestimonials();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/testimonialService/);
+    expect(allTags).toMatch(/getMyTestimonials/);
+  });
+
+  it('getPendingTestimonials wires logError on Testimonials query throw', async () => {
+    __setQueryError('Testimonials', new Error('wixData failure'));
+    const mod = await import('../src/backend/testimonialService.web.js');
+    await mod.getPendingTestimonials();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/testimonialService/);
+    expect(allTags).toMatch(/getPendingTestimonials/);
+  });
+});


### PR DESCRIPTION
## Summary
- **7 catch sites** migrated. All 7 webMethods.
- 21st in the cf-44qt sibling series.

## Test contract (4 new, all green)
getFeaturedTestimonials, getTestimonialsByCategory, getMyTestimonials, getPendingTestimonials.

## Verification
- [x] **4/4** new + **88/88** existing = **92/92 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)