### PR TITLE
fix(cf-44qt wave): postPurchaseCare.web.js console.error → logError (6 sites)

### DIFF
--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -55,6 +55,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 import { sanitize, validateId } from 'backend/utils/sanitize';
 
 async function requireMember() {
@@ -107,7 +108,7 @@ export const getProductGuides = webMethod(
 
       return { success: true, guides };
     } catch (err) {
-      console.error('[postPurchaseCare] Error getting product guides:', err);
+      logError('postPurchaseCare:getProductGuides', err);
       return { success: false, error: 'Failed to load care guides.', guides: [] };
     }
   }
@@ -172,7 +173,7 @@ export const deliverGuidesForOrder = webMethod(
 
       return { success: true, guidesByCategory };
     } catch (err) {
-      console.error('[postPurchaseCare] Error delivering guides for order:', err);
+      logError('postPurchaseCare:deliverGuidesForOrder', err);
       return { success: false, error: 'Failed to load order guides.', guidesByCategory: {} };
     }
   }
@@ -238,7 +239,7 @@ export const getUpsellRecommendations = webMethod(
         recommendations: filtered.map(formatRecommendation),
       };
     } catch (err) {
-      console.error('[postPurchaseCare] Error getting upsell recommendations:', err);
+      logError('postPurchaseCare:getUpsellRecommendations', err);
       return { success: false, error: 'Failed to load recommendations.', recommendations: [] };
     }
   }
@@ -285,7 +286,7 @@ export const trackGuideEngagement = webMethod(
       await wixData.insert('GuideEngagement', record);
       return { success: true };
     } catch (err) {
-      console.error('[postPurchaseCare] Error tracking guide engagement:', err);
+      logError('postPurchaseCare:trackGuideEngagement', err);
       return { success: false, error: 'Failed to track engagement.' };
     }
   }
@@ -332,7 +333,7 @@ export const logUpsellConversion = webMethod(
       await wixData.insert('UpsellConversions', record);
       return { success: true };
     } catch (err) {
-      console.error('[postPurchaseCare] Error logging upsell conversion:', err);
+      logError('postPurchaseCare:logUpsellConversion', err);
       return { success: false, error: 'Failed to log conversion.' };
     }
   }
@@ -373,7 +374,7 @@ export const getReviewSolicitationData = webMethod(
 
       return { success: true, reviewUrl, customerName: cleanName, products: productList };
     } catch (err) {
-      console.error('[postPurchaseCare] Error getting review solicitation data:', err);
+      logError('postPurchaseCare:getReviewSolicitationData', err);
       return { success: false, error: 'Failed to load review data.', reviewUrl: '', customerName: '', products: [] };
     }
   }

--- a/tests/postPurchaseCareLogError.test.js
+++ b/tests/postPurchaseCareLogError.test.js
@@ -1,0 +1,47 @@
+/**
+ * cf-44qt wave — pin postPurchaseCare.web.js console.error → logError migration.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/postPurchaseCare.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'postPurchaseCare:getProductGuides',
+  'postPurchaseCare:deliverGuidesForOrder',
+  'postPurchaseCare:getUpsellRecommendations',
+  'postPurchaseCare:trackGuideEngagement',
+  'postPurchaseCare:logUpsellConversion',
+  'postPurchaseCare:getReviewSolicitationData',
+];
+
+describe('cf-44qt — postPurchaseCare.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`logError('${tag}'`);
+  });
+
+  it('every logError tag uses the postPurchaseCare: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('postPurchaseCare:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Single-file auto-merge slot. Same pattern as cf-comfort PR #1416 + cf-priceMatch PR #1422.
- 6 console.error sites → logError(\`postPurchaseCare:<scope>\`).

## Scope (1 file, 6 sites)
- `src/backend/postPurchaseCare.web.js`:
  - `postPurchaseCare:getProductGuides`
  - `postPurchaseCare:deliverGuidesForOrder`
  - `postPurchaseCare:getUpsellRecommendations`
  - `postPurchaseCare:trackGuideEngagement`
  - `postPurchaseCare:logUpsellConversion`
  - `postPurchaseCare:getReviewSolicitationData`

## Test plan
- [x] `npx vitest run tests/postPurchaseCareLogError.test.js` — 9/9 green
- [x] Zero console.error remain
- [x] All 6 tags pinned + invariant guard
- [ ] AUTO-MERGE eligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)