### PR TITLE
fix(cf-44qt batch6): console.error → logError in 5 backend modules (20 sites)

### DIFF
--- a/src/backend/pinterestCatalogSync.web.js
+++ b/src/backend/pinterestCatalogSync.web.js
@@ -12,6 +12,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 const SITE_NAME = 'Carolina Futons';
@@ -125,7 +126,7 @@ export const validateCatalogProduct = webMethod(
         sanitizedName: name,
       };
     } catch (err) {
-      console.error('[pinterestCatalogSync] validateCatalogProduct error:', err);
+      logError('[pinterestCatalogSync] validateCatalogProduct error:', err);
       return { success: false, error: 'Validation failed.', valid: false, issues: [], warnings: [] };
     }
   }
@@ -191,7 +192,7 @@ export const auditCatalog = webMethod(
         issues,
       };
     } catch (err) {
-      console.error('[pinterestCatalogSync] auditCatalog error:', err);
+      logError('[pinterestCatalogSync] auditCatalog error:', err);
       return {
         success: false,
         error: 'Catalog audit failed.',
@@ -235,7 +236,7 @@ export const getCatalogSyncStatus = webMethod(
         issues: audit.issues,
       };
     } catch (err) {
-      console.error('[pinterestCatalogSync] getCatalogSyncStatus error:', err);
+      logError('[pinterestCatalogSync] getCatalogSyncStatus error:', err);
       return {
         success: false,
         error: 'Failed to get catalog sync status.',
@@ -285,7 +286,7 @@ export const mapProductToBoard = webMethod(
       // Default board
       return { success: true, board: 'Futon Living Rooms' };
     } catch (err) {
-      console.error('[pinterestCatalogSync] mapProductToBoard error:', err);
+      logError('[pinterestCatalogSync] mapProductToBoard error:', err);
       return { success: false, error: 'Board mapping failed.', board: null };
     }
   }
@@ -365,7 +366,7 @@ export const generatePinContent = webMethod(
         link,
       };
     } catch (err) {
-      console.error('[pinterestCatalogSync] generatePinContent error:', err);
+      logError('[pinterestCatalogSync] generatePinContent error:', err);
       return { success: false, error: 'Pin content generation failed.', title: '', description: '', hashtags: [], link: '' };
     }
   }
@@ -466,7 +467,7 @@ export const syncCatalogBatch = webMethod(
         });
         processed++;
       } catch (err) {
-        console.error('[pinterestCatalogSync] syncCatalogBatch product error:', err);
+        logError('[pinterestCatalogSync] syncCatalogBatch product error:', err);
         failed++;
         errors.push({
           productId: product?._id || 'unknown',

--- a/src/backend/pinterestRichPins.web.js
+++ b/src/backend/pinterestRichPins.web.js
@@ -10,6 +10,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { sanitize, validateSlug, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 const SITE_NAME = 'Carolina Futons';
@@ -92,7 +93,7 @@ export const getProductPinData = webMethod(
 
       return { success: true, meta };
     } catch (err) {
-      console.error('[pinterestRichPins] Error generating product pin data:', err);
+      logError('[pinterestRichPins] Error generating product pin data:', err);
       return { success: false, error: 'Failed to generate product pin data.', meta: null };
     }
   }
@@ -154,7 +155,7 @@ export const getGuidePinData = webMethod(
 
       return { success: true, meta };
     } catch (err) {
-      console.error('[pinterestRichPins] Error generating guide pin data:', err);
+      logError('[pinterestRichPins] Error generating guide pin data:', err);
       return { success: false, error: 'Failed to generate guide pin data.', meta: null };
     }
   }
@@ -192,7 +193,7 @@ export const getPinterestMetaTags = webMethod(
         tagString: tags.join('\n'),
       };
     } catch (err) {
-      console.error('[pinterestRichPins] Error generating meta tags:', err);
+      logError('[pinterestRichPins] Error generating meta tags:', err);
       return { success: false, error: 'Failed to generate meta tags.', tags: [], tagString: '' };
     }
   }
@@ -275,7 +276,7 @@ export const validatePinMarkup = webMethod(
         errors,
       };
     } catch (err) {
-      console.error('[pinterestRichPins] Error validating pin markup:', err);
+      logError('[pinterestRichPins] Error validating pin markup:', err);
       return { success: false, error: 'Failed to validate markup.', valid: false, errors: [] };
     }
   }

--- a/src/backend/pointsHistoryService.web.js
+++ b/src/backend/pointsHistoryService.web.js
@@ -16,6 +16,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'PointsTransactions';
 
@@ -61,7 +62,7 @@ export const getRecentPointsHistory = webMethod(
         })),
       };
     } catch (err) {
-      console.error('[pointsHistoryService] getRecentPointsHistory failed:', err);
+      logError('[pointsHistoryService] getRecentPointsHistory failed:', err);
       return { error: 'Unable to fetch points history' };
     }
   }

--- a/src/backend/premiumMembership.web.js
+++ b/src/backend/premiumMembership.web.js
@@ -22,6 +22,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Plan Definitions ────────────────────────────────────────────────
 
@@ -139,7 +140,7 @@ export const checkMembershipStatus = webMethod(
         startDate: membership.startDate,
       };
     } catch (err) {
-      console.error('[premiumMembership] checkMembershipStatus error:', err);
+      logError('[premiumMembership] checkMembershipStatus error:', err);
       return { success: false, error: 'Failed to check membership status' };
     }
   }
@@ -177,7 +178,7 @@ export const getMemberBenefits = webMethod(
         earlyAccess: true,
       };
     } catch (err) {
-      console.error('[premiumMembership] getMemberBenefits error:', err);
+      logError('[premiumMembership] getMemberBenefits error:', err);
       return { success: false, error: 'Failed to get benefits' };
     }
   }
@@ -240,7 +241,7 @@ export const activateMembership = webMethod(
         endDate,
       };
     } catch (err) {
-      console.error('[premiumMembership] activateMembership error:', err);
+      logError('[premiumMembership] activateMembership error:', err);
       return { success: false, error: 'Failed to activate membership' };
     }
   }
@@ -282,7 +283,7 @@ export const cancelMembership = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[premiumMembership] cancelMembership error:', err);
+      logError('[premiumMembership] cancelMembership error:', err);
       return { success: false, error: 'Failed to cancel membership' };
     }
   }
@@ -331,7 +332,7 @@ export const applyMemberDiscount = webMethod(
         finalTotal,
       };
     } catch (err) {
-      console.error('[premiumMembership] applyMemberDiscount error:', err);
+      logError('[premiumMembership] applyMemberDiscount error:', err);
       return { success: false, error: 'Failed to apply discount' };
     }
   }
@@ -395,7 +396,7 @@ export const getPremiumUpsellData = webMethod(
         benefits: PLANS[0].benefits, // same benefits for all plans
       };
     } catch (err) {
-      console.error('[premiumMembership] getPremiumUpsellData error:', err);
+      logError('[premiumMembership] getPremiumUpsellData error:', err);
       return null;
     }
   }

--- a/src/backend/priceAlertService.web.js
+++ b/src/backend/priceAlertService.web.js
@@ -21,6 +21,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'PriceAlerts';
 
@@ -85,7 +86,7 @@ export const subscribe = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[priceAlertService] subscribe error:', err);
+      logError('[priceAlertService] subscribe error:', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -126,7 +127,7 @@ export const unsubscribe = webMethod(
       await wixData.update(COLLECTION, { ...record, active: false });
       return { success: true };
     } catch (err) {
-      console.error('[priceAlertService] unsubscribe error:', err);
+      logError('[priceAlertService] unsubscribe error:', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -160,7 +161,7 @@ export const getSubscribers = webMethod(
 
       return { success: true, subscribers, count: subscribers.length };
     } catch (err) {
-      console.error('[priceAlertService] getSubscribers error:', err);
+      logError('[priceAlertService] getSubscribers error:', err);
       return { success: false, error: 'internal_error' };
     }
   }

--- a/tests/cf-44qt-logError-batch6.test.js
+++ b/tests/cf-44qt-logError-batch6.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock errorHandler ─────────────────────────────────────────────────────
+
+const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }));
+vi.mock('backend/utils/errorHandler', () => ({ logError: mockLogError }));
+
+// ── Mock wix-web-module ───────────────────────────────────────────────────
+
+vi.mock('wix-web-module', () => ({
+  Permissions: { Anyone: 'Anyone', Admin: 'Admin', SiteMember: 'SiteMember' },
+  webMethod: (_, fn) => fn,
+}));
+
+// ── Mock wix-members-backend ──────────────────────────────────────────────
+
+const { mockGetMember } = vi.hoisted(() => ({ mockGetMember: vi.fn() }));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: mockGetMember },
+}));
+
+// ── Mock sanitize ─────────────────────────────────────────────────────────
+
+const { mockSanitize } = vi.hoisted(() => ({ mockSanitize: vi.fn() }));
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: mockSanitize,
+  validateSlug: vi.fn((s) => (typeof s === 'string' && s.trim() ? s.trim() : null)),
+  validateId: vi.fn((s, max) => (typeof s === 'string' && s.trim() ? s.trim().slice(0, max) : null)),
+  validateEmail: vi.fn((s) => (typeof s === 'string' && s.includes('@') ? s : null)),
+}));
+
+// ── wix-data mock ─────────────────────────────────────────────────────────
+
+import { __reset as resetData, __seed, __setQueryError } from './__mocks__/wix-data.js';
+
+// ── SUT imports ───────────────────────────────────────────────────────────
+
+import { auditCatalog } from '../src/backend/pinterestCatalogSync.web.js';
+import { getProductPinData } from '../src/backend/pinterestRichPins.web.js';
+import { getRecentPointsHistory } from '../src/backend/pointsHistoryService.web.js';
+import { checkMembershipStatus } from '../src/backend/premiumMembership.web.js';
+import { getSubscribers } from '../src/backend/priceAlertService.web.js';
+
+// ── Setup ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetData();
+  vi.clearAllMocks();
+  // Default: sanitize passthrough
+  mockSanitize.mockImplementation((str, max = 1000) =>
+    typeof str === 'string' ? str.trim().slice(0, max) : ''
+  );
+  // Default: authenticated member
+  mockGetMember.mockResolvedValue({ _id: 'mem-test' });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// pinterestCatalogSync
+// ════════════════════════════════════════════════════════════════════
+
+describe('pinterestCatalogSync — logError on catch paths', () => {
+  it('calls logError when Stores/Products query fails in auditCatalog', async () => {
+    __setQueryError('Stores/Products', new Error('db error'));
+    const r = await auditCatalog();
+    expect(r.success).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('[pinterestCatalogSync]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// pinterestRichPins
+// ════════════════════════════════════════════════════════════════════
+
+describe('pinterestRichPins — logError on catch paths', () => {
+  it('calls logError when sanitize throws in getProductPinData', async () => {
+    mockSanitize.mockImplementationOnce(() => { throw new Error('sanitize crash'); });
+    const r = await getProductPinData({ name: 'Test Futon', price: 499 });
+    expect(r.success).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('[pinterestRichPins]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// pointsHistoryService
+// ════════════════════════════════════════════════════════════════════
+
+describe('pointsHistoryService — logError on catch paths', () => {
+  it('calls logError when PointsTransactions query fails in getRecentPointsHistory', async () => {
+    __setQueryError('PointsTransactions', new Error('db error'));
+    const r = await getRecentPointsHistory('mem-test');
+    expect(r).toMatchObject({ error: expect.any(String) });
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('[pointsHistoryService]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// premiumMembership
+// ════════════════════════════════════════════════════════════════════
+
+describe('premiumMembership — logError on catch paths', () => {
+  it('calls logError when PremiumMemberships query fails in checkMembershipStatus', async () => {
+    __setQueryError('PremiumMemberships', new Error('db error'));
+    const r = await checkMembershipStatus();
+    expect(r.success).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('[premiumMembership]'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// priceAlertService
+// ════════════════════════════════════════════════════════════════════
+
+describe('priceAlertService — logError on catch paths', () => {
+  it('calls logError when PriceAlerts query fails in getSubscribers', async () => {
+    __setQueryError('PriceAlerts', new Error('db error'));
+    const r = await getSubscribers('prod-1');
+    expect(r.success).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.stringContaining('[priceAlertService]'),
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **pinterestCatalogSync** (6 sites): adds import, migrates all 6 catch paths
- **pinterestRichPins** (4 sites): adds import, migrates all 4 catch paths
- **pointsHistoryService** (1 site): adds import, migrates single catch path
- **premiumMembership** (6 sites): adds import, migrates all 6 catch paths
- **priceAlertService** (3 sites): adds import, migrates all 3 catch paths

## Test plan

- [x] 5 TDD tests in `tests/cf-44qt-logError-batch6.test.js` — RED before, GREEN after
- [x] All 5 files verified `console.error`-free post-migration