### PR TITLE
fix(cf-bundledeals-logerror): bundleDeals.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/bundleDeals.web.js
+++ b/src/backend/bundleDeals.web.js
@@ -27,6 +27,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { cart as ecomCart } from 'wix-ecom-backend';
 import { validateId, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'ProductBundle';
 
@@ -41,7 +42,7 @@ function parseProducts(raw) {
   if (Array.isArray(raw)) return raw;
   if (typeof raw === 'string') {
     try { return JSON.parse(raw); } catch (e) {
-      console.error('[bundleDeals] parseProducts: malformed JSON in products field:', e.message);
+      logError('bundleDeals:parseProducts-malformedJSON', e);
       return [];
     }
   }
@@ -84,7 +85,7 @@ export const listBundles = webMethod(
         .find();
       return { success: true, bundles: result.items.map(formatBundle) };
     } catch (err) {
-      console.error('[bundleDeals] listBundles error:', err.message);
+      logError('bundleDeals:listBundles', err);
       return { success: false, bundles: [] };
     }
   }
@@ -118,7 +119,7 @@ export const getBundleBySlug = webMethod(
 
       return { success: true, bundle: formatBundle(result.items[0]) };
     } catch (err) {
-      console.error('[bundleDeals] getBundleBySlug error:', slug, err.message);
+      logError(`bundleDeals:getBundleBySlug slug=${slug}`, err);
       return { success: false, bundle: null, error: 'Failed to fetch bundle.' };
     }
   }
@@ -213,7 +214,7 @@ export const addBundleToCart = webMethod(
         couponApplied,
       };
     } catch (err) {
-      console.error('[bundleDeals] addBundleToCart error:', slug, err.message);
+      logError(`bundleDeals:addBundleToCart slug=${slug}`, err);
       return { success: false, error: 'Failed to add bundle to cart.' };
     }
   }

--- a/tests/bundleDealsLogErrorMigration.test.js
+++ b/tests/bundleDealsLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-bundledeals-logerror — pins console.error → logError migration in
+ * src/backend/bundleDeals.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/bundleDeals.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_PREFIXES = [
+  'bundleDeals:parseProducts-malformedJSON',
+  'bundleDeals:listBundles',
+  'bundleDeals:getBundleBySlug',
+  'bundleDeals:addBundleToCart',
+];
+
+describe('cf-bundledeals-logerror — bundleDeals.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 4 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_PREFIXES)('uses logError tag prefix %s', (prefix) => {
+    expect(SRC).toContain(prefix);
+  });
+
+  it('drift guard — every logError call uses the bundleDeals: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('bundleDeals:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without bundleDeals: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 10th PR in burst.

## Swaps (4 sites in bundleDeals.web.js)

- `parseProducts` malformed JSON catch → `bundleDeals:parseProducts-malformedJSON`
- `listBundles` → `bundleDeals:listBundles`
- `getBundleBySlug` → `` `bundleDeals:getBundleBySlug slug=${slug}` `` (template-literal — slug context for operator forensics)
- `addBundleToCart` → `` `bundleDeals:addBundleToCart slug=${slug}` `` (same)

## Verification

- New migration test: **7/7** ✅
- Full bundleDeals suite: **62/62** ✅

Auto-merge eligible on CI green.
