### PR TITLE
fix(cf-44qt sibling): topicClusters.web.js console.error → logError ×6

### DIFF
--- a/src/backend/topicClusters.web.js
+++ b/src/backend/topicClusters.web.js
@@ -13,6 +13,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
 import { CLUSTERS, PILLAR_CONTENT, GUIDES_URL, SITE_URL } from 'backend/utils/topicClusterData';
+import { logError } from 'backend/utils/errorHandler';
 const PUBLISHER_NAME = 'Carolina Futons';
 
 // ── Topic Cluster Definitions ─────────────────────────────────────────
@@ -58,7 +59,7 @@ export const getTopicCluster = webMethod(
         },
       };
     } catch (err) {
-      console.error('[topicClusters] Error getting topic cluster:', err);
+      logError('[topicClusters] Error getting topic cluster', err);
       return { success: false, error: 'Failed to load topic cluster.', cluster: null };
     }
   }
@@ -145,7 +146,7 @@ export const getTopicClusterPage = webMethod(
         },
       };
     } catch (err) {
-      console.error('[topicClusters] Error loading cluster page:', pillarSlug, err.name, err.message, err);
+      logError(`[topicClusters] Error loading cluster page ${pillarSlug}`, err);
       return { success: false, error: 'Failed to load cluster page.', page: null };
     }
   }
@@ -201,7 +202,7 @@ export const getClusterForPost = webMethod(
 
       return { success: true, cluster: null };
     } catch (err) {
-      console.error('[topicClusters] Error resolving cluster for post:', err);
+      logError('[topicClusters] Error resolving cluster for post', err);
       return { success: false, error: 'Failed to resolve cluster.', cluster: null };
     }
   }
@@ -332,7 +333,7 @@ export const getSchemaMarkup = webMethod(
 
       return { success: true, schemas };
     } catch (err) {
-      console.error('[topicClusters] Error generating schema markup:', err);
+      logError('[topicClusters] Error generating schema markup', err);
       return { success: false, error: 'Failed to generate schemas.', schemas: {} };
     }
   }
@@ -463,7 +464,7 @@ export const getSEOScore = webMethod(
         checks,
       };
     } catch (err) {
-      console.error('[topicClusters] Error calculating SEO score:', err);
+      logError('[topicClusters] Error calculating SEO score', err);
       return { success: false, error: 'Failed to calculate SEO score.', score: 0, maxScore: 0, checks: [] };
     }
   }
@@ -532,7 +533,7 @@ export const getSitemapData = webMethod(
         },
       };
     } catch (err) {
-      console.error('[topicClusters] Error generating sitemap data:', err);
+      logError('[topicClusters] Error generating sitemap data', err);
       return { success: false, error: 'Failed to generate sitemap.', entries: [], stats: null };
     }
   }

--- a/tests/cf-44qt-sibling-topicClusters-logError.test.js
+++ b/tests/cf-44qt-sibling-topicClusters-logError.test.js
@@ -1,0 +1,66 @@
+/**
+ * @file cf-44qt-sibling-topicClusters-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 6
+ * console.error sites in src/backend/topicClusters.web.js migrated
+ * to canonical logError from backend/utils/errorHandler.
+ *
+ * Source-grep style (mirrors deliveryNotifications sibling PR #1426
+ * pattern) — three contracts pinned: zero bare console.error, all 6
+ * expected sites have logError with canonical [topicClusters] prefix,
+ * exact invocation count locks against accidental drift.
+ *
+ * Sites migrated (6):
+ *   - getTopicCluster — L61
+ *   - getClusterPage — L148 (uses template-literal slug interp)
+ *   - resolveClusterForPost — L204
+ *   - getSchemaMarkup — L335
+ *   - calculateSeoScore — L466
+ *   - getSitemapData — L535
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/topicClusters.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — topicClusters.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    // Positive pin: logError import present.
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 6 expected sites with canonical [topicClusters] prefix', () => {
+    // Five fixed-label sites + one template-literal site (the
+    // "loading cluster page <slug>" site interpolates pillarSlug).
+    const fixedLabels = [
+      'Error getting topic cluster',
+      'Error resolving cluster for post',
+      'Error generating schema markup',
+      'Error calculating SEO score',
+      'Error generating sitemap data',
+    ];
+    for (const label of fixedLabels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[topicClusters\\] ${label.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+    // Template-literal site keeps the slug interpolation but uses logError.
+    expect(SRC).toMatch(
+      /logError\(\s*`\[topicClusters\] Error loading cluster page \$\{pillarSlug\}`/,
+    );
+  });
+
+  it('logError invocation count matches the 6 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(6);
+  });
+});


### PR DESCRIPTION
6 console.error sites migrated. [topicClusters] prefix already canonical. One site uses template-literal slug interpolation (getClusterPage error path); preserved via template-literal logError call.

Sites: getTopicCluster (L61), getClusterPage with slug interp (L148), resolveClusterForPost (L204), getSchemaMarkup (L335), calculateSeoScore (L466), getSitemapData (L535).

3 source-grep TDD pins: drift guard, per-site label presence (fixed + template-literal), exact invocation count = 6.

Sibling wave 4 — radahn. Auto-merge eligible per Stilgar small-class greenlight.