### PR TITLE
fix(cf-44qt sibling): analyticsHelpers.web.js console.error → logError ×6 (P3 obs cleanup)

### DIFF
--- a/src/backend/analyticsHelpers.web.js
+++ b/src/backend/analyticsHelpers.web.js
@@ -20,6 +20,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Track a product page view for analytics and "popular products" features.
@@ -74,7 +75,7 @@ export const trackProductView = webMethod(
       }
     } catch (err) {
       // Analytics tracking is non-critical — log but don't throw
-      console.error('Analytics tracking error:', err);
+      logError('[analyticsHelpers] trackProductView failed', err);
     }
   }
 );
@@ -107,7 +108,7 @@ export const trackAddToCart = webMethod(
         await wixData.update('ProductAnalytics', record);
       }
     } catch (err) {
-      console.error('Cart tracking error:', err);
+      logError('[analyticsHelpers] trackAddToCart failed', err);
     }
   }
 );
@@ -143,7 +144,7 @@ export const trackSocialShare = webMethod(
         await wixData.update('ProductAnalytics', record);
       }
     } catch (err) {
-      console.error('Social share tracking error:', err);
+      logError('[analyticsHelpers] trackSocialShare failed', err);
     }
   }
 );
@@ -198,7 +199,7 @@ export const getMostViewedProducts = webMethod(
         })
         .filter(Boolean);
     } catch (err) {
-      console.error('Error fetching most viewed:', err);
+      logError('[analyticsHelpers] getMostViewedProducts failed', err);
       return [];
     }
   }
@@ -253,7 +254,7 @@ export const getTrendingProducts = webMethod(
         })
         .filter(Boolean);
     } catch (err) {
-      console.error('Error fetching trending:', err);
+      logError('[analyticsHelpers] getTrendingProducts failed', err);
       return [];
     }
   }
@@ -451,7 +452,7 @@ export const trackPurchase = webMethod(
         await wixData.update('ProductAnalytics', record);
       }
     } catch (err) {
-      console.error('Purchase tracking error:', err);
+      logError('[analyticsHelpers] trackPurchase failed', err);
     }
   }
 );

--- a/tests/analyticsHelpersSilentFailureCleanup.test.js
+++ b/tests/analyticsHelpersSilentFailureCleanup.test.js
@@ -1,0 +1,106 @@
+/**
+ * cf-44qt sibling — analyticsHelpers.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch in the 6 mutating
+ * webMethods calls `logError('[analyticsHelpers] <fn> failed', err)`
+ * instead of raw `console.error`. Mirrors the canonical pattern from
+ * the cf-44qt audit memo (PRs #1387/#1389/#1392) and the
+ * wishlistService PR #1410 / priceMatchService PR #1425 siblings.
+ *
+ * 6 tests = 1 per webMethod with a catch block:
+ *   trackProductView, trackAddToCart, trackSocialShare,
+ *   getMostViewedProducts, getTrendingProducts, trackPurchase.
+ *
+ * All 6 query `ProductAnalytics` first; __setQueryError on that
+ * collection triggers the catch path in each.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+}));
+// checkRateLimit callsite destructures `{ allowed }`. Mock must match.
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — analyticsHelpers.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('trackProductView wires logError on ProductAnalytics query throw', async () => {
+    __setQueryError('ProductAnalytics', new Error('wixData query failure'));
+    const mod = await import('../src/backend/analyticsHelpers.web.js');
+    await mod.trackProductView('p-1', 'cat-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/analyticsHelpers/);
+    expect(allTags).toMatch(/trackProductView/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('trackAddToCart wires logError on ProductAnalytics query throw', async () => {
+    __setQueryError('ProductAnalytics', new Error('wixData query failure'));
+    const mod = await import('../src/backend/analyticsHelpers.web.js');
+    await mod.trackAddToCart('p-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/analyticsHelpers/);
+    expect(allTags).toMatch(/trackAddToCart/);
+  });
+
+  it('trackSocialShare wires logError on ProductAnalytics query throw', async () => {
+    __setQueryError('ProductAnalytics', new Error('wixData query failure'));
+    const mod = await import('../src/backend/analyticsHelpers.web.js');
+    await mod.trackSocialShare('p-1', 'twitter');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/analyticsHelpers/);
+    expect(allTags).toMatch(/trackSocialShare/);
+  });
+
+  it('getMostViewedProducts wires logError on ProductAnalytics query throw', async () => {
+    __setQueryError('ProductAnalytics', new Error('wixData query failure'));
+    const mod = await import('../src/backend/analyticsHelpers.web.js');
+    await mod.getMostViewedProducts(10);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/analyticsHelpers/);
+    expect(allTags).toMatch(/getMostViewedProducts/);
+  });
+
+  it('getTrendingProducts wires logError on ProductAnalytics query throw', async () => {
+    __setQueryError('ProductAnalytics', new Error('wixData query failure'));
+    const mod = await import('../src/backend/analyticsHelpers.web.js');
+    await mod.getTrendingProducts(10);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/analyticsHelpers/);
+    expect(allTags).toMatch(/getTrendingProducts/);
+  });
+
+  it('trackPurchase wires logError on ProductAnalytics query throw', async () => {
+    __setQueryError('ProductAnalytics', new Error('wixData query failure'));
+    const mod = await import('../src/backend/analyticsHelpers.web.js');
+    await mod.trackPurchase('p-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/analyticsHelpers/);
+    expect(allTags).toMatch(/trackPurchase/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — analyticsHelpers.web.js console.error → logError × 6 + 6 TDD pins. 3rd same-pattern sibling in my cluster (after wishlistService PR #1410 + priceMatchService PR #1425).

## Migrations

6 mutating webMethods (each with a try/catch that previously called `console.error`):

| webMethod | New logError tag |
|---|---|
| trackProductView | `[analyticsHelpers] trackProductView failed` |
| trackAddToCart | `[analyticsHelpers] trackAddToCart failed` |
| trackSocialShare | `[analyticsHelpers] trackSocialShare failed` |
| getMostViewedProducts | `[analyticsHelpers] getMostViewedProducts failed` |
| getTrendingProducts | `[analyticsHelpers] getTrendingProducts failed` |
| trackPurchase | `[analyticsHelpers] trackPurchase failed` |

The ~10 `buildXxxEvent` constructors (buildViewContentEvent, buildAddToCartEvent, etc.) have no try/catch and no console.error — out of scope for a logger-sweep PR.

## TDD shape (6/6 green)

- Top-level `vi.mock('backend/utils/errorHandler', ...)` per CF-fgsw
- 1 test per webMethod
- All 6 trigger via `__setQueryError('ProductAnalytics', err)` (every catch path reads ProductAnalytics first)
- `checkRateLimit` mock returns `{ allowed: true }` (callsite destructures `{allowed}`)

## Auto-merge eligible

Per Stilgar 2026-05-15 06:46 small-class greenlight + mayor 2026-05-16 08:59 pace-alert authorization.

## Test plan
- [x] `npx vitest run tests/analyticsHelpersSilentFailureCleanup.test.js` — 6/6 green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- Audit memo: my 2026-05-16 1-page
- Cluster: PR #1410 (wishlistService), PR #1425 (priceMatchService)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
