### PR TITLE
fix(cf-questprogress-logerror): questProgressService.web.js — 3 console.error → logError

### DIFF
--- a/src/backend/questProgressService.web.js
+++ b/src/backend/questProgressService.web.js
@@ -18,6 +18,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'QuestProgress';
 const ACTIVE_QUESTS_LIMIT = 50;
@@ -87,7 +88,7 @@ export const saveQuestProgress = webMethod(
       }
       return { success: true };
     } catch (err) {
-      console.error('[questProgressService] saveQuestProgress failed:', err);
+      logError('questProgressService:saveQuestProgress', err);
       return { success: false, error: 'Unable to save quest progress' };
     }
   }
@@ -129,7 +130,7 @@ export const getQuestProgress = webMethod(
       }
       return { success: true, progressData: parsed, status: record.status };
     } catch (err) {
-      console.error('[questProgressService] getQuestProgress failed:', err);
+      logError('questProgressService:getQuestProgress', err);
       return { success: false, error: 'Unable to retrieve quest progress' };
     }
   }
@@ -166,7 +167,7 @@ export const getActiveQuests = webMethod(
 
       return { success: true, quests };
     } catch (err) {
-      console.error('[questProgressService] getActiveQuests failed:', err);
+      logError('questProgressService:getActiveQuests', err);
       return { success: false, error: 'Unable to retrieve active quests' };
     }
   }

--- a/tests/questProgressServiceLogErrorMigration.test.js
+++ b/tests/questProgressServiceLogErrorMigration.test.js
@@ -1,0 +1,48 @@
+/**
+ * cf-questprogress-logerror — pins console.error → logError migration
+ * in src/backend/questProgressService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/questProgressService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'questProgressService:saveQuestProgress',
+  'questProgressService:getQuestProgress',
+  'questProgressService:getActiveQuests',
+];
+
+describe('cf-questprogress-logerror — questProgressService.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 3 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the questProgressService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(3);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('questProgressService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without questProgressService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 12th PR in burst.

## Swaps (3 sites in questProgressService.web.js)

- `saveQuestProgress`, `getQuestProgress`, `getActiveQuests` → all under `questProgressService:<fn>`

## Verification

- New migration test: **6/6** ✅
- Full questProgress suite: **32/32** ✅

Auto-merge eligible on CI green.
