### PR TITLE
fix(cf-marketingsequences-logerror): marketingSequences.web.js — 6 console.error → logError (drop local wrapper)

### DIFF
--- a/src/backend/marketingSequences.web.js
+++ b/src/backend/marketingSequences.web.js
@@ -27,12 +27,9 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { enqueueEmail } from 'backend/emailQueueService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 export const EMAIL_SEQUENCES_COLLECTION = 'EmailSequences';
-
-function logError(msg, err) {
-  console.error(`[marketingSequences] ${msg}`, err?.message ?? err ?? '');
-}
 
 // ── Internal: load active steps for a sequence type ──────────────────────────
 
@@ -97,7 +94,7 @@ export const triggerWelcomeSequence = webMethod(Permissions.Admin, async (params
     });
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerWelcomeSequence failed', err);
+    logError('marketingSequences:triggerWelcomeSequence', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -136,7 +133,7 @@ export const triggerCartAbandonSequence = webMethod(Permissions.Admin, async (pa
     );
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerCartAbandonSequence failed', err);
+    logError('marketingSequences:triggerCartAbandonSequence', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -170,7 +167,7 @@ export const triggerReviewRequestSequence = webMethod(Permissions.Admin, async (
     });
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerReviewRequestSequence failed', err);
+    logError('marketingSequences:triggerReviewRequestSequence', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -241,7 +238,7 @@ export const runReviewRequestEmails = webMethod(Permissions.Admin, async () => {
 
     return { success: true, ordersScanned: orders.length, triggered, skipped, failed };
   } catch (err) {
-    logError('runReviewRequestEmails failed', err);
+    logError('marketingSequences:runReviewRequestEmails', err);
     return { success: false, ordersScanned: 0, triggered: 0, skipped: 0, failed: 0 };
   }
 });
@@ -273,7 +270,7 @@ export const triggerWinbackSequence = webMethod(Permissions.Admin, async (params
     });
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerWinbackSequence failed', err);
+    logError('marketingSequences:triggerWinbackSequence', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -328,7 +325,7 @@ export const scanAndTriggerWinback = webMethod(Permissions.Admin, async () => {
 
     return { success: true, scanned, triggered };
   } catch (err) {
-    logError('scanAndTriggerWinback failed', err);
+    logError('marketingSequences:scanAndTriggerWinback', err);
     return { success: false, scanned: 0, triggered: 0, error: err?.message ?? 'unknown error' };
   }
 });

--- a/tests/marketingSequencesLogErrorMigration.test.js
+++ b/tests/marketingSequencesLogErrorMigration.test.js
@@ -1,0 +1,58 @@
+/**
+ * cf-marketingsequences-logerror — pins console.error → logError
+ * migration in src/backend/marketingSequences.web.js. NOTE: this file
+ * had a LOCAL logError(msg, err) wrapper that internally called
+ * console.error. The migration removes the local wrapper AND swaps to
+ * the shared errorHandler logError + namespaced tags.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/marketingSequences.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'marketingSequences:triggerWelcomeSequence',
+  'marketingSequences:triggerCartAbandonSequence',
+  'marketingSequences:triggerReviewRequestSequence',
+  'marketingSequences:runReviewRequestEmails',
+  'marketingSequences:triggerWinbackSequence',
+  'marketingSequences:scanAndTriggerWinback',
+];
+
+describe('cf-marketingsequences-logerror — marketingSequences.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('local logError(msg, err) wrapper removed (was shadowing the shared name)', () => {
+    expect(SRC).not.toMatch(/^function\s+logError\s*\(/m);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the marketingSequences: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('marketingSequences:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without marketingSequences: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 13th PR in burst.

## Local wrapper removal (unique to this file)

`marketingSequences.web.js` had a LOCAL `function logError(msg, err)` that internally called `console.error` — a NAME SHADOW of the shared `logError`. This PR removes the local wrapper AND swaps to the shared `errorHandler.logError` + namespaced tags. Regression test pins the local wrapper stays gone.

## Swaps (6 sites)

- `triggerWelcomeSequence`, `triggerCartAbandonSequence`, `triggerReviewRequestSequence`, `runReviewRequestEmails`, `triggerWinbackSequence`, `scanAndTriggerWinback` → all under `marketingSequences:<fn>`

## Verification

- New migration test: **10/10** ✅ (incl. local-wrapper-removed pin)
- Full marketing suite: **51/51** ✅

Auto-merge eligible on CI green.
