### PR TITLE
fix(cf-44qt sibling): searchService.web.js console.error → logError ×6 (P3 obs cleanup)

### DIFF
--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -57,7 +57,6 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { logError } from 'backend/utils/errorHandler';
 import { sanitize, validateId } from 'backend/utils/sanitize';
-import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();

--- a/src/backend/searchService.web.js
+++ b/src/backend/searchService.web.js
@@ -14,6 +14,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ─── Cache Layer ─────────────────────────────────────────────────
 // Shared TTL cache for facets, search results, and autocomplete.
@@ -285,7 +286,7 @@ export const searchProducts = webMethod(
         facets,
       };
     } catch (err) {
-      console.error('Error in searchProducts:', err);
+      logError('[searchService] searchProducts failed', err);
       return { products: [], total: 0, facets: {} };
     }
   }
@@ -307,7 +308,7 @@ export const getFilterValues = webMethod(
       const cleanCategory = category ? validateSlug(category) : '';
       return await buildFacets(cleanCategory);
     } catch (err) {
-      console.error('Error in getFilterValues:', err);
+      logError('[searchService] getFilterValues failed', err);
       return {
         priceRanges: [],
         materials: [],
@@ -620,7 +621,7 @@ export const fullTextSearch = webMethod(
       setCachedSearch(cacheKey, result);
       return result;
     } catch (err) {
-      console.error('Error in fullTextSearch:', err);
+      logError('[searchService] fullTextSearch failed', err);
       return { products: [], total: 0, query: '', facets: {} };
     }
   }
@@ -705,7 +706,7 @@ export const getAutocompleteSuggestions = webMethod(
       _cache[cacheKey] = { data: result, timestamp: Date.now() };
       return result;
     } catch (err) {
-      console.error('Error in getAutocompleteSuggestions:', err);
+      logError('[searchService] getAutocompleteSuggestions failed', err);
       return { suggestions: [] };
     }
   }
@@ -727,7 +728,7 @@ export const getPopularSearches = webMethod(
       const safeLimit = Math.min(Math.max(1, Number(limit) || 8), 20);
       return { queries: getTopQueries(safeLimit) };
     } catch (err) {
-      console.error('Error in getPopularSearches:', err);
+      logError('[searchService] getPopularSearches failed', err);
       return { queries: [] };
     }
   }
@@ -751,7 +752,7 @@ export const recordSearchQuery = webMethod(
       recordQuery(cleanQuery);
       return { success: true };
     } catch (err) {
-      console.error('Error in recordSearchQuery:', err);
+      logError('[searchService] recordSearchQuery failed', err);
       return { success: false };
     }
   }

--- a/tests/searchServiceSilentFailureCleanup.test.js
+++ b/tests/searchServiceSilentFailureCleanup.test.js
@@ -1,0 +1,86 @@
+/**
+ * cf-44qt sibling — searchService.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch in the 6 webMethods
+ * calls `logError('[searchService] <fn> failed', err)` instead of
+ * raw `console.error`. Mirrors the canonical pattern from my cf-44qt
+ * audit memo (PRs #1387/#1389/#1392) and the sibling cluster
+ * #1410 wishlistService / #1425 priceMatchService / #1436 analyticsHelpers.
+ *
+ * 4 tests cover the 4 webMethods that read wix-data (and thus can
+ * be made to throw via __setQueryError). The 2 remaining webMethods
+ * — getPopularSearches and recordSearchQuery — use in-memory
+ * top-queries state via module-internal `getTopQueries` /
+ * `recordQuery` helpers; their catches are paranoid (the
+ * synchronous code path doesn't realistically throw). Migration is
+ * mechanically verified (1:1 + same tag shape) but no runtime-throw
+ * test pins them. Same gap-shape documented in PR #1425 for
+ * priceMatchService.getPriceMatchById (wixData.get path).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateSlug: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — searchService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('searchProducts wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/searchService.web.js');
+    await mod.searchProducts({ q: 'futon' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/searchService/);
+    expect(allTags).toMatch(/searchProducts/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('getFilterValues wires logError on Stores/Products query throw (via buildFacets)', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/searchService.web.js');
+    await mod.getFilterValues('futon-frames');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/searchService/);
+    expect(allTags).toMatch(/getFilterValues/);
+  });
+
+  it('fullTextSearch wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/searchService.web.js');
+    await mod.fullTextSearch({ query: 'futon' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/searchService/);
+    expect(allTags).toMatch(/fullTextSearch/);
+  });
+
+  it('getAutocompleteSuggestions wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/searchService.web.js');
+    await mod.getAutocompleteSuggestions('fut');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/searchService/);
+    expect(allTags).toMatch(/getAutocompleteSuggestions/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — searchService.web.js console.error → logError × 6 + 4 TDD pins (2 documented gaps for in-memory-state paths). 4th same-pattern sibling.

## Migrations

6 webMethods, same `[<service>] <fn> failed` tag shape:

| webMethod | New logError tag |
|---|---|
| searchProducts | `[searchService] searchProducts failed` |
| getFilterValues | `[searchService] getFilterValues failed` |
| fullTextSearch | `[searchService] fullTextSearch failed` |
| getAutocompleteSuggestions | `[searchService] getAutocompleteSuggestions failed` |
| getPopularSearches | `[searchService] getPopularSearches failed` |
| recordSearchQuery | `[searchService] recordSearchQuery failed` |

## TDD shape (4 active + 2 gaps)

`tests/searchServiceSilentFailureCleanup.test.js` covers 4 wix-data-using methods via `__setQueryError('Stores/Products', err)`:
- searchProducts
- getFilterValues (queries via buildFacets)
- fullTextSearch
- getAutocompleteSuggestions

**Documented gaps**: `getPopularSearches` + `recordSearchQuery` use module-internal in-memory state (`getTopQueries` / `recordQuery` helpers) — their catches are paranoid. Migration mechanically verified, no runtime-throw test pin. Same gap-shape as PR #1425 priceMatchService.getPriceMatchById.

## Auto-merge eligible

Per Stilgar small-class greenlight + mayor pace-alert authorization.

## Test plan
- [x] `npx vitest run tests/searchServiceSilentFailureCleanup.test.js` — 4/4 green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- Sibling cluster: #1410 wishlist, #1425 priceMatch, #1436 analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
