### PR TITLE
fix(cf-tok3): roomPlanner console.error → logError migration (6 sites)

### DIFF
--- a/src/backend/roomPlanner.web.js
+++ b/src/backend/roomPlanner.web.js
@@ -27,6 +27,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -106,7 +107,7 @@ export const createRoomLayout = webMethod(
       const inserted = await wixData.insert('RoomLayouts', record);
       return { success: true, id: inserted._id, shareId };
     } catch (err) {
-      console.error('[roomPlanner] Error creating room layout:', err);
+      logError('roomPlanner.createRoomLayout', err);
       return { success: false, error: 'Failed to create layout.' };
     }
   }
@@ -193,7 +194,7 @@ export const addProductToLayout = webMethod(
         dimensions: { width: actualWidth, depth: actualHeight, label: dims.label },
       };
     } catch (err) {
-      console.error('[roomPlanner] Error adding product to layout:', err);
+      logError('roomPlanner.addProductToLayout', err);
       return { success: false, error: 'Failed to update layout.' };
     }
   }
@@ -255,7 +256,7 @@ export const getLayoutPreview = webMethod(
         },
       };
     } catch (err) {
-      console.error('[roomPlanner] Error getting layout preview:', err);
+      logError('roomPlanner.getLayoutPreview', err);
       return { success: false, error: 'Failed to load layout.', layout: null };
     }
   }
@@ -294,7 +295,7 @@ export const shareLayout = webMethod(
 
       return { success: true, shareUrl };
     } catch (err) {
-      console.error('[roomPlanner] Error sharing layout:', err);
+      logError('roomPlanner.shareLayout', err);
       return { success: false, error: 'Failed to update sharing.' };
     }
   }
@@ -335,7 +336,7 @@ export const saveLayout = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[roomPlanner] Error saving layout:', err);
+      logError('roomPlanner.saveLayout', err);
       return { success: false, error: 'Failed to save layout.' };
     }
   }
@@ -361,7 +362,7 @@ export const getProductDimensions = webMethod(
 
       return { success: true, products };
     } catch (err) {
-      console.error('[roomPlanner] Error getting product dimensions:', err);
+      logError('roomPlanner.getProductDimensions', err);
       return { success: false, error: 'Failed to load dimensions.', products: [] };
     }
   }

--- a/tests/cf-tok3-roomPlanner-logError.test.js
+++ b/tests/cf-tok3-roomPlanner-logError.test.js
@@ -1,0 +1,39 @@
+/**
+ * @file cf-tok3-roomPlanner-logError.test.js
+ * Source-scan regression pin for roomPlanner migration.
+ * cf-tok3 wave. Mayor PACE ALERT 08:59.
+ */
+import { describe, it, expect } from 'vitest';
+
+async function readSrc() {
+  const { readFile } = await import('node:fs/promises');
+  return readFile(
+    new URL('../src/backend/roomPlanner.web.js', import.meta.url),
+    'utf8',
+  );
+}
+
+describe('cf-tok3 roomPlanner — console.error → logError migration', () => {
+  it('source file contains zero raw console.error calls', async () => {
+    const src = await readSrc();
+    const stripped = src.replace(/\/\/.*$/gm, '');
+    expect(stripped).not.toMatch(/console\.error/);
+  });
+
+  it('source file imports logError from backend/utils/errorHandler', async () => {
+    const src = await readSrc();
+    expect(src).toMatch(
+      /import\s+\{\s*[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('all 6 webMethods route through roomPlanner.* context tags', async () => {
+    const src = await readSrc();
+    expect(src).toMatch(/logError\(\s*['"]roomPlanner\.createRoomLayout['"]/);
+    expect(src).toMatch(/logError\(\s*['"]roomPlanner\.addProductToLayout['"]/);
+    expect(src).toMatch(/logError\(\s*['"]roomPlanner\.getLayoutPreview['"]/);
+    expect(src).toMatch(/logError\(\s*['"]roomPlanner\.shareLayout['"]/);
+    expect(src).toMatch(/logError\(\s*['"]roomPlanner\.saveLayout['"]/);
+    expect(src).toMatch(/logError\(\s*['"]roomPlanner\.getProductDimensions['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

6 console.error sites in `src/backend/roomPlanner.web.js` → canonical `logError`:
- createRoomLayout, addProductToLayout, getLayoutPreview, shareLayout, saveLayout, getProductDimensions

All routed through `roomPlanner.<method>` context tags.

## TDD (3 tests)

1. Source-scan: zero raw console.error
2. Source-scan: logError import present  
3. Source-scan: all 6 webMethods route through roomPlanner.* tags

## Test plan

- [x] 3/3 new tests pass
- [x] 447/447 roomPlanner regression suite passes
- [ ] CI green
- [ ] Auto-merge

Refs cf-tok3 (mayor PACE ALERT 08:59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)