### PR TITLE
fix(cf-44qt sibling): newsletterService.web.js console.error → logError ×3

### DIFF
--- a/src/backend/newsletterService.web.js
+++ b/src/backend/newsletterService.web.js
@@ -24,6 +24,7 @@ import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 
 const DISCOUNT_CODE = 'WELCOME10';
 const KLAVIYO_API_BASE = 'https://a.klaviyo.com/api';
@@ -155,7 +156,7 @@ async function _syncToESPInternal(email, source) {
 
     return { synced: true };
   } catch (err) {
-    console.error('ESP sync error:', err);
+    logError('[newsletterService] ESP sync', err);
     return { synced: false, reason: 'sync_failed' };
   }
 }
@@ -256,7 +257,7 @@ export const unsubscribeFromESP = webMethod(
 
       return { unsubscribed: true };
     } catch (err) {
-      console.error('ESP unsubscribe error:', err);
+      logError('[newsletterService] ESP unsubscribe', err);
       return { unsubscribed: false, reason: 'unsubscribe_failed' };
     }
   }
@@ -358,7 +359,7 @@ export const subscribeToNewsletter = webMethod(
       logAuditEvent('NewsletterSubscribers', 'subscribe', cleaned, { source });
       return { success: true, discountCode: DISCOUNT_CODE };
     } catch (err) {
-      console.error('Newsletter subscription error:', err);
+      logError('[newsletterService] subscribe', err);
       return { success: false, message: 'Subscription failed. Please try again.' };
     }
   }

--- a/tests/cf-44qt-sibling-newsletterService-logError.test.js
+++ b/tests/cf-44qt-sibling-newsletterService-logError.test.js
@@ -1,0 +1,47 @@
+/**
+ * @file cf-44qt-sibling-newsletterService-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 3
+ * console.error sites in src/backend/newsletterService.web.js
+ * migrated to canonical logError. Adds the canonical
+ * [newsletterService] prefix (pre-fix sites had bare 'ESP X error:'
+ * strings — newsletterService prefix added during migration).
+ *
+ * Sites migrated (3):
+ *   - ESP sync (L158) → [newsletterService] ESP sync
+ *   - ESP unsubscribe (L259) → [newsletterService] ESP unsubscribe
+ *   - subscribe outer catch (L361) → [newsletterService] subscribe
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/newsletterService.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — newsletterService.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 3 expected sites with canonical [newsletterService] prefix', () => {
+    const labels = ['ESP sync', 'ESP unsubscribe', 'subscribe'];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[newsletterService\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 3 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(3);
+  });
+});


### PR DESCRIPTION
3 console.error sites migrated. Pre-fix sites lacked the [module] prefix; migration adds canonical [newsletterService] prefix. Sites: ESP sync (L158), ESP unsubscribe (L259), subscribe outer catch (L361). 3 source-grep TDD pins. Auto-merge eligible.