### PR TITLE
fix(cf-seocontenthub-logerror): seoContentHub.web.js — 6 console.error → logError

### DIFF
--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -57,7 +57,6 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { logError } from 'backend/utils/errorHandler';
 import { sanitize, validateId } from 'backend/utils/sanitize';
-import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();

--- a/src/backend/seoContentHub.web.js
+++ b/src/backend/seoContentHub.web.js
@@ -11,6 +11,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 const HUB_PATH = '/buying-guides';
@@ -163,7 +164,7 @@ export const getContentHub = webMethod(
         },
       };
     } catch (err) {
-      console.error('[seoContentHub] Error getting content hub:', err);
+      logError('seoContentHub:getContentHub', err);
       return { success: false, error: 'Failed to load content hub.', hub: null };
     }
   }
@@ -217,7 +218,7 @@ export const getPillarGuide = webMethod(
         relatedGuides,
       };
     } catch (err) {
-      console.error('[seoContentHub] Error getting pillar guide:', err);
+      logError('seoContentHub:getPillarGuide', err);
       return { success: false, error: 'Failed to load guide.', guide: null, relatedGuides: [] };
     }
   }
@@ -237,7 +238,7 @@ export const getPillarGuideSlugs = webMethod(
         slugs: PILLAR_GUIDES.map(g => g.slug),
       };
     } catch (err) {
-      console.error('[seoContentHub] Error getting slugs:', err);
+      logError('seoContentHub:getPillarGuideSlugs', err);
       return { success: false, error: 'Failed to load slugs.', slugs: [] };
     }
   }
@@ -304,7 +305,7 @@ export const getHubSchema = webMethod(
 
       return { success: true, collectionSchema, itemListSchema, breadcrumbSchema };
     } catch (err) {
-      console.error('[seoContentHub] Error generating hub schema:', err);
+      logError('seoContentHub:getHubSchema', err);
       return { success: false, error: 'Failed to generate hub schema.', collectionSchema: '', itemListSchema: '', breadcrumbSchema: '' };
     }
   }
@@ -359,7 +360,7 @@ export const getGuideSchema = webMethod(
 
       return { success: true, breadcrumbSchema, navigationSchema };
     } catch (err) {
-      console.error('[seoContentHub] Error generating guide schema:', err);
+      logError('seoContentHub:getGuideSchema', err);
       return { success: false, error: 'Failed to generate guide schema.', breadcrumbSchema: '', navigationSchema: '' };
     }
   }
@@ -395,7 +396,7 @@ export const getSitemapEntries = webMethod(
 
       return { success: true, entries };
     } catch (err) {
-      console.error('[seoContentHub] Error generating sitemap entries:', err);
+      logError('seoContentHub:getSitemapEntries', err);
       return { success: false, error: 'Failed to generate sitemap.', entries: [] };
     }
   }

--- a/tests/seoContentHubLogErrorMigration.test.js
+++ b/tests/seoContentHubLogErrorMigration.test.js
@@ -1,0 +1,51 @@
+/**
+ * cf-seocontenthub-logerror — pins console.error → logError migration
+ * in src/backend/seoContentHub.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/seoContentHub.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'seoContentHub:getContentHub',
+  'seoContentHub:getPillarGuide',
+  'seoContentHub:getPillarGuideSlugs',
+  'seoContentHub:getHubSchema',
+  'seoContentHub:getGuideSchema',
+  'seoContentHub:getSitemapEntries',
+];
+
+describe('cf-seocontenthub-logerror — seoContentHub.web.js console.error → logError', () => {
+  it('contains zero console.error calls (all 6 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the seoContentHub: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('seoContentHub:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without seoContentHub: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 15th PR in burst.

## Swaps (6 sites in seoContentHub.web.js)

- `getContentHub`, `getPillarGuide`, `getPillarGuideSlugs`, `getHubSchema`, `getGuideSchema`, `getSitemapEntries` → all under `seoContentHub:<fn>`

## Verification

- New migration test: **9/9** ✅
- Full seoContentHub suite: **108/108** ✅

Auto-merge eligible on CI green.
