### PR TITLE
fix(cf-44qt sibling): browseAbandonment.web.js console.error → logError ×6

### DIFF
--- a/src/backend/browseAbandonment.web.js
+++ b/src/backend/browseAbandonment.web.js
@@ -19,6 +19,7 @@ import { sanitize, validateEmail, validateId } from 'backend/utils/sanitize';
 import { safeParse } from 'backend/utils/safeParse';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const HIGH_INTENT_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
 const RECOVERY_WINDOW_MS = 48 * 60 * 60 * 1000; // 48 hours
@@ -114,7 +115,7 @@ export const trackBrowseSession = webMethod(
 
       return { success: true, isHighIntent };
     } catch (err) {
-      console.error('[browseAbandonment] Error tracking session:', err);
+      logError('[browseAbandonment] Error tracking session', err);
       return { success: false, error: 'Failed to track session' };
     }
   }
@@ -198,7 +199,7 @@ export const captureRemindMeRequest = webMethod(
       logAuditEvent('BrowseSessions', 'remind_me', cleanEmail, { sessionId: cleanSessionId });
       return { success: true };
     } catch (err) {
-      console.error('[browseAbandonment] Error capturing remind-me:', err);
+      logError('[browseAbandonment] Error capturing remind-me', err);
       return { success: false, error: 'Failed to capture email' };
     }
   }
@@ -286,7 +287,7 @@ export const triggerBrowseRecovery = webMethod(
 
       return { success: true, triggered, skipped };
     } catch (err) {
-      console.error('[browseAbandonment] Error triggering recovery:', err);
+      logError('[browseAbandonment] Error triggering recovery', err);
       return { success: false, error: 'Failed to trigger recovery' };
     }
   }
@@ -357,7 +358,7 @@ export const getBrowseAbandonmentStats = webMethod(
         recoveryRate: recoverySent > 0 ? Math.round((recoveryConverted / recoverySent) * 100) : 0,
       };
     } catch (err) {
-      console.error('[browseAbandonment] Error fetching stats:', err);
+      logError('[browseAbandonment] Error fetching stats', err);
       return { success: false, error: 'Failed to fetch stats' };
     }
   }
@@ -422,7 +423,7 @@ export const exportAbandonmentInsights = webMethod(
 
       return { success: true, insights };
     } catch (err) {
-      console.error('[browseAbandonment] Error exporting insights:', err);
+      logError('[browseAbandonment] Error exporting insights', err);
       return { success: false, error: 'Failed to export insights' };
     }
   }
@@ -470,7 +471,7 @@ export const markSessionConverted = webMethod(
       }
       return false;
     } catch (err) {
-      console.error('[browseAbandonment] Error marking converted:', err);
+      logError('[browseAbandonment] Error marking converted', err);
       return false;
     }
   }

--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -57,7 +57,6 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { logError } from 'backend/utils/errorHandler';
 import { sanitize, validateId } from 'backend/utils/sanitize';
-import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();

--- a/tests/cf-44qt-sibling-browseAbandonment-logError.test.js
+++ b/tests/cf-44qt-sibling-browseAbandonment-logError.test.js
@@ -1,0 +1,55 @@
+/**
+ * @file cf-44qt-sibling-browseAbandonment-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 6
+ * console.error sites in src/backend/browseAbandonment.web.js
+ * migrated to canonical logError.
+ *
+ * Sites migrated (6):
+ *   - trackSession (L117)
+ *   - captureRemindMe (L201)
+ *   - triggerRecovery (L289)
+ *   - getStats (L360)
+ *   - exportInsights (L425)
+ *   - markConverted (L473)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/browseAbandonment.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — browseAbandonment.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 6 expected sites with canonical [browseAbandonment] prefix', () => {
+    const labels = [
+      'Error tracking session',
+      'Error capturing remind-me',
+      'Error triggering recovery',
+      'Error fetching stats',
+      'Error exporting insights',
+      'Error marking converted',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[browseAbandonment\\] ${label.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 6 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(6);
+  });
+});


### PR DESCRIPTION
6 sites migrated. [browseAbandonment] prefix already canonical. Sites: trackSession (L117), captureRemindMe (L201), triggerRecovery (L289), getStats (L360), exportInsights (L425), markConverted (L473). 3 source-grep TDD pins. Auto-merge eligible.