### PR TITLE
fix(cf-44qt sibling): contentScheduler.web.js console.error → logError ×5 (P3 obs cleanup)

### DIFF
--- a/tests/contentSchedulerSilentFailureCleanup.test.js
+++ b/tests/contentSchedulerSilentFailureCleanup.test.js
@@ -1,0 +1,86 @@
+/**
+ * cf-44qt sibling — contentScheduler.web.js observability cleanup.
+ *
+ * Pins post-migration contract: every catch calls
+ * `logError('[contentScheduler] <fn> failed', err)` or
+ * `logError('[contentScheduler] processContentSchedule item-action
+ * failed for <id>', actionErr)` for the inner per-item action catch.
+ *
+ * 4 tests = 1 per webMethod. All 4 query/mutate `ContentSchedule`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'm-1' })) },
+}));
+// processContentSchedule first verifies a CONTENT_CRON_KEY secret;
+// align the mock so the auth check passes and the catch reaches the
+// wixData query path.
+vi.mock('wix-secrets-backend', () => ({
+  getSecret: vi.fn(async () => 'test-cron-secret'),
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — contentScheduler.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('processContentSchedule wires logError on ContentSchedule query throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData query failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.processContentSchedule('test-cron-secret');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/processContentSchedule/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('getScheduleQueue wires logError on ContentSchedule query throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData query failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.getScheduleQueue();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/getScheduleQueue/);
+  });
+
+  it('cancelScheduledItem wires logError on ContentSchedule query/get throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData query failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.cancelScheduledItem('item-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/cancelScheduledItem/);
+  });
+
+  it('getScheduleStats wires logError on ContentSchedule query throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData query failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.getScheduleStats();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/getScheduleStats/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — contentScheduler.web.js console.error → logError × 5 + 4 TDD pins. 5th same-pattern sibling.

## Migrations

| Site | New logError tag |
|---|---|
| processContentSchedule outer catch | `[contentScheduler] processContentSchedule failed` |
| processContentSchedule per-item inner catch | `[contentScheduler] processContentSchedule item-action failed for ${item._id}` (dynamic) |
| getScheduleQueue | `[contentScheduler] getScheduleQueue failed` |
| cancelScheduledItem | `[contentScheduler] cancelScheduledItem failed` |
| getScheduleStats | `[contentScheduler] getScheduleStats failed` |

Dynamic per-item tag mirrors warrantyService `queueEmail-${templateId}` pattern (flagged as acceptable high-cardinality breadcrumb in my 2026-05-16 audit memo).

## TDD shape (4/4 green)

`tests/contentSchedulerSilentFailureCleanup.test.js`:
- Top-level vi.mock per CF-fgsw
- Mocks include `wix-secrets-backend` for the `CONTENT_CRON_KEY` check (processContentSchedule's first gate)
- All 4 webMethods trigger via `__setQueryError('ContentSchedule', err)`

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 4/4 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- Sibling cluster: #1410 wishlist, #1425 priceMatch, #1436 analytics, #1445 search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
