### PR TITLE
fix(cf-44qt sibling): seoContentHub.web.js console.error → logError ×6 (P3)

### DIFF
--- a/src/backend/seoContentHub.web.js
+++ b/src/backend/seoContentHub.web.js
@@ -11,6 +11,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 const HUB_PATH = '/buying-guides';
@@ -163,7 +164,7 @@ export const getContentHub = webMethod(
         },
       };
     } catch (err) {
-      console.error('[seoContentHub] Error getting content hub:', err);
+      logError('[seoContentHub] getContentHub failed', err);
       return { success: false, error: 'Failed to load content hub.', hub: null };
     }
   }
@@ -217,7 +218,7 @@ export const getPillarGuide = webMethod(
         relatedGuides,
       };
     } catch (err) {
-      console.error('[seoContentHub] Error getting pillar guide:', err);
+      logError('[seoContentHub] getPillarGuide failed', err);
       return { success: false, error: 'Failed to load guide.', guide: null, relatedGuides: [] };
     }
   }
@@ -237,7 +238,7 @@ export const getPillarGuideSlugs = webMethod(
         slugs: PILLAR_GUIDES.map(g => g.slug),
       };
     } catch (err) {
-      console.error('[seoContentHub] Error getting slugs:', err);
+      logError('[seoContentHub] getPillarGuideSlugs failed', err);
       return { success: false, error: 'Failed to load slugs.', slugs: [] };
     }
   }
@@ -304,7 +305,7 @@ export const getHubSchema = webMethod(
 
       return { success: true, collectionSchema, itemListSchema, breadcrumbSchema };
     } catch (err) {
-      console.error('[seoContentHub] Error generating hub schema:', err);
+      logError('[seoContentHub] getHubSchema failed', err);
       return { success: false, error: 'Failed to generate hub schema.', collectionSchema: '', itemListSchema: '', breadcrumbSchema: '' };
     }
   }
@@ -359,7 +360,7 @@ export const getGuideSchema = webMethod(
 
       return { success: true, breadcrumbSchema, navigationSchema };
     } catch (err) {
-      console.error('[seoContentHub] Error generating guide schema:', err);
+      logError('[seoContentHub] getGuideSchema failed', err);
       return { success: false, error: 'Failed to generate guide schema.', breadcrumbSchema: '', navigationSchema: '' };
     }
   }
@@ -395,7 +396,7 @@ export const getSitemapEntries = webMethod(
 
       return { success: true, entries };
     } catch (err) {
-      console.error('[seoContentHub] Error generating sitemap entries:', err);
+      logError('[seoContentHub] getSitemapEntries failed', err);
       return { success: false, error: 'Failed to generate sitemap.', entries: [] };
     }
   }

--- a/tests/seoContentHubSilentFailureCleanup.test.js
+++ b/tests/seoContentHubSilentFailureCleanup.test.js
@@ -1,0 +1,50 @@
+/**
+ * cf-44qt sibling — seoContentHub.web.js observability cleanup.
+ *
+ * This module is pure data + JSON-LD generation (no wixData calls), so the
+ * 6 catch blocks are defensive (unreachable under normal flow). The migration
+ * is mechanical text-replacement; this test pins that the module continues
+ * to function + the new logError import is present at module load.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateSlug: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+describe('cf-44qt sibling — seoContentHub.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+  });
+
+  it('module loads cleanly with the new logError import', async () => {
+    const mod = await import('../src/backend/seoContentHub.web.js');
+    expect(typeof mod.getContentHub).toBe('function');
+    expect(typeof mod.getPillarGuide).toBe('function');
+  });
+
+  it('happy-path getContentHub does not call logError (no spurious noise)', async () => {
+    const mod = await import('../src/backend/seoContentHub.web.js');
+    const result = await mod.getContentHub();
+    expect(result.success).toBe(true);
+    expect(result.hub.guideCount).toBe(8);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('happy-path getPillarGuide does not call logError', async () => {
+    const mod = await import('../src/backend/seoContentHub.web.js');
+    const result = await mod.getPillarGuide('futon-frames');
+    expect(result.success).toBe(true);
+    expect(result.guide).not.toBeNull();
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **6 catch sites** migrated. All 6 webMethods (getContentHub, getPillarGuide, getPillarGuideSlugs, getHubSchema, getGuideSchema, getSitemapEntries).
- 27th in the cf-44qt sibling series.
- Module is pure-data + JSON-LD generation, so catches are defensive — new tests pin happy-path no-logError-noise.

## Test contract (3 new, all green)
Module loads, getContentHub + getPillarGuide happy paths don't call logError.

## Verification
- [x] **3/3** new + **99/99** existing = **102/102 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)