### PR TITLE
fix(cf-tok3): searchService console.error → logError migration (6 sites)

### DIFF
--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -57,7 +57,6 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { logError } from 'backend/utils/errorHandler';
 import { sanitize, validateId } from 'backend/utils/sanitize';
-import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();

--- a/src/backend/searchService.web.js
+++ b/src/backend/searchService.web.js
@@ -14,6 +14,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ─── Cache Layer ─────────────────────────────────────────────────
 // Shared TTL cache for facets, search results, and autocomplete.
@@ -285,7 +286,7 @@ export const searchProducts = webMethod(
         facets,
       };
     } catch (err) {
-      console.error('Error in searchProducts:', err);
+      logError('searchService.searchProducts', err);
       return { products: [], total: 0, facets: {} };
     }
   }
@@ -307,7 +308,7 @@ export const getFilterValues = webMethod(
       const cleanCategory = category ? validateSlug(category) : '';
       return await buildFacets(cleanCategory);
     } catch (err) {
-      console.error('Error in getFilterValues:', err);
+      logError('searchService.getFilterValues', err);
       return {
         priceRanges: [],
         materials: [],
@@ -620,7 +621,7 @@ export const fullTextSearch = webMethod(
       setCachedSearch(cacheKey, result);
       return result;
     } catch (err) {
-      console.error('Error in fullTextSearch:', err);
+      logError('searchService.fullTextSearch', err);
       return { products: [], total: 0, query: '', facets: {} };
     }
   }
@@ -705,7 +706,7 @@ export const getAutocompleteSuggestions = webMethod(
       _cache[cacheKey] = { data: result, timestamp: Date.now() };
       return result;
     } catch (err) {
-      console.error('Error in getAutocompleteSuggestions:', err);
+      logError('searchService.getAutocompleteSuggestions', err);
       return { suggestions: [] };
     }
   }
@@ -727,7 +728,7 @@ export const getPopularSearches = webMethod(
       const safeLimit = Math.min(Math.max(1, Number(limit) || 8), 20);
       return { queries: getTopQueries(safeLimit) };
     } catch (err) {
-      console.error('Error in getPopularSearches:', err);
+      logError('searchService.getPopularSearches', err);
       return { queries: [] };
     }
   }
@@ -751,7 +752,7 @@ export const recordSearchQuery = webMethod(
       recordQuery(cleanQuery);
       return { success: true };
     } catch (err) {
-      console.error('Error in recordSearchQuery:', err);
+      logError('searchService.recordSearchQuery', err);
       return { success: false };
     }
   }

--- a/tests/cf-tok3-searchService-logError.test.js
+++ b/tests/cf-tok3-searchService-logError.test.js
@@ -1,0 +1,39 @@
+/**
+ * @file cf-tok3-searchService-logError.test.js
+ * Source-scan regression pin for searchService migration.
+ * cf-tok3 wave. Mayor PACE ALERT 08:59.
+ */
+import { describe, it, expect } from 'vitest';
+
+async function readSrc() {
+  const { readFile } = await import('node:fs/promises');
+  return readFile(
+    new URL('../src/backend/searchService.web.js', import.meta.url),
+    'utf8',
+  );
+}
+
+describe('cf-tok3 searchService — console.error → logError migration', () => {
+  it('source file contains zero raw console.error calls', async () => {
+    const src = await readSrc();
+    const stripped = src.replace(/\/\/.*$/gm, '');
+    expect(stripped).not.toMatch(/console\.error/);
+  });
+
+  it('source file imports logError from backend/utils/errorHandler', async () => {
+    const src = await readSrc();
+    expect(src).toMatch(
+      /import\s+\{\s*[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('all 6 webMethods route through searchService.* context tags', async () => {
+    const src = await readSrc();
+    expect(src).toMatch(/logError\(\s*['"]searchService\.searchProducts['"]/);
+    expect(src).toMatch(/logError\(\s*['"]searchService\.getFilterValues['"]/);
+    expect(src).toMatch(/logError\(\s*['"]searchService\.fullTextSearch['"]/);
+    expect(src).toMatch(/logError\(\s*['"]searchService\.getAutocompleteSuggestions['"]/);
+    expect(src).toMatch(/logError\(\s*['"]searchService\.getPopularSearches['"]/);
+    expect(src).toMatch(/logError\(\s*['"]searchService\.recordSearchQuery['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

6 console.error sites in `src/backend/searchService.web.js` → canonical `logError`:
- searchProducts, getFilterValues, fullTextSearch, getAutocompleteSuggestions, getPopularSearches, recordSearchQuery

All routed through `searchService.<method>` context tags.

## TDD (3 tests)

1. Source-scan: zero raw console.error
2. Source-scan: logError import present
3. Source-scan: all 6 webMethods route through searchService.* tags

## Test plan

- [x] 3/3 new tests pass
- [ ] CI green
- [ ] Auto-merge under Stilgar small-class greenlight

Refs cf-tok3 (mayor PACE ALERT 08:59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)