### PR TITLE
fix: remove duplicate logError import in postPurchaseCare.web.js [HOTFIX]

### DIFF
--- a/src/backend/postPurchaseCare.web.js
+++ b/src/backend/postPurchaseCare.web.js
@@ -57,7 +57,6 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { logError } from 'backend/utils/errorHandler';
 import { sanitize, validateId } from 'backend/utils/sanitize';
-import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();


### PR DESCRIPTION
## Summary
- `postPurchaseCare.web.js` had a duplicate `import { logError } from 'backend/utils/errorHandler'` (lines 58 and 60)
- This caused ALL open PRs to fail the `check-duplicate-imports` CI check (CF-id8p)
- 13 PR branches have already received individual fix commits; this PR fixes the root on main
- **P0 — unblocks the entire cf-44qt wave merge queue**

## Test plan
- [x] `node scripts/check-duplicate-imports.mjs` passes locally after 1-line deletion
- [x] 1 file changed, 1 deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)