### PR TITLE
fix(cf-44qt sibling): searchService.web.js console.error → logError ×6 (P3)

### DIFF
--- a/src/backend/searchService.web.js
+++ b/src/backend/searchService.web.js
@@ -14,6 +14,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ─── Cache Layer ─────────────────────────────────────────────────
 // Shared TTL cache for facets, search results, and autocomplete.
@@ -285,7 +286,7 @@ export const searchProducts = webMethod(
         facets,
       };
     } catch (err) {
-      console.error('Error in searchProducts:', err);
+      logError('[searchService] searchProducts failed', err);
       return { products: [], total: 0, facets: {} };
     }
   }
@@ -307,7 +308,7 @@ export const getFilterValues = webMethod(
       const cleanCategory = category ? validateSlug(category) : '';
       return await buildFacets(cleanCategory);
     } catch (err) {
-      console.error('Error in getFilterValues:', err);
+      logError('[searchService] getFilterValues failed', err);
       return {
         priceRanges: [],
         materials: [],
@@ -620,7 +621,7 @@ export const fullTextSearch = webMethod(
       setCachedSearch(cacheKey, result);
       return result;
     } catch (err) {
-      console.error('Error in fullTextSearch:', err);
+      logError('[searchService] fullTextSearch failed', err);
       return { products: [], total: 0, query: '', facets: {} };
     }
   }
@@ -705,7 +706,7 @@ export const getAutocompleteSuggestions = webMethod(
       _cache[cacheKey] = { data: result, timestamp: Date.now() };
       return result;
     } catch (err) {
-      console.error('Error in getAutocompleteSuggestions:', err);
+      logError('[searchService] getAutocompleteSuggestions failed', err);
       return { suggestions: [] };
     }
   }
@@ -727,7 +728,7 @@ export const getPopularSearches = webMethod(
       const safeLimit = Math.min(Math.max(1, Number(limit) || 8), 20);
       return { queries: getTopQueries(safeLimit) };
     } catch (err) {
-      console.error('Error in getPopularSearches:', err);
+      logError('[searchService] getPopularSearches failed', err);
       return { queries: [] };
     }
   }
@@ -751,7 +752,7 @@ export const recordSearchQuery = webMethod(
       recordQuery(cleanQuery);
       return { success: true };
     } catch (err) {
-      console.error('Error in recordSearchQuery:', err);
+      logError('[searchService] recordSearchQuery failed', err);
       return { success: false };
     }
   }

--- a/tests/searchServiceSilentFailureCleanup.test.js
+++ b/tests/searchServiceSilentFailureCleanup.test.js
@@ -1,0 +1,60 @@
+/**
+ * cf-44qt sibling — searchService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateSlug: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — searchService.web.js observability cleanup', () => {
+  beforeEach(async () => {
+    logErrorSpy.mockClear();
+    resetData();
+    const mod = await import('../src/backend/searchService.web.js');
+    if (mod.__clearCache) mod.__clearCache();
+  });
+
+  it('searchProducts wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/searchService.web.js');
+    if (mod.__clearCache) mod.__clearCache();
+    await mod.searchProducts({ category: 'futons' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/searchService/);
+    expect(allTags).toMatch(/searchProducts/);
+  });
+
+  it('getFilterValues wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData failure'));
+    const mod = await import('../src/backend/searchService.web.js');
+    if (mod.__clearCache) mod.__clearCache();
+    await mod.getFilterValues('futons');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/searchService/);
+    expect(allTags).toMatch(/getFilterValues/);
+  });
+
+  it('happy-path getPopularSearches does not call logError', async () => {
+    const mod = await import('../src/backend/searchService.web.js');
+    if (mod.__clearCache) mod.__clearCache();
+    await mod.getPopularSearches();
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **6 catch sites** migrated. All 6 webMethods (searchProducts, getFilterValues, fullTextSearch, getAutocompleteSuggestions, getPopularSearches, recordSearchQuery).
- 28th in the cf-44qt sibling series.

## Test contract (3 new, all green)
searchProducts + getFilterValues catch-path + getPopularSearches happy-path.

## Verification
- [x] **3/3** new + **253/253** existing = **256/256 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)