### PR TITLE
fix(cf-44qt sibling): questProgressService.web.js console.error → logError ×3

### DIFF
--- a/src/backend/questProgressService.web.js
+++ b/src/backend/questProgressService.web.js
@@ -18,6 +18,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'QuestProgress';
 const ACTIVE_QUESTS_LIMIT = 50;
@@ -87,7 +88,7 @@ export const saveQuestProgress = webMethod(
       }
       return { success: true };
     } catch (err) {
-      console.error('[questProgressService] saveQuestProgress failed:', err);
+      logError('[questProgressService] saveQuestProgress failed', err);
       return { success: false, error: 'Unable to save quest progress' };
     }
   }
@@ -129,7 +130,7 @@ export const getQuestProgress = webMethod(
       }
       return { success: true, progressData: parsed, status: record.status };
     } catch (err) {
-      console.error('[questProgressService] getQuestProgress failed:', err);
+      logError('[questProgressService] getQuestProgress failed', err);
       return { success: false, error: 'Unable to retrieve quest progress' };
     }
   }
@@ -166,7 +167,7 @@ export const getActiveQuests = webMethod(
 
       return { success: true, quests };
     } catch (err) {
-      console.error('[questProgressService] getActiveQuests failed:', err);
+      logError('[questProgressService] getActiveQuests failed', err);
       return { success: false, error: 'Unable to retrieve active quests' };
     }
   }

--- a/tests/cf-44qt-sibling-questProgress-logError.test.js
+++ b/tests/cf-44qt-sibling-questProgress-logError.test.js
@@ -1,0 +1,49 @@
+/**
+ * @file cf-44qt-sibling-questProgress-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 3
+ * console.error sites in src/backend/questProgressService.web.js
+ * migrated to canonical logError.
+ *
+ * Sites migrated (3):
+ *   - saveQuestProgress (L90)
+ *   - getQuestProgress (L132)
+ *   - getActiveQuests (L169)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/questProgressService.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — questProgressService.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 3 expected sites with canonical [questProgressService] prefix', () => {
+    const labels = [
+      'saveQuestProgress failed',
+      'getQuestProgress failed',
+      'getActiveQuests failed',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[questProgressService\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 3 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(3);
+  });
+});


### PR DESCRIPTION
3 sites migrated. [questProgressService] prefix already canonical. Sites: saveQuestProgress (L90), getQuestProgress (L132), getActiveQuests (L169). 3 source-grep TDD pins. Auto-merge eligible.