### PR TITLE
fix(cf-lifecycleemail-logerror): lifecycleEmailSender.web.js — 1 console.error → logError

### DIFF
--- a/src/backend/lifecycleEmailSender.web.js
+++ b/src/backend/lifecycleEmailSender.web.js
@@ -124,7 +124,7 @@ export async function sendLifecycleEmails() {
 
     return { success: true, totalScanned: ordersScanned, queued, skipped };
   } catch (err) {
-    logError('[lifecycleEmailSender] sendLifecycleEmails', err);
+    logError('lifecycleEmailSender:sendLifecycleEmails', err);
     return { success: false, totalScanned: 0, queued: 0, skipped: 0, error: 'Failed to send lifecycle emails.' };
   }
 }

--- a/tests/lifecycleEmailSenderLogErrorMigration.test.js
+++ b/tests/lifecycleEmailSenderLogErrorMigration.test.js
@@ -1,0 +1,42 @@
+/**
+ * cf-lifecycleemail-logerror — pins console.error → logError migration
+ * in src/backend/lifecycleEmailSender.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/lifecycleEmailSender.web.js'),
+  'utf-8',
+);
+
+describe('cf-lifecycleemail-logerror — lifecycleEmailSender.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('uses logError tag lifecycleEmailSender:sendLifecycleEmails', () => {
+    expect(SRC).toContain(`'lifecycleEmailSender:sendLifecycleEmails'`);
+  });
+
+  it('drift guard — every logError call uses the lifecycleEmailSender: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(1);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('lifecycleEmailSender:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without lifecycleEmailSender: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 17th PR in burst.

## Swap (1 site in lifecycleEmailSender.web.js)

- `sendLifecycleEmails` → `lifecycleEmailSender:sendLifecycleEmails`

## Verification

- New migration test: **4/4** ✅
- lifecycle suite green

Auto-merge eligible on CI green.
