### PR TITLE
fix(cf-customizationservice-logerror): customizationService.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/customizationService.web.js
+++ b/src/backend/customizationService.web.js
@@ -15,6 +15,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Get customization options (swatches + pricing rules) for a product.
@@ -62,7 +63,7 @@ export const getCustomizationOptions = webMethod(
         })),
       };
     } catch (err) {
-      console.error('Error fetching customization options:', err);
+      logError('customizationService:getCustomizationOptions', err);
       return empty;
     }
   }
@@ -135,7 +136,7 @@ export const saveConfiguration = webMethod(
       const result = await wixData.insert('SavedCustomizations', record);
       return result;
     } catch (err) {
-      console.error('Error saving customization config:', err);
+      logError('customizationService:saveConfiguration', err);
       return { error: 'Failed to save configuration' };
     }
   }
@@ -176,7 +177,7 @@ export const getSavedConfigurations = webMethod(
         _createdDate: item._createdDate,
       }));
     } catch (err) {
-      console.error('Error fetching saved configurations:', err);
+      logError('customizationService:getSavedConfigurations', err);
       return [];
     }
   }
@@ -202,7 +203,7 @@ export const getConfigurationById = webMethod(
 
       return result;
     } catch (err) {
-      console.error('Error fetching configuration:', err);
+      logError('customizationService:getConfigurationById', err);
       return null;
     }
   }

--- a/tests/customizationServiceLogErrorMigration.test.js
+++ b/tests/customizationServiceLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-customizationservice-logerror — pins console.error → logError
+ * migration in src/backend/customizationService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/customizationService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'customizationService:getCustomizationOptions',
+  'customizationService:saveConfiguration',
+  'customizationService:getSavedConfigurations',
+  'customizationService:getConfigurationById',
+];
+
+describe('cf-customizationservice-logerror — customizationService.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the customizationService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('customizationService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without customizationService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 18th PR in burst.

## Swaps (4 sites in customizationService.web.js)

- `getCustomizationOptions`, `saveConfiguration`, `getSavedConfigurations`, `getConfigurationById` → all under `customizationService:<fn>`

## Verification

- New migration test: **7/7** ✅
- customization suite green

Auto-merge eligible on CI green.
