### PR TITLE
fix(cf-44qt sibling): guestCheckout.web.js console.error → logError ×4 (P3 obs cleanup)

### DIFF
--- a/src/backend/guestCheckout.web.js
+++ b/src/backend/guestCheckout.web.js
@@ -28,6 +28,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'GuestOrders';
 
@@ -93,7 +94,7 @@ export const saveGuestSession = webMethod(
 
       return { success: true, _id: saved._id };
     } catch (err) {
-      console.error('[guestCheckout] saveGuestSession failed:', err?.message);
+      logError('[guestCheckout] saveGuestSession failed', err);
       return { success: false, error: 'Unable to save guest session' };
     }
   }
@@ -153,13 +154,13 @@ export const linkGuestOrdersToMember = webMethod(
           );
           linkedCount++;
         } catch (err) {
-          console.error('[guestCheckout] Failed to link guest order:', item._id, err?.message);
+          logError(`[guestCheckout] linkGuestOrdersToMember per-order failed for ${item._id}`, err);
         }
       }
 
       return { success: true, linkedCount };
     } catch (err) {
-      console.error('[guestCheckout] linkGuestOrdersToMember failed:', err?.message);
+      logError('[guestCheckout] linkGuestOrdersToMember failed', err);
       return { success: false, linkedCount: 0 };
     }
   }
@@ -206,7 +207,7 @@ export const getGuestOrdersByEmail = webMethod(
 
       return { success: true, orders };
     } catch (err) {
-      console.error('[guestCheckout] getGuestOrdersByEmail failed:', err?.message);
+      logError('[guestCheckout] getGuestOrdersByEmail failed', err);
       return { success: false, orders: [] };
     }
   }

--- a/tests/guestCheckoutSilentFailureCleanup.test.js
+++ b/tests/guestCheckoutSilentFailureCleanup.test.js
@@ -1,0 +1,86 @@
+/**
+ * cf-44qt sibling — guestCheckout.web.js observability cleanup.
+ *
+ * Pins the post-migration contract: every catch in the 3 webMethods
+ * calls `logError('[guestCheckout] <fn> failed', err)` (or
+ * `[guestCheckout] linkGuestOrdersToMember per-order failed for <id>`
+ * for the inner per-item catch). Mirrors the canonical pattern
+ * established in my 2026-05-16 audit memo + 5-PR sibling cluster.
+ *
+ * 3 tests = 1 per webMethod with a catch block reachable via
+ * __setQueryError on the GuestOrders collection.
+ *   - saveGuestSession (insert/upsert path)
+ *   - linkGuestOrdersToMember (query path — IDOR pre-checks must pass)
+ *   - getGuestOrdersByEmail (query path)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+// linkGuestOrdersToMember's IDOR check requires member.loginEmail ===
+// the supplied email. Mock returns a member with the test email so the
+// catch reaches the wixData query path.
+vi.mock('wix-members-backend', () => ({
+  currentMember: {
+    getMember: vi.fn(async () => ({
+      _id: 'member-1',
+      loginEmail: 'guest@example.com',
+    })),
+  },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — guestCheckout.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('saveGuestSession wires logError on GuestOrders insert throw', async () => {
+    __setInsertError('GuestOrders', new Error('wixData insert failure'));
+    // Also set query error so the upsert-style lookup-then-insert path
+    // throws regardless of which side fires first.
+    __setQueryError('GuestOrders', new Error('wixData query failure'));
+    const mod = await import('../src/backend/guestCheckout.web.js');
+    await mod.saveGuestSession({ sessionId: 's-1', email: 'guest@example.com', orderId: 'o-1' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/guestCheckout/);
+    expect(allTags).toMatch(/saveGuestSession/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('linkGuestOrdersToMember wires logError on GuestOrders query throw', async () => {
+    __setQueryError('GuestOrders', new Error('wixData query failure'));
+    const mod = await import('../src/backend/guestCheckout.web.js');
+    await mod.linkGuestOrdersToMember('guest@example.com');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/guestCheckout/);
+    expect(allTags).toMatch(/linkGuestOrdersToMember/);
+  });
+
+  it('getGuestOrdersByEmail wires logError on GuestOrders query throw', async () => {
+    __setQueryError('GuestOrders', new Error('wixData query failure'));
+    const mod = await import('../src/backend/guestCheckout.web.js');
+    await mod.getGuestOrdersByEmail('guest@example.com');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/guestCheckout/);
+    expect(allTags).toMatch(/getGuestOrdersByEmail/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — guestCheckout.web.js console.error → logError × 4 + 3 TDD pins. 6th same-pattern sibling.

## Migrations

| Site | New logError tag |
|---|---|
| saveGuestSession | `[guestCheckout] saveGuestSession failed` |
| linkGuestOrdersToMember per-item inner | `[guestCheckout] linkGuestOrdersToMember per-order failed for ${item._id}` (dynamic) |
| linkGuestOrdersToMember outer | `[guestCheckout] linkGuestOrdersToMember failed` |
| getGuestOrdersByEmail | `[guestCheckout] getGuestOrdersByEmail failed` |

Per-item dynamic-id pattern mirrors PR #1454 contentScheduler + PR #1392 warrantyService.

## TDD shape (3/3 green)

`tests/guestCheckoutSilentFailureCleanup.test.js`:
- Top-level vi.mock per CF-fgsw
- 3 tests = 1 per webMethod
- saveGuestSession: __setInsertError + __setQueryError on `GuestOrders`
- linkGuestOrdersToMember: __setQueryError; IDOR check requires `member.loginEmail === supplied email` → mock matches
- getGuestOrdersByEmail: __setQueryError

## Auto-merge eligible

Per Stilgar small-class greenlight + mayor pace-alert authorization.

## Test plan
- [x] 3/3 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- Sibling cluster: #1410 wishlist, #1425 priceMatch, #1436 analytics, #1445 search, #1454 scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
