### PR TITLE
fix(cf-productreviews-logerror): productReviews.web.js — 5 console.error → logError

### DIFF
--- a/src/backend/productReviews.web.js
+++ b/src/backend/productReviews.web.js
@@ -13,6 +13,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const REVIEWS_COLLECTION = 'Reviews';
 const PHOTO_REVIEWS_COLLECTION = 'PhotoReviews';
@@ -104,7 +105,7 @@ export const getReviewSummary = webMethod(
         recommendRate,
       };
     } catch (err) {
-      console.error('[productReviews] getReviewSummary error:', err);
+      logError('productReviews:getReviewSummary', err);
       return {
         averageRating: 0, totalReviews: 0, totalPhotos: 0,
         breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 }, recommendRate: 0,
@@ -223,7 +224,7 @@ export const getUnifiedReviews = webMethod(
         hasMore: safeOffset + safeLimit < total,
       };
     } catch (err) {
-      console.error('[productReviews] getUnifiedReviews error:', err);
+      logError('productReviews:getUnifiedReviews', err);
       return { reviews: [], total: 0, hasMore: false };
     }
   }
@@ -290,7 +291,7 @@ export const getReviewHighlights = webMethod(
         reviewCount: summary.totalReviews,
       };
     } catch (err) {
-      console.error('[productReviews] getReviewHighlights error:', err);
+      logError('productReviews:getReviewHighlights', err);
       return { topReview: null, topPhoto: null, averageRating: 0, reviewCount: 0 };
     }
   }
@@ -360,7 +361,7 @@ export const getBatchReviewSummaries = webMethod(
 
       return summaries;
     } catch (err) {
-      console.error('[productReviews] getBatchReviewSummaries error:', err);
+      logError('productReviews:getBatchReviewSummaries', err);
       return {};
     }
   }
@@ -434,7 +435,7 @@ export const getModerationQueue = webMethod(
         total: combined.length,
       };
     } catch (err) {
-      console.error('[productReviews] getModerationQueue error:', err);
+      logError('productReviews:getModerationQueue', err);
       return { reviews: [], total: 0 };
     }
   }

--- a/tests/productReviewsLogErrorMigration.test.js
+++ b/tests/productReviewsLogErrorMigration.test.js
@@ -1,0 +1,50 @@
+/**
+ * cf-productreviews-logerror — pins console.error → logError migration
+ * in src/backend/productReviews.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/productReviews.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'productReviews:getReviewSummary',
+  'productReviews:getUnifiedReviews',
+  'productReviews:getReviewHighlights',
+  'productReviews:getBatchReviewSummaries',
+  'productReviews:getModerationQueue',
+];
+
+describe('cf-productreviews-logerror — productReviews.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the productReviews: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(5);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('productReviews:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without productReviews: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 19th PR in burst.

## Swaps (5 sites in productReviews.web.js)

- `getReviewSummary`, `getUnifiedReviews`, `getReviewHighlights`, `getBatchReviewSummaries`, `getModerationQueue` → all under `productReviews:<fn>`

## Verification

- New migration test: **8/8** ✅
- productReviews suite green

Auto-merge eligible on CI green.
