### PR TITLE
fix(cf-dataservice-logerror): dataService.web.js — 3 console.error → logError

### DIFF
--- a/src/backend/dataService.web.js
+++ b/src/backend/dataService.web.js
@@ -29,6 +29,7 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 // ─── Input Sanitization ────────────────────────────────────────────
 
@@ -97,7 +98,7 @@ export const scheduleReviewRequest = webMethod(
 
       return { success: true, requestId: inserted._id };
     } catch (err) {
-      console.error('Error scheduling review request:', err);
+      logError('dataService:scheduleReviewRequest', err);
       return { success: false };
     }
   }
@@ -123,7 +124,7 @@ export const getPendingReviewRequests = webMethod(
         .find();
       return result.items;
     } catch (err) {
-      console.error('Error fetching pending review requests:', err);
+      logError('dataService:getPendingReviewRequests', err);
       return [];
     }
   }
@@ -175,7 +176,7 @@ export const submitReview = webMethod(
       logAuditEvent('ReviewRequests', 'submit_review', record.customerEmail, { rating });
       return { success: true };
     } catch (err) {
-      console.error('Error submitting review:', err);
+      logError('dataService:submitReview', err);
       return { success: false };
     }
   }

--- a/tests/dataServiceLogErrorMigration.test.js
+++ b/tests/dataServiceLogErrorMigration.test.js
@@ -1,0 +1,48 @@
+/**
+ * cf-dataservice-logerror — pins console.error → logError migration
+ * in src/backend/dataService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/dataService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'dataService:scheduleReviewRequest',
+  'dataService:getPendingReviewRequests',
+  'dataService:submitReview',
+];
+
+describe('cf-dataservice-logerror — dataService.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the dataService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(3);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('dataService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without dataService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 20th PR in burst.

## Swaps (3 sites in dataService.web.js)

- `scheduleReviewRequest`, `getPendingReviewRequests`, `submitReview` → all under `dataService:<fn>`

## Verification

- New migration test: **6/6** ✅
- dataService suite green

Auto-merge eligible on CI green.
