### PR TITLE
fix(cf-44qt sibling): cartRecovery.web.js console.error → logError ×6 (P3)

### DIFF
--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -18,6 +18,7 @@ import wixData from 'wix-data';
 import { triggeredEmails } from 'wix-crm-backend';
 import { sanitize } from 'backend/utils/sanitize';
 import { generateRecoveryCoupon } from 'backend/couponsService.web';
+import { logError } from 'backend/utils/errorHandler';
 import { findMemberRecord, computeTierInfo } from 'backend/gamificationCore.web';
 import { resolveTemplateId } from 'backend/emailTemplates.web';
 
@@ -45,7 +46,7 @@ export function wixEcom_onAbandonedCheckoutCreated(event) {
     abandonedAt: new Date().toISOString(),
     status: 'abandoned',
     recoveryEmailSent: false,
-  }).catch(err => console.error('Error recording abandoned cart:', err));
+  }).catch(err => logError('[cartRecovery] recordAbandonedCart insert failed', err));
 }
 
 /**
@@ -58,7 +59,7 @@ export function wixEcom_onAbandonedCheckoutRecovered(event) {
   const checkout = event.entity || event;
 
   markCartRecovered(checkout._id || '')
-    .catch(err => console.error('Error marking cart recovered:', err));
+    .catch(err => logError('[cartRecovery] markCartRecovered update failed', err));
 }
 
 /**
@@ -95,7 +96,7 @@ export const getAbandonedCartStats = webMethod(
 
       return { totalAbandoned: total, totalRecovered: recovered, recoveryRate, recentCarts };
     } catch (err) {
-      console.error('Error getting cart stats:', err);
+      logError('[cartRecovery] getAbandonedCartStats failed', err);
       return { totalAbandoned: 0, totalRecovered: 0, recoveryRate: 0, recentCarts: [] };
     }
   }
@@ -130,7 +131,7 @@ export const getRecoverableCarts = webMethod(
         abandonedAt: c.abandonedAt,
       }));
     } catch (err) {
-      console.error('Error getting recoverable carts:', err);
+      logError('[cartRecovery] getRecoverableCarts failed', err);
       return [];
     }
   }
@@ -161,7 +162,7 @@ export const markRecoveryEmailSent = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('Error marking recovery email sent:', err);
+      logError('[cartRecovery] markRecoveryEmailSent failed', err);
       return { success: false };
     }
   }
@@ -359,7 +360,7 @@ export const exposeCartAbandonPayload = webMethod(
         member_push_enabled: memberPushEnabled,
       };
     } catch (err) {
-      console.error('[cartRecovery] exposeCartAbandonPayload error:', err);
+      logError('[cartRecovery] exposeCartAbandonPayload failed', err);
       return { success: false, cart_items: [], total_price: 0, cart_id: '', member_push_enabled: false };
     }
   }

--- a/tests/cartRecoveryCoupon.test.js
+++ b/tests/cartRecoveryCoupon.test.js
@@ -246,10 +246,10 @@ describe('generateRecoveryCoupon — error handling', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     coupons.createCoupon.mockRejectedValueOnce(new Error('timeout'));
     await generateRecoveryCoupon({ cartId: 'cart-err-123', email: 'buyer@example.com' });
+    // cf-44qt-coupons PR #1413: console.error now routes through logError
+    // which delegates to console.error with a 2-arg shape: ([context], message).
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('[couponsService]'),
-      expect.anything(),
-      expect.anything(),
       expect.anything(),
     );
     errorSpy.mockRestore();

--- a/tests/cartRecoverySilentFailureCleanup.test.js
+++ b/tests/cartRecoverySilentFailureCleanup.test.js
@@ -1,0 +1,66 @@
+/**
+ * cf-44qt sibling — cartRecovery.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({ sanitize: (s) => s }));
+vi.mock('backend/couponsService.web', () => ({
+  generateRecoveryCoupon: vi.fn(async () => ({ code: 'TEST', success: true })),
+}));
+vi.mock('backend/gamificationCore.web', () => ({
+  findMemberRecord: vi.fn(async () => null),
+  computeTierInfo: vi.fn(() => ({ tier: 'Bronze', nextTierName: 'Silver' })),
+}));
+vi.mock('backend/emailTemplates.web', () => ({
+  resolveTemplateId: vi.fn((k) => `tpl_${k}`),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-crm-backend', () => ({
+  triggeredEmails: { emailContact: vi.fn(async () => undefined) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — cartRecovery.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getAbandonedCartStats wires logError on AbandonedCarts query throw', async () => {
+    __setQueryError('AbandonedCarts', new Error('wixData failure'));
+    const mod = await import('../src/backend/cartRecovery.web.js');
+    await mod.getAbandonedCartStats();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/cartRecovery/);
+    expect(allTags).toMatch(/getAbandonedCartStats/);
+  });
+
+  it('getRecoverableCarts wires logError on AbandonedCarts query throw', async () => {
+    __setQueryError('AbandonedCarts', new Error('wixData failure'));
+    const mod = await import('../src/backend/cartRecovery.web.js');
+    await mod.getRecoverableCarts();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/cartRecovery/);
+    expect(allTags).toMatch(/getRecoverableCarts/);
+  });
+
+  it('markRecoveryEmailSent early-return on missing cartId does not call logError', async () => {
+    const mod = await import('../src/backend/cartRecovery.web.js');
+    const result = await mod.markRecoveryEmailSent('');
+    expect(result.success).toBe(false);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **6 catch sites** migrated. 4 webMethods + 2 inline event-handler \`.catch\` arrow forms.
- 29th in the cf-44qt sibling series. Abandoned-cart recovery event handlers + admin dashboard surface.

## Stale-trunk-test fix
\`tests/cartRecoveryCoupon.test.js\` had a test pinning the OLD console.error 4-arg signature from couponsService. PR #1413 (cf-44qt-coupons) migrated couponsService.web.js but missed updating this downstream consumer test — it was already failing on trunk. Updated to assert the new 2-arg logError-wrapped shape.

## Test contract (3 new, all green)
getAbandonedCartStats, getRecoverableCarts, markRecoveryEmailSent (early-return no-noise).

## Verification
- [x] **3/3** new + **113/113** existing (6 files incl. updated coupon test) = **116/116 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)