### PR TITLE
fix(cf-44qt wave): guestCheckout.web.js console.error → logError (4 sites)

### DIFF
--- a/src/backend/guestCheckout.web.js
+++ b/src/backend/guestCheckout.web.js
@@ -28,6 +28,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'GuestOrders';
 
@@ -93,7 +94,7 @@ export const saveGuestSession = webMethod(
 
       return { success: true, _id: saved._id };
     } catch (err) {
-      console.error('[guestCheckout] saveGuestSession failed:', err?.message);
+      logError('guestCheckout:saveGuestSession', err);
       return { success: false, error: 'Unable to save guest session' };
     }
   }
@@ -153,13 +154,13 @@ export const linkGuestOrdersToMember = webMethod(
           );
           linkedCount++;
         } catch (err) {
-          console.error('[guestCheckout] Failed to link guest order:', item._id, err?.message);
+          logError(`guestCheckout:linkGuestOrder item=${item._id}`, err);
         }
       }
 
       return { success: true, linkedCount };
     } catch (err) {
-      console.error('[guestCheckout] linkGuestOrdersToMember failed:', err?.message);
+      logError('guestCheckout:linkGuestOrdersToMember', err);
       return { success: false, linkedCount: 0 };
     }
   }
@@ -206,7 +207,7 @@ export const getGuestOrdersByEmail = webMethod(
 
       return { success: true, orders };
     } catch (err) {
-      console.error('[guestCheckout] getGuestOrdersByEmail failed:', err?.message);
+      logError('guestCheckout:getGuestOrdersByEmail', err);
       return { success: false, orders: [] };
     }
   }

--- a/tests/guestCheckoutLogError.test.js
+++ b/tests/guestCheckoutLogError.test.js
@@ -1,0 +1,34 @@
+/**
+ * cf-44qt wave — pin guestCheckout.web.js console.error → logError migration.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/guestCheckout.web.js'),
+  'utf-8',
+);
+
+describe('cf-44qt — guestCheckout.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('every logError tag uses the guestCheckout: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('guestCheckout:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Single-file auto-merge slot from melania's batch-R. 4 sites migrated to guestCheckout:<scope> tag pattern. Python-sed atomic-rewrite + immediate commit/push to dodge parallel-instance worktree contention.

Tests: 3/3 green (zero console.error, logError import, every-tag-prefix invariant).