### PR TITLE
fix(cf-guestcheckout-logerror): guestCheckout.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/guestCheckout.web.js
+++ b/src/backend/guestCheckout.web.js
@@ -28,6 +28,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'GuestOrders';
 
@@ -93,7 +94,7 @@ export const saveGuestSession = webMethod(
 
       return { success: true, _id: saved._id };
     } catch (err) {
-      console.error('[guestCheckout] saveGuestSession failed:', err?.message);
+      logError('guestCheckout:saveGuestSession', err);
       return { success: false, error: 'Unable to save guest session' };
     }
   }
@@ -153,13 +154,13 @@ export const linkGuestOrdersToMember = webMethod(
           );
           linkedCount++;
         } catch (err) {
-          console.error('[guestCheckout] Failed to link guest order:', item._id, err?.message);
+          logError(`guestCheckout:linkGuestOrdersToMember-singleOrder order=${item._id}`, err);
         }
       }
 
       return { success: true, linkedCount };
     } catch (err) {
-      console.error('[guestCheckout] linkGuestOrdersToMember failed:', err?.message);
+      logError('guestCheckout:linkGuestOrdersToMember', err);
       return { success: false, linkedCount: 0 };
     }
   }
@@ -206,7 +207,7 @@ export const getGuestOrdersByEmail = webMethod(
 
       return { success: true, orders };
     } catch (err) {
-      console.error('[guestCheckout] getGuestOrdersByEmail failed:', err?.message);
+      logError('guestCheckout:getGuestOrdersByEmail', err);
       return { success: false, orders: [] };
     }
   }

--- a/tests/guestCheckoutLogErrorMigration.test.js
+++ b/tests/guestCheckoutLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-guestcheckout-logerror — pins console.error → logError migration
+ * in src/backend/guestCheckout.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/guestCheckout.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_PREFIXES = [
+  'guestCheckout:saveGuestSession',
+  'guestCheckout:linkGuestOrdersToMember-singleOrder',
+  'guestCheckout:linkGuestOrdersToMember',
+  'guestCheckout:getGuestOrdersByEmail',
+];
+
+describe('cf-guestcheckout-logerror — guestCheckout.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_PREFIXES)('uses logError tag prefix %s', (prefix) => {
+    expect(SRC).toContain(prefix);
+  });
+
+  it('drift guard — every logError call uses the guestCheckout: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('guestCheckout:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without guestCheckout: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 21st PR in burst.

## Swaps (4 sites in guestCheckout.web.js)

- `saveGuestSession` → `guestCheckout:saveGuestSession`
- `linkGuestOrdersToMember` per-order inner catch → `` `guestCheckout:linkGuestOrdersToMember-singleOrder order=${item._id}` `` (template-literal w/ order id)
- `linkGuestOrdersToMember` outer catch → `guestCheckout:linkGuestOrdersToMember`
- `getGuestOrdersByEmail` → `guestCheckout:getGuestOrdersByEmail`

## Verification

- New migration test: **7/7** ✅
- guestCheckout suite green

Auto-merge eligible on CI green.
