### PR TITLE
fix(cf-44qt sibling): contentOrchestrator.web.js console.error → logError ×7

### DIFF
--- a/src/backend/contentOrchestrator.web.js
+++ b/src/backend/contentOrchestrator.web.js
@@ -17,6 +17,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const VALID_EVENT_TYPES = ['new_arrival', 'price_drop', 'back_in_stock', 'seasonal', 'blog_published'];
 
@@ -181,7 +182,7 @@ export const triggerManualOrchestration = webMethod(
       if (options.dryRun) response.dryRun = true;
       return response;
     } catch (err) {
-      console.error('[contentOrchestrator] Error in triggerManualOrchestration:', err);
+      logError('[contentOrchestrator] triggerManualOrchestration', err);
       return { success: false, error: err.message || 'Orchestration failed.', scheduled: [] };
     }
   }
@@ -212,7 +213,7 @@ export const triggerEventOrchestration = webMethod(
 
       return { success: true, scheduled: result.scheduled, skipped: result.skipped };
     } catch (err) {
-      console.error('[contentOrchestrator] Error in triggerEventOrchestration:', err);
+      logError('[contentOrchestrator] triggerEventOrchestration', err);
       return { success: false, error: err.message || 'Event orchestration failed.', scheduled: [] };
     }
   }
@@ -243,7 +244,7 @@ export const previewOrchestration = webMethod(
 
       return { success: true, planned, wouldSkip: result.skipped };
     } catch (err) {
-      console.error('[contentOrchestrator] Error in previewOrchestration:', err);
+      logError('[contentOrchestrator] previewOrchestration', err);
       return { success: false, error: err.message || 'Preview failed.', planned: [] };
     }
   }
@@ -286,7 +287,7 @@ export const getOrchestrationDashboard = webMethod(
         stats,
       };
     } catch (err) {
-      console.error('[contentOrchestrator] Error getting dashboard:', err);
+      logError('[contentOrchestrator] getDashboard', err);
       return { success: false, error: err.message || 'Dashboard failed.', pending: [], config: {}, stats: {} };
     }
   }
@@ -309,7 +310,7 @@ export const getOrchestrationHistory = webMethod(
         .find();
       return { success: true, events: result.items };
     } catch (err) {
-      console.error('[contentOrchestrator] Error getting history:', err);
+      logError('[contentOrchestrator] getHistory', err);
       return { success: false, error: err.message || 'Failed to get history.', events: [] };
     }
   }
@@ -327,7 +328,7 @@ export const getOrchestrationConfig = webMethod(
       const config = await getConfig();
       return { success: true, config };
     } catch (err) {
-      console.error('[contentOrchestrator] Error getting config:', err);
+      logError('[contentOrchestrator] getConfig', err);
       return { success: false, error: err.message || 'Failed to get config.', config: {} };
     }
   }
@@ -367,7 +368,7 @@ export const updateOrchestrationConfig = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[contentOrchestrator] Error updating config:', err);
+      logError('[contentOrchestrator] updateConfig', err);
       return { success: false, error: err.message || 'Failed to update config.' };
     }
   }

--- a/tests/cf-44qt-sibling-contentOrch-logError.test.js
+++ b/tests/cf-44qt-sibling-contentOrch-logError.test.js
@@ -1,0 +1,57 @@
+/**
+ * @file cf-44qt-sibling-contentOrch-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 7
+ * console.error sites in src/backend/contentOrchestrator.web.js
+ * migrated to canonical logError.
+ *
+ * Sites migrated (7):
+ *   - triggerManualOrchestration (L184)
+ *   - triggerEventOrchestration (L215)
+ *   - previewOrchestration (L246)
+ *   - getDashboard (L289)
+ *   - getHistory (L312)
+ *   - getConfig (L330)
+ *   - updateConfig (L370)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/contentOrchestrator.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — contentOrchestrator.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 7 expected sites with canonical [contentOrchestrator] prefix', () => {
+    const labels = [
+      'triggerManualOrchestration',
+      'triggerEventOrchestration',
+      'previewOrchestration',
+      'getDashboard',
+      'getHistory',
+      'getConfig',
+      'updateConfig',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[contentOrchestrator\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 7 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(7);
+  });
+});


### PR DESCRIPTION
7 sites migrated. [contentOrchestrator] prefix already canonical. Sites: triggerManualOrchestration (L184), triggerEventOrchestration (L215), previewOrchestration (L246), getDashboard (L289), getHistory (L312), getConfig (L330), updateConfig (L370). 3 source-grep TDD pins. Auto-merge eligible.