### PR TITLE
fix(cf-conversiondashboard-logerror): conversionDashboard.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/conversionDashboard.web.js
+++ b/src/backend/conversionDashboard.web.js
@@ -15,6 +15,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const ANALYTICS_COLLECTION = 'ProductAnalytics';
 const EVENTS_COLLECTION = 'AnalyticsEvents';
@@ -100,7 +101,7 @@ export const getConversionFunnel = webMethod(
         },
       };
     } catch (err) {
-      console.error('[conversionDashboard] getConversionFunnel error:', err);
+      logError('conversionDashboard:getConversionFunnel', err);
       return { success: false, funnel: null };
     }
   }
@@ -156,7 +157,7 @@ export const getDailyConversionTrend = webMethod(
 
       return { success: true, trend };
     } catch (err) {
-      console.error('[conversionDashboard] getDailyConversionTrend error:', err);
+      logError('conversionDashboard:getDailyConversionTrend', err);
       return { success: false, trend: [] };
     }
   }
@@ -211,7 +212,7 @@ export const getCategoryConversion = webMethod(
 
       return { success: true, categories };
     } catch (err) {
-      console.error('[conversionDashboard] getCategoryConversion error:', err);
+      logError('conversionDashboard:getCategoryConversion', err);
       return { success: false, categories: [] };
     }
   }
@@ -250,7 +251,7 @@ export const getDashboardSummary = webMethod(
         },
       };
     } catch (err) {
-      console.error('[conversionDashboard] getDashboardSummary error:', err);
+      logError('conversionDashboard:getDashboardSummary', err);
       return { success: false, summary: null };
     }
   }

--- a/tests/conversionDashboardLogErrorMigration.test.js
+++ b/tests/conversionDashboardLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-conversiondashboard-logerror — pins console.error → logError
+ * migration in src/backend/conversionDashboard.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/conversionDashboard.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'conversionDashboard:getConversionFunnel',
+  'conversionDashboard:getDailyConversionTrend',
+  'conversionDashboard:getCategoryConversion',
+  'conversionDashboard:getDashboardSummary',
+];
+
+describe('cf-conversiondashboard-logerror — conversionDashboard.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the conversionDashboard: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('conversionDashboard:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without conversionDashboard: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 22nd PR in burst.

## Swaps (4 sites in conversionDashboard.web.js)

- `getConversionFunnel`, `getDailyConversionTrend`, `getCategoryConversion`, `getDashboardSummary` → all under `conversionDashboard:<fn>`

## Verification

- New migration test: **7/7** ✅
- conversionDashboard suite green

Auto-merge eligible on CI green.
