### PR TITLE
fix(cf-44qt sibling): browseAbandonment.web.js console.error → logError ×6 (P3)

### DIFF
--- a/src/backend/browseAbandonment.web.js
+++ b/src/backend/browseAbandonment.web.js
@@ -18,6 +18,7 @@ import wixData from 'wix-data';
 import { sanitize, validateEmail, validateId } from 'backend/utils/sanitize';
 import { safeParse } from 'backend/utils/safeParse';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 import { logAuditEvent } from 'backend/utils/auditLog';
 
 const HIGH_INTENT_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
@@ -114,7 +115,7 @@ export const trackBrowseSession = webMethod(
 
       return { success: true, isHighIntent };
     } catch (err) {
-      console.error('[browseAbandonment] Error tracking session:', err);
+      logError('[browseAbandonment] trackBrowseSession failed', err);
       return { success: false, error: 'Failed to track session' };
     }
   }
@@ -198,7 +199,7 @@ export const captureRemindMeRequest = webMethod(
       logAuditEvent('BrowseSessions', 'remind_me', cleanEmail, { sessionId: cleanSessionId });
       return { success: true };
     } catch (err) {
-      console.error('[browseAbandonment] Error capturing remind-me:', err);
+      logError('[browseAbandonment] captureRemindMeRequest failed', err);
       return { success: false, error: 'Failed to capture email' };
     }
   }
@@ -286,7 +287,7 @@ export const triggerBrowseRecovery = webMethod(
 
       return { success: true, triggered, skipped };
     } catch (err) {
-      console.error('[browseAbandonment] Error triggering recovery:', err);
+      logError('[browseAbandonment] triggerBrowseRecovery failed', err);
       return { success: false, error: 'Failed to trigger recovery' };
     }
   }
@@ -357,7 +358,7 @@ export const getBrowseAbandonmentStats = webMethod(
         recoveryRate: recoverySent > 0 ? Math.round((recoveryConverted / recoverySent) * 100) : 0,
       };
     } catch (err) {
-      console.error('[browseAbandonment] Error fetching stats:', err);
+      logError('[browseAbandonment] getBrowseAbandonmentStats failed', err);
       return { success: false, error: 'Failed to fetch stats' };
     }
   }
@@ -422,7 +423,7 @@ export const exportAbandonmentInsights = webMethod(
 
       return { success: true, insights };
     } catch (err) {
-      console.error('[browseAbandonment] Error exporting insights:', err);
+      logError('[browseAbandonment] exportAbandonmentInsights failed', err);
       return { success: false, error: 'Failed to export insights' };
     }
   }
@@ -470,7 +471,7 @@ export const markSessionConverted = webMethod(
       }
       return false;
     } catch (err) {
-      console.error('[browseAbandonment] Error marking converted:', err);
+      logError('[browseAbandonment] markSessionConverted failed', err);
       return false;
     }
   }

--- a/tests/browseAbandonmentSilentFailureCleanup.test.js
+++ b/tests/browseAbandonmentSilentFailureCleanup.test.js
@@ -1,0 +1,67 @@
+/**
+ * cf-44qt sibling — browseAbandonment.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateEmail: () => true,
+  validateId: (s) => s,
+}));
+vi.mock('backend/utils/safeParse', () => ({
+  safeParse: (s) => { try { return JSON.parse(s); } catch { return null; } },
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('backend/utils/auditLog', () => ({ logAuditEvent: vi.fn() }));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — browseAbandonment.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('trackBrowseSession wires logError on BrowseSessions query throw', async () => {
+    __setQueryError('BrowseSessions', new Error('wixData failure'));
+    const mod = await import('../src/backend/browseAbandonment.web.js');
+    await mod.trackBrowseSession({ sessionId: 'sess-1', productsViewed: [], totalDuration: 1000 });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/browseAbandonment/);
+    expect(allTags).toMatch(/trackBrowseSession/);
+  });
+
+  it('getBrowseAbandonmentStats wires logError on BrowseSessions query throw', async () => {
+    __setQueryError('BrowseSessions', new Error('wixData failure'));
+    const mod = await import('../src/backend/browseAbandonment.web.js');
+    await mod.getBrowseAbandonmentStats();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/browseAbandonment/);
+    expect(allTags).toMatch(/getBrowseAbandonmentStats/);
+  });
+
+  it('exportAbandonmentInsights wires logError on BrowseSessions query throw', async () => {
+    __setQueryError('BrowseSessions', new Error('wixData failure'));
+    const mod = await import('../src/backend/browseAbandonment.web.js');
+    await mod.exportAbandonmentInsights();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/browseAbandonment/);
+    expect(allTags).toMatch(/exportAbandonmentInsights/);
+  });
+});


### PR DESCRIPTION
## Summary
- **6 catch sites** migrated. All 6 webMethods.
- 30th in the cf-44qt sibling series. Browse-abandonment tracking + recovery sequences.

## Test contract (3 new, all green)
trackBrowseSession, getBrowseAbandonmentStats, exportAbandonmentInsights.

## Verification
- [x] **3/3** new + **140/140** existing = **143/143 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)