### PR TITLE
fix(cf-trendingsearches-logerror): trendingSearches.web.js — 1 console.error → logError

### DIFF
--- a/src/backend/trendingSearches.web.js
+++ b/src/backend/trendingSearches.web.js
@@ -12,6 +12,7 @@
 
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'TrendingSearches';
 
@@ -50,7 +51,7 @@ export const getTrendingSearches = webMethod(
 
       return { success: true, terms };
     } catch (e) {
-      console.error('[trendingSearches] getTrendingSearches failed:', e);
+      logError('trendingSearches:getTrendingSearches', e);
       return { success: false, terms: [...DEFAULT_TERMS], error: 'Failed to load trending searches' };
     }
   }

--- a/tests/trendingSearchesLogErrorMigration.test.js
+++ b/tests/trendingSearchesLogErrorMigration.test.js
@@ -1,0 +1,42 @@
+/**
+ * cf-trendingsearches-logerror — pins console.error → logError
+ * migration in src/backend/trendingSearches.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/trendingSearches.web.js'),
+  'utf-8',
+);
+
+describe('cf-trendingsearches-logerror — trendingSearches.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('uses logError tag trendingSearches:getTrendingSearches', () => {
+    expect(SRC).toContain(`'trendingSearches:getTrendingSearches'`);
+  });
+
+  it('drift guard — every logError call uses the trendingSearches: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(1);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('trendingSearches:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without trendingSearches: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 23rd PR in burst.

## Swap (1 site in trendingSearches.web.js)

- `getTrendingSearches` → `trendingSearches:getTrendingSearches`

## Verification

- New migration test: **4/4** ✅
- trending suite green

Auto-merge eligible on CI green.
