### PR TITLE
fix(cf-guideseo-logerror): guideSeoService.web.js — 2 console.error → logError

### DIFF
--- a/src/backend/guideSeoService.web.js
+++ b/src/backend/guideSeoService.web.js
@@ -11,6 +11,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 const PUBLISHER = {
@@ -121,7 +122,7 @@ export const getRelatedProducts = webMethod(
         })),
       };
     } catch (err) {
-      console.error('[guideSeoService] getRelatedProducts error:', err);
+      logError('guideSeoService:getRelatedProducts', err);
       return { success: false, products: [] };
     }
   }
@@ -202,7 +203,7 @@ export const getGuidePageSeoData = webMethod(
         relatedGuides: guidesResult.success ? guidesResult.guides : [],
       };
     } catch (err) {
-      console.error('[guideSeoService] getGuidePageSeoData error:', err);
+      logError('guideSeoService:getGuidePageSeoData', err);
       return { success: false, howToSchema: null, relatedProducts: [], relatedGuides: [] };
     }
   }

--- a/tests/guideSeoServiceLogErrorMigration.test.js
+++ b/tests/guideSeoServiceLogErrorMigration.test.js
@@ -1,0 +1,47 @@
+/**
+ * cf-guideseo-logerror — pins console.error → logError migration in
+ * src/backend/guideSeoService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/guideSeoService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'guideSeoService:getRelatedProducts',
+  'guideSeoService:getGuidePageSeoData',
+];
+
+describe('cf-guideseo-logerror — guideSeoService.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the guideSeoService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(2);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('guideSeoService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without guideSeoService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 24th PR in burst.

## Swaps (2 sites in guideSeoService.web.js)

- `getRelatedProducts`, `getGuidePageSeoData` → all under `guideSeoService:<fn>`

## Verification

- New migration test: **5/5** ✅
- guideSeo suite green

Auto-merge eligible on CI green.
