### PR TITLE
fix(cf-44qt sibling): roomPlanner.web.js console.error → logError ×6

### DIFF
--- a/src/backend/roomPlanner.web.js
+++ b/src/backend/roomPlanner.web.js
@@ -27,6 +27,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -106,7 +107,7 @@ export const createRoomLayout = webMethod(
       const inserted = await wixData.insert('RoomLayouts', record);
       return { success: true, id: inserted._id, shareId };
     } catch (err) {
-      console.error('[roomPlanner] Error creating room layout:', err);
+      logError('[roomPlanner] createRoomLayout', err);
       return { success: false, error: 'Failed to create layout.' };
     }
   }
@@ -193,7 +194,7 @@ export const addProductToLayout = webMethod(
         dimensions: { width: actualWidth, depth: actualHeight, label: dims.label },
       };
     } catch (err) {
-      console.error('[roomPlanner] Error adding product to layout:', err);
+      logError('[roomPlanner] addProductToLayout', err);
       return { success: false, error: 'Failed to update layout.' };
     }
   }
@@ -255,7 +256,7 @@ export const getLayoutPreview = webMethod(
         },
       };
     } catch (err) {
-      console.error('[roomPlanner] Error getting layout preview:', err);
+      logError('[roomPlanner] getLayoutPreview', err);
       return { success: false, error: 'Failed to load layout.', layout: null };
     }
   }
@@ -294,7 +295,7 @@ export const shareLayout = webMethod(
 
       return { success: true, shareUrl };
     } catch (err) {
-      console.error('[roomPlanner] Error sharing layout:', err);
+      logError('[roomPlanner] shareLayout', err);
       return { success: false, error: 'Failed to update sharing.' };
     }
   }
@@ -335,7 +336,7 @@ export const saveLayout = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[roomPlanner] Error saving layout:', err);
+      logError('[roomPlanner] saveLayout', err);
       return { success: false, error: 'Failed to save layout.' };
     }
   }
@@ -361,7 +362,7 @@ export const getProductDimensions = webMethod(
 
       return { success: true, products };
     } catch (err) {
-      console.error('[roomPlanner] Error getting product dimensions:', err);
+      logError('[roomPlanner] getProductDimensions', err);
       return { success: false, error: 'Failed to load dimensions.', products: [] };
     }
   }

--- a/tests/cf-44qt-sibling-roomPlanner-logError.test.js
+++ b/tests/cf-44qt-sibling-roomPlanner-logError.test.js
@@ -1,0 +1,55 @@
+/**
+ * @file cf-44qt-sibling-roomPlanner-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 6
+ * console.error sites in src/backend/roomPlanner.web.js migrated
+ * to canonical logError.
+ *
+ * Sites migrated (6):
+ *   - createRoomLayout (L109)
+ *   - addProductToLayout (L196)
+ *   - getLayoutPreview (L258)
+ *   - shareLayout (L297)
+ *   - saveLayout (L338)
+ *   - getProductDimensions (L364)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/roomPlanner.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — roomPlanner.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 6 expected sites with canonical [roomPlanner] prefix', () => {
+    const labels = [
+      'createRoomLayout',
+      'addProductToLayout',
+      'getLayoutPreview',
+      'shareLayout',
+      'saveLayout',
+      'getProductDimensions',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[roomPlanner\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 6 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(6);
+  });
+});


### PR DESCRIPTION
6 sites migrated. [roomPlanner] prefix already canonical. Sites: createRoomLayout (L109), addProductToLayout (L196), getLayoutPreview (L258), shareLayout (L297), saveLayout (L338), getProductDimensions (L364). 3 source-grep TDD pins. Auto-merge eligible.