### PR TITLE
fix(cf-44qt sibling): protectionPlan.web.js console.error → logError ×4 (P3 obs cleanup)

### DIFF
--- a/src/backend/protectionPlan.web.js
+++ b/src/backend/protectionPlan.web.js
@@ -23,6 +23,7 @@ import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const SELECTIONS_COLLECTION = 'ProtectionPlanSelections';
 
@@ -137,7 +138,7 @@ export const getProtectionPlans = webMethod(
 
       return { success: true, plans };
     } catch (err) {
-      console.error('[protectionPlan] getProtectionPlans error:', err);
+      logError('[protectionPlan] getProtectionPlans failed', err);
       return { success: false, plans: [] };
     }
   }
@@ -215,7 +216,7 @@ export const addProtectionPlan = webMethod(
         },
       };
     } catch (err) {
-      console.error('[protectionPlan] addProtectionPlan error:', err);
+      logError('[protectionPlan] addProtectionPlan failed', err);
       return { success: false };
     }
   }
@@ -252,7 +253,7 @@ export const removeProtectionPlan = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[protectionPlan] removeProtectionPlan error:', err);
+      logError('[protectionPlan] removeProtectionPlan failed', err);
       return { success: false };
     }
   }
@@ -300,7 +301,7 @@ export const getProtectionPlanSummary = webMethod(
         },
       };
     } catch (err) {
-      console.error('[protectionPlan] getProtectionPlanSummary error:', err);
+      logError('[protectionPlan] getProtectionPlanSummary failed', err);
       return { success: false, data: { selections: [], totalProtectionCost: 0 } };
     }
   }

--- a/tests/protectionPlanSilentFailureCleanup.test.js
+++ b/tests/protectionPlanSilentFailureCleanup.test.js
@@ -1,0 +1,87 @@
+/**
+ * cf-44qt sibling — protectionPlan.web.js observability cleanup.
+ *
+ * Pins post-migration contract: every catch in the 4 webMethods
+ * calls `logError('[protectionPlan] <fn> failed', err)` instead of
+ * raw `console.error`. Mirrors the canonical pattern.
+ *
+ * 4 tests = 1 per webMethod. All 4 query the
+ * `ProtectionPlanSelections` collection.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('backend/utils/auditLog', () => ({
+  logAuditEvent: vi.fn(async () => {}),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __seed,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — protectionPlan.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getProtectionPlans wires logError on ProtectionPlanSelections query throw', async () => {
+    __setQueryError('ProtectionPlanSelections', new Error('wixData query failure'));
+    const mod = await import('../src/backend/protectionPlan.web.js');
+    await mod.getProtectionPlans(['p-1', 'p-2'], 'session-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/protectionPlan/);
+    expect(allTags).toMatch(/getProtectionPlans/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('addProtectionPlan wires logError on ProtectionPlanSelections query throw', async () => {
+    // Seed the Stores/Products record so the wixData.get gate doesn't
+    // short-circuit before the catch can fire on the selections query.
+    __seed('Stores/Products', [{ _id: 'p-1', name: 'Test Frame', price: 1000 }]);
+    __setQueryError('ProtectionPlanSelections', new Error('wixData query failure'));
+    const mod = await import('../src/backend/protectionPlan.web.js');
+    await mod.addProtectionPlan('p-1', 'basic', 'session-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/protectionPlan/);
+    expect(allTags).toMatch(/addProtectionPlan/);
+  });
+
+  it('removeProtectionPlan wires logError on ProtectionPlanSelections query throw', async () => {
+    __setQueryError('ProtectionPlanSelections', new Error('wixData query failure'));
+    const mod = await import('../src/backend/protectionPlan.web.js');
+    await mod.removeProtectionPlan('p-1', 'session-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/protectionPlan/);
+    expect(allTags).toMatch(/removeProtectionPlan/);
+  });
+
+  it('getProtectionPlanSummary wires logError on ProtectionPlanSelections query throw', async () => {
+    __setQueryError('ProtectionPlanSelections', new Error('wixData query failure'));
+    const mod = await import('../src/backend/protectionPlan.web.js');
+    await mod.getProtectionPlanSummary('session-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/protectionPlan/);
+    expect(allTags).toMatch(/getProtectionPlanSummary/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — protectionPlan.web.js console.error → logError × 4 + 4 TDD pins. 9th same-pattern sibling.

## Migrations

| webMethod | New logError tag |
|---|---|
| getProtectionPlans | `[protectionPlan] getProtectionPlans failed` |
| addProtectionPlan | `[protectionPlan] addProtectionPlan failed` |
| removeProtectionPlan | `[protectionPlan] removeProtectionPlan failed` |
| getProtectionPlanSummary | `[protectionPlan] getProtectionPlanSummary failed` |

## TDD shape (4/4 green)

`tests/protectionPlanSilentFailureCleanup.test.js`:
- Top-level vi.mock per CF-fgsw
- 4 tests = 1 per webMethod
- All trigger via `__setQueryError('ProtectionPlanSelections', err)`
- addProtectionPlan seeds Stores/Products so `wixData.get` doesn't short-circuit before the catch fires
- Positional args `(productId, tier, sessionId)` for add/remove
- checkRateLimit returns `{ allowed: true }` per established convention; logAuditEvent + sanitize + validateId all mocked

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 4/4 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- 8 prior PRs in cluster (#1410-#1480)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
