### PR TITLE
fix(cf-44qt sibling): roomPlanner.web.js console.error → logError ×6 (P3)

### DIFF
--- a/src/backend/roomPlanner.web.js
+++ b/src/backend/roomPlanner.web.js
@@ -27,6 +27,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -106,7 +107,7 @@ export const createRoomLayout = webMethod(
       const inserted = await wixData.insert('RoomLayouts', record);
       return { success: true, id: inserted._id, shareId };
     } catch (err) {
-      console.error('[roomPlanner] Error creating room layout:', err);
+      logError('[roomPlanner] createRoomLayout failed', err);
       return { success: false, error: 'Failed to create layout.' };
     }
   }
@@ -193,7 +194,7 @@ export const addProductToLayout = webMethod(
         dimensions: { width: actualWidth, depth: actualHeight, label: dims.label },
       };
     } catch (err) {
-      console.error('[roomPlanner] Error adding product to layout:', err);
+      logError('[roomPlanner] addProductToLayout failed', err);
       return { success: false, error: 'Failed to update layout.' };
     }
   }
@@ -255,7 +256,7 @@ export const getLayoutPreview = webMethod(
         },
       };
     } catch (err) {
-      console.error('[roomPlanner] Error getting layout preview:', err);
+      logError('[roomPlanner] getLayoutPreview failed', err);
       return { success: false, error: 'Failed to load layout.', layout: null };
     }
   }
@@ -294,7 +295,7 @@ export const shareLayout = webMethod(
 
       return { success: true, shareUrl };
     } catch (err) {
-      console.error('[roomPlanner] Error sharing layout:', err);
+      logError('[roomPlanner] shareLayout failed', err);
       return { success: false, error: 'Failed to update sharing.' };
     }
   }
@@ -335,7 +336,7 @@ export const saveLayout = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[roomPlanner] Error saving layout:', err);
+      logError('[roomPlanner] saveLayout failed', err);
       return { success: false, error: 'Failed to save layout.' };
     }
   }
@@ -361,7 +362,7 @@ export const getProductDimensions = webMethod(
 
       return { success: true, products };
     } catch (err) {
-      console.error('[roomPlanner] Error getting product dimensions:', err);
+      logError('[roomPlanner] getProductDimensions failed', err);
       return { success: false, error: 'Failed to load dimensions.', products: [] };
     }
   }

--- a/tests/roomPlannerSilentFailureCleanup.test.js
+++ b/tests/roomPlannerSilentFailureCleanup.test.js
@@ -1,0 +1,62 @@
+/**
+ * cf-44qt sibling — roomPlanner.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — roomPlanner.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('createRoomLayout wires logError on RoomLayouts insert throw', async () => {
+    __setInsertError('RoomLayouts', new Error('wixData failure'));
+    const mod = await import('../src/backend/roomPlanner.web.js');
+    await mod.createRoomLayout({ name: 'Test Room', roomWidth: 120, roomLength: 144 });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/roomPlanner/);
+    expect(allTags).toMatch(/createRoomLayout/);
+  });
+
+  it('shareLayout early-return on missing layoutId does not call logError', async () => {
+    const mod = await import('../src/backend/roomPlanner.web.js');
+    await mod.shareLayout('', true);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('saveLayout early-return on missing layoutId does not call logError', async () => {
+    const mod = await import('../src/backend/roomPlanner.web.js');
+    await mod.saveLayout('', {});
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('getProductDimensions returns the catalog without invoking logError', async () => {
+    const mod = await import('../src/backend/roomPlanner.web.js');
+    const result = await mod.getProductDimensions();
+    expect(result.success).toBe(true);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **6 catch sites** migrated. All 6 webMethods.
- 31st in the cf-44qt sibling series.

## Test contract (4 new, all green)
createRoomLayout catch-path + 3 early-return-guard no-noise tests.

## Verification
- [x] **4/4** new + **30/30** existing = **34/34 combined**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)