### PR TITLE
fix(cf-styleconsultant-logerror): styleConsultant.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/styleConsultant.web.js
+++ b/src/backend/styleConsultant.web.js
@@ -43,6 +43,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, isWixMediaUrl } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const SESSION_COLLECTION = 'StyleConsultantSessions';
 
@@ -482,7 +483,7 @@ export const getStyleConsultation = webMethod(
     try {
       session = await lookupSession(cleanKey);
     } catch (err) {
-      console.error('[styleConsultant] Session lookup failed:', err?.message ?? err);
+      logError('styleConsultant:sessionLookup', err);
       return { success: false, error: 'Session lookup failed. Please try again.', errorCode: 'AI_ERROR' };
     }
 
@@ -498,7 +499,7 @@ export const getStyleConsultation = webMethod(
       styleTags = aiResult.styleTags;
       explanation = aiResult.explanation;
     } catch (err) {
-      console.error('[styleConsultant] Claude API call failed:', err?.message ?? err);
+      logError('styleConsultant:claudeApi', err);
       return { success: false, error: 'Style analysis unavailable. Please try again later.', errorCode: 'AI_ERROR' };
     }
 
@@ -507,7 +508,7 @@ export const getStyleConsultation = webMethod(
     try {
       recommendations = await getProductRecommendations(styleTags);
     } catch (err) {
-      console.error('[styleConsultant] Product matching failed:', err?.message ?? err);
+      logError('styleConsultant:productMatching', err);
       return { success: false, error: 'Could not fetch recommendations. Please try again.', errorCode: 'AI_ERROR' };
     }
 
@@ -515,7 +516,7 @@ export const getStyleConsultation = webMethod(
     try {
       await upsertSession(session, cleanKey, updatedCounts, textInput, photoUrl, recommendations);
     } catch (err) {
-      console.error('[styleConsultant] Session upsert failed:', err?.message ?? err);
+      logError('styleConsultant:sessionUpsert', err);
     }
 
     if (recommendations.length === 0) {

--- a/tests/styleConsultantLogErrorMigration.test.js
+++ b/tests/styleConsultantLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-styleconsultant-logerror — pins console.error → logError migration
+ * in src/backend/styleConsultant.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/styleConsultant.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'styleConsultant:sessionLookup',
+  'styleConsultant:claudeApi',
+  'styleConsultant:productMatching',
+  'styleConsultant:sessionUpsert',
+];
+
+describe('cf-styleconsultant-logerror — styleConsultant.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the styleConsultant: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('styleConsultant:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without styleConsultant: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 25th PR in burst.

## Swaps (4 sites in styleConsultant.web.js)

- `sessionLookup`, `claudeApi`, `productMatching`, `sessionUpsert` → all under `styleConsultant:<fn>`

## Verification

- New migration test: **7/7** ✅
- styleConsultant suite green

Auto-merge eligible on CI green.
