### PR TITLE
fix(cf-photoreviews-logerror): photoReviews.web.js — 3 console.error → logError

### DIFF
--- a/src/backend/photoReviews.web.js
+++ b/src/backend/photoReviews.web.js
@@ -39,6 +39,7 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId, isWixMediaUrl } from 'backend/utils/sanitize';
 import { receiveGamificationEvent } from 'backend/gamificationEventReceiver.web';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -118,7 +119,7 @@ export const submitPhotoReview = webMethod(
 
       return { success: true, id: inserted._id };
     } catch (err) {
-      console.error('[photoReviews] Error submitting photo review:', err);
+      logError('photoReviews:submitPhotoReview', err);
       return { success: false, error: 'Failed to submit photo review.' };
     }
   }
@@ -185,7 +186,7 @@ export const moderatePhotoReview = webMethod(
       await wixData.update('PhotoReviews', existing);
       return { success: true, previousStatus, newStatus };
     } catch (err) {
-      console.error('[photoReviews] Error moderating review:', err);
+      logError('photoReviews:moderatePhotoReview', err);
       return { success: false, error: 'Failed to moderate review.' };
     }
   }
@@ -230,7 +231,7 @@ export const getPhotoGallery = webMethod(
 
       return { success: true, photos };
     } catch (err) {
-      console.error('[photoReviews] Error getting photo gallery:', err);
+      logError('photoReviews:getPhotoGallery', err);
       return { success: false, error: 'Failed to load gallery.', photos: [] };
     }
   }

--- a/tests/photoReviewsLogErrorMigration.test.js
+++ b/tests/photoReviewsLogErrorMigration.test.js
@@ -1,0 +1,48 @@
+/**
+ * cf-photoreviews-logerror — pins console.error → logError migration
+ * in src/backend/photoReviews.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/photoReviews.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'photoReviews:submitPhotoReview',
+  'photoReviews:moderatePhotoReview',
+  'photoReviews:getPhotoGallery',
+];
+
+describe('cf-photoreviews-logerror — photoReviews.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the photoReviews: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(3);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('photoReviews:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without photoReviews: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 26th PR in burst.

## Swaps (3 sites in photoReviews.web.js)

- `submitPhotoReview`, `moderatePhotoReview`, `getPhotoGallery` → all under `photoReviews:<fn>`

## Verification

- New migration test: **6/6** ✅
- photoReviews suite green

Auto-merge eligible on CI green.
