### PR TITLE
fix(cf-44qt sibling): productReviews.web.js console.error → logError ×5

### DIFF
--- a/src/backend/productReviews.web.js
+++ b/src/backend/productReviews.web.js
@@ -13,6 +13,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const REVIEWS_COLLECTION = 'Reviews';
 const PHOTO_REVIEWS_COLLECTION = 'PhotoReviews';
@@ -104,7 +105,7 @@ export const getReviewSummary = webMethod(
         recommendRate,
       };
     } catch (err) {
-      console.error('[productReviews] getReviewSummary error:', err);
+      logError('[productReviews] getReviewSummary', err);
       return {
         averageRating: 0, totalReviews: 0, totalPhotos: 0,
         breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 }, recommendRate: 0,
@@ -223,7 +224,7 @@ export const getUnifiedReviews = webMethod(
         hasMore: safeOffset + safeLimit < total,
       };
     } catch (err) {
-      console.error('[productReviews] getUnifiedReviews error:', err);
+      logError('[productReviews] getUnifiedReviews', err);
       return { reviews: [], total: 0, hasMore: false };
     }
   }
@@ -290,7 +291,7 @@ export const getReviewHighlights = webMethod(
         reviewCount: summary.totalReviews,
       };
     } catch (err) {
-      console.error('[productReviews] getReviewHighlights error:', err);
+      logError('[productReviews] getReviewHighlights', err);
       return { topReview: null, topPhoto: null, averageRating: 0, reviewCount: 0 };
     }
   }
@@ -360,7 +361,7 @@ export const getBatchReviewSummaries = webMethod(
 
       return summaries;
     } catch (err) {
-      console.error('[productReviews] getBatchReviewSummaries error:', err);
+      logError('[productReviews] getBatchReviewSummaries', err);
       return {};
     }
   }
@@ -434,7 +435,7 @@ export const getModerationQueue = webMethod(
         total: combined.length,
       };
     } catch (err) {
-      console.error('[productReviews] getModerationQueue error:', err);
+      logError('[productReviews] getModerationQueue', err);
       return { reviews: [], total: 0 };
     }
   }

--- a/tests/cf-44qt-sibling-productReviews-logError.test.js
+++ b/tests/cf-44qt-sibling-productReviews-logError.test.js
@@ -1,0 +1,53 @@
+/**
+ * @file cf-44qt-sibling-productReviews-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 5
+ * console.error sites in src/backend/productReviews.web.js
+ * migrated to canonical logError.
+ *
+ * Sites migrated (5):
+ *   - getReviewSummary (L107)
+ *   - getUnifiedReviews (L226)
+ *   - getReviewHighlights (L293)
+ *   - getBatchReviewSummaries (L363)
+ *   - getModerationQueue (L437)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/productReviews.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — productReviews.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 5 expected sites with canonical [productReviews] prefix', () => {
+    const labels = [
+      'getReviewSummary',
+      'getUnifiedReviews',
+      'getReviewHighlights',
+      'getBatchReviewSummaries',
+      'getModerationQueue',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[productReviews\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 5 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(5);
+  });
+});


### PR DESCRIPTION
5 sites migrated. [productReviews] prefix already canonical. Sites: getReviewSummary (L107), getUnifiedReviews (L226), getReviewHighlights (L293), getBatchReviewSummaries (L363), getModerationQueue (L437). 3 source-grep TDD pins. Auto-merge eligible.