### PR TITLE
fix(cf-44qt sibling): sustainability.web.js console.error → logError ×4 (P3 obs cleanup)

### DIFF
--- a/src/backend/sustainability.web.js
+++ b/src/backend/sustainability.web.js
@@ -40,6 +40,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -112,7 +113,7 @@ export const getSustainabilityInfo = webMethod(
         },
       };
     } catch (err) {
-      console.error('[sustainability] Error getting sustainability info:', err);
+      logError('[sustainability] getSustainabilityInfo failed', err);
       return { success: false, error: 'Failed to load sustainability info.', sustainability: null };
     }
   }
@@ -165,7 +166,7 @@ export const calculateCarbonOffset = webMethod(
         },
       };
     } catch (err) {
-      console.error('[sustainability] Error calculating carbon offset:', err);
+      logError('[sustainability] calculateCarbonOffset failed', err);
       return { success: false, error: 'Failed to calculate offset.', offset: null };
     }
   }
@@ -233,7 +234,7 @@ export const submitTradeIn = webMethod(
         },
       };
     } catch (err) {
-      console.error('[sustainability] Error submitting trade-in:', err);
+      logError('[sustainability] submitTradeIn failed', err);
       return { success: false, error: 'Failed to submit trade-in request.' };
     }
   }
@@ -279,7 +280,7 @@ export const getTradeInStatus = webMethod(
         requests: result.items.map(formatTradeIn),
       };
     } catch (err) {
-      console.error('[sustainability] Error getting trade-in status:', err);
+      logError('[sustainability] getTradeInStatus failed', err);
       return { success: false, error: 'Failed to load trade-in status.', requests: [] };
     }
   }

--- a/tests/sustainabilitySilentFailureCleanup.test.js
+++ b/tests/sustainabilitySilentFailureCleanup.test.js
@@ -1,0 +1,86 @@
+/**
+ * cf-44qt sibling — sustainability.web.js observability cleanup.
+ *
+ * Pins post-migration contract: every catch in the 4 webMethods
+ * calls `logError('[sustainability] <fn> failed', err)` instead of
+ * raw `console.error`. Mirrors the canonical pattern.
+ *
+ * 4 tests = 1 per webMethod. ProductSustainability + TradeInRequests
+ * collections drive each catch path via __setQueryError.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1', loginEmail: 'm@example.com' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — sustainability.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getSustainabilityInfo wires logError on ProductSustainability query throw', async () => {
+    __setQueryError('ProductSustainability', new Error('wixData query failure'));
+    const mod = await import('../src/backend/sustainability.web.js');
+    await mod.getSustainabilityInfo('p-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/sustainability/);
+    expect(allTags).toMatch(/getSustainabilityInfo/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('calculateCarbonOffset wires logError on ProductSustainability query throw', async () => {
+    __setQueryError('ProductSustainability', new Error('wixData query failure'));
+    const mod = await import('../src/backend/sustainability.web.js');
+    await mod.calculateCarbonOffset(['p-1', 'p-2']);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/sustainability/);
+    expect(allTags).toMatch(/calculateCarbonOffset/);
+  });
+
+  it('submitTradeIn wires logError on TradeInRequests insert throw', async () => {
+    __setInsertError('TradeInRequests', new Error('wixData insert failure'));
+    const mod = await import('../src/backend/sustainability.web.js');
+    await mod.submitTradeIn({
+      productType: 'futon-frame',
+      condition: 'good',
+      photos: [],
+    });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/sustainability/);
+    expect(allTags).toMatch(/submitTradeIn/);
+  });
+
+  it('getTradeInStatus wires logError on TradeInRequests query throw', async () => {
+    __setQueryError('TradeInRequests', new Error('wixData query failure'));
+    const mod = await import('../src/backend/sustainability.web.js');
+    // No requestId → goes to the bulk query path that __setQueryError catches.
+    await mod.getTradeInStatus();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/sustainability/);
+    expect(allTags).toMatch(/getTradeInStatus/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — sustainability.web.js console.error → logError × 4 + 4 TDD pins. 10th same-pattern sibling.

## Migrations

| webMethod | New logError tag |
|---|---|
| getSustainabilityInfo | `[sustainability] getSustainabilityInfo failed` |
| calculateCarbonOffset | `[sustainability] calculateCarbonOffset failed` |
| submitTradeIn | `[sustainability] submitTradeIn failed` |
| getTradeInStatus | `[sustainability] getTradeInStatus failed` |

## TDD shape (4/4 green)

`tests/sustainabilitySilentFailureCleanup.test.js`:
- Top-level vi.mock per CF-fgsw
- getSustainabilityInfo / calculateCarbonOffset trigger via `__setQueryError('ProductSustainability', err)`
- submitTradeIn triggers via `__setInsertError('TradeInRequests', err)`
- getTradeInStatus called with no `requestId` arg → bulk-query path catches `__setQueryError('TradeInRequests', err)`. The requestId branch uses `wixData.get` which short-circuits on null (no __setGetError helper).

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 4/4 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- 9 prior cluster PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
