### PR TITLE
fix(cf-44qt sibling): events.js console.error → logError ×26 (LARGE — Wix lifecycle event hub) (P3)

### DIFF
--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -22,6 +22,7 @@
  */
 import wixData from 'wix-data';
 import { sanitize, redactEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── CWF ISR Revalidate Helper ─────────────────────────────────────────
 
@@ -118,7 +119,7 @@ export async function wixEcom_onAbandonedCheckoutCreated(event) {
       recoveryEmailSent: false,
     });
   } catch (err) {
-    console.error(`[events] DROPPED abandoned cart — checkoutId: ${checkoutId || 'unknown'}, email: ${redactEmail(buyerEmail)}, error:`, err);
+    logError(`[events] wixEcom_onAbandonedCheckoutCreated DROPPED checkoutId=${checkoutId || 'unknown'} email=${redactEmail(buyerEmail)}`, err);
     await logFailedEvent({
       handler: 'wixEcom_onAbandonedCheckoutCreated',
       checkoutId: checkoutId || 'unknown',
@@ -153,7 +154,7 @@ export async function wixEcom_onAbandonedCheckoutRecovered(event) {
       status: 'recovered',
     });
   } catch (err) {
-    console.error(`[events] FAILED to mark cart recovered — checkoutId: ${checkoutId || 'unknown'}, error:`, err);
+    logError(`[events] wixEcom_onAbandonedCheckoutRecovered checkoutId=${checkoutId || 'unknown'}`, err);
     await logFailedEvent({
       handler: 'wixEcom_onAbandonedCheckoutRecovered',
       checkoutId: checkoutId || 'unknown',
@@ -195,7 +196,7 @@ export async function wixMembers_onMemberCreated(event) {
     const { triggerWelcomeSequence } = await import('backend/emailAutomation.web');
     await triggerWelcomeSequence(contactId, email, firstName);
   } catch (err) {
-    console.error('[events] Error triggering welcome sequence:', err);
+    logError('[events] wixMembers_onMemberCreated welcome-sequence-trigger failed', err);
   }
 
   // CF-9swp: Seed welcome points (endowed progress) for new members
@@ -203,7 +204,7 @@ export async function wixMembers_onMemberCreated(event) {
     const { seedWelcomePoints } = await import('backend/gamificationEventReceiver.web');
     await seedWelcomePoints(contactId);
   } catch (err) {
-    console.error('[events] Error seeding welcome points:', err);
+    logError('[events] wixMembers_onMemberCreated welcome-points-seed failed', err);
   }
 }
 
@@ -233,14 +234,14 @@ export async function wixEcom_onOrderCreated(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'confirmed');
   } catch (err) {
-    console.error('[events] Order status webhook (confirmed) failed:', err);
+    logError('[events] wixEcom_onOrderCreated webhook-confirmed failed', err);
   }
 
   try {
     const { triggerPostPurchaseSequence } = await import('backend/emailAutomation.web');
     await triggerPostPurchaseSequence(contactId, email, firstName, orderNumber, total, lineItems, { memberId });
   } catch (err) {
-    console.error('[events] Error triggering post-purchase sequence:', err);
+    logError('[events] wixEcom_onOrderCreated post-purchase-trigger failed', err);
   }
 
   if (memberId) {
@@ -259,7 +260,7 @@ export async function wixEcom_onOrderCreated(event) {
           const { checkAndTriggerTierMilestone } = await import('backend/emailAutomation.web');
           await checkAndTriggerTierMilestone(memberId, email, firstName, newTotal, oldTotal);
         } catch (err) {
-          console.error('[events] Error checking tier milestone:', err);
+          logError('[events] wixEcom_onOrderCreated tier-milestone-check failed', err);
         }
       }
 
@@ -272,7 +273,7 @@ export async function wixEcom_onOrderCreated(event) {
         await recordChallengeProgress({ memberId, challengeId: challenge.challengeId });
       }
     } catch (err) {
-      console.error('[events] Error recording gamification on order:', err);
+      logError('[events] wixEcom_onOrderCreated gamification-record failed', err);
     }
 
     // cf-bu2: complete any pending referral attribution for web checkouts
@@ -280,7 +281,7 @@ export async function wixEcom_onOrderCreated(event) {
       const { _processReferralOnOrderCreated } = await import('backend/referralService.web');
       await _processReferralOnOrderCreated(memberId, orderNumber);
     } catch (err) {
-      console.error('[events] Error processing referral on order:', err);
+      logError('[events] wixEcom_onOrderCreated referral-process failed', err);
     }
   }
 
@@ -290,7 +291,7 @@ export async function wixEcom_onOrderCreated(event) {
       const { checkSwatchAttribution } = await import('backend/swatchAttribution.web');
       await checkSwatchAttribution(email, orderNumber, Number(total));
     } catch (err) {
-      console.error('[events] Error checking swatch attribution:', err);
+      logError('[events] wixEcom_onOrderCreated swatch-attribution-check failed', err);
     }
   }
 
@@ -300,11 +301,11 @@ export async function wixEcom_onOrderCreated(event) {
     if (orderContainsSwatchKit(order.lineItems || [])) {
       const result = await recordSwatchKitPurchase(orderNumber, memberId, email, []);
       if (!result?.success && !result?.alreadyIssued) {
-        console.error('[events] Swatch kit credit issuance failed silently:', result?.error, { orderNumber });
+        logError(`[events] wixEcom_onOrderCreated swatch-kit-credit-issue silent-failure orderNumber=${orderNumber}`, new Error(String(result?.error || 'unknown')));
       }
     }
   } catch (err) {
-    console.error('[events] Swatch kit credit issuance failed:', err);
+    logError('[events] wixEcom_onOrderCreated swatch-kit-credit-issue failed', err);
   }
 }
 
@@ -327,7 +328,7 @@ export async function wixEcom_onOrderApproved(event) {
     const { receiveGamificationEvent } = await import('backend/gamificationEventReceiver.web');
     await receiveGamificationEvent('gamification_order_complete', { orderTotal }, memberId);
   } catch (err) {
-    console.error('[events] wixEcom_onOrderApproved: gamification earn failed', err);
+    logError('[events] wixEcom_onOrderApproved gamification-earn failed', err);
   }
 }
 
@@ -349,7 +350,7 @@ export async function wixEcom_onOrderFulfilled(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'shipped');
   } catch (err) {
-    console.error('[events] Order status webhook (shipped) failed:', err);
+    logError('[events] wixEcom_onOrderFulfilled webhook-shipped failed', err);
   }
 
   if (!memberId) return;
@@ -358,7 +359,7 @@ export async function wixEcom_onOrderFulfilled(event) {
     const { handleOrderFulfilled } = await import('backend/notificationOrchestrator.web');
     await handleOrderFulfilled({ memberId, orderNumber, trackingNumber });
   } catch (err) {
-    console.error('[events] Error handling order fulfilled SMS:', err);
+    logError('[events] wixEcom_onOrderFulfilled SMS-handle failed', err);
   }
 }
 
@@ -377,7 +378,7 @@ export async function wixEcom_onFulfillmentCreated(event) {
     const { handleFulfillmentShippingNotification } = await import('backend/emailAutomation.web');
     handleFulfillmentShippingNotification(event);
   } catch (err) {
-    console.error('[events] Error handling fulfillment created:', err);
+    logError('[events] wixEcom_onFulfillmentCreated failed', err);
   }
 }
 
@@ -398,7 +399,7 @@ export async function wixEcom_onFulfillmentUpdated(event) {
     const { handleFulfillmentShippingNotification } = await import('backend/emailAutomation.web');
     handleFulfillmentShippingNotification(event);
   } catch (err) {
-    console.error('[events] Error handling fulfillment updated:', err);
+    logError('[events] wixEcom_onFulfillmentUpdated failed', err);
   }
 }
 
@@ -415,7 +416,7 @@ export async function wixEcom_onOrderDelivered(event) {
     const { handleOrderDelivered } = await import('backend/emailAutomation.web');
     handleOrderDelivered(event);
   } catch (err) {
-    console.error('[events] Error handling order delivered:', err);
+    logError('[events] wixEcom_onOrderDelivered failed', err);
   }
 }
 
@@ -433,7 +434,7 @@ export async function wixEcom_onOrderCanceled(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'cancelled');
   } catch (err) {
-    console.error('[events] Order status webhook (cancelled) failed:', err);
+    logError('[events] wixEcom_onOrderCanceled webhook-cancelled failed', err);
   }
 
   if (!email) return;
@@ -442,7 +443,7 @@ export async function wixEcom_onOrderCanceled(event) {
     const { cancelSequenceForOrder } = await import('backend/emailAutomation.web');
     await cancelSequenceForOrder(email, orderNumber);
   } catch (err) {
-    console.error('[events] Error cancelling care sequence:', err);
+    logError('[events] wixEcom_onOrderCanceled care-sequence-cancel failed', err);
   }
 }
 
@@ -474,7 +475,7 @@ export async function wixStores_onProductCreated(event) {
       imageUrl: product.mainMedia || product.media?.mainMedia?.image?.url || '',
     });
   } catch (err) {
-    console.error('[events] Content orchestration failed for new product:', err);
+    logError('[events] wixStores_onProductCreated content-orchestration failed', err);
     await logFailedEvent({
       handler: 'wixStores_onProductCreated',
       productId,
@@ -521,7 +522,7 @@ export async function wixStores_onProductUpdated(event) {
       newPrice,
     });
   } catch (err) {
-    console.error('[events] Content orchestration failed for price drop:', err);
+    logError('[events] wixStores_onProductUpdated price-drop-orchestration failed', err);
     await logFailedEvent({
       handler: 'wixStores_onProductUpdated',
       productId,
@@ -565,7 +566,7 @@ export async function wixStores_onInventoryVariantUpdated(event) {
 
     // Check for soft failure (returned { success: false } without throwing)
     if (result && !result.success) {
-      console.error(`[events] Restock notifications returned failure — productId: ${productId}, error: ${result.error || 'unknown'}`);
+      logError(`[events] wixStores_onInventoryVariantUpdated restock-notifications returned failure productId=${productId}`, new Error(String(result.error || 'unknown')));
       await logFailedEvent({
         handler: 'wixStores_onInventoryVariantUpdated',
         productId: productId || 'unknown',
@@ -588,10 +589,10 @@ export async function wixStores_onInventoryVariantUpdated(event) {
         });
       }
     } catch (orchErr) {
-      console.error('[events] Content orchestration failed for restock:', orchErr);
+      logError('[events] wixStores_onInventoryVariantUpdated restock-orchestration failed', orchErr);
     }
   } catch (err) {
-    console.error(`[events] FAILED restock notifications — productId: ${productId || 'unknown'}, error:`, err);
+    logError(`[events] wixStores_onInventoryVariantUpdated restock-notifications-fire failed productId=${productId || 'unknown'}`, err);
     await logFailedEvent({
       handler: 'wixStores_onInventoryVariantUpdated',
       productId: productId || 'unknown',
@@ -645,7 +646,7 @@ export async function wixMembers_onMemberUpdated(event) {
       birthday_day: parsed.day,
     });
   } catch (err) {
-    console.error(`[events] Failed to sync birthday fields for member ${memberId}:`, err?.message ?? err);
+    logError(`[events] wixMembers_onMemberUpdated birthday-sync failed memberId=${memberId}`, err);
     await logFailedEvent({
       handler: 'wixMembers_onMemberUpdated',
       error: err.message,

--- a/tests/eventsSilentFailureCleanup.test.js
+++ b/tests/eventsSilentFailureCleanup.test.js
@@ -1,0 +1,71 @@
+/**
+ * cf-44qt sibling — events.js observability cleanup.
+ * All 26 raw console.error catches migrated to logError with structured
+ * `[events] <handler> <reason>` tags for greppable on-call surface.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  redactEmail: (e) => e ? e.replace(/^(.{2}).*@/, '$1***@') : '',
+}));
+vi.mock('backend/emailAutomation.web', () => ({
+  triggerWelcomeSequence: vi.fn(async () => { throw new Error('email-automation failure'); }),
+  triggerPostPurchaseSequence: vi.fn(async () => undefined),
+  triggerRestockNotifications: vi.fn(async () => ({ success: true, count: 0 })),
+  cancelCareSequence: vi.fn(async () => undefined),
+}));
+vi.mock('backend/contentOrchestrator.web', () => ({
+  triggerEventOrchestration: vi.fn(async () => ({ success: true, scheduled: [] })),
+}));
+vi.mock('backend/gamificationEventReceiver.web', () => ({
+  seedWelcomePoints: vi.fn(async () => undefined),
+  receiveGamificationEvent: vi.fn(async () => ({ success: true })),
+}));
+
+import {
+  __reset as resetData,
+  __seed,
+  __onInsert,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — events.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('wixEcom_onAbandonedCheckoutCreated wires logError on AbandonedCarts insert throw', async () => {
+    __seed('AbandonedCarts', []);
+    __onInsert(() => { throw new Error('DB down'); });
+    const mod = await import('../src/backend/events.js');
+    await mod.wixEcom_onAbandonedCheckoutCreated({
+      entity: {
+        _id: 'co-1',
+        buyerInfo: { email: 'alice@test.com' },
+      },
+    });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/\[events\]/);
+    expect(allTags).toMatch(/wixEcom_onAbandonedCheckoutCreated/);
+    // Redaction preserved through logError context.
+    expect(allTags).toContain('al***@test.com');
+    expect(allTags).not.toContain('alice@test.com');
+  });
+
+  it('wixMembers_onMemberCreated wires logError on welcome-sequence throw', async () => {
+    const mod = await import('../src/backend/events.js');
+    await mod.wixMembers_onMemberCreated({
+      entity: { _id: 'member-1', loginEmail: 'new@test.com' },
+    });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/\[events\]/);
+    expect(allTags).toMatch(/wixMembers_onMemberCreated/);
+  });
+});


### PR DESCRIPTION
## Summary
- **26 catch sites** migrated across **14 Wix lifecycle event handlers** — the largest single-file migration in the cf-44qt sibling series.
- 32nd in the series.
- Wix platform event handler hub: abandoned-cart, member, order, fulfillment, product, blog, member-update lifecycle.

## Email redaction preserved
\`wixEcom_onAbandonedCheckoutCreated\` catch includes \`redactEmail(buyerEmail)\` in the logError tag — pinned by test asserting \`al***@test.com\` IS in the captured args and \`alice@test.com\` is NOT.

## Non-error logging preserved
\`console.warn\` sites (revalidate webhook non-2xx, dead-letter queue write-failure) are intentional informational logging — kept as-is.

## Verification
- [x] New tests: **2/2 green**
- [x] Existing events suite (3 files: events + eventsErrorHandling + events-revalidate): **67/67 green** (existing assertions use \`consoleSpy.mock.calls[0].join(' ') + toContain\` — works through logError's console.error delegation)
- [x] Combined: **69/69**
- [ ] CI lint-typecheck-test
- [ ] 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)