### PR TITLE
fix(cf-n4wy): cf-44qt batch-O — 8-file logger sweep (44 sites) + 11 ripple-test updates

### DIFF
--- a/src/backend/couponsService.web.js
+++ b/src/backend/couponsService.web.js
@@ -184,7 +184,7 @@ export const createBirthdayCoupon = webMethod(
           active: true,
         });
       } catch (insertErr) {
-        console.warn('[couponsService] MemberCoupons insert failed for birthday coupon:', insertErr.message);
+        logError('couponsService:issueBirthdayCoupon-memberCouponsInsertFailed', insertErr);
       }
 
       return {
@@ -250,7 +250,7 @@ export const createTierUpgradeCoupon = webMethod(
           active: true,
         });
       } catch (insertErr) {
-        console.warn('[couponsService] MemberCoupons insert failed for tier upgrade coupon:', insertErr.message);
+        logError('couponsService:issueTierUpgradeCoupon-memberCouponsInsertFailed', insertErr);
       }
 
       return {
@@ -335,8 +335,7 @@ export const generateRecoveryCoupon = webMethod(
           expiresAt: expiresAtISO,
         });
       } catch (insertErr) {
-        console.warn('[couponsService] RecoveryCoupons insert failed for cartId:', cartId,
-          '— idempotency not guaranteed on retry:', insertErr.message);
+        logError(`couponsService:generateRecoveryCoupon-recoveryCouponsInsertFailed cartId=${cartId}`, insertErr);
       }
 
       // Track in MemberCoupons for DB-level member scoping in getActiveCoupons
@@ -357,8 +356,7 @@ export const generateRecoveryCoupon = webMethod(
           active: true,
         });
       } catch (insertErr) {
-        console.warn('[couponsService] MemberCoupons insert failed for recovery coupon cartId:', cartId,
-          ':', insertErr.message);
+        logError(`couponsService:generateRecoveryCoupon-memberCouponsInsertFailed cartId=${cartId}`, insertErr);
       }
 
       return {
@@ -425,7 +423,7 @@ export const createCartRecoveryCoupon = webMethod(
           active: true,
         });
       } catch (insertErr) {
-        console.warn('[couponsService] MemberCoupons insert failed for cart recovery coupon:', insertErr.message);
+        logError('couponsService:issueCartRecoveryCoupon-memberCouponsInsertFailed', insertErr);
       }
 
       return {
@@ -457,8 +455,7 @@ async function generateCode(prefix) {
       if (!existing.items || existing.items.length === 0) return code;
     } catch (e) {
       // Collision check failed — returning unchecked code; collision is statistically unlikely
-      console.warn('[couponsService] generateCode collision check failed (attempt', attempt, '):', e.message,
-        '— returning unchecked code');
+      logError(`couponsService:generateCode-collisionCheckFailed attempt=${attempt}`, e);
       return code;
     }
   }

--- a/src/backend/emailService.web.js
+++ b/src/backend/emailService.web.js
@@ -92,7 +92,7 @@ export async function _checkEmailRateLimit(key, opts = {}) {
     });
     return { allowed: true };
   } catch (err) {
-    console.warn('[emailService] Rate limit check failed, allowing request:', err?.message);
+    logError('emailService:checkEmailRateLimit-failedOpen', err);
     return { allowed: true };
   }
 }
@@ -117,15 +117,12 @@ async function _resolveSiteOwnerContactId() {
   try {
     const id = await getSecret('SITE_OWNER_CONTACT_ID');
     if (!id) {
-      console.warn('[emailService] SITE_OWNER_CONTACT_ID secret returned empty — owner notification skipped');
+      logError('emailService:resolveSiteOwnerContactId-secretEmpty', null);
       return null;
     }
     return id;
   } catch (err) {
-    console.warn(
-      '[emailService] SITE_OWNER_CONTACT_ID secret missing or unreadable — owner notification skipped:',
-      err?.message ?? err,
-    );
+    logError('emailService:resolveSiteOwnerContactId-secretUnreadable', err);
     return null;
   }
 }
@@ -230,7 +227,7 @@ export const sendEmail = webMethod(
         subject: cleanSubject,
         message: cleanMessage,
       }).catch((err) => {
-        console.warn('[emailService] customer auto-reply failed (non-blocking):', err?.message ?? err);
+        logError('emailService:sendCustomerContactAutoReply-nonblocking', err);
       });
 
       logAuditEvent('ContactSubmissions', 'send_email', cleanEmail, { subject: cleanSubject });
@@ -269,7 +266,7 @@ async function _sendCustomerContactAutoReply({ email, name, subject, message }) 
   });
   const customerContactId = contactResult?.contactId || contactResult?._id;
   if (!customerContactId) {
-    console.warn('[emailService] customer auto-reply skipped — appendOrCreateContact returned empty', { email });
+    logError('emailService:sendCustomerContactAutoReply-skippedEmptyContactId', null);
     return;
   }
   // cf-hafn: dispatch via the Wix dashboard ID resolved from

--- a/src/backend/facebookCatalog.web.js
+++ b/src/backend/facebookCatalog.web.js
@@ -19,6 +19,7 @@ import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { notifyOwner } from 'backend/notificationService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -493,7 +494,7 @@ export function buildCatalogBatch(products) {
       });
       processed++;
     } catch (err) {
-      console.error('[facebookCatalog] buildCatalogBatch product error:', err);
+      logError('facebookCatalog:buildCatalogBatch', err);
       failed++;
       errors.push({
         productId: product?._id || 'unknown',
@@ -544,7 +545,7 @@ export const refreshFacebookCatalog = webMethod(
       try {
         await notifyOwner(subject, msg);
       } catch (notifyErr) {
-        console.error('[facebookCatalog] notifyOwner failed:', notifyErr?.message);
+        logError('facebookCatalog:refreshFacebookCatalog-notifyOwnerFailed', notifyErr);
       }
     }
 
@@ -573,16 +574,16 @@ export const refreshFacebookCatalog = webMethod(
 
       if (failed > 0) {
         const msg = `${failed} product(s) failed catalog validation. Errors: ${JSON.stringify(errors.slice(0, 5))}`;
-        console.warn('[facebookCatalog] refreshFacebookCatalog failures:', msg);
+        logError(`facebookCatalog:refreshFacebookCatalog-failures msg=${msg}`, null);
         await safeNotify('facebook catalog sync — validation failures', msg);
       }
 
       const summary = { success: failed === 0, processed, failed, errors };
-      console.log('[facebookCatalog] refreshFacebookCatalog complete:', JSON.stringify({ processed, failed }));
+      logError(`facebookCatalog:refreshFacebookCatalog-complete processed=${processed} failed=${failed}`, null);
       return summary;
     } catch (err) {
       const msg = `catalog refresh failed: ${err?.message ?? String(err)}`;
-      console.error('[facebookCatalog] refreshFacebookCatalog error:', msg);
+      logError(`facebookCatalog:refreshFacebookCatalog msg=${msg}`, null);
       await safeNotify('facebook catalog sync — cron error', msg);
       return { success: false, processed, failed, errors: [msg] };
     }
@@ -652,7 +653,7 @@ export const exportCustomerAudienceData = webMethod(
         customers: Array.from(customerMap.values()),
       };
     } catch (err) {
-      console.error('exportCustomerAudienceData error:', err);
+      logError('facebookCatalog:exportCustomerAudienceData', err);
       return { success: false, customers: [], error: 'Failed to export audience data' };
     }
   }

--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -758,7 +758,7 @@ export const getActiveChallenges = webMethod(
       // through (stale session, misconfiguration). Surface it as a distinct
       // error instead of returning "no challenges" — that's silent-failure
       // masquerade. See cf-1y7 (cf-2ag cascade).
-      console.warn('[gamificationCore] getActiveChallenges: no memberId on session (cf-1y7)');
+      logError('gamificationCore:getActiveChallenges-noMemberId', null);
       return { challenges: [], error: 'auth_required' };
     }
 
@@ -1089,7 +1089,7 @@ export const getStreakData = webMethod(
       // Velo SiteMember gate leak — distinguishable from "authed but no streak
       // yet" (which also returns zeros, but without the error field).
       // See cf-1y7 (cf-2ag cascade).
-      console.warn('[gamificationCore] getStreakData: no memberId on session (cf-1y7)');
+      logError('gamificationCore:getStreakData-noMemberId', null);
       return { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
     }
     const record = await findMemberRecord(memberId);
@@ -1208,7 +1208,7 @@ export const getMemberTier = webMethod(
       // Velo SiteMember gate leak — return the baseline Trail Blazer shape
       // but signal the auth anomaly so widgets can gate tier benefits display.
       // See cf-1y7 (cf-2ag cascade).
-      console.warn('[gamificationCore] getMemberTier: no memberId on session (cf-1y7)');
+      logError('gamificationCore:getMemberTier-noMemberId', null);
       return { ...computeTierInfo(0), error: 'auth_required' };
     }
     const record = await findMemberRecord(memberId);
@@ -1248,13 +1248,13 @@ export const getActivityFeed = webMethod(
       // Velo SiteMember gate leak. Array return preserved for consumer compat;
       // observability lives in the warn so Wix runtime logs surface the leak.
       // See cf-1y7 (cf-2ag cascade).
-      console.warn('[gamificationCore] getActivityFeed: no member on session (auth_required) (cf-1y7)');
+      logError('gamificationCore:getActivityFeed-authRequired', null);
       return [];
     }
     if (caller._id !== memberId) {
       // Cross-member read attempt. Keep defense-in-depth (empty array) but
       // warn distinctly so the two failure modes are separable in logs.
-      console.warn('[gamificationCore] getActivityFeed: caller/memberId mismatch (forbidden) (cf-1y7)');
+      logError('gamificationCore:getActivityFeed-forbidden', null);
       return [];
     }
 

--- a/src/backend/styleConsultant.web.js
+++ b/src/backend/styleConsultant.web.js
@@ -43,6 +43,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, isWixMediaUrl } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const SESSION_COLLECTION = 'StyleConsultantSessions';
 
@@ -290,7 +291,7 @@ async function callClaudeVision(photoUrl, textInput) {
       });
       hasImage = true;
     } else {
-      console.warn('[styleConsultant] Could not convert photo URL to CDN URL — proceeding text-only:', photoUrl);
+      logError(`styleConsultant:callClaudeVision-photoUrlConversionFailed photoUrl=${photoUrl}`, null);
     }
   }
 
@@ -482,7 +483,7 @@ export const getStyleConsultation = webMethod(
     try {
       session = await lookupSession(cleanKey);
     } catch (err) {
-      console.error('[styleConsultant] Session lookup failed:', err?.message ?? err);
+      logError('styleConsultant:getStyleConsultation-sessionLookupFailed', err);
       return { success: false, error: 'Session lookup failed. Please try again.', errorCode: 'AI_ERROR' };
     }
 
@@ -498,7 +499,7 @@ export const getStyleConsultation = webMethod(
       styleTags = aiResult.styleTags;
       explanation = aiResult.explanation;
     } catch (err) {
-      console.error('[styleConsultant] Claude API call failed:', err?.message ?? err);
+      logError('styleConsultant:getStyleConsultation-claudeApiFailed', err);
       return { success: false, error: 'Style analysis unavailable. Please try again later.', errorCode: 'AI_ERROR' };
     }
 
@@ -507,7 +508,7 @@ export const getStyleConsultation = webMethod(
     try {
       recommendations = await getProductRecommendations(styleTags);
     } catch (err) {
-      console.error('[styleConsultant] Product matching failed:', err?.message ?? err);
+      logError('styleConsultant:getStyleConsultation-productMatchFailed', err);
       return { success: false, error: 'Could not fetch recommendations. Please try again.', errorCode: 'AI_ERROR' };
     }
 
@@ -515,7 +516,7 @@ export const getStyleConsultation = webMethod(
     try {
       await upsertSession(session, cleanKey, updatedCounts, textInput, photoUrl, recommendations);
     } catch (err) {
-      console.error('[styleConsultant] Session upsert failed:', err?.message ?? err);
+      logError('styleConsultant:getStyleConsultation-sessionUpsertFailed', err);
     }
 
     if (recommendations.length === 0) {

--- a/src/backend/swatchRequest.web.js
+++ b/src/backend/swatchRequest.web.js
@@ -102,7 +102,7 @@ async function resolveSwatchNames(swatchIds) {
       wixData.query('FabricSwatches').eq('_id', id).limit(1).find()
         .then(r => {
           const name = r.items[0]?.name;
-          if (!name) console.warn(`[swatchRequest] Swatch not found in CMS: ${id}`);
+          if (!name) logError(`swatchRequest:resolveSwatchNames-notFound id=${id}`, null);
           return name || id;
         })
     )
@@ -243,10 +243,10 @@ export const submitSwatchRequest = webMethod(
             productSlug: cleanSlug || null,
           });
         } catch (emailErr) {
-          console.error('[swatchRequest] Failed to enqueue nurture emails:', emailErr);
+          logError('swatchRequest:submitSwatchRequest-nurtureQueueFailed', emailErr);
         }
       } else {
-        console.warn('[swatchRequest] Skipping swatch nurture queue — upsertContact returned no contactId for', contact.email);
+        logError('swatchRequest:submitSwatchRequest-skippedEmptyContactId', null);
       }
 
       // cf-obsb Path A: send the customer-facing swatch confirmation email
@@ -262,13 +262,13 @@ export const submitSwatchRequest = webMethod(
           swatchNames,
           productName: productNameForEmail,
         }).catch((emailErr) => {
-          console.warn('[swatchRequest] swatch_confirmation send failed (non-blocking):', emailErr?.message ?? emailErr);
+          logError('swatchRequest:submitSwatchRequest-confirmationSendFailed', emailErr);
         });
       }
 
       return { success: true, requestId: inserted._id };
     } catch (err) {
-      console.error('[swatchRequest] submitSwatchRequest error:', err);
+      logError('swatchRequest:submitSwatchRequest', err);
       return { success: false, error: err.message || 'Failed to submit swatch request.' };
     }
   }

--- a/tests/cartRecoveryCoupon.test.js
+++ b/tests/cartRecoveryCoupon.test.js
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+// cf-n4wy: couponsService migrated console.warn (RecoveryCoupons insert) → logError
 vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
 
 import { generateRecoveryCoupon } from '../src/backend/couponsService.web.js';
@@ -304,16 +305,14 @@ describe('generateRecoveryCoupon — RecoveryCoupons insert failure', () => {
     expect(coupons.createCoupon).toHaveBeenCalledOnce();
   });
 
-  it('logs a warning when RecoveryCoupons insert fails', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('logs canonical logError tag when RecoveryCoupons insert fails', async () => {
+    vi.mocked(logError).mockClear();
     vi.spyOn(wixData, 'insert').mockRejectedValueOnce(new Error('Insert timeout'));
     await generateRecoveryCoupon({ cartId: 'cart-warn', email: 'buyer@example.com' });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[couponsService]'),
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
+    // cf-n4wy: canonical logError tag replaces the previous console.warn
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('couponsService:generateRecoveryCoupon-recoveryCouponsInsertFailed'),
+      expect.any(Error),
     );
-    warnSpy.mockRestore();
   });
 });

--- a/tests/cf-n4wy-batchO-LogErrorMigration.test.js
+++ b/tests/cf-n4wy-batchO-LogErrorMigration.test.js
@@ -1,0 +1,151 @@
+/**
+ * cf-n4wy (cf-44qt batch-O): 8-file logger sweep migration pins.
+ *
+ * Convoy continuation after cf-i8b4 batch-M (PR #1459) and cf-06ug
+ * batch-N (PR #1474). 44 console.* sites across 8 files migrated to
+ * canonical `logError(tag, err)` from `backend/utils/errorHandler`
+ * with the `<module>:<fn>-<reason>` tag namespace.
+ *
+ * Regex shape accepts ', ", AND backtick — folded from cf-mrcm.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC_BACKEND = path.resolve(TEST_DIR, '../src/backend');
+
+function readSrc(rel) {
+  return fs.readFileSync(path.resolve(SRC_BACKEND, rel), 'utf-8');
+}
+
+const FILES = {
+  'swatchKitService.web.js': {
+    requiresImport: true,
+    tags: [
+      'swatchKitService:issueSwatchKitCredit-idempotencyCheckFailed',
+      'swatchKitService:issueSwatchKitCredit-creditFailed',
+      'swatchKitService:issueSwatchKitCredit-creditThrew',
+      'swatchKitService:issueSwatchKitCredit-cmsInsertFailedManualReconcile',
+      'swatchKitService:getSwatchKitCreditStatus-noMember',
+      'swatchKitService:getSwatchKitCreditStatus',
+      'swatchKitService:markCreditApplied',
+    ],
+  },
+  'facebookCatalog.web.js': {
+    requiresImport: true,
+    tags: [
+      'facebookCatalog:buildCatalogBatch',
+      'facebookCatalog:refreshFacebookCatalog-notifyOwnerFailed',
+      'facebookCatalog:refreshFacebookCatalog-failures',
+      'facebookCatalog:refreshFacebookCatalog-complete',
+      'facebookCatalog:refreshFacebookCatalog',
+      'facebookCatalog:exportCustomerAudienceData',
+    ],
+  },
+  'couponsService.web.js': {
+    requiresImport: true,
+    tags: [
+      'couponsService:issueBirthdayCoupon-memberCouponsInsertFailed',
+      'couponsService:issueTierUpgradeCoupon-memberCouponsInsertFailed',
+      'couponsService:generateRecoveryCoupon-recoveryCouponsInsertFailed',
+      'couponsService:generateRecoveryCoupon-memberCouponsInsertFailed',
+      'couponsService:issueCartRecoveryCoupon-memberCouponsInsertFailed',
+      'couponsService:generateCode-collisionCheckFailed',
+    ],
+  },
+  'videoReviewService.web.js': {
+    requiresImport: true,
+    tags: [
+      'videoReviewService:submitVideoReview',
+      'videoReviewService:getVideoReviews',
+      'videoReviewService:moderateVideoReview',
+      'videoReviewService:getProductVideoReviews',
+      'videoReviewService:getVideoReviewCount',
+    ],
+  },
+  'swatchRequest.web.js': {
+    requiresImport: true,
+    tags: [
+      'swatchRequest:resolveSwatchNames-notFound',
+      'swatchRequest:submitSwatchRequest-nurtureQueueFailed',
+      'swatchRequest:submitSwatchRequest-skippedEmptyContactId',
+      'swatchRequest:submitSwatchRequest-confirmationSendFailed',
+      'swatchRequest:submitSwatchRequest',
+    ],
+  },
+  'styleConsultant.web.js': {
+    requiresImport: true,
+    tags: [
+      'styleConsultant:callClaudeVision-photoUrlConversionFailed',
+      'styleConsultant:getStyleConsultation-sessionLookupFailed',
+      'styleConsultant:getStyleConsultation-claudeApiFailed',
+      'styleConsultant:getStyleConsultation-productMatchFailed',
+      'styleConsultant:getStyleConsultation-sessionUpsertFailed',
+    ],
+  },
+  'gamificationCore.web.js': {
+    requiresImport: true,
+    tags: [
+      'gamificationCore:getActiveChallenges-noMemberId',
+      'gamificationCore:getStreakData-noMemberId',
+      'gamificationCore:getMemberTier-noMemberId',
+      'gamificationCore:getActivityFeed-authRequired',
+      'gamificationCore:getActivityFeed-forbidden',
+    ],
+  },
+  'emailService.web.js': {
+    requiresImport: true,
+    tags: [
+      'emailService:checkEmailRateLimit-failedOpen',
+      'emailService:resolveSiteOwnerContactId-secretEmpty',
+      'emailService:resolveSiteOwnerContactId-secretUnreadable',
+      'emailService:sendCustomerContactAutoReply-nonblocking',
+      'emailService:sendCustomerContactAutoReply-skippedEmptyContactId',
+    ],
+  },
+};
+
+function tagPattern(tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+  );
+}
+
+describe('cf-n4wy (cf-44qt batch-O): 8-file logger sweep migration', () => {
+  for (const [filePath, spec] of Object.entries(FILES)) {
+    describe(filePath, () => {
+      const src = readSrc(filePath);
+
+      it('contains zero console.error|warn|log|debug|info CALLS (matches the strict call-pattern, not comment text)', () => {
+        const calls = src.match(/console\.(error|warn|log|debug|info)\s*\(/g) || [];
+        const allowed = spec.allowsConsoleCalls || 0;
+        expect(calls.length).toBe(allowed);
+      });
+
+      if (spec.requiresImport) {
+        it('imports logError from backend/utils/errorHandler', () => {
+          const importPattern =
+            /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler/;
+          expect(src).toMatch(importPattern);
+        });
+      }
+
+      for (const tag of spec.tags) {
+        it(`tag "${tag}" appears as a logError() call`, () => {
+          expect(src).toMatch(tagPattern(tag));
+        });
+      }
+    });
+  }
+
+  it('summary: 44 console.* call sites migrated across 8 files', () => {
+    const totalTags = Object.values(FILES).reduce(
+      (sum, spec) => sum + spec.tags.length,
+      0,
+    );
+    expect(totalTags).toBe(44);
+  });
+});

--- a/tests/contactFormAutoReply.cfhafn.test.js
+++ b/tests/contactFormAutoReply.cfhafn.test.js
@@ -18,6 +18,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { __seed, __reset as resetData } from './__mocks__/wix-data.js';
 import { __setSecrets, __reset as resetSecrets } from './__mocks__/wix-secrets-backend.js';
+
+// cf-n4wy: emailService migrated console.warn (auto-reply non-blocking +
+// skip-on-empty-contactId) → canonical logError. Mock so non-blocking
+// tests can assert tag namespace instead of console.warn.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
 import {
   __getEmailLog,
   __reset as resetCrm,
@@ -25,6 +30,7 @@ import {
 } from './__mocks__/wix-crm-backend.js';
 
 import { sendEmail } from '../src/backend/emailService.web.js';
+import { logError } from '../src/backend/utils/errorHandler.js';
 
 const flushMicrotasks = async () => {
   // Drain multiple turns: cf-hafn auto-reply does
@@ -118,7 +124,7 @@ describe('cf-hafn · sendEmail customer auto-reply', () => {
 
 describe('cf-hafn · auto-reply is non-blocking', () => {
   it('still returns success when the auto-reply triggered email fails', async () => {
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     // Fail the SECOND emailContact call (the auto-reply) but let the first
     // (owner notification) succeed. Without skip-count support in the mock,
     // simulate via spying on the imported triggeredEmails.
@@ -136,29 +142,28 @@ describe('cf-hafn · auto-reply is non-blocking', () => {
 
     expect(result.success).toBe(true); // owner email + CMS row already happened
     expect(__getEmailLog().some((e) => e.templateId === 'VJBU6zD')).toBe(true);
-    expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining('customer auto-reply failed'),
-      expect.any(String),
+    // cf-n4wy: canonical logError tag replaces the console.warn assertion
+    expect(logError).toHaveBeenCalledWith(
+      'emailService:sendCustomerContactAutoReply-nonblocking',
+      expect.any(Error),
     );
-    consoleWarn.mockRestore();
     vi.restoreAllMocks();
   });
 
   it('skips auto-reply when appendOrCreateContact returns empty', async () => {
     const crm = await import('wix-crm-backend');
     vi.spyOn(crm.contacts, 'appendOrCreateContact').mockResolvedValue({});
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
 
     const result = await sendEmail(validSubmission());
     await flushMicrotasks();
 
     expect(result.success).toBe(true);
     expect(__getEmailLog().some((e) => e.templateId === 'VJBOnfD')).toBe(false);
-    expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining('customer auto-reply skipped'),
-      expect.any(Object),
+    expect(logError).toHaveBeenCalledWith(
+      'emailService:sendCustomerContactAutoReply-skippedEmptyContactId',
+      null,
     );
-    consoleWarn.mockRestore();
     vi.restoreAllMocks();
   });
 });

--- a/tests/emailService.test.js
+++ b/tests/emailService.test.js
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { __seed, __onInsert } from './__mocks__/wix-data.js';
 import { __setSecrets, __reset as __resetSecrets } from './__mocks__/wix-secrets-backend.js';
 import { __getEmailLog, __failNextEmail } from './__mocks__/wix-crm-backend.js';
+
+// cf-n4wy: emailService migrated console.warn (SITE_OWNER_CONTACT_ID) → canonical logError
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
 import {
   sendEmail,
   submitSwatchRequest,
@@ -446,7 +450,7 @@ describe('sendOrderNotification', () => {
   // observability can distinguish missing-secret from other failures.
   it('returns structured failure when SITE_OWNER_CONTACT_ID secret is missing', async () => {
     __resetSecrets(); // clear all secrets including the beforeEach default
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     const result = await sendOrderNotification({
       number: '10043',
       buyerName: 'No Owner',
@@ -455,13 +459,15 @@ describe('sendOrderNotification', () => {
     });
     expect(result.success).toBe(false);
     expect(result.reason).toBe('site_owner_contact_id_missing');
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/SITE_OWNER_CONTACT_ID/),
-      expect.anything(),
+    // cf-n4wy: canonical logError tag (matches either -secretEmpty or -secretUnreadable)
+    const ownerSecretTagCall = vi.mocked(logError).mock.calls.find(
+      (call) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('emailService:resolveSiteOwnerContactId'),
     );
+    expect(ownerSecretTagCall).toBeTruthy();
     // No email should have been queued — owner notify is the only side effect.
     const emails = __getEmailLog();
     expect(emails).toHaveLength(0);
-    warnSpy.mockRestore();
   });
 });

--- a/tests/emailServiceCoverage.test.js
+++ b/tests/emailServiceCoverage.test.js
@@ -25,6 +25,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { __reset, __getEmailLog, __failNextEmail } from './__mocks__/wix-crm-backend.js';
 import { __setSecrets, __reset as __resetSecrets } from './__mocks__/wix-secrets-backend.js';
 import { __setMember, __reset as __resetMember } from './__mocks__/wix-members-backend.js';
+
+// cf-n4wy: emailService auto-reply skip-on-empty-contactId migrated to logError
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
 import {
   sendEmail,
   sendOrderConfirmation,
@@ -107,13 +111,12 @@ describe('sendOrderConfirmation — branch coverage', () => {
   });
 
   it('returns success: false on triggeredEmails throw (covers catch + logs)', async () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     __failNextEmail();
     const res = await sendOrderConfirmation(baseOrder);
     expect(res).toEqual({ success: false });
-    // catch path must log — guards against regression to fully-silent swallow.
-    expect(errSpy).toHaveBeenCalled();
-    errSpy.mockRestore();
+    // catch path must log via canonical logError — guards against regression to fully-silent swallow.
+    expect(logError).toHaveBeenCalled();
   });
 });
 
@@ -177,12 +180,12 @@ describe('sendShippingNotification — branch coverage', () => {
   });
 
   it('returns success: false on triggeredEmails throw (catch logs)', async () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     __failNextEmail();
     const res = await sendShippingNotification(baseShip);
     expect(res).toEqual({ success: false });
-    expect(errSpy).toHaveBeenCalled();
-    errSpy.mockRestore();
+    expect(logError).toHaveBeenCalled();
+    
   });
 });
 
@@ -250,12 +253,11 @@ describe('sendFreightShippingNotification — branch coverage', () => {
   });
 
   it('returns success: false on triggeredEmails throw (catch logs)', async () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     __failNextEmail();
     const res = await sendFreightShippingNotification(baseFreight);
     expect(res).toEqual({ success: false });
-    expect(errSpy).toHaveBeenCalled();
-    errSpy.mockRestore();
+    expect(logError).toHaveBeenCalled();
   });
 });
 
@@ -308,12 +310,11 @@ describe('sendDeliveryConfirmation — branch coverage', () => {
   });
 
   it('returns success: false on triggeredEmails throw (catch logs)', async () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     __failNextEmail();
     const res = await sendDeliveryConfirmation(baseDelivery);
     expect(res).toEqual({ success: false });
-    expect(errSpy).toHaveBeenCalled();
-    errSpy.mockRestore();
+    expect(logError).toHaveBeenCalled();
   });
 });
 
@@ -333,12 +334,7 @@ describe('_sendCustomerContactAutoReply — auto-reply branch coverage', () => {
     const crm = await import('./__mocks__/wix-crm-backend.js');
     const real = crm.contacts.appendOrCreateContact;
     crm.contacts.appendOrCreateContact = async () => ({ /* no contactId */ });
-
-    const warn = console.warn;
-    // Capture full args (don't join) so we can inspect the structured
-    // payload object passed as the second argument.
-    const warnCalls = [];
-    console.warn = (...args) => warnCalls.push(args);
+    vi.mocked(logError).mockClear();
     try {
       const res = await sendEmail({
         name: 'Test',
@@ -357,18 +353,15 @@ describe('_sendCustomerContactAutoReply — auto-reply branch coverage', () => {
       // template was sent, NOT contact_form_auto_reply.
       const replyEmails = log.filter(e => e.templateId === 'contact_form_auto_reply');
       expect(replyEmails).toHaveLength(0);
-      const skipCall = warnCalls.find(args =>
-        typeof args[0] === 'string' && args[0].includes('customer auto-reply skipped')
+      // cf-n4wy: canonical logError tag replaces the previous console.warn
+      // assertion. The tag itself encodes the skip-on-empty-contactId signal;
+      // PII (email) is no longer logged here per the namespace standardization.
+      expect(logError).toHaveBeenCalledWith(
+        'emailService:sendCustomerContactAutoReply-skippedEmptyContactId',
+        null,
       );
-      expect(skipCall).toBeDefined();
-      // The warn payload must include the customer email — that's the only
-      // breadcrumb tying the skipped log line back to a specific submission.
-      // Production format: console.warn('...skipped...', { email })
-      const payload = skipCall[1];
-      expect(payload).toMatchObject({ email: 'noreply-skip@example.com' });
     } finally {
       crm.contacts.appendOrCreateContact = real;
-      console.warn = warn;
     }
   });
 });

--- a/tests/emailServiceSecretsF1.test.js
+++ b/tests/emailServiceSecretsF1.test.js
@@ -21,16 +21,34 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { __reset as resetSecrets } from './__mocks__/wix-secrets-backend.js';
 import { __reset as resetCrm, __getEmailLog } from './__mocks__/wix-crm-backend.js';
+
+// cf-n4wy: emailService migrated console.warn (SITE_OWNER_CONTACT_ID secret)
+// → canonical logError. Mock the errorHandler module so this test asserts
+// the tag namespace instead of console.warn.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
 import {
   sendEmail,
   submitSwatchRequest,
   sendOrderNotification,
 } from '../src/backend/emailService.web.js';
+import { logError } from '../src/backend/utils/errorHandler.js';
 
 beforeEach(() => {
   resetSecrets(); // No SITE_OWNER_CONTACT_ID configured in any test below.
   resetCrm();
+  vi.mocked(logError).mockClear();
 });
+
+// Helper: assert that a logError call's tag contains the SITE_OWNER signal.
+function expectOwnerSecretTagLogged() {
+  const found = vi.mocked(logError).mock.calls.find(
+    (call) =>
+      typeof call[0] === 'string' &&
+      call[0].includes('emailService:resolveSiteOwnerContactId'),
+  );
+  expect(found, `expected a resolveSiteOwnerContactId logError; got: ${JSON.stringify(vi.mocked(logError).mock.calls)}`).toBeDefined();
+}
 
 const validContactForm = {
   name: 'Bob Test',
@@ -42,29 +60,21 @@ const validContactForm = {
 
 describe('sendEmail — SITE_OWNER_CONTACT_ID missing (cf-d8ta)', () => {
   it('returns success: true — customer path continues even when owner secret is missing', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await sendEmail(validContactForm);
     expect(res.success).toBe(true);
-    warnSpy.mockRestore();
   });
 
-  it('logs the explicit "SITE_OWNER_CONTACT_ID" warn', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('logs the explicit "SITE_OWNER_CONTACT_ID" warn (via canonical logError tag)', async () => {
     await sendEmail(validContactForm);
-    const warnings = warnSpy.mock.calls.map((args) => args.map(String).join(' '));
-    const found = warnings.find((w) => w.includes('SITE_OWNER_CONTACT_ID'));
-    expect(found, `expected explicit SITE_OWNER_CONTACT_ID warn; got: ${JSON.stringify(warnings)}`).toBeDefined();
-    warnSpy.mockRestore();
+    expectOwnerSecretTagLogged();
   });
 
   it('does NOT emit an owner-notification email (customer auto-reply may still fire)', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await sendEmail(validContactForm);
     // With rennala's "continue customer path" behavior, the customer auto-reply
     // can fire even when the owner secret is missing. Only the owner email is
     // skipped. If owner email were also sent, log would have 2 entries.
     expect(__getEmailLog().length).toBeLessThanOrEqual(1);
-    warnSpy.mockRestore();
   });
 });
 
@@ -79,20 +89,13 @@ describe('submitSwatchRequest — SITE_OWNER_CONTACT_ID missing (cf-d8ta)', () =
   };
 
   it('returns success: true — customer path continues even when owner secret is missing', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await submitSwatchRequest(validRequest);
     expect(res.success).toBe(true);
-    warnSpy.mockRestore();
   });
 
-  it('logs the explicit "SITE_OWNER_CONTACT_ID" warn', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('logs the explicit "SITE_OWNER_CONTACT_ID" warn (via canonical logError tag)', async () => {
     await submitSwatchRequest(validRequest);
-    const found = warnSpy.mock.calls
-      .map((args) => args.map(String).join(' '))
-      .find((w) => w.includes('SITE_OWNER_CONTACT_ID'));
-    expect(found).toBeDefined();
-    warnSpy.mockRestore();
+    expectOwnerSecretTagLogged();
   });
 });
 
@@ -105,19 +108,12 @@ describe('sendOrderNotification — SITE_OWNER_CONTACT_ID missing (cf-d8ta)', ()
   };
 
   it('returns { success: false, reason: "site_owner_contact_id_missing" } without throwing', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await sendOrderNotification(validOrder);
     expect(res).toEqual({ success: false, reason: 'site_owner_contact_id_missing' });
-    warnSpy.mockRestore();
   });
 
-  it('logs the explicit "SITE_OWNER_CONTACT_ID" warn', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('logs the explicit "SITE_OWNER_CONTACT_ID" warn (via canonical logError tag)', async () => {
     await sendOrderNotification(validOrder);
-    const found = warnSpy.mock.calls
-      .map((args) => args.map(String).join(' '))
-      .find((w) => w.includes('SITE_OWNER_CONTACT_ID'));
-    expect(found).toBeDefined();
-    warnSpy.mockRestore();
+    expectOwnerSecretTagLogged();
   });
 });

--- a/tests/facebookCatalogAlert.test.js
+++ b/tests/facebookCatalogAlert.test.js
@@ -7,6 +7,11 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { __seed, __reset, __setQueryError } from './__mocks__/wix-data.js';
 
+// cf-n4wy: facebookCatalog migrated console.warn/error → canonical logError.
+// Mock the module so refresh-failure/refresh-error assertions can target tags.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
+
 // ── jobs.config cron registration ─────────────────────────────────────────
 
 describe('Facebook Catalog — Cron Registration', () => {
@@ -98,16 +103,14 @@ describe('refreshFacebookCatalog — failure alert', () => {
 
   beforeEach(() => {
     __reset();
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('reports failed > 0 and logs a warning when products fail validation', async () => {
+  it('reports failed > 0 and logs canonical failures tag when products fail validation', async () => {
     // Seed products that fail catalog validation (missing name, price, image)
     __seed('Stores/Products', [
       { _id: 'bad-1', name: '', price: null, slug: '' },
@@ -119,10 +122,10 @@ describe('refreshFacebookCatalog — failure alert', () => {
     expect(result.failed).toBeGreaterThan(0);
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.success).toBe(false);
-    // Warning should be logged when failures occur
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[facebookCatalog]'),
-      expect.stringContaining('failed'),
+    // cf-n4wy: canonical logError tag replaces the previous console.warn
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('facebookCatalog:refreshFacebookCatalog-failures'),
+      null,
     );
   });
 
@@ -136,19 +139,24 @@ describe('refreshFacebookCatalog — failure alert', () => {
 
     expect(result.failed).toBe(0);
     expect(result.success).toBe(true);
-    expect(console.warn).not.toHaveBeenCalled();
+    // No -failures tag should fire on a clean run (a -complete info tag is allowed)
+    const failureTagCalls = vi.mocked(logError).mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('-failures'),
+    );
+    expect(failureTagCalls).toEqual([]);
   });
 
-  it('returns success: false and logs error when wixData.query throws', async () => {
+  it('returns success: false and logs canonical refresh tag when wixData.query throws', async () => {
     __setQueryError('Stores/Products', new Error('DB connection timeout'));
 
     const result = await refreshFacebookCatalog();
 
     expect(result.success).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('[facebookCatalog]'),
-      expect.stringContaining('catalog refresh failed'),
+    // cf-n4wy: outer catch logs via canonical logError
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('facebookCatalog:refreshFacebookCatalog'),
+      null,
     );
   });
 });

--- a/tests/facebookCatalogHarden.test.js
+++ b/tests/facebookCatalogHarden.test.js
@@ -11,6 +11,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
 import { __seed, __reset, __setQueryError } from './__mocks__/wix-data.js';
 
+// cf-n4wy: facebookCatalog migrated console.warn (validation-failures alert) →
+// canonical logError. Mock so this harden test asserts the canonical tag.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
+
 // ═══════════════════════════════════════════════════════════════════════
 // refreshFacebookCatalog — "all products fail" (product count = 0 processed)
 // ═══════════════════════════════════════════════════════════════════════
@@ -24,9 +29,7 @@ describe('refreshFacebookCatalog — all products fail validation (product count
 
   beforeEach(() => {
     __reset();
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
   });
 
   afterEach(() => {
@@ -48,7 +51,7 @@ describe('refreshFacebookCatalog — all products fail validation (product count
     expect(result.success).toBe(false);
   });
 
-  it('error alert fires (console.warn) when all products fail and processed = 0', async () => {
+  it('error alert fires via canonical logError tag when all products fail and processed = 0', async () => {
     __seed('Stores/Products', [
       { _id: 'bad-1', name: '', price: null, slug: '' },
       { _id: 'bad-2', name: '', price: null, slug: '' },
@@ -56,13 +59,13 @@ describe('refreshFacebookCatalog — all products fail validation (product count
 
     await refreshFacebookCatalog();
 
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[facebookCatalog]'),
-      expect.stringContaining('failed'),
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('facebookCatalog:refreshFacebookCatalog-failures'),
+      null,
     );
   });
 
-  it('error alert message includes the failure count', async () => {
+  it('error alert tag includes the failure count', async () => {
     __seed('Stores/Products', [
       { _id: 'bad-1', name: '', price: null, slug: '' },
       { _id: 'bad-2', name: '', price: null, slug: '' },
@@ -71,9 +74,13 @@ describe('refreshFacebookCatalog — all products fail validation (product count
 
     await refreshFacebookCatalog();
 
-    const warnCall = console.warn.mock.calls[0];
-    // Second arg is the message string that includes the count
-    expect(warnCall[1]).toMatch(/3 product/);
+    // Find the -failures tag emitted by refreshFacebookCatalog; its body
+    // carries the failure count in the message text.
+    const failureCall = vi.mocked(logError).mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('-failures'),
+    );
+    expect(failureCall).toBeTruthy();
+    expect(failureCall[0]).toMatch(/3 product/);
   });
 
   it('safeNotify swallows notifyOwner errors — result is still returned', async () => {

--- a/tests/gamificationCoreWebMethods.test.js
+++ b/tests/gamificationCoreWebMethods.test.js
@@ -86,6 +86,12 @@ vi.mock('wix-secrets-backend', () => ({
   getSecret: vi.fn(() => Promise.resolve('test-secret')),
 }));
 
+// cf-n4wy: gamificationCore migrated console.warn no-memberId guards →
+// canonical logError. Mock the errorHandler module so the cf-1y7
+// null-member guard cascade tests can spy on the tag namespace instead
+// of console.warn.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
 // ── Import after mocks ──────────────────────────────────────────────
 
 import {
@@ -97,6 +103,7 @@ import {
   getActiveChallengeOfWeek,
   computeTierInfo,
 } from '../src/backend/gamificationCore.web.js';
+import { logError } from '../src/backend/utils/errorHandler.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -287,8 +294,8 @@ describe('getActivityFeed', () => {
 
 describe('cf-1y7 null-member guard cascade', () => {
   describe('getStreakData', () => {
-    it('returns zero-streak baseline + error: auth_required + warns when memberId is null', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('returns zero-streak baseline + error: auth_required + logs canonical tag when memberId is null', async () => {
+      vi.mocked(logError).mockClear();
       const result = await getStreakData(null);
       expect(result).toEqual({
         currentStreak: 0,
@@ -296,19 +303,19 @@ describe('cf-1y7 null-member guard cascade', () => {
         lastActivityDate: null,
         error: 'auth_required',
       });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[gamificationCore] getStreakData: no memberId on session'),
+      // cf-n4wy: migrated to canonical logError tag
+      expect(logError).toHaveBeenCalledWith(
+        'gamificationCore:getStreakData-noMemberId',
+        null,
       );
-      warnSpy.mockRestore();
     });
 
-    it('returns zero-streak baseline + error: auth_required + warns when memberId is undefined', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('returns zero-streak baseline + error: auth_required + logs when memberId is undefined', async () => {
+      vi.mocked(logError).mockClear();
       const result = await getStreakData();
       expect(result.error).toBe('auth_required');
       expect(result.currentStreak).toBe(0);
-      expect(warnSpy).toHaveBeenCalled();
-      warnSpy.mockRestore();
+      expect(logError).toHaveBeenCalled();
     });
 
     it('omits error field on successful authenticated read', async () => {
@@ -320,15 +327,15 @@ describe('cf-1y7 null-member guard cascade', () => {
   });
 
   describe('getMemberTier', () => {
-    it('returns lowest-tier baseline + error: auth_required + warns when memberId is null', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('returns lowest-tier baseline + error: auth_required + logs canonical tag when memberId is null', async () => {
+      vi.mocked(logError).mockClear();
       const result = await getMemberTier(null);
       expect(result.tierName).toBe('Trail Blazer'); // computeTierInfo(0) baseline preserved
       expect(result.error).toBe('auth_required');
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[gamificationCore] getMemberTier: no memberId on session'),
+      expect(logError).toHaveBeenCalledWith(
+        'gamificationCore:getMemberTier-noMemberId',
+        null,
       );
-      warnSpy.mockRestore();
     });
 
     it('omits error field on successful authenticated read', async () => {
@@ -339,14 +346,14 @@ describe('cf-1y7 null-member guard cascade', () => {
   });
 
   describe('getActiveChallenges', () => {
-    it('returns { challenges: [], error: auth_required } + warns when memberId is null', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('returns { challenges: [], error: auth_required } + logs canonical tag when memberId is null', async () => {
+      vi.mocked(logError).mockClear();
       const result = await getActiveChallenges(null);
       expect(result).toEqual({ challenges: [], error: 'auth_required' });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[gamificationCore] getActiveChallenges: no memberId on session'),
+      expect(logError).toHaveBeenCalledWith(
+        'gamificationCore:getActiveChallenges-noMemberId',
+        null,
       );
-      warnSpy.mockRestore();
     });
 
     it('omits error field on successful authenticated call', async () => {
@@ -381,38 +388,38 @@ describe('cf-1y7 null-member guard cascade', () => {
     });
   });
 
-  describe('getActivityFeed (Array-return, warn-only observability)', () => {
+  describe('getActivityFeed (Array-return, observability via canonical logError)', () => {
     // Consumer compat: this handler returns Array, so error-object shape would
-    // be a breaking change. We preserve Array return but add dev-only warns at
-    // the two silent branches so auth/IDOR leaks surface in Wix runtime logs.
-    it('warns distinctly when no member is authenticated (auth_required)', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // be a breaking change. We preserve Array return but log at the two
+    // silent branches via canonical logError so auth/IDOR leaks surface in
+    // Wix runtime logs (cf-n4wy migrated from console.warn).
+    it('logs auth_required tag when no member is authenticated', async () => {
+      vi.mocked(logError).mockClear();
       __mockMemberId = null;
       const result = await getActivityFeed('mem-1');
       expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[gamificationCore] getActivityFeed: no member on session (auth_required)'),
+      expect(logError).toHaveBeenCalledWith(
+        'gamificationCore:getActivityFeed-authRequired',
+        null,
       );
-      warnSpy.mockRestore();
     });
 
-    it('warns distinctly when caller does not match memberId (forbidden)', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs forbidden tag when caller does not match memberId', async () => {
+      vi.mocked(logError).mockClear();
       __mockMemberId = 'other-member';
       const result = await getActivityFeed('mem-1');
       expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[gamificationCore] getActivityFeed: caller/memberId mismatch (forbidden)'),
+      expect(logError).toHaveBeenCalledWith(
+        'gamificationCore:getActivityFeed-forbidden',
+        null,
       );
-      warnSpy.mockRestore();
     });
 
-    it('does NOT warn on legitimate authenticated call', async () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('does NOT log on legitimate authenticated call', async () => {
+      vi.mocked(logError).mockClear();
       __mockMemberId = 'mem-1';
       await getActivityFeed('mem-1');
-      expect(warnSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
+      expect(logError).not.toHaveBeenCalled();
     });
   });
 });
@@ -518,16 +525,17 @@ describe('getActiveChallengeOfWeek (cf-16h: discriminable progressStatus)', () =
     membersMod.currentMember.getMember = vi.fn(() =>
       Promise.reject(new Error('wix-members-backend transient failure')),
     );
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     try {
       const result = await getActiveChallengeOfWeek();
       expect(result.progressStatus).toBe('unavailable');
       expect(result.progressValue).toBe(0);
-      // errorHandler silent-mute downgrades to console.warn (cf-n54)
-      expect(warnSpy).toHaveBeenCalled();
+      // cf-n4wy: errorHandler is mocked at module scope; the failure path
+      // calls logError, which the mock records (replacing the old
+      // console.warn-downgrade indirection).
+      expect(logError).toHaveBeenCalled();
     } finally {
       membersMod.currentMember.getMember = origGetMember;
-      warnSpy.mockRestore();
     }
   });
 });

--- a/tests/styleConsultant.test.js
+++ b/tests/styleConsultant.test.js
@@ -28,6 +28,11 @@ import {
 import { __reset as resetFetch, __setHandler } from './__mocks__/wix-fetch.js';
 import { __reset as resetSecrets, __setSecrets } from './__mocks__/wix-secrets-backend.js';
 
+// cf-n4wy: styleConsultant migrated console.warn (photo URL conversion) →
+// canonical logError. Mock the errorHandler module so the photo-URL test
+// can assert on the canonical tag instead of console.warn.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
 import {
   getStyleConsultation,
   _getProductRecommendations,
@@ -35,6 +40,7 @@ import {
   _callClaudeVision,
   _wixMediaToCdnUrl,
 } from '../src/backend/styleConsultant.web.js';
+import { logError } from '../src/backend/utils/errorHandler.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -641,9 +647,9 @@ describe('_callClaudeVision — real implementation', () => {
     expect(result.explanation).toBe('');
   });
 
-  it('omits image block and warns when photo URL cannot be converted to CDN URL', async () => {
+  it('omits image block and logs canonical tag when photo URL cannot be converted to CDN URL', async () => {
     const captured = [];
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
     __setHandler((_url, opts) => {
       captured.push(JSON.parse(opts.body));
       return makeClaudeResponse(['modern'], 'Modern.');
@@ -654,11 +660,13 @@ describe('_callClaudeVision — real implementation', () => {
 
     const content = captured[0].messages[0].content;
     expect(content.every(b => b.type !== 'image')).toBe(true);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[styleConsultant]'),
-      expect.stringContaining('wix:document://')
+    // cf-n4wy: canonical logError tag with the photoUrl in the tag body
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('styleConsultant:callClaudeVision-photoUrlConversionFailed'),
+      null,
     );
-    warnSpy.mockRestore();
+    const tag = vi.mocked(logError).mock.calls[0][0];
+    expect(tag).toContain('wix:document://');
   });
 
   it('uses generic text prompt when photo conversion fails (no "room photo" reference)', async () => {

--- a/tests/swatchKitService.test.js
+++ b/tests/swatchKitService.test.js
@@ -31,6 +31,11 @@ vi.mock('wix-members-backend', () => ({
   currentMember: { getMember: () => mockGetMember() },
 }));
 
+// cf-n4wy: swatchKitService migrated console.warn no-member guard →
+// canonical logError. Mock so the cf-2ag auth-required test can assert
+// the tag namespace.
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
 import {
   orderContainsSwatchKit,
   isQualifyingOrder,
@@ -42,6 +47,7 @@ import {
   QUALIFYING_ORDER_MIN,
   CREDIT_EXPIRY_DAYS,
 } from '../src/backend/swatchKitService.web.js';
+import { logError } from '../src/backend/utils/errorHandler.js';
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -257,15 +263,16 @@ describe('getSwatchKitCreditStatus', () => {
   it.each([
     ['null', null],
     ['no _id', {}],
-  ])('returns auth_required + warns when getMember returns %s (cf-2ag)', async (_label, memberValue) => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  ])('returns auth_required + logs canonical tag when getMember returns %s (cf-2ag)', async (_label, memberValue) => {
+    vi.mocked(logError).mockClear();
     mockGetMember.mockResolvedValue(memberValue);
     const result = await getSwatchKitCreditStatus();
     expect(result).toEqual({ hasPendingCredit: false, error: 'auth_required' });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[swatchKitService] getSwatchKitCreditStatus: no member on session'),
+    // cf-n4wy: canonical logError tag replaces the previous bracket-prefix console.warn
+    expect(logError).toHaveBeenCalledWith(
+      'swatchKitService:getSwatchKitCreditStatus-noMember',
+      null,
     );
-    warnSpy.mockRestore();
   });
 
   it('returns pending credit details when found', async () => {


### PR DESCRIPTION
## Summary

Convoy continuation of cf-44qt logger sweep after cf-i8b4 batch-M (PR #1459) and cf-06ug batch-N (PR #1474). Migrates **44 console.* sites across 8 files** to canonical `logError(tag, err)` with `<module>:<fn>-<reason>` namespace.

### Files (44 migrations)

- `swatchKitService.web.js` (7) — credit issue + status + apply, with manual-reconciliation tag
- `facebookCatalog.web.js` (6) — buildCatalogBatch + refresh + customer-audience export
- `couponsService.web.js` (6) — birthday + tier-upgrade + recovery + collision-check
- `videoReviewService.web.js` (5) — submit + get + moderate + product + count
- `swatchRequest.web.js` (5) — submitSwatchRequest pathways + resolveSwatchNames-notFound
- `styleConsultant.web.js` (5) — `callClaudeVision-photoUrlConversionFailed` + 4 catches inside getStyleConsultation
- `gamificationCore.web.js` (5) — cf-1y7 null-member guards (challenges/streak/tier/activityFeed×2)
- `emailService.web.js` (5) — rate-limit failed-open + SITE_OWNER secrets (×2) + customer auto-reply (×2)

### Ripple-test updates (11 tests)

Tests that previously pinned `console.warn` / `console.error` now spy on canonical `logError` via `vi.mock('backend/utils/errorHandler')`:

- `gamificationCoreWebMethods.test.js` — cf-1y7 cascade (6) + cf-n54 throw-classification
- `styleConsultant.test.js` — photo URL conversion
- `swatchKitService.test.js` — cf-2ag auth_required (×2)
- `facebookCatalog{Alert,Harden}.test.js` — 5 assertions
- `contactFormAutoReply.cfhafn.test.js` — auto-reply non-blocking + skip-on-empty
- `emailService{,Coverage,SecretsF1}.test.js` — SITE_OWNER + triggeredEmails-throw paths
- `cartRecoveryCoupon.test.js` — RecoveryCoupons insert

## De-conflicting

Original ~20-file candidate set shrank to 8 after checking the open-PR queue (searchService #1462, customizationService #1466, roomPlanner #1438, roomStaging #1461, contentScheduler #1454, virtualConsultation, cartRecovery, browseAbandonment all in flight by other crew).

## Test plan

- [x] New `tests/cf-n4wy-batchO-LogErrorMigration.test.js` (61 tests): per-file canonical-import + per-tag logError regex + 44-site summary
- [x] All 11 ripple-test updates landed in the same commit
- [x] Full suite: **net-neutral on regressions** (28 failures = same pre-existing pollution as the batch-N baseline)
- [x] Pre-existing failures unchanged: priceMatchServiceLogError (stale aspirational tags), buyingGuides/buyingGuidesLogErrorMigration / cf-44qt-sibling-analyticsDashboard / cf-44qt-sibling-buyingGuides / analyticsHelpers / cf-44qt-logError-batch4 (all in files outside batch-O scope)

Auto-merge class · 5-agent review per 2026-05-15 mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)