### PR TITLE
fix(cf-contentscheduler-logerror): contentScheduler.web.js — 5 console.error → logError

### DIFF
--- a/src/backend/contentScheduler.web.js
+++ b/src/backend/contentScheduler.web.js
@@ -17,6 +17,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const DEDUP_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -148,7 +149,7 @@ export const processContentSchedule = webMethod(
         } catch (actionErr) {
           item.status = 'failed';
           item.error = 'Processing error';
-          console.error(`[contentScheduler] Action failed for ${item._id}:`, actionErr);
+          logError(`contentScheduler:processContentSchedule-action item=${item._id}`, actionErr);
         }
 
         item.processedAt = now;
@@ -159,7 +160,7 @@ export const processContentSchedule = webMethod(
 
       return { success: true, processed, failed, skipped };
     } catch (err) {
-      console.error('[contentScheduler] Error processing schedule:', err);
+      logError('contentScheduler:processContentSchedule', err);
       return { success: false, error: 'Failed to process schedule.', processed: 0, failed: 0, skipped: 0 };
     }
   }
@@ -191,7 +192,7 @@ export const getScheduleQueue = webMethod(
 
       return { success: true, items: result.items };
     } catch (err) {
-      console.error('[contentScheduler] Error getting queue:', err);
+      logError('contentScheduler:getScheduleQueue', err);
       return { success: false, error: err.message || 'Failed to get queue.', items: [] };
     }
   }
@@ -228,7 +229,7 @@ export const cancelScheduledItem = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[contentScheduler] Error cancelling item:', err);
+      logError('contentScheduler:cancelScheduledItem', err);
       return { success: false, error: err.message || 'Failed to cancel item.' };
     }
   }
@@ -260,7 +261,7 @@ export const getScheduleStats = webMethod(
 
       return { success: true, stats };
     } catch (err) {
-      console.error('[contentScheduler] Error getting stats:', err);
+      logError('contentScheduler:getScheduleStats', err);
       return { success: false, error: err.message || 'Failed to get stats.', stats: {} };
     }
   }

--- a/tests/contentSchedulerLogErrorMigration.test.js
+++ b/tests/contentSchedulerLogErrorMigration.test.js
@@ -1,0 +1,50 @@
+/**
+ * cf-contentscheduler-logerror — pins console.error → logError migration
+ * in src/backend/contentScheduler.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/contentScheduler.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_PREFIXES = [
+  'contentScheduler:processContentSchedule-action',
+  'contentScheduler:processContentSchedule',
+  'contentScheduler:getScheduleQueue',
+  'contentScheduler:cancelScheduledItem',
+  'contentScheduler:getScheduleStats',
+];
+
+describe('cf-contentscheduler-logerror — contentScheduler.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_PREFIXES)('uses logError tag prefix %s', (prefix) => {
+    expect(SRC).toContain(prefix);
+  });
+
+  it('drift guard — every logError call uses the contentScheduler: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(5);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('contentScheduler:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without contentScheduler: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 27th PR in burst.

## Swaps (5 sites in contentScheduler.web.js)

- `processContentSchedule` action inner catch → `` `contentScheduler:processContentSchedule-action item=${item._id}` `` (template-literal w/ item id)
- `processContentSchedule` outer catch → `contentScheduler:processContentSchedule`
- `getScheduleQueue`, `cancelScheduledItem`, `getScheduleStats` → all under `contentScheduler:<fn>`

## Verification

- New migration test: **8/8** ✅
- contentScheduler suite green

Auto-merge eligible on CI green.
