### PR TITLE
fix(cf-completethelook-logerror): completeTheLookService.web.js — 3 console.error → logError

### DIFF
--- a/src/backend/completeTheLookService.web.js
+++ b/src/backend/completeTheLookService.web.js
@@ -9,6 +9,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { validateId, isWixMediaUrl } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'CompleteTheLook';
 const MAX_ITEMS = 12;
@@ -50,7 +51,7 @@ export const getCompleteTheLook = webMethod(
         roomItems: normalizeItems(look.roomItems),
       };
     } catch (err) {
-      console.error('[completeTheLookService] getCompleteTheLook failed', err);
+      logError('completeTheLookService:getCompleteTheLook', err);
       return null;
     }
   }
@@ -79,7 +80,7 @@ export const createLook = webMethod(
       }, { suppressAuth: true });
       return { success: true, look };
     } catch (err) {
-      console.error('[completeTheLookService] createLook failed', err);
+      logError('completeTheLookService:createLook', err);
       return { success: false, error: 'insert-failed' };
     }
   }
@@ -115,7 +116,7 @@ export const updateLook = webMethod(
       }, { suppressAuth: true });
       return { success: true, look };
     } catch (err) {
-      console.error('[completeTheLookService] updateLook failed', err);
+      logError('completeTheLookService:updateLook', err);
       return { success: false, error: 'update-failed' };
     }
   }

--- a/tests/completeTheLookServiceLogErrorMigration.test.js
+++ b/tests/completeTheLookServiceLogErrorMigration.test.js
@@ -1,0 +1,48 @@
+/**
+ * cf-completethelook-logerror — pins console.error → logError migration
+ * in src/backend/completeTheLookService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/completeTheLookService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'completeTheLookService:getCompleteTheLook',
+  'completeTheLookService:createLook',
+  'completeTheLookService:updateLook',
+];
+
+describe('cf-completethelook-logerror — completeTheLookService.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the completeTheLookService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(3);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('completeTheLookService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without completeTheLookService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 28th PR in burst.

## Swaps (3 sites in completeTheLookService.web.js)

- `getCompleteTheLook`, `createLook`, `updateLook` → all under `completeTheLookService:<fn>`

## Verification

- New migration test: **6/6** ✅
- completeTheLook suite green

Auto-merge eligible on CI green.
