### PR TITLE
fix(cf-44qt sibling): facebookCatalog.web.js console.error → logError ×4

### DIFF
--- a/src/backend/facebookCatalog.web.js
+++ b/src/backend/facebookCatalog.web.js
@@ -19,6 +19,7 @@ import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
 import { getImageUrl } from 'backend/utils/mediaHelpers';
 import { notifyOwner } from 'backend/notificationService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -493,7 +494,7 @@ export function buildCatalogBatch(products) {
       });
       processed++;
     } catch (err) {
-      console.error('[facebookCatalog] buildCatalogBatch product error:', err);
+      logError('[facebookCatalog] buildCatalogBatch product', err);
       failed++;
       errors.push({
         productId: product?._id || 'unknown',
@@ -544,7 +545,7 @@ export const refreshFacebookCatalog = webMethod(
       try {
         await notifyOwner(subject, msg);
       } catch (notifyErr) {
-        console.error('[facebookCatalog] notifyOwner failed:', notifyErr?.message);
+        logError('[facebookCatalog] notifyOwner failed', notifyErr);
       }
     }
 
@@ -582,7 +583,7 @@ export const refreshFacebookCatalog = webMethod(
       return summary;
     } catch (err) {
       const msg = `catalog refresh failed: ${err?.message ?? String(err)}`;
-      console.error('[facebookCatalog] refreshFacebookCatalog error:', msg);
+      logError('[facebookCatalog] refreshFacebookCatalog', msg);
       await safeNotify('facebook catalog sync — cron error', msg);
       return { success: false, processed, failed, errors: [msg] };
     }
@@ -652,7 +653,7 @@ export const exportCustomerAudienceData = webMethod(
         customers: Array.from(customerMap.values()),
       };
     } catch (err) {
-      console.error('exportCustomerAudienceData error:', err);
+      logError('[facebookCatalog] exportCustomerAudienceData', err);
       return { success: false, customers: [], error: 'Failed to export audience data' };
     }
   }

--- a/tests/cf-44qt-sibling-fbCatalog-logError.test.js
+++ b/tests/cf-44qt-sibling-fbCatalog-logError.test.js
@@ -1,0 +1,51 @@
+/**
+ * @file cf-44qt-sibling-fbCatalog-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 4
+ * console.error sites in src/backend/facebookCatalog.web.js
+ * migrated to canonical logError.
+ *
+ * Sites migrated (4):
+ *   - buildCatalogBatch product error (L496)
+ *   - notifyOwner failed (L547)
+ *   - refreshFacebookCatalog (L585)
+ *   - exportCustomerAudienceData (L655) — pre-fix lacked [module] prefix
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/facebookCatalog.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — facebookCatalog.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 4 expected sites with canonical [facebookCatalog] prefix', () => {
+    const labels = [
+      'buildCatalogBatch product',
+      'notifyOwner failed',
+      'refreshFacebookCatalog',
+      'exportCustomerAudienceData',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[facebookCatalog\\] ${label.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 4 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
4 sites migrated. [facebookCatalog] prefix already canonical on 3/4; exportCustomerAudienceData (L655) lacked the prefix pre-fix — migration adds it. Sites: buildCatalogBatch product (L496), notifyOwner failed (L547), refreshFacebookCatalog (L585), exportCustomerAudienceData (L655). 3 source-grep TDD pins. Auto-merge eligible.