### PR TITLE
fix(cf-44qt sibling): priceDropCron.web.js console.error → logError ×4 (P3 obs cleanup)

### DIFF
--- a/src/backend/priceDropCron.web.js
+++ b/src/backend/priceDropCron.web.js
@@ -38,6 +38,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { triggeredEmails } from 'wix-crm-backend';
 import { getSubscribers } from 'backend/priceAlertService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 const PRICE_HISTORY_COLLECTION = 'ProductPriceHistory';
 const PRICE_DROP_QUEUE_COLLECTION = 'PriceDropQueue';
@@ -111,7 +112,7 @@ export const detectPriceDrops = webMethod(
         emailsQueued,
       };
     } catch (err) {
-      console.error('[priceDropCron] detectPriceDrops failed:', err?.message);
+      logError('[priceDropCron] detectPriceDrops failed', err);
       return { success: false, productsScanned: 0, dropsDetected: 0, notificationsSent: 0, emailsQueued: 0 };
     }
   }
@@ -139,7 +140,7 @@ export const queuePriceDropNotifications = webMethod(
       const sent = await notifyWishlistedMembers(productId, oldPrice, newPrice, pctDrop);
       return { success: true, notificationsSent: sent };
     } catch (err) {
-      console.error('[priceDropCron] queuePriceDropNotifications failed:', err?.message);
+      logError('[priceDropCron] queuePriceDropNotifications failed', err);
       return { success: false, notificationsSent: 0 };
     }
   }
@@ -282,7 +283,7 @@ async function notifyWishlistedMembers(productId, oldPrice, newPrice, pctDrop) {
       );
       sent++;
     } catch (err) {
-      console.error('[priceDropCron] Failed to notify member:', wishItem.memberId, err?.message);
+      logError(`[priceDropCron] queuePriceDropNotifications per-member notify failed for ${wishItem.memberId}`, err);
     }
   }
 
@@ -355,7 +356,7 @@ async function emailPriceAlertSubscribers(productId, productName, productSlug, o
       );
       sent++;
     } catch (emailErr) {
-      console.error('[priceDropCron] Failed to send email to member:', sub.memberId, emailErr?.message);
+      logError(`[priceDropCron] sendPriceDropEmail per-subscriber failed for ${sub.memberId}`, emailErr);
     }
   }
 

--- a/tests/priceDropCron.test.js
+++ b/tests/priceDropCron.test.js
@@ -20,6 +20,9 @@
  * - Error resilience: wixData failures return success:false
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
 import {
   __reset,
   __seed,
@@ -85,7 +88,7 @@ beforeEach(() => {
   __resetCrm();
   __setMember({ _id: 'system' });
   __setRoles([{ title: 'Admin' }]);
-  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.mocked(logError).mockClear();
   vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
@@ -482,9 +485,9 @@ describe('detectPriceDrops — error resilience', () => {
     __setQueryError('Stores/Products', new Error('boom'));
 
     await detectPriceDrops();
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('[priceDropCron] detectPriceDrops failed:'),
-      expect.any(String)
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[priceDropCron] detectPriceDrops failed'),
+      expect.any(Error)
     );
   });
 });

--- a/tests/priceDropCronSilentFailureCleanup.test.js
+++ b/tests/priceDropCronSilentFailureCleanup.test.js
@@ -1,0 +1,64 @@
+/**
+ * cf-44qt sibling — priceDropCron.web.js observability cleanup.
+ *
+ * Pins post-migration contract: catches in both webMethods + inner
+ * per-member catches all call `logError('[priceDropCron] <fn> failed', err)`.
+ *
+ * 2 tests cover the 2 webMethods' outer catches via __setQueryError
+ * on Stores/Products. The 2 inner per-member catches use dynamic
+ * `${memberId}` context (mirrors warrantyService PR #1392 + scheduler
+ * PR #1454 pattern) and are mechanically verified via the migration
+ * diff; runtime-pinning the per-member catch would require richer
+ * mock orchestration than scope warrants.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-crm-backend', () => ({
+  triggeredEmails: { emailContact: vi.fn(async () => ({})) },
+}));
+vi.mock('backend/priceAlertService.web', () => ({
+  getSubscribers: vi.fn(async () => []),
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — priceDropCron.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('detectPriceDrops wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/priceDropCron.web.js');
+    await mod.detectPriceDrops();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/priceDropCron/);
+    expect(allTags).toMatch(/detectPriceDrops/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('queuePriceDropNotifications wires logError on Wishlist query throw via notifyWishlistedMembers', async () => {
+    // notifyWishlistedMembers queries Wishlist for wishlisters; injecting
+    // a query error there fires the outer catch.
+    __setQueryError('Wishlist', new Error('wixData query failure'));
+    const mod = await import('../src/backend/priceDropCron.web.js');
+    await mod.queuePriceDropNotifications('p-1', 1000, 800);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/priceDropCron/);
+    expect(allTags).toMatch(/queuePriceDropNotifications/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — priceDropCron.web.js console.error → logError × 4 + 2 TDD pins. 11th same-pattern sibling.

## Migrations

| Site | New logError tag |
|---|---|
| detectPriceDrops outer | `[priceDropCron] detectPriceDrops failed` |
| queuePriceDropNotifications outer | `[priceDropCron] queuePriceDropNotifications failed` |
| notifyWishlistedMembers per-member inner | `[priceDropCron] queuePriceDropNotifications per-member notify failed for ${wishItem.memberId}` (dynamic) |
| sendPriceDropEmail per-subscriber inner | `[priceDropCron] sendPriceDropEmail per-subscriber failed for ${sub.memberId}` (dynamic) |

## TDD shape (2/2 green + 2 inner-catch documented gaps)

`tests/priceDropCronSilentFailureCleanup.test.js`:
- Top-level vi.mock per CF-fgsw
- 2 tests cover both webMethods' outer catches:
  - detectPriceDrops via `__setQueryError('Stores/Products', err)`
  - queuePriceDropNotifications via `__setQueryError('Wishlist', err)` (inside notifyWishlistedMembers)

**Documented gaps**: the 2 inner per-member/per-subscriber catches use dynamic-id tags; mechanically verified via diff but no runtime pin (same gap-shape as PR #1454 / #1467 inner catches).

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 2/2 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- 10 prior cluster PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
