### PR TITLE
fix(cf-storecredit-logerror): storeCreditService.web.js — 6 console.error → logError

### DIFF
--- a/src/backend/storeCreditService.web.js
+++ b/src/backend/storeCreditService.web.js
@@ -21,6 +21,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -101,7 +102,7 @@ export const issueStoreCredit = webMethod(
         expirationDate: expirationDate.toISOString(),
       };
     } catch (err) {
-      console.error('[storeCreditService] Error issuing store credit:', err);
+      logError('storeCreditService:issueStoreCredit', err);
       return { success: false, message: 'Failed to issue store credit.' };
     }
   }
@@ -167,7 +168,7 @@ export const getMyStoreCredit = webMethod(
         credits: activeCredits,
       };
     } catch (err) {
-      console.error('[storeCreditService] Error getting store credit:', err);
+      logError('storeCreditService:getMyStoreCredit', err);
       return { success: false, message: 'Failed to retrieve store credit.' };
     }
   }
@@ -259,7 +260,7 @@ export const applyStoreCredit = webMethod(
         creditsUsed,
       };
     } catch (err) {
-      console.error('[storeCreditService] Error applying store credit:', err);
+      logError('storeCreditService:applyStoreCredit', err);
       return { success: false, message: 'Failed to apply store credit.' };
     }
   }
@@ -313,7 +314,7 @@ export const getStoreCreditHistory = webMethod(
 
       return { success: true, credits };
     } catch (err) {
-      console.error('[storeCreditService] Error getting credit history:', err);
+      logError('storeCreditService:getStoreCreditHistory', err);
       return { success: false, message: 'Failed to retrieve credit history.' };
     }
   }
@@ -442,7 +443,7 @@ export const giftStoreCredit = webMethod(
         newCreditId: newCredit._id,
       };
     } catch (err) {
-      console.error('[storeCreditService] Error gifting store credit:', err);
+      logError('storeCreditService:giftStoreCredit', err);
       return { success: false, message: 'Failed to gift store credit.' };
     }
   }
@@ -501,7 +502,7 @@ export const getExpiringCredits = webMethod(
         expiringTotal,
       };
     } catch (err) {
-      console.error('[storeCreditService] Error getting expiring credits:', err);
+      logError('storeCreditService:getExpiringCredits', err);
       return { success: false, message: 'Failed to retrieve expiring credits.' };
     }
   }

--- a/tests/storeCreditServiceLogErrorMigration.test.js
+++ b/tests/storeCreditServiceLogErrorMigration.test.js
@@ -1,0 +1,51 @@
+/**
+ * cf-storecredit-logerror — pins console.error → logError migration in
+ * src/backend/storeCreditService.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/storeCreditService.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'storeCreditService:issueStoreCredit',
+  'storeCreditService:getMyStoreCredit',
+  'storeCreditService:applyStoreCredit',
+  'storeCreditService:getStoreCreditHistory',
+  'storeCreditService:giftStoreCredit',
+  'storeCreditService:getExpiringCredits',
+];
+
+describe('cf-storecredit-logerror — storeCreditService.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the storeCreditService: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('storeCreditService:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without storeCreditService: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 29th PR in burst.

## Swaps (6 sites in storeCreditService.web.js)

- `issueStoreCredit`, `getMyStoreCredit`, `applyStoreCredit`, `getStoreCreditHistory`, `giftStoreCredit`, `getExpiringCredits` → all under `storeCreditService:<fn>`

## Verification

- New migration test: **9/9** ✅
- storeCredit suite green

Auto-merge eligible on CI green.
