### PR TITLE
fix(cf-44qt sibling): localSeoService.web.js console.error → logError ×4

### DIFF
--- a/src/backend/localSeoService.web.js
+++ b/src/backend/localSeoService.web.js
@@ -21,6 +21,7 @@ import {
 } from 'backend/utils/localSeoData';
 import { generateLocalBusinessSchema, SCHEMA_OPENING_HOURS, STORE_HOURS_DISPLAY } from 'backend/localSeo.web';
 import { buildBreadcrumbSchema, buildBreadcrumbList, buildFaqSchema } from 'public/localSeoHelpers';
+import { logError } from 'backend/utils/errorHandler';
 
 const CMS_COLLECTION = 'LocalSeoCities';
 
@@ -167,7 +168,7 @@ export const getLocalPage = webMethod(
         },
       };
     } catch (err) {
-      console.error('[localSeoService] Error loading local page:', slug, err.name, err.message, err);
+      logError(`[localSeoService] loadLocalPage ${slug}`, err);
       return { success: false, error: 'Failed to load local page.', page: null };
     }
   }
@@ -282,7 +283,7 @@ export const getFeaturedProductsForCity = webMethod(
       const products = await _fetchProductsByCity(cityData, limit);
       return { success: true, products };
     } catch (err) {
-      console.error('[localSeoService] Error loading featured products:', slug, err.name, err.message, err);
+      logError(`[localSeoService] loadFeaturedProducts ${slug}`, err);
       return { success: false, error: 'Failed to load featured products.', products: [] };
     }
   }
@@ -331,7 +332,7 @@ export const getRelatedCityLinks = webMethod(
 
       return { success: true, links };
     } catch (err) {
-      console.error('[localSeoService] Error loading related city links:', slug, err.name, err.message, err);
+      logError(`[localSeoService] loadRelatedCityLinks ${slug}`, err);
       return { success: false, error: 'Failed to load related city links.', links: [] };
     }
   }
@@ -359,7 +360,7 @@ export const getAllLocalSlugs = webMethod(
       const allSlugs = [...new Set([...staticSlugs, ...cmsSlugs])];
       return { success: true, slugs: allSlugs };
     } catch (err) {
-      console.error('[localSeoService] Error getting local slugs:', err.name, err.message, err);
+      logError('[localSeoService] getLocalSlugs', err);
       return { success: false, slugs: [] };
     }
   }

--- a/tests/cf-44qt-sibling-localSeo-logError.test.js
+++ b/tests/cf-44qt-sibling-localSeo-logError.test.js
@@ -1,0 +1,56 @@
+/**
+ * @file cf-44qt-sibling-localSeo-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 4
+ * console.error sites in src/backend/localSeoService.web.js
+ * migrated to canonical logError. Three sites use template-literal
+ * slug interpolation (loadLocalPage / loadFeaturedProducts /
+ * loadRelatedCityLinks); fourth (getLocalSlugs) is fixed.
+ *
+ * Sites migrated (4):
+ *   - loadLocalPage with `${slug}` (L170)
+ *   - loadFeaturedProducts with `${slug}` (L285)
+ *   - loadRelatedCityLinks with `${slug}` (L334)
+ *   - getLocalSlugs (L362)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/localSeoService.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — localSeoService.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError with canonical [localSeoService] prefix on template-literal slug-interp sites', () => {
+    const templateLabels = [
+      'loadLocalPage',
+      'loadFeaturedProducts',
+      'loadRelatedCityLinks',
+    ];
+    for (const label of templateLabels) {
+      const re = new RegExp(
+        `logError\\(\\s*\`\\[localSeoService\\] ${label} \\$\\{slug\\}\``,
+      );
+      expect(SRC).toMatch(re);
+    }
+    // Fixed-label site
+    expect(SRC).toMatch(
+      /logError\(\s*['"]\[localSeoService\] getLocalSlugs['"]/,
+    );
+  });
+
+  it('logError invocation count matches the 4 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
4 sites migrated. [localSeoService] prefix already canonical. 3 sites use template-literal slug interp (loadLocalPage / loadFeaturedProducts / loadRelatedCityLinks); 1 fixed-label (getLocalSlugs). 3 source-grep TDD pins (template-literal regex + fixed-label). Auto-merge eligible.