### PR TITLE
fix(cf-xknq): cf-44qt batch-P — 7-file logger sweep (25 sites)

### DIFF
--- a/src/backend/chatbotService.web.js
+++ b/src/backend/chatbotService.web.js
@@ -121,7 +121,7 @@ export async function _fetchProductCatalog() {
       slug: p.slug || '',
     }));
   } catch (err) {
-    console.warn('[chatbotService] product catalog fetch failed — chatbot will respond without product context:', err?.message);
+    logError('chatbotService:fetchProductCatalog-failed', err);
     return [];
   }
 }
@@ -157,7 +157,7 @@ export const sendMessage = webMethod(
       flagEnabled = flag === 'true';
       apiKey = key;
     } catch (err) {
-      console.warn('[chatbotService] secrets fetch failed:', err?.message);
+      logError('chatbotService:fetchSecrets-failed', err);
       flagEnabled = false;
     }
     if (!flagEnabled) return { enabled: false };
@@ -207,7 +207,7 @@ export const sendMessage = webMethod(
         statsRecord = statsRes.items[0] || null;
       } catch (err) {
         // Fail open — don't block visitors on DB errors
-        console.warn('[chatbotService] daily stats query failed, allowing session:', err?.message);
+        logError('chatbotService:dailyStatsQueryFailed', err);
       }
 
       if ((statsRecord?.sessionCount ?? 0) >= MAX_SESSIONS_PER_DAY) {
@@ -225,7 +225,7 @@ export const sendMessage = webMethod(
           await wixData.insert(DAILY_STATS, { date: todayUTC, sessionCount: 1 });
         }
       } catch (err) {
-        console.warn('[chatbotService] daily stats write failed:', err?.message);
+        logError('chatbotService:dailyStatsWriteFailed', err);
       }
 
       sessionRecord = {

--- a/src/backend/showroomService.web.js
+++ b/src/backend/showroomService.web.js
@@ -7,6 +7,7 @@
  */
 import { webMethod, Permissions } from 'wix-web-module';
 import { getSecret } from 'wix-secrets-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -45,7 +46,7 @@ export const getShowroomBookingUrl = webMethod(Permissions.Anyone, async () => {
       serviceName: 'Book a Showroom Visit',
     };
   } catch (err) {
-    console.error('[showroomService] getShowroomBookingUrl failed:', err);
+    logError('showroomService:getShowroomBookingUrl', err);
     return { error: 'Unable to load booking URL. Please try again.' };
   }
 });
@@ -85,7 +86,7 @@ export const getShowroomEligibleIds = webMethod(Permissions.Anyone, async (produ
       .filter(p => p && isShowroomEligible(p))
       .map(p => p._id);
   } catch (err) {
-    console.error('[showroomService] getShowroomEligibleIds failed:', err);
+    logError('showroomService:getShowroomEligibleIds', err);
     return [];
   }
 });
@@ -124,7 +125,7 @@ export const getShowroomSectionData = webMethod(Permissions.Anyone, async () => 
       mapUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(SHOWROOM_INFO.mapEmbedQuery)}`,
     };
   } catch (err) {
-    console.error('[showroomService] getShowroomSectionData failed:', err);
+    logError('showroomService:getShowroomSectionData', err);
     return { error: 'Unable to load showroom info.' };
   }
 });

--- a/src/backend/sommelierService.web.js
+++ b/src/backend/sommelierService.web.js
@@ -23,6 +23,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -157,7 +158,7 @@ export const getRecommendations = webMethod(
 
       return { success: true, recommendations: scored };
     } catch (err) {
-      console.error('[sommelierService] getRecommendations error:', err);
+      logError('sommelierService:getRecommendations', err);
       return { success: false, recommendations: [], error: 'internal_error' };
     }
   }
@@ -209,7 +210,7 @@ export const savePreferences = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[sommelierService] savePreferences error:', err);
+      logError('sommelierService:savePreferences', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -249,7 +250,7 @@ export const getMyPreferences = webMethod(
         return { success: true, prefs: null };
       }
     } catch (err) {
-      console.error('[sommelierService] getMyPreferences error:', err);
+      logError('sommelierService:getMyPreferences', err);
       return { success: false, prefs: null, error: 'internal_error' };
     }
   }

--- a/src/backend/spinRedemptionService.web.js
+++ b/src/backend/spinRedemptionService.web.js
@@ -15,6 +15,7 @@
  */
 
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 export const SPIN_GRANTS_COLLECTION = 'SpinGrants';
 const SPIN_EXPIRY_DAYS = 30;
@@ -44,7 +45,7 @@ export async function grantSpin(memberId) {
     );
     return { success: true, spinId: item._id };
   } catch (err) {
-    console.error('[spinRedemptionService] grantSpin error:', err);
+    logError('spinRedemptionService:grantSpin', err);
     return { success: false, error: err.message };
   }
 }
@@ -66,7 +67,7 @@ export async function getPendingSpins(memberId) {
       .find({ suppressAuth: true });
     return result.items;
   } catch (err) {
-    console.error('[spinRedemptionService] getPendingSpins error:', err);
+    logError('spinRedemptionService:getPendingSpins', err);
     return [];
   }
 }
@@ -96,7 +97,7 @@ export async function redeemSpin(memberId, spinId, { reward, rewardValue }) {
     );
     return { success: true };
   } catch (err) {
-    console.error('[spinRedemptionService] redeemSpin error:', err);
+    logError('spinRedemptionService:redeemSpin', err);
     return { success: false, error: err.message };
   }
 }

--- a/tests/cf-xknq-batchP-LogErrorMigration.test.js
+++ b/tests/cf-xknq-batchP-LogErrorMigration.test.js
@@ -1,0 +1,133 @@
+/**
+ * cf-xknq (cf-44qt batch-P): 7-file logger sweep migration pins.
+ *
+ * Convoy continuation after cf-i8b4 batch-M (PR #1459),
+ * cf-06ug batch-N (PR #1474), cf-n4wy batch-O (PR #1495).
+ *
+ * 25 console.* sites across 7 files migrated to canonical
+ * `logError(tag, err)` with the `<module>:<fn>(-<reason>)?` tag
+ * namespace.
+ *
+ * Notes:
+ *   - errorMonitoring.web.js intentionally NOT in this batch — it
+ *     would be a circular dependency on backend/utils/errorHandler.
+ *
+ * Regex shape accepts ', ", AND backtick — folded from cf-mrcm.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC_BACKEND = path.resolve(TEST_DIR, '../src/backend');
+
+function readSrc(rel) {
+  return fs.readFileSync(path.resolve(SRC_BACKEND, rel), 'utf-8');
+}
+
+const FILES = {
+  'swatchService.web.js': {
+    requiresImport: true,
+    tags: [
+      'swatchService:getProductSwatches',
+      'swatchService:getAllSwatchFamilies',
+      'swatchService:getSwatchCount',
+      'swatchService:getSwatchPreviewColors',
+    ],
+  },
+  'priceDropCron.web.js': {
+    requiresImport: true,
+    tags: [
+      'priceDropCron:detectPriceDrops',
+      'priceDropCron:queuePriceDropNotifications',
+      'priceDropCron:queuePriceDropNotifications-notifyMemberFailed',
+      'priceDropCron:queuePriceDropNotifications-sendEmailFailed',
+    ],
+  },
+  'deliveryExperience.web.js': {
+    requiresImport: true,
+    tags: [
+      'deliveryExperience:getDeliveryStatus',
+      'deliveryExperience:updateMilestone',
+      'deliveryExperience:submitSurvey',
+      'deliveryExperience:getSurveyStats',
+    ],
+  },
+  'chatbotService.web.js': {
+    requiresImport: true,
+    tags: [
+      'chatbotService:fetchProductCatalog-failed',
+      'chatbotService:fetchSecrets-failed',
+      'chatbotService:dailyStatsQueryFailed',
+      'chatbotService:dailyStatsWriteFailed',
+    ],
+  },
+  'spinRedemptionService.web.js': {
+    requiresImport: true,
+    tags: [
+      'spinRedemptionService:grantSpin',
+      'spinRedemptionService:getPendingSpins',
+      'spinRedemptionService:redeemSpin',
+    ],
+  },
+  'sommelierService.web.js': {
+    requiresImport: true,
+    tags: [
+      'sommelierService:getRecommendations',
+      'sommelierService:savePreferences',
+      'sommelierService:getMyPreferences',
+    ],
+  },
+  'showroomService.web.js': {
+    requiresImport: true,
+    tags: [
+      'showroomService:getShowroomBookingUrl',
+      'showroomService:getShowroomEligibleIds',
+      'showroomService:getShowroomSectionData',
+    ],
+  },
+};
+
+function tagPattern(tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+  );
+}
+
+describe('cf-xknq (cf-44qt batch-P): 7-file logger sweep migration', () => {
+  for (const [filePath, spec] of Object.entries(FILES)) {
+    describe(filePath, () => {
+      const src = readSrc(filePath);
+
+      it('contains zero console.error|warn|log|debug|info CALLS (matches the strict call-pattern, not comment text)', () => {
+        const calls = src.match(/console\.(error|warn|log|debug|info)\s*\(/g) || [];
+        const allowed = spec.allowsConsoleCalls || 0;
+        expect(calls.length).toBe(allowed);
+      });
+
+      if (spec.requiresImport) {
+        it('imports logError from backend/utils/errorHandler', () => {
+          const importPattern =
+            /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler/;
+          expect(src).toMatch(importPattern);
+        });
+      }
+
+      for (const tag of spec.tags) {
+        it(`tag "${tag}" appears as a logError() call`, () => {
+          expect(src).toMatch(tagPattern(tag));
+        });
+      }
+    });
+  }
+
+  it('summary: 25 console.* call sites migrated across 7 files', () => {
+    const totalTags = Object.values(FILES).reduce(
+      (sum, spec) => sum + spec.tags.length,
+      0,
+    );
+    expect(totalTags).toBe(25);
+  });
+});

--- a/tests/priceDropCron.test.js
+++ b/tests/priceDropCron.test.js
@@ -39,6 +39,9 @@ import {
   __failNextEmail,
 } from 'wix-crm-backend';
 
+// cf-xknq: priceDropCron migrated console.error → canonical logError
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
 import {
   detectPriceDrops,
   queuePriceDropNotifications,
@@ -48,6 +51,7 @@ import {
   _PRICE_DROP_NOTIFICATIONS_COLLECTION,
   _emailPriceAlertSubscribers,
 } from '../src/backend/priceDropCron.web.js';
+import { logError } from '../src/backend/utils/errorHandler.js';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -481,13 +485,15 @@ describe('detectPriceDrops — error resilience', () => {
     expect(result.dropsDetected).toBe(0);
   });
 
-  it('logs an error message on failure', async () => {
+  it('logs an error via canonical logError on failure', async () => {
+    vi.mocked(logError).mockClear();
     __setQueryError('Stores/Products', new Error('boom'));
 
     await detectPriceDrops();
+    // cf-xknq: canonical logError tag replaces the previous console.error
     expect(logError).toHaveBeenCalledWith(
-      expect.stringContaining('[priceDropCron] detectPriceDrops failed'),
-      expect.any(Error)
+      'priceDropCron:detectPriceDrops',
+      expect.any(Error),
     );
   });
 });


### PR DESCRIPTION
## Summary

Convoy continuation of cf-44qt logger sweep after cf-i8b4 batch-M (PR #1459), cf-06ug batch-N (PR #1474), cf-n4wy batch-O (PR #1495). Migrates **25 console.* sites across 7 files** to canonical `logError(tag, err)` with `<module>:<fn>(-<reason>)?` namespace.

### Files (25 sites)

- `swatchService.web.js` (4) — getProductSwatches / getAllSwatchFamilies / getSwatchCount / getSwatchPreviewColors
- `priceDropCron.web.js` (4) — detectPriceDrops / queuePriceDropNotifications + 2 dynamic per-member tags
- `deliveryExperience.web.js` (4) — getDeliveryStatus / updateMilestone / submitSurvey / getSurveyStats
- `chatbotService.web.js` (4) — fetchProductCatalog / fetchSecrets / dailyStatsQuery / dailyStatsWrite
- `spinRedemptionService.web.js` (3) — grantSpin / getPendingSpins / redeemSpin
- `sommelierService.web.js` (3) — getRecommendations / savePreferences / getMyPreferences
- `showroomService.web.js` (3) — getShowroomBookingUrl / getShowroomEligibleIds / getShowroomSectionData

### Ripple test

- `tests/priceDropCron.test.js` — 1 assertion migrated from console.error spy to canonical logError spy.

### Explicitly NOT in this batch

- `errorMonitoring.web.js` (4 sites) — would be a circular dependency on `backend/utils/errorHandler`. Needs a different approach.

## Test plan

- [x] New `tests/cf-xknq-batchP-LogErrorMigration.test.js` (40 tests): per-file canonical-import + per-tag logError regex + 25-site summary
- [x] `priceDropCron.test.js` ripple updated
- [x] Full suite: **net-neutral on regressions** (28 failures = same pre-existing pollution baseline; all in files outside batch-P scope)

Auto-merge class · 5-agent review per 2026-05-15 mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)