### PR TITLE
fix(cf-contentorch-logerror): contentOrchestrator.web.js — 7 console.error → logError

### DIFF
--- a/src/backend/contentOrchestrator.web.js
+++ b/src/backend/contentOrchestrator.web.js
@@ -17,6 +17,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const VALID_EVENT_TYPES = ['new_arrival', 'price_drop', 'back_in_stock', 'seasonal', 'blog_published'];
 
@@ -181,7 +182,7 @@ export const triggerManualOrchestration = webMethod(
       if (options.dryRun) response.dryRun = true;
       return response;
     } catch (err) {
-      console.error('[contentOrchestrator] Error in triggerManualOrchestration:', err);
+      logError('contentOrchestrator:triggerManualOrchestration', err);
       return { success: false, error: err.message || 'Orchestration failed.', scheduled: [] };
     }
   }
@@ -212,7 +213,7 @@ export const triggerEventOrchestration = webMethod(
 
       return { success: true, scheduled: result.scheduled, skipped: result.skipped };
     } catch (err) {
-      console.error('[contentOrchestrator] Error in triggerEventOrchestration:', err);
+      logError('contentOrchestrator:triggerEventOrchestration', err);
       return { success: false, error: err.message || 'Event orchestration failed.', scheduled: [] };
     }
   }
@@ -243,7 +244,7 @@ export const previewOrchestration = webMethod(
 
       return { success: true, planned, wouldSkip: result.skipped };
     } catch (err) {
-      console.error('[contentOrchestrator] Error in previewOrchestration:', err);
+      logError('contentOrchestrator:previewOrchestration', err);
       return { success: false, error: err.message || 'Preview failed.', planned: [] };
     }
   }
@@ -286,7 +287,7 @@ export const getOrchestrationDashboard = webMethod(
         stats,
       };
     } catch (err) {
-      console.error('[contentOrchestrator] Error getting dashboard:', err);
+      logError('contentOrchestrator:getOrchestrationDashboard', err);
       return { success: false, error: err.message || 'Dashboard failed.', pending: [], config: {}, stats: {} };
     }
   }
@@ -309,7 +310,7 @@ export const getOrchestrationHistory = webMethod(
         .find();
       return { success: true, events: result.items };
     } catch (err) {
-      console.error('[contentOrchestrator] Error getting history:', err);
+      logError('contentOrchestrator:getOrchestrationHistory', err);
       return { success: false, error: err.message || 'Failed to get history.', events: [] };
     }
   }
@@ -327,7 +328,7 @@ export const getOrchestrationConfig = webMethod(
       const config = await getConfig();
       return { success: true, config };
     } catch (err) {
-      console.error('[contentOrchestrator] Error getting config:', err);
+      logError('contentOrchestrator:getOrchestrationConfig', err);
       return { success: false, error: err.message || 'Failed to get config.', config: {} };
     }
   }
@@ -367,7 +368,7 @@ export const updateOrchestrationConfig = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[contentOrchestrator] Error updating config:', err);
+      logError('contentOrchestrator:updateOrchestrationConfig', err);
       return { success: false, error: err.message || 'Failed to update config.' };
     }
   }

--- a/tests/contentOrchestratorLogErrorMigration.test.js
+++ b/tests/contentOrchestratorLogErrorMigration.test.js
@@ -1,0 +1,52 @@
+/**
+ * cf-contentorch-logerror — pins console.error → logError migration in
+ * src/backend/contentOrchestrator.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/contentOrchestrator.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'contentOrchestrator:triggerManualOrchestration',
+  'contentOrchestrator:triggerEventOrchestration',
+  'contentOrchestrator:previewOrchestration',
+  'contentOrchestrator:getOrchestrationDashboard',
+  'contentOrchestrator:getOrchestrationHistory',
+  'contentOrchestrator:getOrchestrationConfig',
+  'contentOrchestrator:updateOrchestrationConfig',
+];
+
+describe('cf-contentorch-logerror — contentOrchestrator.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the contentOrchestrator: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(7);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('contentOrchestrator:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without contentOrchestrator: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 31st PR in burst — 7 sites (largest since buyingGuides PR #1411).

## Swaps (7 sites in contentOrchestrator.web.js)

- `triggerManualOrchestration`, `triggerEventOrchestration`, `previewOrchestration`, `getOrchestrationDashboard`, `getOrchestrationHistory`, `getOrchestrationConfig`, `updateOrchestrationConfig` → all under `contentOrchestrator:<fn>`

## Verification

- New migration test: **10/10** ✅
- contentOrchestrator suite green

Auto-merge eligible on CI green.
