### PR TITLE
fix(cf-44qt batch8): console.error → logError in 4 backend modules (12 sites)

### DIFF
--- a/src/backend/completeTheLookService.web.js
+++ b/src/backend/completeTheLookService.web.js
@@ -9,6 +9,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { validateId, isWixMediaUrl } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'CompleteTheLook';
 const MAX_ITEMS = 12;
@@ -50,7 +51,7 @@ export const getCompleteTheLook = webMethod(
         roomItems: normalizeItems(look.roomItems),
       };
     } catch (err) {
-      console.error('[completeTheLookService] getCompleteTheLook failed', err);
+      logError('[completeTheLookService] getCompleteTheLook', err);
       return null;
     }
   }
@@ -79,7 +80,7 @@ export const createLook = webMethod(
       }, { suppressAuth: true });
       return { success: true, look };
     } catch (err) {
-      console.error('[completeTheLookService] createLook failed', err);
+      logError('[completeTheLookService] createLook', err);
       return { success: false, error: 'insert-failed' };
     }
   }
@@ -115,7 +116,7 @@ export const updateLook = webMethod(
       }, { suppressAuth: true });
       return { success: true, look };
     } catch (err) {
-      console.error('[completeTheLookService] updateLook failed', err);
+      logError('[completeTheLookService] updateLook', err);
       return { success: false, error: 'update-failed' };
     }
   }

--- a/src/backend/dataService.web.js
+++ b/src/backend/dataService.web.js
@@ -29,6 +29,7 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 // ─── Input Sanitization ────────────────────────────────────────────
 
@@ -97,7 +98,7 @@ export const scheduleReviewRequest = webMethod(
 
       return { success: true, requestId: inserted._id };
     } catch (err) {
-      console.error('Error scheduling review request:', err);
+      logError('[dataService] scheduleReviewRequest', err);
       return { success: false };
     }
   }
@@ -123,7 +124,7 @@ export const getPendingReviewRequests = webMethod(
         .find();
       return result.items;
     } catch (err) {
-      console.error('Error fetching pending review requests:', err);
+      logError('[dataService] fetchPendingReviewRequests', err);
       return [];
     }
   }
@@ -175,7 +176,7 @@ export const submitReview = webMethod(
       logAuditEvent('ReviewRequests', 'submit_review', record.customerEmail, { rating });
       return { success: true };
     } catch (err) {
-      console.error('Error submitting review:', err);
+      logError('[dataService] submitReview', err);
       return { success: false };
     }
   }

--- a/src/backend/sommelierService.web.js
+++ b/src/backend/sommelierService.web.js
@@ -23,6 +23,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -157,7 +158,7 @@ export const getRecommendations = webMethod(
 
       return { success: true, recommendations: scored };
     } catch (err) {
-      console.error('[sommelierService] getRecommendations error:', err);
+      logError('[sommelierService] getRecommendations', err);
       return { success: false, recommendations: [], error: 'internal_error' };
     }
   }
@@ -209,7 +210,7 @@ export const savePreferences = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[sommelierService] savePreferences error:', err);
+      logError('[sommelierService] savePreferences', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -249,7 +250,7 @@ export const getMyPreferences = webMethod(
         return { success: true, prefs: null };
       }
     } catch (err) {
-      console.error('[sommelierService] getMyPreferences error:', err);
+      logError('[sommelierService] getMyPreferences', err);
       return { success: false, prefs: null, error: 'internal_error' };
     }
   }

--- a/src/backend/spinRedemptionService.web.js
+++ b/src/backend/spinRedemptionService.web.js
@@ -15,6 +15,7 @@
  */
 
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 export const SPIN_GRANTS_COLLECTION = 'SpinGrants';
 const SPIN_EXPIRY_DAYS = 30;
@@ -44,7 +45,7 @@ export async function grantSpin(memberId) {
     );
     return { success: true, spinId: item._id };
   } catch (err) {
-    console.error('[spinRedemptionService] grantSpin error:', err);
+    logError('[spinRedemptionService] grantSpin', err);
     return { success: false, error: err.message };
   }
 }
@@ -66,7 +67,7 @@ export async function getPendingSpins(memberId) {
       .find({ suppressAuth: true });
     return result.items;
   } catch (err) {
-    console.error('[spinRedemptionService] getPendingSpins error:', err);
+    logError('[spinRedemptionService] getPendingSpins', err);
     return [];
   }
 }
@@ -96,7 +97,7 @@ export async function redeemSpin(memberId, spinId, { reward, rewardValue }) {
     );
     return { success: true };
   } catch (err) {
-    console.error('[spinRedemptionService] redeemSpin error:', err);
+    logError('[spinRedemptionService] redeemSpin', err);
     return { success: false, error: err.message };
   }
 }

--- a/tests/cf-44qt-batch8-logError.test.js
+++ b/tests/cf-44qt-batch8-logError.test.js
@@ -1,0 +1,80 @@
+/**
+ * @file cf-44qt-batch8-logError.test.js
+ * @description TDD red → green for cf-44qt batch8: 4 backend modules
+ * migrated to canonical logError. Mirrors batch3 / batch4 / batch6 /
+ * batch7 shape.
+ *
+ * Modules migrated (4 files, 12 sites):
+ *   - dataService.web.js (3 sites: scheduleReviewRequest,
+ *     fetchPendingReviewRequests, submitReview) — pre-fix lacked the
+ *     [module] prefix on console.error; migration adds it.
+ *   - completeTheLookService.web.js (3 sites: getCompleteTheLook,
+ *     createLook, updateLook)
+ *   - sommelierService.web.js (3 sites: getRecommendations,
+ *     savePreferences, getMyPreferences)
+ *   - spinRedemptionService.web.js (3 sites: grantSpin, getPendingSpins,
+ *     redeemSpin)
+ *
+ * Deliberately dropped from this batch: notificationPreferences.web.js
+ * (has a pre-existing `logError` import from backend/errorMonitoring.web.js
+ * with a different object-shape signature; needs a dedicated migration
+ * that reconciles the two telemetry mechanisms).
+ *
+ * cf-44qt batch8 — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p) => readFileSync(resolve(__dirname, '..', p), 'utf8');
+
+const FILES = [
+  {
+    path: 'src/backend/dataService.web.js',
+    module: 'dataService',
+    labels: ['scheduleReviewRequest', 'fetchPendingReviewRequests', 'submitReview'],
+  },
+  {
+    path: 'src/backend/completeTheLookService.web.js',
+    module: 'completeTheLookService',
+    labels: ['getCompleteTheLook', 'createLook', 'updateLook'],
+  },
+  {
+    path: 'src/backend/sommelierService.web.js',
+    module: 'sommelierService',
+    labels: ['getRecommendations', 'savePreferences', 'getMyPreferences'],
+  },
+  {
+    path: 'src/backend/spinRedemptionService.web.js',
+    module: 'spinRedemptionService',
+    labels: ['grantSpin', 'getPendingSpins', 'redeemSpin'],
+  },
+];
+
+describe('cf-44qt batch8 — 4-module logError migration', () => {
+  it.each(FILES)('$path has NO remaining bare console.error calls', ({ path }) => {
+    const src = read(path);
+    expect(src).not.toMatch(/console\.error/);
+  });
+
+  it.each(FILES)('$path imports canonical logError from backend/utils/errorHandler', ({ path }) => {
+    const src = read(path);
+    expect(src).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(FILES)('$path uses canonical [$module] prefix on all 3 labels', ({ path, module, labels }) => {
+    const src = read(path);
+    for (const label of labels) {
+      const re = new RegExp(`logError\\(\\s*['"]\\[${module}\\] ${label}['"]`);
+      expect(src).toMatch(re);
+    }
+  });
+
+  it.each(FILES)('$path logError invocation count = 3 (no over-migration drift)', ({ path }) => {
+    const src = read(path);
+    const matches = src.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(3);
+  });
+});


### PR DESCRIPTION
Sibling batch8. 4 modules, 12 sites: dataService (3, prefix added), completeTheLookService (3), sommelierService (3), spinRedemptionService (3). 4 it.each TDD pins per file (no-bare, import, prefix, count=3). notificationPreferences dropped from scope (pre-existing logError from errorMonitoring.web.js with object-shape signature — needs dedicated migration). Auto-merge eligible.