### PR TITLE
fix(cf-44qt sibling): promotions.web.js console.error → logError ×2 (P3 obs cleanup)

### DIFF
--- a/tests/promotionsSilentFailureCleanup.test.js
+++ b/tests/promotionsSilentFailureCleanup.test.js
@@ -1,0 +1,54 @@
+/**
+ * cf-44qt sibling — promotions.web.js observability cleanup.
+ *
+ * Pins post-migration contract: 2 webMethods' catches call
+ * `logError('[promotions] <fn> failed', err)`. Same canonical
+ * pattern.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateSlug: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — promotions.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getActivePromotion wires logError on Promotions query throw', async () => {
+    __setQueryError('Promotions', new Error('wixData query failure'));
+    const mod = await import('../src/backend/promotions.web.js');
+    await mod.getActivePromotion('homepage');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/promotions/);
+    expect(allTags).toMatch(/getActivePromotion/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('getFlashSales wires logError on Promotions query throw', async () => {
+    __setQueryError('Promotions', new Error('wixData query failure'));
+    const mod = await import('../src/backend/promotions.web.js');
+    await mod.getFlashSales();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/promotions/);
+    expect(allTags).toMatch(/getFlashSales/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — promotions.web.js console.error → logError × 2 + 2 TDD pins. 13th same-pattern sibling.

## Migrations

| webMethod | New logError tag |
|---|---|
| getActivePromotion | `[promotions] getActivePromotion failed` |
| getFlashSales | `[promotions] getFlashSales failed` |

## TDD shape (2/2 green)

Top-level vi.mock per CF-fgsw. Both trigger via `__setQueryError('Promotions')`.

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 2/2 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- 12 prior cluster PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
