### PR TITLE
fix(cf-protectionplan-logerror): protectionPlan.web.js — 4 console.error → logError

### DIFF
--- a/src/backend/protectionPlan.web.js
+++ b/src/backend/protectionPlan.web.js
@@ -23,6 +23,7 @@ import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const SELECTIONS_COLLECTION = 'ProtectionPlanSelections';
 
@@ -137,7 +138,7 @@ export const getProtectionPlans = webMethod(
 
       return { success: true, plans };
     } catch (err) {
-      console.error('[protectionPlan] getProtectionPlans error:', err);
+      logError('protectionPlan:getProtectionPlans', err);
       return { success: false, plans: [] };
     }
   }
@@ -215,7 +216,7 @@ export const addProtectionPlan = webMethod(
         },
       };
     } catch (err) {
-      console.error('[protectionPlan] addProtectionPlan error:', err);
+      logError('protectionPlan:addProtectionPlan', err);
       return { success: false };
     }
   }
@@ -252,7 +253,7 @@ export const removeProtectionPlan = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[protectionPlan] removeProtectionPlan error:', err);
+      logError('protectionPlan:removeProtectionPlan', err);
       return { success: false };
     }
   }
@@ -300,7 +301,7 @@ export const getProtectionPlanSummary = webMethod(
         },
       };
     } catch (err) {
-      console.error('[protectionPlan] getProtectionPlanSummary error:', err);
+      logError('protectionPlan:getProtectionPlanSummary', err);
       return { success: false, data: { selections: [], totalProtectionCost: 0 } };
     }
   }

--- a/tests/protectionPlanLogErrorMigration.test.js
+++ b/tests/protectionPlanLogErrorMigration.test.js
@@ -1,0 +1,49 @@
+/**
+ * cf-protectionplan-logerror — pins console.error → logError migration
+ * in src/backend/protectionPlan.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/protectionPlan.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'protectionPlan:getProtectionPlans',
+  'protectionPlan:addProtectionPlan',
+  'protectionPlan:removeProtectionPlan',
+  'protectionPlan:getProtectionPlanSummary',
+];
+
+describe('cf-protectionplan-logerror — protectionPlan.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the protectionPlan: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(4);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('protectionPlan:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without protectionPlan: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 32nd PR in burst.

## Swaps (4 sites in protectionPlan.web.js)

- `getProtectionPlans`, `addProtectionPlan`, `removeProtectionPlan`, `getProtectionPlanSummary` → all under `protectionPlan:<fn>`

## Verification

- New migration test: **7/7** ✅
- protectionPlan suite green

Auto-merge eligible on CI green.
