### PR TITLE
fix(cf-44qt sibling): contentScheduler.web.js console.error → logError ×5 (P3)

### DIFF
--- a/src/backend/contentScheduler.web.js
+++ b/src/backend/contentScheduler.web.js
@@ -17,6 +17,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const DEDUP_WINDOW_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -148,7 +149,7 @@ export const processContentSchedule = webMethod(
         } catch (actionErr) {
           item.status = 'failed';
           item.error = 'Processing error';
-          console.error(`[contentScheduler] Action failed for ${item._id}:`, actionErr);
+          logError(`[contentScheduler] processContentSchedule action-failed item=${item._id}`, actionErr);
         }
 
         item.processedAt = now;
@@ -159,7 +160,7 @@ export const processContentSchedule = webMethod(
 
       return { success: true, processed, failed, skipped };
     } catch (err) {
-      console.error('[contentScheduler] Error processing schedule:', err);
+      logError('[contentScheduler] processContentSchedule failed', err);
       return { success: false, error: 'Failed to process schedule.', processed: 0, failed: 0, skipped: 0 };
     }
   }
@@ -191,7 +192,7 @@ export const getScheduleQueue = webMethod(
 
       return { success: true, items: result.items };
     } catch (err) {
-      console.error('[contentScheduler] Error getting queue:', err);
+      logError('[contentScheduler] getScheduleQueue failed', err);
       return { success: false, error: err.message || 'Failed to get queue.', items: [] };
     }
   }
@@ -228,7 +229,7 @@ export const cancelScheduledItem = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[contentScheduler] Error cancelling item:', err);
+      logError('[contentScheduler] cancelScheduledItem failed', err);
       return { success: false, error: err.message || 'Failed to cancel item.' };
     }
   }
@@ -260,7 +261,7 @@ export const getScheduleStats = webMethod(
 
       return { success: true, stats };
     } catch (err) {
-      console.error('[contentScheduler] Error getting stats:', err);
+      logError('[contentScheduler] getScheduleStats failed', err);
       return { success: false, error: err.message || 'Failed to get stats.', stats: {} };
     }
   }

--- a/tests/contentSchedulerSilentFailureCleanup.test.js
+++ b/tests/contentSchedulerSilentFailureCleanup.test.js
@@ -1,0 +1,66 @@
+/**
+ * cf-44qt sibling — contentScheduler.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: {
+    getMember: vi.fn(async () => ({ _id: 'admin-1' })),
+    getRoles: vi.fn(async () => [{ _id: 'admin', title: 'Admin' }]),
+  },
+}));
+vi.mock('wix-secrets-backend', () => ({ getSecret: vi.fn(async () => 'cron-secret') }));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — contentScheduler.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('processContentSchedule wires logError on ContentSchedule query throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.processContentSchedule('cron-secret');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/processContentSchedule/);
+  });
+
+  it('getScheduleQueue wires logError on ContentSchedule query throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.getScheduleQueue();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/getScheduleQueue/);
+  });
+
+  it('getScheduleStats wires logError on ContentSchedule query throw', async () => {
+    __setQueryError('ContentSchedule', new Error('wixData failure'));
+    const mod = await import('../src/backend/contentScheduler.web.js');
+    await mod.getScheduleStats();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/contentScheduler/);
+    expect(allTags).toMatch(/getScheduleStats/);
+  });
+});


### PR DESCRIPTION
## Summary
- **5 catch sites** migrated. 4 webMethods + 1 inline per-item catch.
- 35th in the cf-44qt sibling series.

## Verification
- [x] **3/3** new + **71/71** existing = **74/74 combined**
- [ ] CI / 5-agent CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)