### PR TITLE
fix(cf-44qt sibling): styleQuiz.web.js console.error → logError ×2 (P3 obs cleanup)

### DIFF
--- a/src/backend/styleQuiz.web.js
+++ b/src/backend/styleQuiz.web.js
@@ -13,6 +13,7 @@ import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 // Map quiz answers to product collection queries and scoring criteria
 const ROOM_CATEGORY_MAP = {
@@ -155,7 +156,7 @@ export const getQuizRecommendations = webMethod(
       scored.sort((a, b) => b.score - a.score);
       return scored.slice(0, 5);
     } catch (err) {
-      console.error('Error getting quiz recommendations:', err);
+      logError('[styleQuiz] getQuizRecommendations failed', err);
       return [];
     }
   }
@@ -350,7 +351,7 @@ export const captureQuizLead = webMethod(
       logAuditEvent('NewsletterSubscribers', 'quiz_lead', cleaned);
       return { success: true };
     } catch (err) {
-      console.error('Quiz lead capture error:', err);
+      logError('[styleQuiz] captureQuizLead failed', err);
       return { success: false, message: 'Capture failed. Please try again.' };
     }
   }

--- a/tests/styleQuizSilentFailureCleanup.test.js
+++ b/tests/styleQuizSilentFailureCleanup.test.js
@@ -1,0 +1,65 @@
+/**
+ * cf-44qt sibling — styleQuiz.web.js observability cleanup.
+ *
+ * Pins post-migration contract: the 2 webMethods with catch blocks
+ * call `logError('[styleQuiz] <fn> failed', err)`. Same canonical
+ * pattern.
+ *
+ * getQuizOptions + getPersonalizedCopy have no catch blocks
+ * (synchronous answer-aggregation only) — out of scope.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateEmail: () => true,
+}));
+vi.mock('backend/utils/rateLimit', () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+}));
+vi.mock('backend/utils/auditLog', () => ({
+  logAuditEvent: vi.fn(async () => {}),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — styleQuiz.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getQuizRecommendations wires logError on Stores/Products query throw', async () => {
+    __setQueryError('Stores/Products', new Error('wixData query failure'));
+    const mod = await import('../src/backend/styleQuiz.web.js');
+    await mod.getQuizRecommendations({ use: 'guest', size: 'queen', style: 'modern', budget: 'mid' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/styleQuiz/);
+    expect(allTags).toMatch(/getQuizRecommendations/);
+    expect(allTags).toMatch(/failed/);
+  });
+
+  it('captureQuizLead wires logError on NewsletterSubscribers insert throw', async () => {
+    __setInsertError('NewsletterSubscribers', new Error('wixData insert failure'));
+    __setQueryError('NewsletterSubscribers', new Error('wixData query failure'));
+    const mod = await import('../src/backend/styleQuiz.web.js');
+    await mod.captureQuizLead('user@example.com', { use: 'guest' });
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/styleQuiz/);
+    expect(allTags).toMatch(/captureQuizLead/);
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — styleQuiz.web.js console.error → logError × 2 + 2 TDD pins. 14th same-pattern sibling.

## Migrations

| webMethod | New logError tag |
|---|---|
| getQuizRecommendations | `[styleQuiz] getQuizRecommendations failed` |
| captureQuizLead | `[styleQuiz] captureQuizLead failed` |

getQuizOptions + getPersonalizedCopy have no catch blocks (synchronous answer-aggregation only) — out of scope.

## TDD shape (2/2 green)

Top-level vi.mock per CF-fgsw.
- getQuizRecommendations: `__setQueryError('Stores/Products', err)`
- captureQuizLead: `__setInsertError + __setQueryError` on `NewsletterSubscribers`

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 2/2 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- 13 prior cluster PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
