### PR TITLE
fix(cf-44qt sibling): styleConsultant.web.js console.error → logError ×4

### DIFF
--- a/src/backend/styleConsultant.web.js
+++ b/src/backend/styleConsultant.web.js
@@ -43,6 +43,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, isWixMediaUrl } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const SESSION_COLLECTION = 'StyleConsultantSessions';
 
@@ -482,7 +483,7 @@ export const getStyleConsultation = webMethod(
     try {
       session = await lookupSession(cleanKey);
     } catch (err) {
-      console.error('[styleConsultant] Session lookup failed:', err?.message ?? err);
+      logError('[styleConsultant] sessionLookup', err);
       return { success: false, error: 'Session lookup failed. Please try again.', errorCode: 'AI_ERROR' };
     }
 
@@ -498,7 +499,7 @@ export const getStyleConsultation = webMethod(
       styleTags = aiResult.styleTags;
       explanation = aiResult.explanation;
     } catch (err) {
-      console.error('[styleConsultant] Claude API call failed:', err?.message ?? err);
+      logError('[styleConsultant] claudeApiCall', err);
       return { success: false, error: 'Style analysis unavailable. Please try again later.', errorCode: 'AI_ERROR' };
     }
 
@@ -507,7 +508,7 @@ export const getStyleConsultation = webMethod(
     try {
       recommendations = await getProductRecommendations(styleTags);
     } catch (err) {
-      console.error('[styleConsultant] Product matching failed:', err?.message ?? err);
+      logError('[styleConsultant] productMatching', err);
       return { success: false, error: 'Could not fetch recommendations. Please try again.', errorCode: 'AI_ERROR' };
     }
 
@@ -515,7 +516,7 @@ export const getStyleConsultation = webMethod(
     try {
       await upsertSession(session, cleanKey, updatedCounts, textInput, photoUrl, recommendations);
     } catch (err) {
-      console.error('[styleConsultant] Session upsert failed:', err?.message ?? err);
+      logError('[styleConsultant] sessionUpsert', err);
     }
 
     if (recommendations.length === 0) {

--- a/tests/cf-44qt-sibling-styleConsultant-logError.test.js
+++ b/tests/cf-44qt-sibling-styleConsultant-logError.test.js
@@ -1,0 +1,46 @@
+/**
+ * @file cf-44qt-sibling-styleConsultant-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 4
+ * console.error sites in src/backend/styleConsultant.web.js
+ * migrated to canonical logError.
+ *
+ * Sites migrated (4):
+ *   - sessionLookup (L485)
+ *   - claudeApiCall (L501)
+ *   - productMatching (L510)
+ *   - sessionUpsert (L518)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/styleConsultant.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — styleConsultant.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 4 expected sites with canonical [styleConsultant] prefix', () => {
+    const labels = ['sessionLookup', 'claudeApiCall', 'productMatching', 'sessionUpsert'];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[styleConsultant\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 4 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
4 sites migrated. [styleConsultant] prefix already canonical. Pre-fix sites had err?.message ?? err fallback — logError handles the error shape internally so the conditional is no longer needed. Sites: sessionLookup (L485), claudeApiCall (L501), productMatching (L510), sessionUpsert (L518). 3 source-grep TDD pins. Auto-merge eligible.