### PR TITLE
fix(cf-xv1g): normalize reviewsService.web.js bracket-style logError tags to colon format

### DIFF
--- a/src/backend/reviewsService.web.js
+++ b/src/backend/reviewsService.web.js
@@ -233,7 +233,7 @@ export const submitReview = webMethod(
 
       return { success: true, reviewId: saved._id };
     } catch (err) {
-      logError('[reviewsService] submitReview failed', err);
+      logError('reviewsService:submitReview', err);
       return { success: false, error: 'Unable to submit review. Please try again.' };
     }
   }
@@ -260,7 +260,7 @@ export const markHelpful = webMethod(
       await wixData.update(COLLECTION, review);
       return { success: true, helpful: review.helpful };
     } catch (err) {
-      logError('[reviewsService] markHelpful failed', err);
+      logError('reviewsService:markHelpful', err);
       return { success: false };
     }
   }
@@ -305,7 +305,7 @@ export const flagReview = webMethod(
 
       return { success: true };
     } catch (err) {
-      logError('[reviewsService] flagReview failed', err);
+      logError('reviewsService:flagReview', err);
       return { success: false, error: 'Failed to flag review' };
     }
   }
@@ -334,7 +334,7 @@ export const getPendingReviews = webMethod(
         total: result.totalCount,
       };
     } catch (err) {
-      logError('[reviewsService] getPendingReviews failed', err);
+      logError('reviewsService:getPendingReviews', err);
       return { success: false, reviews: [], total: 0 };
     }
   }
@@ -390,7 +390,7 @@ export const moderateReview = webMethod(
       logAuditEvent(COLLECTION, `moderate_${action}`, rid, { previousStatus, newStatus });
       return { success: true, previousStatus, newStatus };
     } catch (err) {
-      logError('[reviewsService] moderateReview failed', err);
+      logError('reviewsService:moderateReview', err);
       return { success: false, error: 'Failed to moderate review.' };
     }
   }
@@ -448,7 +448,7 @@ export const getCategoryReviewSummaries = webMethod(
 
       return summaries;
     } catch (err) {
-      logError('[reviewsService] getCategoryReviewSummaries failed', err);
+      logError('reviewsService:getCategoryReviewSummaries', err);
       return {};
     }
   }
@@ -476,7 +476,7 @@ async function checkVerifiedPurchase(memberId, productId) {
     }
     return false;
   } catch (err) {
-    logError('[reviewsService] verifiedPurchaseCheck failed', err);
+    logError('reviewsService:verifiedPurchaseCheck', err);
     return false;
   }
 }
@@ -573,7 +573,7 @@ export const submitVideoReview = webMethod(
 
       return { success: true, reviewId: inserted._id };
     } catch (err) {
-      logError('[reviewsService] submitVideoReview failed', err);
+      logError('reviewsService:submitVideoReview', err);
       return { success: false, error: 'Failed to submit video review.' };
     }
   }
@@ -615,7 +615,7 @@ export const getVideoReviews = webMethod(
 
       return { success: true, reviews, totalCount: result.totalCount };
     } catch (err) {
-      logError('[reviewsService] getVideoReviews failed', err);
+      logError('reviewsService:getVideoReviews', err);
       return { success: false, error: 'Failed to load video reviews.', reviews: [] };
     }
   }
@@ -654,13 +654,13 @@ export const moderateVideoReview = webMethod(
         try {
           await receiveGamificationEvent('video_review_approved', { memberId: review.memberId });
         } catch (e) {
-          logError('[reviewsService] moderateVideoReview gamification-trigger failed', e);
+          logError('reviewsService:moderateVideoReview-gamificationTrigger', e);
         }
       }
 
       return { success: true };
     } catch (err) {
-      logError('[reviewsService] moderateVideoReview failed', err);
+      logError('reviewsService:moderateVideoReview', err);
       return { success: false, error: 'Failed to moderate video review.' };
     }
   }
@@ -744,7 +744,7 @@ export const getFeaturedReviews = webMethod(
 
       return { success: true, reviews };
     } catch (err) {
-      logError('[reviewsService] getFeaturedReviews failed', err);
+      logError('reviewsService:getFeaturedReviews', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }

--- a/tests/reviewsServiceLogErrorMigration.test.js
+++ b/tests/reviewsServiceLogErrorMigration.test.js
@@ -58,11 +58,12 @@ describe('cf-m7yg: reviewsService.web.js logError migration', () => {
     }
   });
 
-  it(`total logError call count is at least ${EXPECTED_TAGS.length + 4} (6 migrated + 4 pre-existing)`, () => {
-    // Floor: the 4 pre-existing logError calls (submitReview / markHelpful /
-    // flagReview / getPendingReviews error catches) are out-of-scope for this
-    // batch but still must persist. 6 new + 4 pre-existing = 10 minimum.
+  it(`total logError call count is at least ${EXPECTED_TAGS.length + 4} (6 migrated + many normalized)`, () => {
     const calls = SRC.match(/logError\s*\(/g) || [];
     expect(calls.length).toBeGreaterThanOrEqual(EXPECTED_TAGS.length + 4);
+  });
+
+  it('contains no bracket-style [reviewsService] logError tags (cf-xv1g drift guard)', () => {
+    expect(SRC).not.toMatch(/logError\s*\(\s*['"`]\[reviewsService\]/);
   });
 });


### PR DESCRIPTION
## Summary
- Normalizes 12 pre-existing `[reviewsService] X failed` bracket-style `logError` calls to `reviewsService:fn` colon-namespace format per cf-44qt wave convention
- Adds drift-guard assertion in `reviewsServiceLogErrorMigration.test.js` to prevent regression to bracket format
- All 114 affected tests pass locally

## Test plan
- [x] `reviewsServiceLogErrorMigration.test.js` — drift guard added + passes
- [x] `reviewsServiceSilentFailureCleanup.test.js` — passes (loose `/reviewsService/` match, not format-specific)
- [x] `reviewsService.test.js`, `reviewsServiceErrorPaths.test.js`, `reviewsServiceHardening.test.js`, `reviewsServiceVideoReview.test.js` — all pass

Closes cf-xv1g

🤖 Generated with [Claude Code](https://claude.com/claude-code)