### PR TITLE
fix(cf-liveinventory-logerror): liveInventory.web.js — 2 console.error → logError

### DIFF
--- a/src/backend/liveInventory.web.js
+++ b/src/backend/liveInventory.web.js
@@ -7,6 +7,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { getStockStatus, signUpBackInStock } from 'backend/inventoryService.web';
 import { validateEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── getProductInventory ───────────────────────────────────────────────
 
@@ -38,7 +39,7 @@ export const getProductInventory = webMethod(
 
       return { success: true, status, quantity };
     } catch (e) {
-      console.error('[liveInventory] getProductInventory failed:', e);
+      logError('liveInventory:getProductInventory', e);
       return { success: false, error: 'Failed to fetch inventory' };
     }
   }
@@ -62,7 +63,7 @@ export const registerStockNotification = webMethod(
 
       return await signUpBackInStock({ productId, email });
     } catch (e) {
-      console.error('[liveInventory] registerStockNotification failed:', e);
+      logError('liveInventory:registerStockNotification', e);
       return { success: false, error: 'Failed to register notification' };
     }
   }

--- a/tests/liveInventoryLogErrorMigration.test.js
+++ b/tests/liveInventoryLogErrorMigration.test.js
@@ -1,0 +1,47 @@
+/**
+ * cf-liveinventory-logerror — pins console.error → logError migration
+ * in src/backend/liveInventory.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/liveInventory.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'liveInventory:getProductInventory',
+  'liveInventory:registerStockNotification',
+];
+
+describe('cf-liveinventory-logerror — liveInventory.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the liveInventory: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(2);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('liveInventory:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without liveInventory: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 33rd PR in burst.

## Swaps (2 sites in liveInventory.web.js)

- `getProductInventory`, `registerStockNotification` → all under `liveInventory:<fn>`

## Verification

- New migration test: **5/5** ✅
- liveInventory suite green

Auto-merge eligible on CI green.
