### PR TITLE
fix(cf-44qt sibling): guestCheckout.web.js console.error → logError ×4

### DIFF
--- a/src/backend/guestCheckout.web.js
+++ b/src/backend/guestCheckout.web.js
@@ -28,6 +28,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'GuestOrders';
 
@@ -93,7 +94,7 @@ export const saveGuestSession = webMethod(
 
       return { success: true, _id: saved._id };
     } catch (err) {
-      console.error('[guestCheckout] saveGuestSession failed:', err?.message);
+      logError('[guestCheckout] saveGuestSession', err);
       return { success: false, error: 'Unable to save guest session' };
     }
   }
@@ -153,13 +154,13 @@ export const linkGuestOrdersToMember = webMethod(
           );
           linkedCount++;
         } catch (err) {
-          console.error('[guestCheckout] Failed to link guest order:', item._id, err?.message);
+          logError(`[guestCheckout] linkGuestOrder ${item._id}`, err);
         }
       }
 
       return { success: true, linkedCount };
     } catch (err) {
-      console.error('[guestCheckout] linkGuestOrdersToMember failed:', err?.message);
+      logError('[guestCheckout] linkGuestOrdersToMember', err);
       return { success: false, linkedCount: 0 };
     }
   }
@@ -206,7 +207,7 @@ export const getGuestOrdersByEmail = webMethod(
 
       return { success: true, orders };
     } catch (err) {
-      console.error('[guestCheckout] getGuestOrdersByEmail failed:', err?.message);
+      logError('[guestCheckout] getGuestOrdersByEmail', err);
       return { success: false, orders: [] };
     }
   }

--- a/tests/cf-44qt-sibling-guestCheckout-logError.test.js
+++ b/tests/cf-44qt-sibling-guestCheckout-logError.test.js
@@ -1,0 +1,49 @@
+/**
+ * @file cf-44qt-sibling-guestCheckout-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 4
+ * console.error sites in src/backend/guestCheckout.web.js migrated
+ * to canonical logError. One site uses template-literal interpolation
+ * (linkGuestOrder per-item failure logs the item._id).
+ *
+ * Sites migrated (4):
+ *   - saveGuestSession (L96)
+ *   - linkGuestOrder per-item with `${item._id}` (L156)
+ *   - linkGuestOrdersToMember (L162)
+ *   - getGuestOrdersByEmail (L209)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/guestCheckout.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — guestCheckout.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for the 3 fixed-label sites + 1 template-literal site', () => {
+    const fixedLabels = ['saveGuestSession', 'linkGuestOrdersToMember', 'getGuestOrdersByEmail'];
+    for (const label of fixedLabels) {
+      const re = new RegExp(`logError\\(\\s*['"]\\[guestCheckout\\] ${label}['"]`);
+      expect(SRC).toMatch(re);
+    }
+    // Template-literal site: per-item linkGuestOrder logs item._id
+    expect(SRC).toMatch(
+      /logError\(\s*`\[guestCheckout\] linkGuestOrder \$\{item\._id\}`/,
+    );
+  });
+
+  it('logError invocation count matches the 4 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
4 sites migrated. [guestCheckout] prefix already canonical. One site uses template-literal interp (linkGuestOrder per-item log records item._id). Sites: saveGuestSession (L96), linkGuestOrder per-item (L156), linkGuestOrdersToMember (L162), getGuestOrdersByEmail (L209). 3 source-grep TDD pins. Auto-merge eligible.