### PR TITLE
fix(cf-44qt wave): cartRecovery.web.js — complete logError migration (remaining 6 sites)

### DIFF
--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -20,6 +20,7 @@ import { sanitize } from 'backend/utils/sanitize';
 import { generateRecoveryCoupon } from 'backend/couponsService.web';
 import { findMemberRecord, computeTierInfo } from 'backend/gamificationCore.web';
 import { resolveTemplateId } from 'backend/emailTemplates.web';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Event handler: Abandoned checkout created.

--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -45,7 +45,7 @@ export function wixEcom_onAbandonedCheckoutCreated(event) {
     abandonedAt: new Date().toISOString(),
     status: 'abandoned',
     recoveryEmailSent: false,
-  }).catch(err => console.error('Error recording abandoned cart:', err));
+  }).catch(err => logError('cartRecovery:recordAbandonedCart', err));
 }
 
 /**
@@ -58,7 +58,7 @@ export function wixEcom_onAbandonedCheckoutRecovered(event) {
   const checkout = event.entity || event;
 
   markCartRecovered(checkout._id || '')
-    .catch(err => console.error('Error marking cart recovered:', err));
+    .catch(err => logError('cartRecovery:markCartRecovered', err));
 }
 
 /**
@@ -95,7 +95,7 @@ export const getAbandonedCartStats = webMethod(
 
       return { totalAbandoned: total, totalRecovered: recovered, recoveryRate, recentCarts };
     } catch (err) {
-      console.error('Error getting cart stats:', err);
+      logError('cartRecovery:getCartStats', err);
       return { totalAbandoned: 0, totalRecovered: 0, recoveryRate: 0, recentCarts: [] };
     }
   }
@@ -130,7 +130,7 @@ export const getRecoverableCarts = webMethod(
         abandonedAt: c.abandonedAt,
       }));
     } catch (err) {
-      console.error('Error getting recoverable carts:', err);
+      logError('cartRecovery:getRecoverableCarts', err);
       return [];
     }
   }
@@ -161,7 +161,7 @@ export const markRecoveryEmailSent = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('Error marking recovery email sent:', err);
+      logError('cartRecovery:markRecoveryEmailSent', err);
       return { success: false };
     }
   }
@@ -359,7 +359,7 @@ export const exposeCartAbandonPayload = webMethod(
         member_push_enabled: memberPushEnabled,
       };
     } catch (err) {
-      console.error('[cartRecovery] exposeCartAbandonPayload error:', err);
+      logError('cartRecovery:exposeCartAbandonPayload', err);
       return { success: false, cart_items: [], total_price: 0, cart_id: '', member_push_enabled: false };
     }
   }

--- a/tests/cartRecoveryLogError.test.js
+++ b/tests/cartRecoveryLogError.test.js
@@ -1,0 +1,35 @@
+/**
+ * cf-44qt wave — pin cartRecovery.web.js full console.error → logError migration.
+ * Prior partial migration left 6 sites unconverted; this completes them.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/cartRecovery.web.js'),
+  'utf-8',
+);
+
+describe('cf-44qt — cartRecovery.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('every logError tag uses the cartRecovery: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('cartRecovery:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Single-file auto-merge slot from melania's batch-R. Prior partial migration left 6 console.error sites; this completes them. All cartRecovery:<scope> tags. 3/3 tests green.