### PR TITLE
fix(cf-44qt sibling): productReviews.web.js console.error → logError ×5 (P3)

### DIFF
--- a/src/backend/productReviews.web.js
+++ b/src/backend/productReviews.web.js
@@ -13,6 +13,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const REVIEWS_COLLECTION = 'Reviews';
 const PHOTO_REVIEWS_COLLECTION = 'PhotoReviews';
@@ -104,7 +105,7 @@ export const getReviewSummary = webMethod(
         recommendRate,
       };
     } catch (err) {
-      console.error('[productReviews] getReviewSummary error:', err);
+      logError('[productReviews] getReviewSummary failed', err);
       return {
         averageRating: 0, totalReviews: 0, totalPhotos: 0,
         breakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 }, recommendRate: 0,
@@ -223,7 +224,7 @@ export const getUnifiedReviews = webMethod(
         hasMore: safeOffset + safeLimit < total,
       };
     } catch (err) {
-      console.error('[productReviews] getUnifiedReviews error:', err);
+      logError('[productReviews] getUnifiedReviews failed', err);
       return { reviews: [], total: 0, hasMore: false };
     }
   }
@@ -290,7 +291,7 @@ export const getReviewHighlights = webMethod(
         reviewCount: summary.totalReviews,
       };
     } catch (err) {
-      console.error('[productReviews] getReviewHighlights error:', err);
+      logError('[productReviews] getReviewHighlights failed', err);
       return { topReview: null, topPhoto: null, averageRating: 0, reviewCount: 0 };
     }
   }
@@ -360,7 +361,7 @@ export const getBatchReviewSummaries = webMethod(
 
       return summaries;
     } catch (err) {
-      console.error('[productReviews] getBatchReviewSummaries error:', err);
+      logError('[productReviews] getBatchReviewSummaries failed', err);
       return {};
     }
   }
@@ -434,7 +435,7 @@ export const getModerationQueue = webMethod(
         total: combined.length,
       };
     } catch (err) {
-      console.error('[productReviews] getModerationQueue error:', err);
+      logError('[productReviews] getModerationQueue failed', err);
       return { reviews: [], total: 0 };
     }
   }

--- a/tests/productReviewsSilentFailureCleanup.test.js
+++ b/tests/productReviewsSilentFailureCleanup.test.js
@@ -1,0 +1,59 @@
+/**
+ * cf-44qt sibling — productReviews.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  validateId: (s) => s,
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — productReviews.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('getReviewSummary wires logError on Reviews query throw', async () => {
+    __setQueryError('Reviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/productReviews.web.js');
+    await mod.getReviewSummary('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productReviews/);
+    expect(allTags).toMatch(/getReviewSummary/);
+  });
+
+  it('getUnifiedReviews wires logError on Reviews query throw', async () => {
+    __setQueryError('Reviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/productReviews.web.js');
+    await mod.getUnifiedReviews('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productReviews/);
+    expect(allTags).toMatch(/getUnifiedReviews/);
+  });
+
+  it('getModerationQueue wires logError on Reviews query throw', async () => {
+    __setQueryError('Reviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/productReviews.web.js');
+    await mod.getModerationQueue();
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/productReviews/);
+    expect(allTags).toMatch(/getModerationQueue/);
+  });
+});


### PR DESCRIPTION
## Summary
- **5 catch sites** migrated. All 5 webMethods.
- 36th in the cf-44qt sibling series.

## Verification
- [x] **3/3** new + **239/239** existing = **242/242 combined**

🤖 Generated with [Claude Code](https://claude.com/claude-code)