### PR TITLE
fix(cf-44qt sibling): wwex-freight.web.js console.error → logError ×2 (P3 obs cleanup)

### DIFF
--- a/tests/wwexFreightSilentFailureCleanup.test.js
+++ b/tests/wwexFreightSilentFailureCleanup.test.js
@@ -1,0 +1,60 @@
+/**
+ * cf-44qt sibling — wwex-freight.web.js observability cleanup.
+ *
+ * Pins post-migration contract: both error paths in getLTLRates
+ * (HTTP-error branch + catch block) call logError instead of raw
+ * console.error. Same canonical pattern.
+ *
+ * 2 tests = HTTP-error path + catch-block path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('wix-secrets-backend', () => ({
+  getSecret: vi.fn(async () => 'test-secret'),
+}));
+
+// fetch is module-level; swap per-test via fetchImpl ref.
+let fetchImpl = vi.fn(async () => ({ ok: true, text: async () => '<xml/>' }));
+vi.mock('wix-fetch', () => ({
+  fetch: (...args) => fetchImpl(...args),
+}));
+
+describe('cf-44qt sibling — wwex-freight.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+  });
+
+  it('getLTLRates wires logError on WWEX API HTTP-error response', async () => {
+    fetchImpl = vi.fn(async () => ({ ok: false, status: 503, text: async () => '' }));
+    const mod = await import('../src/backend/wwex-freight.web.js');
+    const result = await mod.getLTLRates('28792', '90210', [
+      { weight: 100, length: 48, width: 30, height: 12 },
+    ]);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/wwex-freight/);
+    expect(allTags).toMatch(/getLTLRates/);
+    expect(allTags).toMatch(/503/);
+    expect(result.success).toBe(false);
+    expect(result.fallback).toBeDefined();
+  });
+
+  it('getLTLRates wires logError on fetch throw (network failure)', async () => {
+    fetchImpl = vi.fn(async () => { throw new Error('network down'); });
+    const mod = await import('../src/backend/wwex-freight.web.js');
+    const result = await mod.getLTLRates('28792', '90210', [
+      { weight: 100, length: 48, width: 30, height: 12 },
+    ]);
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
+    expect(allTags).toMatch(/wwex-freight/);
+    expect(allTags).toMatch(/getLTLRates/);
+    expect(allTags).toMatch(/failed/);
+    expect(result.success).toBe(false);
+    expect(result.fallback).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt sibling — wwex-freight.web.js console.error → logError × 2 + 2 TDD pins. 15th same-pattern sibling.

## Migrations

Both sites are inside `getLTLRates`:

| Branch | New logError tag |
|---|---|
| HTTP-error branch | `[wwex-freight] getLTLRates HTTP <status> from WWEX API` (synthetic Error wraps the response status) |
| outer catch | `[wwex-freight] getLTLRates failed` |

The HTTP-error branch now constructs a real `Error` so structured logging gets an Error object rather than the bare `response.status` integer the previous `console.error` passed.

## TDD shape (2/2 green)

Top-level vi.mock per CF-fgsw. Both branches via swapped `wix-fetch`:
- ok:false + status 503 → HTTP-error log path
- throw → outer catch path

## Auto-merge eligible

Per Stilgar + mayor authorization.

## Test plan
- [x] 2/2 vitest green
- [ ] CI green
- [ ] No Vercel risk

## Refs
- Convoy: cf-44qt
- 14 prior cluster PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
