### PR TITLE
fix(cf-tok3 hotfix): analyticsHelpers logError tags — add .failed suffix

### DIFF
--- a/src/backend/analyticsHelpers.web.js
+++ b/src/backend/analyticsHelpers.web.js
@@ -75,7 +75,7 @@ export const trackProductView = webMethod(
       }
     } catch (err) {
       // Analytics tracking is non-critical — log but don't throw
-      logError('analyticsHelpers.trackProductView failed', err);
+      logError('analyticsHelpers.trackProductView.failed', err);
     }
   }
 );
@@ -108,7 +108,7 @@ export const trackAddToCart = webMethod(
         await wixData.update('ProductAnalytics', record);
       }
     } catch (err) {
-      logError('analyticsHelpers.trackAddToCart failed', err);
+      logError('analyticsHelpers.trackAddToCart.failed', err);
     }
   }
 );
@@ -144,7 +144,7 @@ export const trackSocialShare = webMethod(
         await wixData.update('ProductAnalytics', record);
       }
     } catch (err) {
-      logError('analyticsHelpers.trackSocialShare', err);
+      logError('analyticsHelpers.trackSocialShare.failed', err);
     }
   }
 );
@@ -199,7 +199,7 @@ export const getMostViewedProducts = webMethod(
         })
         .filter(Boolean);
     } catch (err) {
-      logError('analyticsHelpers.getMostViewedProducts', err);
+      logError('analyticsHelpers.getMostViewedProducts.failed', err);
       return [];
     }
   }
@@ -254,7 +254,7 @@ export const getTrendingProducts = webMethod(
         })
         .filter(Boolean);
     } catch (err) {
-      logError('analyticsHelpers.getTrendingProducts', err);
+      logError('analyticsHelpers.getTrendingProducts.failed', err);
       return [];
     }
   }
@@ -452,7 +452,7 @@ export const trackPurchase = webMethod(
         await wixData.update('ProductAnalytics', record);
       }
     } catch (err) {
-      logError('analyticsHelpers.trackPurchase', err);
+      logError('analyticsHelpers.trackPurchase.failed', err);
     }
   }
 );

--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -20,6 +20,7 @@ import { sanitize } from 'backend/utils/sanitize';
 import { generateRecoveryCoupon } from 'backend/couponsService.web';
 import { findMemberRecord, computeTierInfo } from 'backend/gamificationCore.web';
 import { resolveTemplateId } from 'backend/emailTemplates.web';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Event handler: Abandoned checkout created.

--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -45,7 +45,7 @@ export function wixEcom_onAbandonedCheckoutCreated(event) {
     abandonedAt: new Date().toISOString(),
     status: 'abandoned',
     recoveryEmailSent: false,
-  }).catch(err => console.error('Error recording abandoned cart:', err));
+  }).catch(err => logError('cartRecovery:recordAbandonedCart', err));
 }
 
 /**
@@ -58,7 +58,7 @@ export function wixEcom_onAbandonedCheckoutRecovered(event) {
   const checkout = event.entity || event;
 
   markCartRecovered(checkout._id || '')
-    .catch(err => console.error('Error marking cart recovered:', err));
+    .catch(err => logError('cartRecovery:markCartRecovered', err));
 }
 
 /**
@@ -95,7 +95,7 @@ export const getAbandonedCartStats = webMethod(
 
       return { totalAbandoned: total, totalRecovered: recovered, recoveryRate, recentCarts };
     } catch (err) {
-      console.error('Error getting cart stats:', err);
+      logError('cartRecovery:getCartStats', err);
       return { totalAbandoned: 0, totalRecovered: 0, recoveryRate: 0, recentCarts: [] };
     }
   }
@@ -130,7 +130,7 @@ export const getRecoverableCarts = webMethod(
         abandonedAt: c.abandonedAt,
       }));
     } catch (err) {
-      console.error('Error getting recoverable carts:', err);
+      logError('cartRecovery:getRecoverableCarts', err);
       return [];
     }
   }
@@ -161,7 +161,7 @@ export const markRecoveryEmailSent = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('Error marking recovery email sent:', err);
+      logError('cartRecovery:markRecoveryEmailSent', err);
       return { success: false };
     }
   }
@@ -359,7 +359,7 @@ export const exposeCartAbandonPayload = webMethod(
         member_push_enabled: memberPushEnabled,
       };
     } catch (err) {
-      console.error('[cartRecovery] exposeCartAbandonPayload error:', err);
+      logError('cartRecovery:exposeCartAbandonPayload', err);
       return { success: false, cart_items: [], total_price: 0, cart_id: '', member_push_enabled: false };
     }
   }

--- a/tests/cartRecoveryLogError.test.js
+++ b/tests/cartRecoveryLogError.test.js
@@ -1,0 +1,35 @@
+/**
+ * cf-44qt wave — pin cartRecovery.web.js full console.error → logError migration.
+ * Prior partial migration left 6 sites unconverted; this completes them.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/cartRecovery.web.js'),
+  'utf-8',
+);
+
+describe('cf-44qt — cartRecovery.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('every logError tag uses the cartRecovery: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('cartRecovery:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `.failed` suffix to all 6 analyticsHelpers logError context tags so they pass the cf-44qt sibling test `tests/analyticsHelpersSilentFailureCleanup.test.js` which expects the tag to match `/failed/`.

## Background

PR #1437 (cf-tok3 batch4) merged analyticsHelpers migration with dot-notation tags (`analyticsHelpers.<method>`). Shortly after, a cf-44qt sibling silent-failure-cleanup test landed expecting bracket-format tags with 'failed' suffix. The two conventions collided; the silent-failure-cleanup test now fails on every PR.

Fix: rename tags from `analyticsHelpers.<method>` → `analyticsHelpers.<method>.failed`. Satisfies BOTH the cf-tok3 'module.method' contract AND the cf-44qt '/failed/' regex.

## Test plan

- [x] tests/analyticsHelpersSilentFailureCleanup.test.js passes
- [ ] CI green (this unblocks the queue: #1443/1446/1451/1465 should pass after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)