### PR TITLE
fix(cf-browseabandon-logerror): browseAbandonment.web.js — 6 console.error → logError

### DIFF
--- a/src/backend/browseAbandonment.web.js
+++ b/src/backend/browseAbandonment.web.js
@@ -19,6 +19,7 @@ import { sanitize, validateEmail, validateId } from 'backend/utils/sanitize';
 import { safeParse } from 'backend/utils/safeParse';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const HIGH_INTENT_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
 const RECOVERY_WINDOW_MS = 48 * 60 * 60 * 1000; // 48 hours
@@ -114,7 +115,7 @@ export const trackBrowseSession = webMethod(
 
       return { success: true, isHighIntent };
     } catch (err) {
-      console.error('[browseAbandonment] Error tracking session:', err);
+      logError('browseAbandonment:trackBrowseSession', err);
       return { success: false, error: 'Failed to track session' };
     }
   }
@@ -198,7 +199,7 @@ export const captureRemindMeRequest = webMethod(
       logAuditEvent('BrowseSessions', 'remind_me', cleanEmail, { sessionId: cleanSessionId });
       return { success: true };
     } catch (err) {
-      console.error('[browseAbandonment] Error capturing remind-me:', err);
+      logError('browseAbandonment:captureRemindMeRequest', err);
       return { success: false, error: 'Failed to capture email' };
     }
   }
@@ -286,7 +287,7 @@ export const triggerBrowseRecovery = webMethod(
 
       return { success: true, triggered, skipped };
     } catch (err) {
-      console.error('[browseAbandonment] Error triggering recovery:', err);
+      logError('browseAbandonment:triggerBrowseRecovery', err);
       return { success: false, error: 'Failed to trigger recovery' };
     }
   }
@@ -357,7 +358,7 @@ export const getBrowseAbandonmentStats = webMethod(
         recoveryRate: recoverySent > 0 ? Math.round((recoveryConverted / recoverySent) * 100) : 0,
       };
     } catch (err) {
-      console.error('[browseAbandonment] Error fetching stats:', err);
+      logError('browseAbandonment:getBrowseAbandonmentStats', err);
       return { success: false, error: 'Failed to fetch stats' };
     }
   }
@@ -422,7 +423,7 @@ export const exportAbandonmentInsights = webMethod(
 
       return { success: true, insights };
     } catch (err) {
-      console.error('[browseAbandonment] Error exporting insights:', err);
+      logError('browseAbandonment:exportAbandonmentInsights', err);
       return { success: false, error: 'Failed to export insights' };
     }
   }
@@ -470,7 +471,7 @@ export const markSessionConverted = webMethod(
       }
       return false;
     } catch (err) {
-      console.error('[browseAbandonment] Error marking converted:', err);
+      logError('browseAbandonment:markSessionConverted', err);
       return false;
     }
   }

--- a/tests/browseAbandonmentLogErrorMigration.test.js
+++ b/tests/browseAbandonmentLogErrorMigration.test.js
@@ -1,0 +1,51 @@
+/**
+ * cf-browseabandon-logerror — pins console.error → logError migration
+ * in src/backend/browseAbandonment.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/browseAbandonment.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'browseAbandonment:trackBrowseSession',
+  'browseAbandonment:captureRemindMeRequest',
+  'browseAbandonment:triggerBrowseRecovery',
+  'browseAbandonment:getBrowseAbandonmentStats',
+  'browseAbandonment:exportAbandonmentInsights',
+  'browseAbandonment:markSessionConverted',
+];
+
+describe('cf-browseabandon-logerror — browseAbandonment.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('drift guard — every logError call uses the browseAbandonment: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(6);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('browseAbandonment:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without browseAbandonment: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 34th PR in burst.

## Swaps (6 sites in browseAbandonment.web.js)

- `trackBrowseSession`, `captureRemindMeRequest`, `triggerBrowseRecovery`, `getBrowseAbandonmentStats`, `exportAbandonmentInsights`, `markSessionConverted` → all under `browseAbandonment:<fn>`

## Verification

- New migration test: **9/9** ✅
- browseAbandonment suite green

Auto-merge eligible on CI green.
