### PR TITLE
fix(cf-44qt wave): loyaltyMarketing.web.js console.error → logError (2 sites)

### DIFF
--- a/src/backend/loyaltyMarketing.web.js
+++ b/src/backend/loyaltyMarketing.web.js
@@ -101,7 +101,7 @@ export const getEnrollmentPrompt = webMethod(
         },
       };
     } catch (err) {
-      console.error('[loyaltyMarketing] getEnrollmentPrompt error:', err);
+      logError('loyaltyMarketing:getEnrollmentPrompt', err);
       return { success: false, shouldPrompt: false, benefits: null };
     }
   }
@@ -426,7 +426,7 @@ export const enrollMember = webMethod(
 
       return { success: true, welcomePoints: totalWelcome, account };
     } catch (err) {
-      console.error('[loyaltyMarketing] enrollMember error:', err);
+      logError('loyaltyMarketing:enrollMember', err);
       return { success: false, welcomePoints: 0, account: null, error: 'Enrollment failed' };
     }
   }

--- a/tests/loyaltyMarketingLogError.test.js
+++ b/tests/loyaltyMarketingLogError.test.js
@@ -1,0 +1,34 @@
+/**
+ * cf-44qt wave — pin loyaltyMarketing.web.js console.error → logError migration.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/loyaltyMarketing.web.js'),
+  'utf-8',
+);
+
+describe('cf-44qt — loyaltyMarketing.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('every logError tag uses the loyaltyMarketing: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(2);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('loyaltyMarketing:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});

--- a/tests/loyaltyMarketingLogError.test.js
+++ b/tests/loyaltyMarketingLogError.test.js
@@ -24,11 +24,12 @@ describe('cf-44qt — loyaltyMarketing.web.js console.error → logError migrati
     );
   });
 
-  it('every logError tag uses the loyaltyMarketing: prefix', () => {
-    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
-    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
-    expect(tags.length).toBeGreaterThanOrEqual(2);
-    const nonPrefixed = tags.filter((t) => !t.startsWith('loyaltyMarketing:'));
-    expect(nonPrefixed).toEqual([]);
+  it('this-PR migration sites use the loyaltyMarketing: prefix', () => {
+    // The file has pre-existing logError calls with non-conforming prefixes
+    // (sendMonthlyLoyaltyStatements:..., [loyaltyMarketing] saveBirthday ...)
+    // that pre-date this migration. cf-g79m normalization can sweep them later;
+    // this test pins ONLY the two sites this PR converted.
+    expect(SRC).toContain("logError('loyaltyMarketing:getEnrollmentPrompt'");
+    expect(SRC).toContain("logError('loyaltyMarketing:enrollMember'");
   });
 });


### PR DESCRIPTION
Single-file auto-merge slot from cf-44qt sweep (outside melania's batch-R but adjacent). 2 sites → loyaltyMarketing:<scope>. logError already imported pre-this-PR. 3/3 tests green.