### PR TITLE
fix(cf-44qt batch9): console.error → logError in 5 backend modules (8 sites)

### DIFF
--- a/src/backend/contacts/contactResolver.web.js
+++ b/src/backend/contacts/contactResolver.web.js
@@ -31,6 +31,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { contacts } from 'wix-crm-backend';
 import { sanitize, validateEmail, redactEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Resolve (or create) a Wix CRM contact for an email address.
@@ -99,7 +100,7 @@ export async function _resolveContactIdInternal(email, firstName) {
     // CRM upstream failure — caller decides whether to retry. Logged with
     // the email so support can correlate; never log full PII beyond what
     // the caller already has access to (the email).
-    console.error('[contactResolver] appendOrCreateContact failed for', cleanEmail, '— error:', err?.message ?? err);
+    logError(`[contactResolver] appendOrCreateContact ${cleanEmail}`, err);
     return null;
   }
 

--- a/src/backend/lifecycleCron.web.js
+++ b/src/backend/lifecycleCron.web.js
@@ -31,6 +31,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sendBatchReminders } from 'backend/challengeReminderService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 const ORDERS_COLLECTION = 'Stores/Orders';
 const PAGE_SIZE = 100;
@@ -113,7 +114,7 @@ export const scanLifecycleMilestones = webMethod(
         results,
       };
     } catch (err) {
-      console.error('[lifecycleCron] scanLifecycleMilestones failed:', err?.message);
+      logError('[lifecycleCron] scanLifecycleMilestones', err);
       return { success: false, ordersScanned: 0, milestonesFound: 0, results: [] };
     }
   }
@@ -197,14 +198,14 @@ export const runDailyChallengeReminders = webMethod(
             await sendPushToMember(record.memberId, PUSH_EVENTS.CHALLENGE_REMINDER, {});
           }
         } catch (pushErr) {
-          console.error(`[lifecycleCron] challenge reminder push failed for ${record.memberId}:`, pushErr?.message);
+          logError(`[lifecycleCron] challengeReminderPush ${record.memberId}`, pushErr);
         }
       };
 
       const { sent, failed } = await sendBatchReminders('daily', sendFn);
       return { success: true, sent, failed };
     } catch (err) {
-      console.error('[lifecycleCron] runDailyChallengeReminders failed:', err?.message);
+      logError('[lifecycleCron] runDailyChallengeReminders', err);
       return { success: false, sent: 0, failed: 0 };
     }
   }

--- a/src/backend/lifecycleEmailSender.web.js
+++ b/src/backend/lifecycleEmailSender.web.js
@@ -22,6 +22,7 @@
 
 import wixData from 'wix-data';
 import { scanLifecycleMilestones } from 'backend/lifecycleCron.web';
+import { logError } from 'backend/utils/errorHandler';
 
 export const SENT_LIFECYCLE_MAILS_COLLECTION = 'SentLifecycleMails';
 export const LIFECYCLE_EMAIL_QUEUE_TYPE = 'lifecycle';
@@ -123,7 +124,7 @@ export async function sendLifecycleEmails() {
 
     return { success: true, totalScanned: ordersScanned, queued, skipped };
   } catch (err) {
-    console.error('[lifecycleEmailSender] sendLifecycleEmails failed:', err);
+    logError('[lifecycleEmailSender] sendLifecycleEmails', err);
     return { success: false, totalScanned: 0, queued: 0, skipped: 0, error: 'Failed to send lifecycle emails.' };
   }
 }

--- a/src/backend/promotions.web.js
+++ b/src/backend/promotions.web.js
@@ -13,6 +13,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { validateSlug } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Get the currently active promotion, if any.
@@ -79,7 +80,7 @@ export const getActivePromotion = webMethod(
         products,
       };
     } catch (err) {
-      console.error('Error fetching active promotion:', err);
+      logError('[promotions] getActivePromotion', err);
       return null;
     }
   }
@@ -134,7 +135,7 @@ export const getFlashSales = webMethod(
         ctaText: promo.ctaText,
       }));
     } catch (err) {
-      console.error('Error fetching flash sales:', err);
+      logError('[promotions] getFlashSales', err);
       return [];
     }
   }

--- a/src/backend/rewardEngine.web.js
+++ b/src/backend/rewardEngine.web.js
@@ -17,14 +17,18 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { getNewPerksOnPromotion, PERK_TYPES, TIER_PERK_CATALOG, TIER_THRESHOLDS, getTierForPoints } from 'public/gamificationTokens.js';
 import { validateId } from 'backend/utils/sanitize';
+import { logError as _logErrorCanonical } from 'backend/utils/errorHandler';
 
 const DELIVERIES_COLLECTION = 'TierPerkDeliveries';
 const MEMBER_POINTS_COLLECTION = 'MemberPoints';
 
 const STYLING_CALL_BOOKING_URL = 'https://calendly.com/carolinafutons-brenda/styling-call';
 
+// cf-44qt: thin wrapper that prefixes [rewardEngine] to keep the
+// existing (msg, err) call-site signature unchanged. Routes through
+// the canonical logError so Sentry/logging see a uniform shape.
 function logError(msg, err) {
-  console.error(`[rewardEngine] ${msg}`, err?.message ?? err ?? '');
+  _logErrorCanonical(`[rewardEngine] ${msg}`, err);
 }
 
 /**

--- a/tests/cf-44qt-batch9-logError.test.js
+++ b/tests/cf-44qt-batch9-logError.test.js
@@ -1,0 +1,89 @@
+/**
+ * @file cf-44qt-batch9-logError.test.js
+ * @description TDD red → green for cf-44qt batch9: 5 backend modules
+ * migrated to canonical logError.
+ *
+ * Modules + sites:
+ *   - lifecycleCron.web.js (3 sites: scanLifecycleMilestones,
+ *     challengeReminderPush per-member with `${record.memberId}` template,
+ *     runDailyChallengeReminders)
+ *   - promotions.web.js (2 sites: getActivePromotion, getFlashSales —
+ *     [promotions] prefix added; pre-fix sites had bare 'Error X')
+ *   - rewardEngine.web.js (1 site: local logError wrapper now routes
+ *     through canonical errorHandler via 'logError as _logErrorCanonical'
+ *     alias — preserves the (msg, err) 1-arg-prefixed call-site shape)
+ *   - lifecycleEmailSender.web.js (1 site: sendLifecycleEmails)
+ *   - contacts/contactResolver.web.js (1 site: appendOrCreateContact
+ *     with `${cleanEmail}` template)
+ *
+ * Total: 8 console.error sites across 5 files.
+ *
+ * cf-44qt batch9 — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p) => readFileSync(resolve(__dirname, '..', p), 'utf8');
+
+const FILES_NO_CONSOLE = [
+  { path: 'src/backend/lifecycleCron.web.js' },
+  { path: 'src/backend/promotions.web.js' },
+  { path: 'src/backend/rewardEngine.web.js' },
+  { path: 'src/backend/lifecycleEmailSender.web.js' },
+  { path: 'src/backend/contacts/contactResolver.web.js' },
+];
+
+describe('cf-44qt batch9 — 5-module logError migration', () => {
+  it.each(FILES_NO_CONSOLE)('$path has NO remaining bare console.error', ({ path }) => {
+    expect(read(path)).not.toMatch(/console\.error/);
+  });
+
+  it('lifecycleCron.web.js: 3 expected labels with canonical [lifecycleCron] prefix', () => {
+    const src = read('src/backend/lifecycleCron.web.js');
+    expect(src).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+    expect(src).toMatch(/logError\(\s*['"]\[lifecycleCron\] scanLifecycleMilestones['"]/);
+    expect(src).toMatch(/logError\(\s*['"]\[lifecycleCron\] runDailyChallengeReminders['"]/);
+    expect(src).toMatch(/logError\(\s*`\[lifecycleCron\] challengeReminderPush \$\{record\.memberId\}`/);
+  });
+
+  it('promotions.web.js: 2 expected labels with canonical [promotions] prefix (added)', () => {
+    const src = read('src/backend/promotions.web.js');
+    expect(src).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+    expect(src).toMatch(/logError\(\s*['"]\[promotions\] getActivePromotion['"]/);
+    expect(src).toMatch(/logError\(\s*['"]\[promotions\] getFlashSales['"]/);
+  });
+
+  it('rewardEngine.web.js: local logError wrapper routes through canonical via _logErrorCanonical alias', () => {
+    const src = read('src/backend/rewardEngine.web.js');
+    expect(src).toMatch(
+      /import\s*{\s*logError\s+as\s+_logErrorCanonical\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+    expect(src).toMatch(/_logErrorCanonical\(\s*`\[rewardEngine\]/);
+    expect(src).not.toMatch(/console\.error/);
+  });
+
+  it('lifecycleEmailSender.web.js: sendLifecycleEmails label', () => {
+    const src = read('src/backend/lifecycleEmailSender.web.js');
+    expect(src).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+    expect(src).toMatch(
+      /logError\(\s*['"]\[lifecycleEmailSender\] sendLifecycleEmails['"]/,
+    );
+  });
+
+  it('contacts/contactResolver.web.js: appendOrCreateContact template label with cleanEmail interp', () => {
+    const src = read('src/backend/contacts/contactResolver.web.js');
+    expect(src).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+    expect(src).toMatch(
+      /logError\(\s*`\[contactResolver\] appendOrCreateContact \$\{cleanEmail\}`/,
+    );
+  });
+});

--- a/tests/contactResolver.cfxdji.test.js
+++ b/tests/contactResolver.cfxdji.test.js
@@ -25,6 +25,9 @@ import {
   contacts,
 } from './__mocks__/wix-crm-backend.js';
 
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
+
 import {
   resolveContactId,
   _resolveContactIdInternal,
@@ -115,15 +118,12 @@ describe('cf-xdji · resolveContactId — validation', () => {
 describe('cf-xdji · resolveContactId — failure modes', () => {
   it('returns null when appendOrCreateContact throws', async () => {
     vi.spyOn(contacts, 'appendOrCreateContact').mockRejectedValue(new Error('CRM unavailable'));
-    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
-    // Logged with the email + 'failed' substring so support can correlate
-    // a queue-side "no contact ID for recipient" with the upstream cause.
-    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
-    expect(logged).toContain('shopper@example.com');
-    expect(logged).toContain('appendOrCreateContact failed');
-    consoleErr.mockRestore();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('appendOrCreateContact'),
+      expect.any(Error),
+    );
   });
 
   it('returns null when appendOrCreateContact resolves with no contactId', async () => {

--- a/tests/promotions.flashSale.test.js
+++ b/tests/promotions.flashSale.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import wixData, { __seed } from './__mocks__/wix-data.js';
 import { getFlashSales } from '../src/backend/promotions.web.js';
 
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
+
 const now = new Date();
 const yesterday = new Date(now.getTime() - 86400000);
 const tomorrow = new Date(now.getTime() + 86400000);
@@ -252,24 +255,21 @@ describe('getFlashSales', () => {
   });
 
   it('returns empty array and logs error when CMS query throws', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const querySpy = vi.spyOn(wixData, 'query').mockImplementation(() => {
       throw new Error('CMS unavailable');
     });
 
     const deals = await getFlashSales();
     expect(deals).toEqual([]);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Error fetching flash sales:',
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[promotions]'),
       expect.any(Error)
     );
 
     querySpy.mockRestore();
-    consoleSpy.mockRestore();
   });
 
   it('returns empty array when query().find() rejects', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const querySpy = vi.spyOn(wixData, 'query').mockImplementation(() => ({
       eq() { return this; },
       le() { return this; },
@@ -283,7 +283,6 @@ describe('getFlashSales', () => {
     expect(deals).toEqual([]);
 
     querySpy.mockRestore();
-    consoleSpy.mockRestore();
   });
 
   it('handles null/undefined fields gracefully', async () => {

--- a/tests/promotions.test.js
+++ b/tests/promotions.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import wixData, { __seed } from './__mocks__/wix-data.js';
 import { getActivePromotion, getFlashSales } from '../src/backend/promotions.web.js';
 
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+import { logError } from '../src/backend/utils/errorHandler.js';
+
 const now = new Date();
 const yesterday = new Date(now.getTime() - 86400000);
 const tomorrow = new Date(now.getTime() + 86400000);
@@ -472,24 +475,21 @@ describe('getActivePromotion', () => {
   // ── Error handling ─────────────────────────────────────────────────
 
   it('returns null and logs error when CMS query throws', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const querySpy = vi.spyOn(wixData, 'query').mockImplementation(() => {
       throw new Error('CMS unavailable');
     });
 
     const promo = await getActivePromotion();
     expect(promo).toBeNull();
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Error fetching active promotion:',
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[promotions]'),
       expect.any(Error)
     );
 
     querySpy.mockRestore();
-    consoleSpy.mockRestore();
   });
 
   it('returns null when query().find() rejects', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const querySpy = vi.spyOn(wixData, 'query').mockImplementation(() => ({
       eq() { return this; },
       le() { return this; },
@@ -503,7 +503,6 @@ describe('getActivePromotion', () => {
     expect(promo).toBeNull();
 
     querySpy.mockRestore();
-    consoleSpy.mockRestore();
   });
 
   // ── Product count / limit ──────────────────────────────────────────
@@ -787,20 +786,18 @@ describe('getFlashSales', () => {
   });
 
   it('returns empty array on wixData error', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const querySpy = vi.spyOn(wixData, 'query').mockImplementation(() => {
       throw new Error('CMS error');
     });
 
     const result = await getFlashSales();
     expect(result).toEqual([]);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Error fetching flash sales:',
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('[promotions]'),
       expect.any(Error)
     );
 
     querySpy.mockRestore();
-    consoleSpy.mockRestore();
   });
 
   it('sanitizes categorySlug input (dirty chars stripped)', async () => {


### PR DESCRIPTION
5 modules, 8 sites: lifecycleCron (3, template-literal per-member), promotions (2, prefix added), rewardEngine (1, alias-delegate pattern matching marketingSequences in batch7), lifecycleEmailSender (1), contactResolver (1, template-literal email). 6 it.each + per-module TDD pins. Auto-merge eligible.