### PR TITLE
fix(cf-0xkm): cf-44qt batch-R — 15-file cleanup sweep (20 sites)

### DIFF
--- a/src/backend/abTestDashboard.web.js
+++ b/src/backend/abTestDashboard.web.js
@@ -359,7 +359,7 @@ export const autoStopSignificantExperiments = webMethod(
 
         // Multi-variant experiments: auto-stop only supports 2-variant significance testing
         if (variants.length > 2) {
-          console.warn(`[abTestDashboard] autoStop: "${test.testName}" has ${variants.length} variants — skipping (only 2-variant tests supported)`);
+          logError(`abTestDashboard:autoStop-skipped test=${test.testName} variants=${variants.length}`, null);
           continue;
         }
 
@@ -387,7 +387,7 @@ export const autoStopSignificantExperiments = webMethod(
           });
 
           stopped.push({ testName: cleanName, winner });
-          console.log(`[abTestDashboard] Auto-stopped "${cleanName}" — winner: ${winner} (${sig.confidence}% confidence)`);
+          logError(`abTestDashboard:autoStop-completed test=${cleanName} winner=${winner} confidence=${sig.confidence}`, null);
         } catch (itemErr) {
           logError('abTestDashboard.autoStopSignificantExperiments', itemErr);
         }

--- a/src/backend/birthdayMigration.web.js
+++ b/src/backend/birthdayMigration.web.js
@@ -60,7 +60,7 @@ export const backfillBirthdayFields = webMethod(
 
         const parsed = _parseBirthdayMonthDay(birthday);
         if (!parsed) {
-          console.warn('[birthdayMigration] Unparseable birthday for member', member._id, ':', birthday);
+          logError(`birthdayMigration:unparseableBirthday member=${member._id}`, null);
           skipped++;
           continue;
         }
@@ -88,7 +88,7 @@ export const backfillBirthdayFields = webMethod(
       lastSeenId = page.items[page.items.length - 1]._id;
     }
 
-    console.log(`[birthdayMigration] Complete — processed:${processed} updated:${updated} skipped:${skipped} errors:${errors}`);
+    logError(`birthdayMigration:complete processed=${processed} updated=${updated} skipped=${skipped} errors=${errors}`, null);
     return { processed, updated, skipped, errors };
   }
 );

--- a/src/backend/bundleDeals.web.js
+++ b/src/backend/bundleDeals.web.js
@@ -192,7 +192,7 @@ export const addBundleToCart = webMethod(
           alreadyApplied = currentCart?.appliedCoupon?.code === bundle.couponCode;
         } catch (cartErr) {
           // Non-fatal: if we can't read cart state, attempt coupon apply anyway
-          console.warn('[bundleDeals] getCurrentCart failed (non-fatal):', cartErr.message);
+          logError('bundleDeals:getCurrentCart-failed', cartErr);
         }
         if (!alreadyApplied) {
           try {
@@ -200,7 +200,7 @@ export const addBundleToCart = webMethod(
             couponApplied = true;
           } catch (couponErr) {
             // Non-fatal: products are already in cart; log and continue
-            console.warn('[bundleDeals] Coupon apply failed (non-fatal):', bundle.couponCode, couponErr.message);
+            logError(`bundleDeals:couponApply-failed coupon=${bundle.couponCode}`, couponErr);
           }
         }
       }

--- a/src/backend/gamificationChatbot.web.js
+++ b/src/backend/gamificationChatbot.web.js
@@ -96,7 +96,7 @@ export const getChatGreeting = webMethod(
       const flag = await getSecret('GAMIFICATION_CHATBOT_ENABLED');
       flagEnabled = flag === 'true';
     } catch (err) {
-      console.warn('[gamificationChatbot] getChatGreeting: flag fetch failed, defaulting to disabled:', err?.message);
+      logError('gamificationChatbot:getChatGreeting-flagFetchFailed', err);
       flagEnabled = false;
     }
     if (!flagEnabled) return { enabled: false };

--- a/src/backend/pushNotificationService.web.js
+++ b/src/backend/pushNotificationService.web.js
@@ -13,6 +13,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { getActiveTokensForMember, deactivateToken } from 'backend/pushTokenRegistry.web';
+import { logError } from 'backend/utils/errorHandler';
 
 export const PUSH_EVENTS = {
   BADGE_EARNED:       'badge_earned',
@@ -90,7 +91,7 @@ export async function sendPushToMember(memberId, event, payload = {}) {
           }
         }
       } catch (err) {
-        console.error('[pushNotificationService] FCM error:', err);
+        logError('pushNotificationService:sendPush-fcmError', err);
         failed++;
       }
     })

--- a/src/backend/referralService.web.js
+++ b/src/backend/referralService.web.js
@@ -645,7 +645,7 @@ export async function _processReferralOnOrderCreated(memberId, orderNumber, isFi
           resultObj.pointsAwarded = BONUS_POINTS.REFERRAL_COMPLETE;
         }
       } catch (loyaltyErr) {
-        console.warn('_processReferralOnOrderCreated: earnPoints failed (non-fatal)', loyaltyErr.message);
+        logError('referralService:processReferralOnOrderCreated-earnPointsFailed', loyaltyErr);
       }
     }
 

--- a/src/backend/returnsService.web.js
+++ b/src/backend/returnsService.web.js
@@ -373,7 +373,7 @@ export const lookupReturn = webMethod(
 
       // Rate limit by email to prevent order enumeration
       if (!(await _checkRateLimit(cleanEmail))) {
-        console.warn('[returnsService] Rate limit exceeded for lookupReturn:', redactEmail(cleanEmail));
+        logError(`returnsService:lookupReturn-rateLimitExceeded email=${redactEmail(cleanEmail)}`, null);
         return { success: false, error: 'Too many attempts. Please try again in a minute.' };
       }
 
@@ -443,7 +443,7 @@ export const submitGuestReturn = webMethod(
 
       // Rate limit by email to prevent order enumeration
       if (!(await _checkRateLimit(cleanEmail))) {
-        console.warn('[returnsService] Rate limit exceeded for submitGuestReturn:', redactEmail(cleanEmail));
+        logError(`returnsService:submitGuestReturn-rateLimitExceeded email=${redactEmail(cleanEmail)}`, null);
         return { success: false, error: 'Too many attempts. Please try again in a minute.' };
       }
 

--- a/src/backend/sitemapEnhancer.web.js
+++ b/src/backend/sitemapEnhancer.web.js
@@ -17,6 +17,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { getImageUrl } from 'backend/utils/mediaHelpers';
+import { logError } from 'backend/utils/errorHandler';
 
 const SITE_URL = 'https://www.carolinafutons.com';
 
@@ -218,7 +219,7 @@ export const getProductSitemapEntries = webMethod(
 
       return { success: true, entries, xml, count: entries.length };
     } catch (err) {
-      console.error('[sitemapEnhancer] getProductSitemapEntries error:', err);
+      logError('sitemapEnhancer:getProductSitemapEntries', err);
       return { success: false, entries: [], xml: '', count: 0, error: 'Failed to generate sitemap.' };
     }
   }

--- a/src/backend/socialProofBadge.web.js
+++ b/src/backend/socialProofBadge.web.js
@@ -14,6 +14,7 @@
 
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 const MEMBER_POINTS_COLLECTION = 'MemberPoints';
 
@@ -54,7 +55,7 @@ export const getNeighborCount = webMethod(
         isNational: !zipPrefix,
       };
     } catch (err) {
-      console.error('[socialProofBadge] getNeighborCount failed:', err);
+      logError('socialProofBadge:getNeighborCount', err);
       return { count: 0, zipPrefix: null, isNational: true, error: true };
     }
   }

--- a/src/backend/surveyService.web.js
+++ b/src/backend/surveyService.web.js
@@ -123,7 +123,7 @@ export const scheduleSurvey = webMethod(
         createdAt: new Date(),
       });
     } catch (emailErr) {
-      console.warn('[surveyService] Email queue insert failed:', emailErr.message);
+      logError('surveyService:queueEmail-insertFailed', emailErr);
       // Non-fatal — survey record was created; email can be retried
     }
 

--- a/src/backend/ugcService.web.js
+++ b/src/backend/ugcService.web.js
@@ -292,7 +292,7 @@ export const voteForPhoto = webMethod(
           const errMsg = dupErr?.message || '';
           if (errMsg.includes('duplicate') || errMsg.includes('unique')) {
             // Unique constraint violation — vote already counted by concurrent request
-            console.warn('[ugcService] duplicate vote insert (concurrent), treating as voted', errMsg);
+            logError(`ugcService:vote-duplicateInsert msg=${errMsg}`, null);
             return { success: true, voted: true, voteCount: photo.voteCount || 0 };
           }
           throw dupErr;

--- a/src/backend/utils/crossRigSyncUtils.js
+++ b/src/backend/utils/crossRigSyncUtils.js
@@ -9,6 +9,7 @@
  */
 import wixData from 'wix-data';
 import { sendPushToMember, skipIfOptedOut, PUSH_EVENTS } from 'backend/pushNotificationService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 export const SYNC_LOG_COLLECTION = 'CrossRigSyncLog';
 const ALLOWED_SOURCE_RIGS = ['cfutons_mobile'];
@@ -49,7 +50,7 @@ export async function syncMobilePoints(memberId, points, eventType, sourceRig) {
     );
     return { success: true, points };
   } catch (err) {
-    console.error('[crossRigSyncUtils] syncMobilePoints error:', err);
+    logError('crossRigSyncUtils:syncMobilePoints', err);
     return { success: false, error: err.message };
   }
 }
@@ -69,7 +70,7 @@ export async function syncBadgeEarnedToPush(memberId, badgeId) {
     const { sent } = await sendPushToMember(memberId, PUSH_EVENTS.BADGE_EARNED, { badgeId });
     return { success: true, pushSent: sent };
   } catch (err) {
-    console.error('[crossRigSyncUtils] syncBadgeEarnedToPush error:', err);
+    logError('crossRigSyncUtils:syncBadgeEarnedToPush', err);
     return { success: false, error: err.message };
   }
 }

--- a/src/backend/utils/memberPointsLedger.js
+++ b/src/backend/utils/memberPointsLedger.js
@@ -4,6 +4,7 @@
  * CF-ela
  */
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 export const MEMBER_POINTS_LEDGER_COLLECTION = 'MemberPointsLedger';
 
@@ -67,7 +68,7 @@ export async function getPointsHistory(memberId, limit = 20, offset = 0) {
       .find({ suppressAuth: true });
     return { success: true, entries: result.items, total: result.totalCount };
   } catch (err) {
-    console.error('[memberPointsLedger] getPointsHistory error:', err);
+    logError('memberPointsLedger:getPointsHistory', err);
     return { success: false, entries: [], error: err.message };
   }
 }

--- a/src/backend/warrantyService.web.js
+++ b/src/backend/warrantyService.web.js
@@ -91,7 +91,7 @@ async function requireMemberWithEmail() {
 async function queueEmail(templateId, recipientEmail, variables) {
   const cleanEmail = sanitize(recipientEmail, 254);
   if (!validateEmail(cleanEmail)) {
-    console.warn(`[warrantyService] queueEmail skipped — invalid recipientEmail for template ${templateId}`);
+    logError(`warrantyService:queueEmail-invalidRecipient template=${templateId}`, null);
     return;
   }
   try {

--- a/src/backend/wwex-freight.web.js
+++ b/src/backend/wwex-freight.web.js
@@ -23,6 +23,7 @@
 
 import { getSecret } from 'wix-secrets-backend';
 import { fetch } from 'wix-fetch';
+import { logError } from 'backend/utils/errorHandler';
 
 /** WWEX SpeedFreight SOAP endpoint */
 const WWEX_ENDPOINT = 'https://api.wwex.com/SpeedFreight/RateQuote';
@@ -141,7 +142,7 @@ export async function getLTLRates(originZip, destZip, packages) {
     });
 
     if (!response.ok) {
-      console.error('WWEX API error:', response.status);
+      logError(`wwex-freight:getLTLRates-apiError status=${response.status}`, null);
       return {
         success: false,
         error: `WWEX API returned ${response.status}`,
@@ -156,7 +157,7 @@ export async function getLTLRates(originZip, destZip, packages) {
     return { success: true, rates };
 
   } catch (err) {
-    console.error('WWEX getLTLRates error:', err);
+    logError('wwex-freight:getLTLRates', err);
     return {
       success: false,
       error: err.message || 'WWEX rate lookup failed',

--- a/tests/cf-0xkm-batchR-LogErrorMigration.test.js
+++ b/tests/cf-0xkm-batchR-LogErrorMigration.test.js
@@ -1,0 +1,147 @@
+/**
+ * cf-0xkm (cf-44qt batch-R): cleanup sweep of the long tail.
+ *
+ * 20 console.* sites across 15 small files (1-2 sites each) that
+ * survived earlier batches because they're small enough to fall through
+ * cluster groupings.
+ *
+ * Excluded: utils/safeParse + errorMonitoring — both would risk a
+ * circular dependency on backend/utils/errorHandler.
+ *
+ * Regex shape accepts ', ", AND backtick — folded from cf-mrcm.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC_BACKEND = path.resolve(TEST_DIR, '../src/backend');
+
+function readSrc(rel) {
+  return fs.readFileSync(path.resolve(SRC_BACKEND, rel), 'utf-8');
+}
+
+const FILES = {
+  'wwex-freight.web.js': {
+    requiresImport: true,
+    tags: [
+      'wwex-freight:getLTLRates-apiError',
+      'wwex-freight:getLTLRates',
+    ],
+  },
+  'utils/crossRigSyncUtils.js': {
+    requiresImport: true,
+    tags: [
+      'crossRigSyncUtils:syncMobilePoints',
+      'crossRigSyncUtils:syncBadgeEarnedToPush',
+    ],
+  },
+  'returnsService.web.js': {
+    requiresImport: true,
+    tags: [
+      'returnsService:lookupReturn-rateLimitExceeded',
+      'returnsService:submitGuestReturn-rateLimitExceeded',
+    ],
+  },
+  'bundleDeals.web.js': {
+    requiresImport: true,
+    tags: [
+      'bundleDeals:getCurrentCart-failed',
+      'bundleDeals:couponApply-failed',
+    ],
+  },
+  'birthdayMigration.web.js': {
+    requiresImport: true,
+    tags: [
+      'birthdayMigration:unparseableBirthday',
+      'birthdayMigration:complete',
+    ],
+  },
+  'abTestDashboard.web.js': {
+    requiresImport: true,
+    tags: [
+      'abTestDashboard:autoStop-skipped',
+      'abTestDashboard:autoStop-completed',
+    ],
+  },
+  'warrantyService.web.js': {
+    requiresImport: true,
+    tags: ['warrantyService:queueEmail-invalidRecipient'],
+  },
+  'utils/memberPointsLedger.js': {
+    requiresImport: true,
+    tags: ['memberPointsLedger:getPointsHistory'],
+  },
+  'ugcService.web.js': {
+    requiresImport: true,
+    tags: ['ugcService:vote-duplicateInsert'],
+  },
+  'surveyService.web.js': {
+    requiresImport: true,
+    tags: ['surveyService:queueEmail-insertFailed'],
+  },
+  'socialProofBadge.web.js': {
+    requiresImport: true,
+    tags: ['socialProofBadge:getNeighborCount'],
+  },
+  'sitemapEnhancer.web.js': {
+    requiresImport: true,
+    tags: ['sitemapEnhancer:getProductSitemapEntries'],
+  },
+  'referralService.web.js': {
+    requiresImport: true,
+    tags: ['referralService:processReferralOnOrderCreated-earnPointsFailed'],
+  },
+  'pushNotificationService.web.js': {
+    requiresImport: true,
+    tags: ['pushNotificationService:sendPush-fcmError'],
+  },
+  'gamificationChatbot.web.js': {
+    requiresImport: true,
+    tags: ['gamificationChatbot:getChatGreeting-flagFetchFailed'],
+  },
+};
+
+function tagPattern(tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+  );
+}
+
+describe('cf-0xkm (cf-44qt batch-R): 15-file cleanup sweep', () => {
+  for (const [filePath, spec] of Object.entries(FILES)) {
+    describe(filePath, () => {
+      const src = readSrc(filePath);
+
+      it('contains zero console.error|warn|log|debug|info CALLS (matches strict call-pattern, not comment text)', () => {
+        const calls = src.match(/console\.(error|warn|log|debug|info)\s*\(/g) || [];
+        const allowed = spec.allowsConsoleCalls || 0;
+        expect(calls.length).toBe(allowed);
+      });
+
+      if (spec.requiresImport) {
+        it('imports logError from backend/utils/errorHandler', () => {
+          const importPattern =
+            /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler/;
+          expect(src).toMatch(importPattern);
+        });
+      }
+
+      for (const tag of spec.tags) {
+        it(`tag "${tag}" appears as a logError() call`, () => {
+          expect(src).toMatch(tagPattern(tag));
+        });
+      }
+    });
+  }
+
+  it('summary: at least 20 console.* call sites migrated across 15 files', () => {
+    const totalTags = Object.values(FILES).reduce(
+      (sum, spec) => sum + spec.tags.length,
+      0,
+    );
+    expect(totalTags).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/tests/gamificationChatbotGreeting.test.js
+++ b/tests/gamificationChatbotGreeting.test.js
@@ -30,12 +30,17 @@ beforeEach(() => {
 describe('getChatGreeting — feature flag', () => {
   it('returns { enabled: false } when GAMIFICATION_CHATBOT_ENABLED secret is absent', async () => {
     // No secrets seeded — getSecret throws
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // cf-0xkm: console.warn migrated to canonical logError, which the real
+    // errorHandler routes to console.error with `[<tag>]` prefix.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { getChatGreeting } = await vi.importActual('../src/backend/gamificationChatbot.web.js');
     const result = await getChatGreeting();
     expect(result).toEqual({ enabled: false });
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('getChatGreeting'), expect.anything());
-    warnSpy.mockRestore();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('getChatGreeting'),
+      expect.anything(),
+    );
+    errSpy.mockRestore();
   });
 
   it('returns { enabled: false } when flag is "false"', async () => {


### PR DESCRIPTION
## Summary

Cleanup pass picking up the long tail of small files (1-2 console.* sites each) that survived earlier batches because they fell outside cluster groupings. Migrates **20 sites across 15 files** to canonical `logError(tag, err)` with `<module>:<fn>(-<reason>)?` namespace.

### Files (15 / 20 sites)

- `wwex-freight.web.js` (2)
- `utils/crossRigSyncUtils.js` (2)
- `returnsService.web.js` (2) — rate-limit-exceeded with `redactEmail()` in tag body
- `bundleDeals.web.js` (2)
- `birthdayMigration.web.js` (2) — including `-complete` info tag
- `abTestDashboard.web.js` (2) — autoStop-skipped + autoStop-completed
- 9 single-site files: warrantyService, utils/memberPointsLedger, ugcService, surveyService, socialProofBadge, sitemapEnhancer, referralService, pushNotificationService, gamificationChatbot

### Explicitly NOT in this batch

- `utils/safeParse.js` + `errorMonitoring.web.js` — both would risk a **circular dependency** on `backend/utils/errorHandler`. They need separate handling (use the same module's local writer, or accept the silent-failure mode there).

## Test plan

- [x] New `tests/cf-0xkm-batchR-LogErrorMigration.test.js` (52 tests): per-file canonical-import + per-tag logError regex
- [x] Ripple-updated `tests/gamificationChatbotGreeting.test.js`: console.warn spy → console.error to match real `errorHandler.logError` routing (tag prefix wraps console.error)
- [x] Full suite: **net-neutral on regressions** (28 failures = same pre-existing pollution baseline)

Auto-merge class · 5-agent review per 2026-05-15 mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)