### PR TITLE
fix(cf-visualsearch-logerror): visualSearch.web.js — 1 console.error → logError

### DIFF
--- a/src/backend/visualSearch.web.js
+++ b/src/backend/visualSearch.web.js
@@ -12,6 +12,7 @@
  */
 import { Permissions, webMethod } from 'wix-web-module';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const VISION_API_BASE = 'https://vision.googleapis.com/v1/images:annotate';
 const MAX_RESULTS = 20;
@@ -266,7 +267,7 @@ export const analyzeRoomPhoto = webMethod(
         labelCount: labels.length,
       };
     } catch (err) {
-      console.error('[visualSearch] analyzeRoomPhoto error:', err?.message ?? err);
+      logError('visualSearch:analyzeRoomPhoto', err);
       const reason = err?.message?.startsWith('vision_') ? err.message : 'analysis_failed';
       return { success: false, tags: [], products: [], error: reason };
     }

--- a/tests/visualSearchLogErrorMigration.test.js
+++ b/tests/visualSearchLogErrorMigration.test.js
@@ -1,0 +1,42 @@
+/**
+ * cf-visualsearch-logerror — pins console.error → logError migration
+ * in src/backend/visualSearch.web.js.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/visualSearch.web.js'),
+  'utf-8',
+);
+
+describe('cf-visualsearch-logerror — visualSearch.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('uses logError tag visualSearch:analyzeRoomPhoto', () => {
+    expect(SRC).toContain(`'visualSearch:analyzeRoomPhoto'`);
+  });
+
+  it('drift guard — every logError call uses the visualSearch: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(1);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('visualSearch:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without visualSearch: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 35th PR in burst.

## Swap (1 site in visualSearch.web.js)

- `analyzeRoomPhoto` → `visualSearch:analyzeRoomPhoto`

## Verification

- New migration test: **4/4** ✅
- visualSearch suite green

Auto-merge eligible on CI green.
