### PR TITLE
fix(cf-44qt wave): membershipService.web.js console.error → logError (2 sites)

### DIFF
--- a/src/backend/membershipService.web.js
+++ b/src/backend/membershipService.web.js
@@ -15,6 +15,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { orders, plans } from 'wix-pricing-plans.v2';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 /** Plan slug identifiers — must match Wix Dashboard plan slugs. */
 export const PLAN_SLUGS = {
@@ -58,7 +59,7 @@ async function getActiveOrder() {
       o.status === 'ACTIVE' && CF_PLUS_SLUG_SET.has(o.planSlug)
     ) || null;
   } catch (err) {
-    console.error('[membershipService] Error fetching orders:', err);
+    logError('membershipService:getOrders', err);
     return null;
   }
 }
@@ -80,7 +81,7 @@ export const getMembershipPlans = webMethod(
       const allPlans = result.plans || [];
       return allPlans.filter(p => CF_PLUS_SLUG_SET.has(p.slug) && p.active);
     } catch (err) {
-      console.error('[membershipService] Error listing plans:', err);
+      logError('membershipService:listPlans', err);
       return [];
     }
   }

--- a/tests/membershipServiceLogError.test.js
+++ b/tests/membershipServiceLogError.test.js
@@ -1,0 +1,34 @@
+/**
+ * cf-44qt wave — pin membershipService.web.js console.error → logError migration.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/membershipService.web.js'),
+  'utf-8',
+);
+
+describe('cf-44qt — membershipService.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('every logError tag uses the membershipService: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(2);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('membershipService:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Single-file auto-merge slot from cf-44qt sweep. 2 sites → membershipService:<scope>. 3/3 tests green.