### PR TITLE
fix(cf-loyaltymarketing-logerror): loyaltyMarketing.web.js — 2 console.error → logError

### DIFF
--- a/src/backend/loyaltyMarketing.web.js
+++ b/src/backend/loyaltyMarketing.web.js
@@ -101,7 +101,7 @@ export const getEnrollmentPrompt = webMethod(
         },
       };
     } catch (err) {
-      console.error('[loyaltyMarketing] getEnrollmentPrompt error:', err);
+      logError('loyaltyMarketing:getEnrollmentPrompt', err);
       return { success: false, shouldPrompt: false, benefits: null };
     }
   }
@@ -426,7 +426,7 @@ export const enrollMember = webMethod(
 
       return { success: true, welcomePoints: totalWelcome, account };
     } catch (err) {
-      console.error('[loyaltyMarketing] enrollMember error:', err);
+      logError('loyaltyMarketing:enrollMember', err);
       return { success: false, welcomePoints: 0, account: null, error: 'Enrollment failed' };
     }
   }

--- a/tests/loyaltyMarketingLogErrorMigration.test.js
+++ b/tests/loyaltyMarketingLogErrorMigration.test.js
@@ -1,0 +1,48 @@
+/**
+ * cf-loyaltymarketing-logerror — pins console.error → logError migration
+ * in src/backend/loyaltyMarketing.web.js. NOTE: file already imported
+ * logError; this PR completes the 2 remaining console.error sites.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/loyaltyMarketing.web.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  'loyaltyMarketing:getEnrollmentPrompt',
+  'loyaltyMarketing:enrollMember',
+];
+
+describe('cf-loyaltymarketing-logerror — loyaltyMarketing.web.js console.error → logError', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses logError tag %s', (tag) => {
+    expect(SRC).toContain(`'${tag}'`);
+  });
+
+  it('logError call count is at least 2 (the migrated sites)', () => {
+    // Pre-existing logError calls in this file use older tag conventions
+    // (sendMonthlyLoyaltyStatements:${memberId}, [loyaltyMarketing] saveBirthday — member: ${mid}).
+    // Those are out of cf-loyaltymarketing-logerror scope; a future
+    // normalization pass (like cf-g79m) can unify the schema. This test
+    // only pins the 2 new migrated sites; full drift guard deferred.
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 36th PR in burst.

## Swaps (2 sites in loyaltyMarketing.web.js)

File already imported `logError` from earlier work — this PR completes the 2 remaining `console.error` sites that bypassed the import.

- `getEnrollmentPrompt` → `loyaltyMarketing:getEnrollmentPrompt`
- `enrollMember` → `loyaltyMarketing:enrollMember`

## Verification

- New migration test: **5/5** ✅
- loyaltyMarketing suite green

Auto-merge eligible on CI green.
