### PR TITLE
fix(cf-44qt sibling): customizationService.web.js console.error → logError ×4

### DIFF
--- a/src/backend/customizationService.web.js
+++ b/src/backend/customizationService.web.js
@@ -15,6 +15,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
 import { sanitize, validateId } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Get customization options (swatches + pricing rules) for a product.
@@ -62,7 +63,7 @@ export const getCustomizationOptions = webMethod(
         })),
       };
     } catch (err) {
-      console.error('Error fetching customization options:', err);
+      logError('[customizationService] getCustomizationOptions', err);
       return empty;
     }
   }
@@ -135,7 +136,7 @@ export const saveConfiguration = webMethod(
       const result = await wixData.insert('SavedCustomizations', record);
       return result;
     } catch (err) {
-      console.error('Error saving customization config:', err);
+      logError('[customizationService] saveCustomizationConfig', err);
       return { error: 'Failed to save configuration' };
     }
   }
@@ -176,7 +177,7 @@ export const getSavedConfigurations = webMethod(
         _createdDate: item._createdDate,
       }));
     } catch (err) {
-      console.error('Error fetching saved configurations:', err);
+      logError('[customizationService] getSavedConfigurations', err);
       return [];
     }
   }
@@ -202,7 +203,7 @@ export const getConfigurationById = webMethod(
 
       return result;
     } catch (err) {
-      console.error('Error fetching configuration:', err);
+      logError('[customizationService] getConfiguration', err);
       return null;
     }
   }

--- a/tests/cf-44qt-sibling-customization-logError.test.js
+++ b/tests/cf-44qt-sibling-customization-logError.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file cf-44qt-sibling-customization-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 4
+ * console.error sites in src/backend/customizationService.web.js
+ * migrated to canonical logError. Pre-fix sites lacked the [module]
+ * prefix — migration adds canonical [customizationService] prefix.
+ *
+ * Sites migrated (4):
+ *   - getCustomizationOptions (L65)
+ *   - saveCustomizationConfig (L138)
+ *   - getSavedConfigurations (L179)
+ *   - getConfiguration (L205)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/customizationService.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — customizationService.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 4 expected sites with canonical [customizationService] prefix (added)', () => {
+    const labels = [
+      'getCustomizationOptions',
+      'saveCustomizationConfig',
+      'getSavedConfigurations',
+      'getConfiguration',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[customizationService\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 4 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
4 sites migrated. Pre-fix sites lacked the [module] prefix; migration adds canonical [customizationService] prefix. Sites: getCustomizationOptions (L65), saveCustomizationConfig (L138), getSavedConfigurations (L179), getConfiguration (L205). 3 source-grep TDD pins. Auto-merge eligible.