### PR TITLE
fix(cf-44qt sibling): videoReviewService.web.js console.error → logError ×5 (P3)

### DIFF
--- a/src/backend/videoReviewService.web.js
+++ b/src/backend/videoReviewService.web.js
@@ -38,6 +38,7 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, isWixMediaUrl } from 'backend/utils/sanitize';
 import { receiveGamificationEvent } from 'backend/gamificationEventReceiver.web';
+import { logError } from 'backend/utils/errorHandler';
 
 /** @public — consumed by Dallas mobile SDK */
 export const VIDEO_REVIEWS_COLLECTION = 'VideoReviews';
@@ -112,7 +113,7 @@ export const submitVideoReview = webMethod(
 
       return { success: true, reviewId: record._id };
     } catch (err) {
-      console.error('[videoReviewService] submitVideoReview error:', err);
+      logError('[videoReviewService] submitVideoReview failed', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -160,7 +161,7 @@ export const getVideoReviews = webMethod(
 
       return { success: true, reviews, totalCount: result.totalCount ?? reviews.length };
     } catch (err) {
-      console.error('[videoReviewService] getVideoReviews error:', err);
+      logError('[videoReviewService] getVideoReviews failed', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }
@@ -209,7 +210,7 @@ export const moderateVideoReview = webMethod(
 
       return { success: true };
     } catch (err) {
-      console.error('[videoReviewService] moderateVideoReview error:', err);
+      logError('[videoReviewService] moderateVideoReview failed', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -250,7 +251,7 @@ export const getProductVideoReviews = webMethod(
 
       return { success: true, reviews };
     } catch (err) {
-      console.error('[videoReviewService] getProductVideoReviews error:', err);
+      logError('[videoReviewService] getProductVideoReviews failed', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }
@@ -279,7 +280,7 @@ export const getVideoReviewCount = webMethod(
 
       return { success: true, count };
     } catch (err) {
-      console.error('[videoReviewService] getVideoReviewCount error:', err);
+      logError('[videoReviewService] getVideoReviewCount failed', err);
       return { success: false, count: 0, error: 'internal_error' };
     }
   }

--- a/tests/videoReviewServiceSilentFailureCleanup.test.js
+++ b/tests/videoReviewServiceSilentFailureCleanup.test.js
@@ -1,0 +1,66 @@
+/**
+ * cf-44qt sibling — videoReviewService.web.js observability cleanup.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const logErrorSpy = vi.fn();
+vi.mock('backend/utils/errorHandler', () => ({ logError: logErrorSpy }));
+
+vi.mock('backend/utils/sanitize', () => ({
+  sanitize: (s) => s,
+  isWixMediaUrl: () => true,
+}));
+vi.mock('backend/gamificationEventReceiver.web', () => ({
+  receiveGamificationEvent: vi.fn(async () => ({ success: true })),
+}));
+vi.mock('wix-web-module', () => ({
+  Permissions: { Admin: 'Admin', SiteMember: 'SiteMember', Anyone: 'Anyone' },
+  webMethod: (_perm, fn) => fn,
+}));
+vi.mock('wix-members-backend', () => ({
+  currentMember: { getMember: vi.fn(async () => ({ _id: 'member-1' })) },
+}));
+
+import {
+  __reset as resetData,
+  __setQueryError,
+  __setInsertError,
+} from './__mocks__/wix-data.js';
+
+describe('cf-44qt sibling — videoReviewService.web.js observability cleanup', () => {
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    resetData();
+  });
+
+  it('submitVideoReview wires logError on VideoReviews insert throw', async () => {
+    __setInsertError('VideoReviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/videoReviewService.web.js');
+    await mod.submitVideoReview('prod-1', 'wix:video://v1/abc/file.mp4', 'caption');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/videoReviewService/);
+    expect(allTags).toMatch(/submitVideoReview/);
+  });
+
+  it('getVideoReviews wires logError on VideoReviews query throw', async () => {
+    __setQueryError('VideoReviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/videoReviewService.web.js');
+    await mod.getVideoReviews('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/videoReviewService/);
+    expect(allTags).toMatch(/getVideoReviews/);
+  });
+
+  it('getProductVideoReviews wires logError on VideoReviews query throw', async () => {
+    __setQueryError('VideoReviews', new Error('wixData failure'));
+    const mod = await import('../src/backend/videoReviewService.web.js');
+    await mod.getProductVideoReviews('prod-1');
+    expect(logErrorSpy).toHaveBeenCalled();
+    const allTags = logErrorSpy.mock.calls.map(c => c[0]).join('|');
+    expect(allTags).toMatch(/videoReviewService/);
+    expect(allTags).toMatch(/getProductVideoReviews/);
+  });
+});


### PR DESCRIPTION
## Summary
- **5 catch sites** migrated. All 5 webMethods.
- 38th in the cf-44qt sibling series.

## Verification
- [x] **3/3** new + **109/109** existing = **112/112 combined**

🤖 Generated with [Claude Code](https://claude.com/claude-code)