### PR TITLE
fix(cf-44qt wave): roomStaging.web.js console.error → logError (2 sites)

### DIFF
--- a/src/backend/roomStaging.web.js
+++ b/src/backend/roomStaging.web.js
@@ -26,6 +26,7 @@ import { getSecret } from 'wix-secrets-backend';
 import { fetch } from 'wix-fetch';
 import { mediaManager } from 'wix-media-backend';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 
 const MAX_IMAGE_SIZE_MB = 10;
 const STAGING_CACHE_COLLECTION = 'RoomStagingCache';
@@ -140,7 +141,7 @@ export const generateStagedRoom = webMethod(
 
       if (!response.ok) {
         const errText = await response.text().catch(() => '');
-        console.error('[roomStaging] AI API error:', response.status, errText.slice(0, 200));
+        logError('roomStaging:aiApiNon200', new Error(`status=${response.status} body=${errText.slice(0, 200)}`));
         return { success: false, stagedImageUrl: '', error: `AI generation failed (${response.status})` };
       }
 
@@ -175,7 +176,7 @@ export const generateStagedRoom = webMethod(
 
       return { success: true, stagedImageUrl, prompt };
     } catch (err) {
-      console.error('[roomStaging] generateStagedRoom failed:', err?.message);
+      logError('roomStaging:generateStagedRoom', err);
       return { success: false, stagedImageUrl: '', error: err?.message || 'Unknown error' };
     }
   }

--- a/tests/roomStagingLogError.test.js
+++ b/tests/roomStagingLogError.test.js
@@ -1,0 +1,34 @@
+/**
+ * cf-44qt wave — pin roomStaging.web.js console.error → logError migration.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/roomStaging.web.js'),
+  'utf-8',
+);
+
+describe('cf-44qt — roomStaging.web.js console.error → logError migration', () => {
+  it('contains zero console.error calls', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('every logError tag uses the roomStaging: prefix', () => {
+    const tagRe = /\blogError\s*\(\s*['"`]([^'"`]+)/g;
+    const tags = Array.from(SRC.matchAll(tagRe), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(2);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('roomStaging:'));
+    expect(nonPrefixed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Single-file auto-merge slot from cf-44qt sweep. 2 sites → roomStaging:<scope>. AI API non-200 site wraps response.status + body slice in new Error() to preserve context. 3/3 tests green.