### PR TITLE
fix(cf-44qt sibling): swatchService.web.js console.error → logError ×4

### DIFF
--- a/src/backend/swatchService.web.js
+++ b/src/backend/swatchService.web.js
@@ -2,6 +2,7 @@
 // Queries FabricSwatches CMS collection for swatch data
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
+import { logError } from 'backend/utils/errorHandler';
 
 // Get available swatches for a product, optionally filtered by color family
 export const getProductSwatches = webMethod(
@@ -35,7 +36,7 @@ export const getProductSwatches = webMethod(
         careInstructions: item.careInstructions,
       }));
     } catch (err) {
-      console.error('Error fetching product swatches:', err);
+      logError('[swatchService] getProductSwatches', err);
       return [];
     }
   }
@@ -51,7 +52,7 @@ export const getAllSwatchFamilies = webMethod(
 
       return results.items || [];
     } catch (err) {
-      console.error('Error fetching swatch families:', err);
+      logError('[swatchService] getSwatchFamilies', err);
       return [];
     }
   }
@@ -71,7 +72,7 @@ export const getSwatchCount = webMethod(
 
       return results;
     } catch (err) {
-      console.error('Error counting swatches:', err);
+      logError('[swatchService] countSwatches', err);
       return 0;
     }
   }
@@ -96,7 +97,7 @@ export const getSwatchPreviewColors = webMethod(
         swatchName: item.swatchName,
       }));
     } catch (err) {
-      console.error('Error fetching swatch preview colors:', err);
+      logError('[swatchService] getSwatchPreviewColors', err);
       return [];
     }
   }

--- a/tests/cf-44qt-sibling-swatchService-logError.test.js
+++ b/tests/cf-44qt-sibling-swatchService-logError.test.js
@@ -1,0 +1,52 @@
+/**
+ * @file cf-44qt-sibling-swatchService-logError.test.js
+ * @description TDD red → green for cf-44qt sibling sweep: 4
+ * console.error sites in src/backend/swatchService.web.js migrated
+ * to canonical logError. Pre-fix sites lacked the [module] prefix;
+ * migration adds canonical [swatchService] prefix.
+ *
+ * Sites migrated (4):
+ *   - getProductSwatches (L38)
+ *   - getSwatchFamilies (L54)
+ *   - countSwatches (L74)
+ *   - getSwatchPreviewColors (L99)
+ *
+ * cf-44qt sibling — radahn (Stilgar pace-alert dispatch).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(
+  resolve(__dirname, '../src/backend/swatchService.web.js'),
+  'utf8',
+);
+
+describe('cf-44qt sibling — swatchService.web.js console.error → logError', () => {
+  it('source file has NO remaining bare console.error calls (drift guard)', () => {
+    expect(SRC).not.toMatch(/console\.error/);
+    expect(SRC).toMatch(
+      /import\s*{\s*logError\s*}\s*from\s*['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it('source file uses logError for all 4 expected sites with canonical [swatchService] prefix (added)', () => {
+    const labels = [
+      'getProductSwatches',
+      'getSwatchFamilies',
+      'countSwatches',
+      'getSwatchPreviewColors',
+    ];
+    for (const label of labels) {
+      const re = new RegExp(
+        `logError\\(\\s*['"]\\[swatchService\\] ${label}['"]`,
+      );
+      expect(SRC).toMatch(re);
+    }
+  });
+
+  it('logError invocation count matches the 4 migrated sites (no over-migration drift)', () => {
+    const matches = SRC.match(/logError\s*\(/g) || [];
+    expect(matches.length).toBe(4);
+  });
+});


### PR DESCRIPTION
4 sites migrated. Pre-fix sites lacked the [module] prefix; migration adds canonical [swatchService] prefix. Sites: getProductSwatches (L38), getSwatchFamilies (L54), countSwatches (L74), getSwatchPreviewColors (L99). 3 source-grep TDD pins. Auto-merge eligible.