### PR TITLE
fix(cf-events-logerror): events.js — 26 console.error → logError

### DIFF
--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -119,7 +119,7 @@ export async function wixEcom_onAbandonedCheckoutCreated(event) {
       recoveryEmailSent: false,
     });
   } catch (err) {
-    console.error(`[events] DROPPED abandoned cart — checkoutId: ${checkoutId || 'unknown'}, email: ${redactEmail(buyerEmail)}, error:`, err);
+    logError(`events:wixEcom_onCartAbandoned-dropped checkoutId=${checkoutId || 'unknown'} email=${redactEmail(buyerEmail)}`, err);
     await logFailedEvent({
       handler: 'wixEcom_onAbandonedCheckoutCreated',
       checkoutId: checkoutId || 'unknown',
@@ -154,7 +154,7 @@ export async function wixEcom_onAbandonedCheckoutRecovered(event) {
       status: 'recovered',
     });
   } catch (err) {
-    console.error(`[events] FAILED to mark cart recovered — checkoutId: ${checkoutId || 'unknown'}, error:`, err);
+    logError(`events:markCartRecovered checkoutId=${checkoutId || 'unknown'}`, err);
     await logFailedEvent({
       handler: 'wixEcom_onAbandonedCheckoutRecovered',
       checkoutId: checkoutId || 'unknown',
@@ -196,7 +196,7 @@ export async function wixMembers_onMemberCreated(event) {
     const { triggerWelcomeSequence } = await import('backend/emailAutomation.web');
     await triggerWelcomeSequence(contactId, email, firstName);
   } catch (err) {
-    console.error('[events] Error triggering welcome sequence:', err);
+    logError('events:welcomeSequence', err);
   }
 
   // CF-9swp: Seed welcome points (endowed progress) for new members
@@ -204,7 +204,7 @@ export async function wixMembers_onMemberCreated(event) {
     const { seedWelcomePoints } = await import('backend/gamificationEventReceiver.web');
     await seedWelcomePoints(contactId);
   } catch (err) {
-    console.error('[events] Error seeding welcome points:', err);
+    logError('events:seedWelcomePoints', err);
   }
 }
 
@@ -249,14 +249,14 @@ export async function wixEcom_onOrderCreated(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'confirmed');
   } catch (err) {
-    console.error('[events] Order status webhook (confirmed) failed:', err);
+    logError('events:orderStatusWebhook-confirmed', err);
   }
 
   try {
     const { triggerPostPurchaseSequence } = await import('backend/emailAutomation.web');
     await triggerPostPurchaseSequence(contactId, email, firstName, orderNumber, total, lineItems, { memberId });
   } catch (err) {
-    console.error('[events] Error triggering post-purchase sequence:', err);
+    logError('events:postPurchaseSequence', err);
   }
 
   if (memberId) {
@@ -275,7 +275,7 @@ export async function wixEcom_onOrderCreated(event) {
           const { checkAndTriggerTierMilestone } = await import('backend/emailAutomation.web');
           await checkAndTriggerTierMilestone(memberId, email, firstName, newTotal, oldTotal);
         } catch (err) {
-          console.error('[events] Error checking tier milestone:', err);
+          logError('events:tierMilestoneCheck', err);
         }
       }
 
@@ -288,7 +288,7 @@ export async function wixEcom_onOrderCreated(event) {
         await recordChallengeProgress({ memberId, challengeId: challenge.challengeId });
       }
     } catch (err) {
-      console.error('[events] Error recording gamification on order:', err);
+      logError('events:gamificationOnOrder', err);
     }
 
     // cf-bu2: complete any pending referral attribution for web checkouts
@@ -296,7 +296,7 @@ export async function wixEcom_onOrderCreated(event) {
       const { _processReferralOnOrderCreated } = await import('backend/referralService.web');
       await _processReferralOnOrderCreated(memberId, orderNumber);
     } catch (err) {
-      console.error('[events] Error processing referral on order:', err);
+      logError('events:referralOnOrder', err);
     }
   }
 
@@ -306,7 +306,7 @@ export async function wixEcom_onOrderCreated(event) {
       const { checkSwatchAttribution } = await import('backend/swatchAttribution.web');
       await checkSwatchAttribution(email, orderNumber, Number(total));
     } catch (err) {
-      console.error('[events] Error checking swatch attribution:', err);
+      logError('events:swatchAttributionCheck', err);
     }
   }
 
@@ -316,11 +316,11 @@ export async function wixEcom_onOrderCreated(event) {
     if (orderContainsSwatchKit(order.lineItems || [])) {
       const result = await recordSwatchKitPurchase(orderNumber, memberId, email, []);
       if (!result?.success && !result?.alreadyIssued) {
-        console.error('[events] Swatch kit credit issuance failed silently:', result?.error, { orderNumber });
+        logError(`events:swatchKitCredit-silentFailure orderNumber=${orderNumber}`, new Error(String(result?.error || 'unknown')));
       }
     }
   } catch (err) {
-    console.error('[events] Swatch kit credit issuance failed:', err);
+    logError('events:swatchKitCreditIssuance', err);
   }
 }
 
@@ -343,7 +343,7 @@ export async function wixEcom_onOrderApproved(event) {
     const { receiveGamificationEvent } = await import('backend/gamificationEventReceiver.web');
     await receiveGamificationEvent('gamification_order_complete', { orderTotal }, memberId);
   } catch (err) {
-    console.error('[events] wixEcom_onOrderApproved: gamification earn failed', err);
+    logError('events:wixEcom_onOrderApproved-gamificationEarn', err);
   }
 }
 
@@ -365,7 +365,7 @@ export async function wixEcom_onOrderFulfilled(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'shipped');
   } catch (err) {
-    console.error('[events] Order status webhook (shipped) failed:', err);
+    logError('events:orderStatusWebhook-shipped', err);
   }
 
   if (!memberId) return;
@@ -374,7 +374,7 @@ export async function wixEcom_onOrderFulfilled(event) {
     const { handleOrderFulfilled } = await import('backend/notificationOrchestrator.web');
     await handleOrderFulfilled({ memberId, orderNumber, trackingNumber });
   } catch (err) {
-    console.error('[events] Error handling order fulfilled SMS:', err);
+    logError('events:onOrderFulfilled-sms', err);
   }
 }
 
@@ -393,7 +393,7 @@ export async function wixEcom_onFulfillmentCreated(event) {
     const { handleFulfillmentShippingNotification } = await import('backend/emailAutomation.web');
     handleFulfillmentShippingNotification(event);
   } catch (err) {
-    console.error('[events] Error handling fulfillment created:', err);
+    logError('events:onFulfillmentCreated', err);
   }
 }
 
@@ -414,7 +414,7 @@ export async function wixEcom_onFulfillmentUpdated(event) {
     const { handleFulfillmentShippingNotification } = await import('backend/emailAutomation.web');
     handleFulfillmentShippingNotification(event);
   } catch (err) {
-    console.error('[events] Error handling fulfillment updated:', err);
+    logError('events:onFulfillmentUpdated', err);
   }
 }
 
@@ -431,7 +431,7 @@ export async function wixEcom_onOrderDelivered(event) {
     const { handleOrderDelivered } = await import('backend/emailAutomation.web');
     handleOrderDelivered(event);
   } catch (err) {
-    console.error('[events] Error handling order delivered:', err);
+    logError('events:onOrderDelivered', err);
   }
 }
 
@@ -449,7 +449,7 @@ export async function wixEcom_onOrderCanceled(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'cancelled');
   } catch (err) {
-    console.error('[events] Order status webhook (cancelled) failed:', err);
+    logError('events:orderStatusWebhook-cancelled', err);
   }
 
   if (!email) return;
@@ -458,7 +458,7 @@ export async function wixEcom_onOrderCanceled(event) {
     const { cancelSequenceForOrder } = await import('backend/emailAutomation.web');
     await cancelSequenceForOrder(email, orderNumber);
   } catch (err) {
-    console.error('[events] Error cancelling care sequence:', err);
+    logError('events:cancelCareSequence', err);
   }
 }
 
@@ -490,7 +490,7 @@ export async function wixStores_onProductCreated(event) {
       imageUrl: product.mainMedia || product.media?.mainMedia?.image?.url || '',
     });
   } catch (err) {
-    console.error('[events] Content orchestration failed for new product:', err);
+    logError('events:contentOrchestration-newProduct', err);
     await logFailedEvent({
       handler: 'wixStores_onProductCreated',
       productId,
@@ -537,7 +537,7 @@ export async function wixStores_onProductUpdated(event) {
       newPrice,
     });
   } catch (err) {
-    console.error('[events] Content orchestration failed for price drop:', err);
+    logError('events:contentOrchestration-priceDrop', err);
     await logFailedEvent({
       handler: 'wixStores_onProductUpdated',
       productId,
@@ -581,7 +581,7 @@ export async function wixStores_onInventoryVariantUpdated(event) {
 
     // Check for soft failure (returned { success: false } without throwing)
     if (result && !result.success) {
-      console.error(`[events] Restock notifications returned failure — productId: ${productId}, error: ${result.error || 'unknown'}`);
+      logError(`events:restockNotifications-resultFailure productId=${productId}`, new Error(String(result.error || 'unknown')));
       await logFailedEvent({
         handler: 'wixStores_onInventoryVariantUpdated',
         productId: productId || 'unknown',
@@ -604,10 +604,10 @@ export async function wixStores_onInventoryVariantUpdated(event) {
         });
       }
     } catch (orchErr) {
-      console.error('[events] Content orchestration failed for restock:', orchErr);
+      logError('events:contentOrchestration-restock', orchErr);
     }
   } catch (err) {
-    console.error(`[events] FAILED restock notifications — productId: ${productId || 'unknown'}, error:`, err);
+    logError(`events:restockNotifications productId=${productId || 'unknown'}`, err);
     await logFailedEvent({
       handler: 'wixStores_onInventoryVariantUpdated',
       productId: productId || 'unknown',
@@ -661,7 +661,7 @@ export async function wixMembers_onMemberUpdated(event) {
       birthday_day: parsed.day,
     });
   } catch (err) {
-    console.error(`[events] Failed to sync birthday fields for member ${memberId}:`, err?.message ?? err);
+    logError(`events:syncBirthdayFields member=${memberId}`, err);
     await logFailedEvent({
       handler: 'wixMembers_onMemberUpdated',
       error: err.message,

--- a/tests/contactResolver.cfxdji.test.js
+++ b/tests/contactResolver.cfxdji.test.js
@@ -122,7 +122,7 @@ describe('cf-xdji · resolveContactId — failure modes', () => {
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
     expect(logError).toHaveBeenCalledWith(
-      expect.stringContaining('appendOrCreateContact'),
+      expect.stringContaining('appendOrCreateFailed'),
       expect.any(Error),
     );
   });

--- a/tests/contactResolver.cfxdji.test.js
+++ b/tests/contactResolver.cfxdji.test.js
@@ -36,6 +36,7 @@ import {
 beforeEach(() => {
   resetCrm();
   vi.restoreAllMocks();
+  vi.clearAllMocks();
 });
 
 describe('cf-xdji · resolveContactId — happy path', () => {
@@ -128,14 +129,12 @@ describe('cf-xdji · resolveContactId — failure modes', () => {
 
   it('returns null when appendOrCreateContact resolves with no contactId', async () => {
     vi.spyOn(contacts, 'appendOrCreateContact').mockResolvedValue({});
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
-    expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining('returned no contactId'),
-      expect.anything(),
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('noContactId'),
+      null,
     );
-    consoleWarn.mockRestore();
   });
 });
 

--- a/tests/contactResolver.cfxdji.test.js
+++ b/tests/contactResolver.cfxdji.test.js
@@ -36,7 +36,6 @@ import {
 beforeEach(() => {
   resetCrm();
   vi.restoreAllMocks();
-  vi.clearAllMocks();
 });
 
 describe('cf-xdji · resolveContactId — happy path', () => {
@@ -122,19 +121,21 @@ describe('cf-xdji · resolveContactId — failure modes', () => {
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
     expect(logError).toHaveBeenCalledWith(
-      expect.stringContaining('appendOrCreateFailed'),
+      expect.stringContaining('appendOrCreateContact'),
       expect.any(Error),
     );
   });
 
   it('returns null when appendOrCreateContact resolves with no contactId', async () => {
     vi.spyOn(contacts, 'appendOrCreateContact').mockResolvedValue({});
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
-    expect(logError).toHaveBeenCalledWith(
-      expect.stringContaining('noContactId'),
-      null,
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('returned no contactId'),
+      expect.anything(),
     );
+    consoleWarn.mockRestore();
   });
 });
 

--- a/tests/eventsLogErrorMigration.test.js
+++ b/tests/eventsLogErrorMigration.test.js
@@ -1,0 +1,72 @@
+/**
+ * cf-events-logerror — pins console.error → logError migration in
+ * src/backend/events.js. Largest single-file count in the pace-alert
+ * burst (26 sites; Wix platform event handlers).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/events.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAG_PREFIXES = [
+  'events:wixEcom_onCartAbandoned-dropped',
+  'events:markCartRecovered',
+  'events:welcomeSequence',
+  'events:seedWelcomePoints',
+  'events:orderStatusWebhook-confirmed',
+  'events:postPurchaseSequence',
+  'events:tierMilestoneCheck',
+  'events:gamificationOnOrder',
+  'events:referralOnOrder',
+  'events:swatchAttributionCheck',
+  'events:swatchKitCredit-silentFailure',
+  'events:swatchKitCreditIssuance',
+  'events:wixEcom_onOrderApproved-gamificationEarn',
+  'events:orderStatusWebhook-shipped',
+  'events:onOrderFulfilled-sms',
+  'events:onFulfillmentCreated',
+  'events:onFulfillmentUpdated',
+  'events:onOrderDelivered',
+  'events:orderStatusWebhook-cancelled',
+  'events:cancelCareSequence',
+  'events:contentOrchestration-newProduct',
+  'events:contentOrchestration-priceDrop',
+  'events:restockNotifications-resultFailure',
+  'events:contentOrchestration-restock',
+  'events:restockNotifications',
+  'events:syncBirthdayFields',
+];
+
+describe('cf-events-logerror — events.js console.error → logError', () => {
+  it('contains zero console.error calls (all 26 sites converted)', () => {
+    const matches = SRC.match(/console\.error\s*\(/g) || [];
+    expect(matches.length).toBe(0);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it.each(EXPECTED_TAG_PREFIXES)('uses logError tag prefix %s', (prefix) => {
+    expect(SRC).toContain(prefix);
+  });
+
+  it('drift guard — every logError call uses the events: prefix', () => {
+    const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
+    const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
+    expect(tags.length).toBeGreaterThanOrEqual(26);
+    const nonPrefixed = tags.filter((t) => !t.startsWith('events:'));
+    expect(
+      nonPrefixed,
+      `found logError tags without events: prefix: ${nonPrefixed.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Per mayor STILGAR PACE ALERT small-class greenlight. 37th PR in burst — **largest single-file count yet (26 sites)**.

## Swaps (26 sites in events.js — Wix platform event handlers)

Across all major lifecycle events:
- Cart: `wixEcom_onCartAbandoned-dropped`, `markCartRecovered`
- Welcome: `welcomeSequence`, `seedWelcomePoints`
- Order status webhooks: `orderStatusWebhook-{confirmed,shipped,cancelled}`
- Order events: `postPurchaseSequence`, `tierMilestoneCheck`, `gamificationOnOrder`, `referralOnOrder`, `swatchAttributionCheck`, `swatchKitCredit-silentFailure`, `swatchKitCreditIssuance`, `wixEcom_onOrderApproved-gamificationEarn`
- Fulfillment: `onOrderFulfilled-sms`, `onFulfillmentCreated`, `onFulfillmentUpdated`, `onOrderDelivered`, `cancelCareSequence`
- Content orchestration: `-newProduct`, `-priceDrop`, `-restock`
- Restock: `restockNotifications-resultFailure`, `restockNotifications`
- Members: `syncBirthdayFields`

Template-literal tags preserve cart-id, order-number, product-id, member-id context for operator forensics. Silent-failure sites wrap `result.error` in `new Error(...)` to satisfy logError signature.

## Verification

- New migration test: **29/29** ✅ (26 tag prefixes + zero console.error + import + drift-guard)
- events suite green

Auto-merge eligible on CI green.
