### PR TITLE
feat(cf-m6t0): wire sendOrderConfirmation into events.js — F3 dead-code fix

### DIFF
--- a/docs/email-audit-2026-05-04.md
+++ b/docs/email-audit-2026-05-04.md
@@ -1,4 +1,44 @@
-# Email Touchpoint Audit — 2026-05-04 (refreshed 2026-05-05; cf-6k6u corrections 2026-05-05 PM)
+# Email Touchpoint Audit — 2026-05-04 (refreshed 2026-05-05; cf-6k6u corrections 2026-05-05 PM; staging verification 2026-05-20)
+
+> **2026-05-20 staging verification addendum** (rennala, cf-icww):
+>
+> ## STAGING_SITE verification — data-layer results (2026-05-20)
+>
+> STAGING_SITE id: `3af610bf-06fb-410d-a406-c1258fa84372`. Accessed via Wix MCP REST API.
+>
+> ### EmailQueue baseline
+> - **Total records:** 61 (59 welcome-series from 2026-05-05 godfrey diagnostic probe + 2 legacy seed rows)
+> - **Sent:** 2 (legacy seed rows from 2026-03-11/14; `tpl-cart-recovery-1` + `tpl-post-purchase-1` old-format IDs)
+> - **Failed:** 0
+> - **Pending:** 59 — all past `scheduledFor`, **cron NOT processing** on STAGING_SITE. Emails will not send until cron jobs are enabled on staging.
+> - **Non-welcome sequences (post_purchase, cart_recovery, browse_recovery, reengagement, winback):** 0 records — no test events (orders, carts, fulfillments) have ever been fired on this STAGING_SITE.
+>
+> ### F1 fix confirmed (data layer)
+> All 59 post-fix EmailQueue rows have non-empty `recipientContactId` (e.g. `10d661ff-7c69-4318-bb10-2b35632040d0`). Proves `_resolveContactIdInternal` ran successfully at queue-write time. Variables are populated (`discountCode`, `firstName`, `email`, `discountPercent`). **F1: PASS at data layer.**
+>
+> ### TEMPLATE_ID_MAP verified
+> `src/backend/emailTemplates.web.js#TEMPLATE_ID_MAP` confirmed populated for all P0/P1 templates. All P0 templates have Wix CRM dashboard IDs: `order_confirmation: 'VJBTjjZ'`, `order_shipped: 'VJBTpK1'`, `delivery_confirmation: 'VJBTuXp'`, `freight_shipped: 'VJBUKCa'`. Dispatch calls will resolve correctly when the event path fires.
+>
+> ### Cron stall — blocking live send verification
+> The staging cron is not running. Without a live-backend publish + cron enable, the remaining 8-step acceptance test plan (§Verification gaps) cannot be executed. Stilgar must publish backend to STAGING_SITE and enable cron before inbox-level verification can proceed. Filed in cf-w1u1.
+>
+> ## Code-level finding status as of 2026-05-20
+>
+> | Finding | Code status on `main` | Evidence |
+> |---------|----------------------|----------|
+> | F1 — welcome series empty recipientContactId | ✅ FIXED | `emailAutomation.web.js` calls `_resolveContactIdInternal` before queuing; confirmed in STAGING_SITE EmailQueue data |
+> | F2 — subscribeToNewsletter no welcome | ✅ FIXED (cf-3l0d) | `newsletterService.web.js` now calls `resolveContactId` and queues welcome_series_1..5 at the success branch |
+> | F3 — order_confirmation never sends | ❌ **STILL BROKEN** | `sendOrderConfirmation` call is still in `emailAutomation.web.js#wixEcom_onOrderCreated` (dead code). `events.js#wixEcom_onOrderCreated` does NOT call `sendOrderConfirmation`. cf-i23b bead CLOSED 2026-05-05 but no merged PR on main. **Bead-trail drift — flag to mayor.** |
+> | F4 — shipping notifications never fire | ✅ FIXED (cf-fovb PR #1202) | `events.js#wixEcom_onFulfillmentCreated` delegates to `emailAutomation.web.js#handleFulfillmentShippingNotification` |
+> | F5 — delivery/Day-14/NPS never fire | ✅ FIXED (cf-jmmk PR #1141) | `events.js#wixEcom_onOrderDelivered` delegates to `handleOrderDelivered` |
+> | F6 — no contact form auto-reply | ✅ FIXED (cf-hafn) | `emailService.web.js#_sendCustomerContactAutoReply` wired; template `contact_form_auto_reply: 'VJBOnfD'` in TEMPLATE_ID_MAP |
+> | F7 — swatch confirmation skipped for new visitors | ❌ **STILL BROKEN** | `emailService.web.js#submitSwatchRequest` still uses `contacts.queryContacts()` — fires only if contact pre-exists. cf-xdji resolved the helper but item 2 (apply `appendOrCreateContact` at swatch site) never landed |
+>
+> ### F3 remediation (URGENT — P0 gap, open 2026-05-15)
+> One-line fix needed in `src/backend/events.js#wixEcom_onOrderCreated`: add `sendOrderConfirmation(...)` call after the existing `if (!email) return` guard. Delete dormant copy in `emailAutomation.web.js`. cf-i23b bead was closed 2026-05-05 citing "MR created: cf-wisp-edi" but no commit on main. Melania notified via mail — awaiting re-dispatch.
+>
+> ### F7 remediation (P2 gap)
+> `emailService.web.js#submitSwatchRequest` line ~372: replace `contacts.queryContacts().eq(...)` with `contacts.appendOrCreateContact({ emails: [{ email }], name: { first: cleanName } })` — same pattern used by `_sendCustomerContactAutoReply`. New visitor now gets the confirmation. Tracked as follow-up to cf-xdji item 2.
 
 > **cf-6k6u correction summary** (radahn 5-agent review on merged PR #1140):
 > 1. **Row 14 winback template IDs were fabricated.** Earlier revision listed `lifecycle_winback_30d/60d/90d`. Those template IDs do not exist. Real winback templates load at runtime from the `EmailSequences` Wix Data collection via `marketingSequences.web.js#loadActiveSteps('winback')`. Static analysis cannot enumerate them. Row 14 has been corrected.

--- a/src/backend/emailAutomation.web.js
+++ b/src/backend/emailAutomation.web.js
@@ -160,11 +160,16 @@ const SEND_WINDOW = { startHour: 8, endHour: 20, timezone: 'America/New_York' };
 // Carts at or above this total qualify for the free shipping note in step 2.
 const CART_FREE_SHIPPING_THRESHOLD = 150;
 
-// ── Event Handlers (auto-register in backend/) ───────────────────────
+// ── Dead event-handler stubs (test backward-compat) ──────────────────
+// Wix Velo auto-registers event handlers ONLY from backend/events.js.
+// These functions are never invoked by Wix. They are kept exported here
+// solely so pre-existing tests that imported them directly continue to
+// pass without a mass-refactor. Real implementations live in events.js.
+// Do NOT add business logic here — it will never run in production.
 
 /**
- * Triggered when a new site member is created.
- * Queues the welcome email series.
+ * @deprecated Real handler: events.js#wixMembers_onMemberCreated.
+ * Kept for test backward-compat (cf-m6t0).
  */
 export function wixMembers_onMemberCreated(event) {
   const member = event.entity || event;
@@ -179,8 +184,10 @@ export function wixMembers_onMemberCreated(event) {
 }
 
 /**
- * Triggered when an order is created.
- * Queues the post-purchase care sequence.
+ * @deprecated Real handler: events.js#wixEcom_onOrderCreated (which sends
+ * order confirmation + queues post-purchase sequence). sendOrderConfirmation
+ * has been removed from this stub — it now lives in events.js (cf-m6t0 F3).
+ * Kept for test backward-compat.
  */
 export function wixEcom_onOrderCreated(event) {
   const order = event.entity || event;
@@ -197,15 +204,6 @@ export function wixEcom_onOrderCreated(event) {
   }));
 
   if (!email) return;
-
-  sendOrderConfirmation({
-    contactId,
-    email,
-    firstName,
-    orderNumber: String(orderNumber),
-    total: typeof total === 'number' ? `$${total.toFixed(2)}` : String(total),
-    itemSummary: lineItems.map(i => `${i.quantity}× ${i.name}`).join(', '),
-  }).catch(err => logError('emailAutomation:orderConfirmation-send', err));
 
   // CF-fzsd: Queue post-purchase care sequence at order creation so slug
   // extraction from lineItems is available (Day 7 review URL uses product slug).

--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -22,6 +22,7 @@
  */
 import wixData from 'wix-data';
 import { sanitize, redactEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── CWF ISR Revalidate Helper ─────────────────────────────────────────
 
@@ -240,7 +241,7 @@ export async function wixEcom_onOrderCreated(event) {
       itemSummary: lineItems.map(i => `${i.quantity}× ${i.name}`).join(', '),
     });
   } catch (err) {
-    console.error('[events] sendOrderConfirmation failed:', err);
+    logError('events:sendOrderConfirmation', err);
   }
 
   // CF-hfao: mobile push notification for order confirmation

--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -228,6 +228,21 @@ export async function wixEcom_onOrderCreated(event) {
 
   if (!email) return;
 
+  // cf-m6t0 (F3): branded order confirmation — was in dead code at emailAutomation.web.js#wixEcom_onOrderCreated
+  try {
+    const { sendOrderConfirmation } = await import('backend/emailService.web');
+    await sendOrderConfirmation({
+      contactId,
+      email,
+      firstName,
+      orderNumber: String(orderNumber),
+      total: typeof total === 'number' ? `$${total.toFixed(2)}` : String(total),
+      itemSummary: lineItems.map(i => `${i.quantity}× ${i.name}`).join(', '),
+    });
+  } catch (err) {
+    console.error('[events] sendOrderConfirmation failed:', err);
+  }
+
   // CF-hfao: mobile push notification for order confirmation
   try {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');

--- a/tests/emailAutomationLogErrorMigration.test.js
+++ b/tests/emailAutomationLogErrorMigration.test.js
@@ -24,9 +24,12 @@ const SRC = fs.readFileSync(
 
 // Each expected logError tag — one per swapped site. Order matches the
 // file's top-to-bottom layout for ease of forensic review.
+// cf-m6t0: wixMembers_onMemberCreated + wixEcom_onOrderCreated are kept as
+// @deprecated stubs (test backward-compat) so their logError tags remain.
+// wixEcom_onOrderCreated stub lost 'emailAutomation:orderConfirmation-send'
+// (that call moved to events.js). Count drops 25 → 24.
 const EXPECTED_TAGS = [
   'emailAutomation:welcomeSequence-trigger',
-  'emailAutomation:orderConfirmation-send',
   'emailAutomation:postPurchase-queue-onOrderCreated',
   'emailAutomation:shippingNotification-send-freight',
   'emailAutomation:shippingNotification-send-parcel',
@@ -65,12 +68,10 @@ describe('cf-uydr — emailAutomation.web.js console.error → logError migratio
     expect(SRC).toMatch(new RegExp(`logError\\([\\s\\n]*['\`]${tag.replace(/[.*+?^${}()|[\\\]\\\\]/g, '\\\\$&')}`));
   });
 
-  it('logError call count is at least 25 (the 19 migrated sites + 6 pre-existing)', () => {
-    // Pre-cf-uydr: 6 logError calls (handleOrderDelivered :confirmation /
-    // :postPurchaseCare / :survey + triggerConsultationFollowup +
-    // triggerSwatchFollowupSequence + checkAndTriggerTierMilestone).
-    // Post-cf-uydr: + 19 new = 25 total minimum.
+  it('logError call count is at least 24 (cf-m6t0: orderConfirmation-send moved to events.js)', () => {
+    // Pre-cf-uydr: 6 logError calls. Post-cf-uydr: +19 = 25.
+    // cf-m6t0: -1 (emailAutomation:orderConfirmation-send removed from stub; now in events.js) = 24.
     const matches = SRC.match(/\blogError\s*\(/g) || [];
-    expect(matches.length).toBeGreaterThanOrEqual(25);
+    expect(matches.length).toBeGreaterThanOrEqual(24);
   });
 });

--- a/tests/emailAutomationTagNormalization.test.js
+++ b/tests/emailAutomationTagNormalization.test.js
@@ -59,9 +59,10 @@ describe('cf-g79m — emailAutomation.web.js logError tag normalization', () => 
     // catch site forgets the prefix.
     const tagPattern = /\blogError\s*\(\s*['"`]([^'"`]+)['"`]/g;
     const tags = Array.from(SRC.matchAll(tagPattern), (m) => m[1]);
-    // Sanity floor: at least 25 logError calls present (19 cf-uydr +
-    // 6 cf-g79m). The exact count may drift up as new code lands.
-    expect(tags.length).toBeGreaterThanOrEqual(25);
+    // Sanity floor: at least 24 logError calls present (19 cf-uydr +
+    // 6 cf-g79m − 1 cf-m6t0: emailAutomation:orderConfirmation-send removed
+    // from dead wixEcom_onOrderCreated stub; call moved to events.js).
+    expect(tags.length).toBeGreaterThanOrEqual(24);
     const nonPrefixed = tags.filter((t) => !t.startsWith('emailAutomation:'));
     expect(
       nonPrefixed,

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -19,6 +19,12 @@ vi.mock('backend/emailAutomation.web', () => ({
   handleOrderDelivered: mockHandleOrderDelivered,
 }));
 
+// cf-m6t0: mock emailService for sendOrderConfirmation
+const mockSendOrderConfirmation = vi.fn().mockResolvedValue({ success: true });
+vi.mock('backend/emailService.web', () => ({
+  sendOrderConfirmation: mockSendOrderConfirmation,
+}));
+
 vi.mock('backend/utils/sanitize', () => ({
   sanitize: (val, max) => String(val || '').slice(0, max),
   // cf-ewnw: log-side PII redaction helper.
@@ -441,6 +447,73 @@ describe('wixEcom_onOrderCreated', () => {
     await expect(
       wixEcom_onOrderCreated({
         entity: { number: 'ORD-ERR', buyerInfo: { email: 'err@test.com' }, lineItems: [] },
+      })
+    ).resolves.not.toThrow();
+  });
+});
+
+// ── wixEcom_onOrderCreated — sendOrderConfirmation (cf-m6t0 F3) ──────
+
+describe('wixEcom_onOrderCreated — sendOrderConfirmation (cf-m6t0)', () => {
+  it('calls sendOrderConfirmation with order details', async () => {
+    await wixEcom_onOrderCreated({
+      entity: {
+        number: 'ORD-CF3',
+        buyerInfo: { email: 'alice@test.com', contactId: 'c-alice' },
+        billingInfo: { firstName: 'Alice' },
+        priceSummary: { total: { amount: 899 } },
+        lineItems: [
+          { productName: { original: 'Eureka Futon' }, quantity: 1, price: { amount: 899 } },
+        ],
+      },
+    });
+
+    expect(mockSendOrderConfirmation).toHaveBeenCalledWith({
+      contactId: 'c-alice',
+      email: 'alice@test.com',
+      firstName: 'Alice',
+      orderNumber: 'ORD-CF3',
+      total: '$899.00',
+      itemSummary: '1× Eureka Futon',
+    });
+  });
+
+  it('formats multiple line items as comma-joined summary', async () => {
+    await wixEcom_onOrderCreated({
+      entity: {
+        number: 'ORD-CF3B',
+        buyerInfo: { email: 'bob@test.com', contactId: 'c-bob' },
+        priceSummary: { total: { amount: 1198 } },
+        lineItems: [
+          { productName: { original: 'Albany Frame' }, quantity: 1, price: { amount: 699 } },
+          { name: 'Mattress', quantity: 1, price: { amount: 499 } },
+        ],
+      },
+    });
+
+    expect(mockSendOrderConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({ itemSummary: '1× Albany Frame, 1× Mattress' })
+    );
+  });
+
+  it('skips sendOrderConfirmation when email is empty', async () => {
+    await wixEcom_onOrderCreated({
+      entity: { number: 'ORD-CF3C', buyerInfo: {} },
+    });
+
+    expect(mockSendOrderConfirmation).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when sendOrderConfirmation rejects', async () => {
+    mockSendOrderConfirmation.mockRejectedValueOnce(new Error('CRM timeout'));
+
+    await expect(
+      wixEcom_onOrderCreated({
+        entity: {
+          number: 'ORD-CF3D',
+          buyerInfo: { email: 'err@test.com', contactId: 'c-err' },
+          lineItems: [],
+        },
       })
     ).resolves.not.toThrow();
   });


### PR DESCRIPTION
## Summary

- `sendOrderConfirmation` was only called from `emailAutomation.web.js#wixEcom_onOrderCreated`, which is dead code — Wix Velo only auto-registers event handlers exported from `backend/events.js`
- Adds the call to `events.js#wixEcom_onOrderCreated` so order confirmation emails fire in production
- Dead handler stubs in `emailAutomation.web.js` kept with `@deprecated` comments for test backward-compat; `sendOrderConfirmation` call removed from stub
- logError tag count drops 25→24; both tag-normalization and migration tests updated

## Files changed

- `src/backend/events.js` — added `sendOrderConfirmation` try/catch in `wixEcom_onOrderCreated`
- `src/backend/emailAutomation.web.js` — dead handlers converted to `@deprecated` stubs, `sendOrderConfirmation` call removed
- `tests/events.test.js` — 4 new sendOrderConfirmation tests (51 total, all passing)
- `tests/emailAutomationLogErrorMigration.test.js` — tag count 25→24
- `tests/emailAutomationTagNormalization.test.js` — floor updated to `toBeGreaterThanOrEqual(24)`

## Test plan

- [x] `npx vitest run tests/events.test.js` — 51 tests pass
- [x] `npx vitest run tests/emailAutomationLogErrorMigration.test.js` — all pass
- [x] `npx vitest run tests/emailAutomationTagNormalization.test.js` — all pass

## Reviewers needed (5-agent sign-off per Stilgar standing order)

Requesting 5 reviewer approvals before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)