### PR TITLE
fix(cf-homn): 20-file console.* → logError batch-M (cf-44qt)

### DIFF
--- a/src/backend/contacts/contactResolver.web.js
+++ b/src/backend/contacts/contactResolver.web.js
@@ -30,7 +30,8 @@
 
 import { Permissions, webMethod } from 'wix-web-module';
 import { contacts } from 'wix-crm-backend';
-import { sanitize, validateEmail, redactEmail } from 'backend/utils/sanitize';
+import { sanitize, validateEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 /**
  * Resolve (or create) a Wix CRM contact for an email address.
@@ -99,7 +100,7 @@ export async function _resolveContactIdInternal(email, firstName) {
     // CRM upstream failure — caller decides whether to retry. Logged with
     // the email so support can correlate; never log full PII beyond what
     // the caller already has access to (the email).
-    console.error('[contactResolver] appendOrCreateContact failed for', cleanEmail, '— error:', err?.message ?? err);
+    logError('contactResolver:_resolveContactIdInternal-appendOrCreateFailed', err);
     return null;
   }
 
@@ -108,7 +109,7 @@ export async function _resolveContactIdInternal(email, firstName) {
   // resolution covers both.
   const contactId = result?.contactId || result?.contact?._id || result?._id;
   if (!contactId) {
-    console.warn('[contactResolver] appendOrCreateContact returned no contactId for', redactEmail(cleanEmail));
+    logError('contactResolver:_resolveContactIdInternal-noContactId', null);
     return null;
   }
   return contactId;

--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -22,6 +22,7 @@
  */
 import wixData from 'wix-data';
 import { sanitize, redactEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── CWF ISR Revalidate Helper ─────────────────────────────────────────
 
@@ -44,10 +45,10 @@ async function _postRevalidateWebhook(body) {
       body: payload,
     });
     if (!res.ok) {
-      console.warn('[events] revalidate webhook returned', res.status);
+      logError(`events:revalidate-webhookStatus status=${res.status}`, null);
     }
   } catch (err) {
-    console.warn('[events] revalidate webhook failed (non-fatal):', err?.message ?? err);
+    logError('events:revalidate-webhookFailed', err);
   }
 }
 
@@ -65,7 +66,7 @@ async function logFailedEvent(entry) {
       resolved: false,
     });
   } catch (dlErr) {
-    console.warn('[events] Dead-letter queue write also failed:', dlErr.message);
+    logError('events:writeFailedEvent-dlqFailed', dlErr);
   }
 }
 
@@ -118,7 +119,7 @@ export async function wixEcom_onAbandonedCheckoutCreated(event) {
       recoveryEmailSent: false,
     });
   } catch (err) {
-    console.error(`[events] DROPPED abandoned cart — checkoutId: ${checkoutId || 'unknown'}, email: ${redactEmail(buyerEmail)}, error:`, err);
+    logError(`events:wixEcom_onAbandonedCart-failed checkoutId=${checkoutId || 'unknown'} email=${redactEmail(buyerEmail)}`, err);
     await logFailedEvent({
       handler: 'wixEcom_onAbandonedCheckoutCreated',
       checkoutId: checkoutId || 'unknown',
@@ -153,7 +154,7 @@ export async function wixEcom_onAbandonedCheckoutRecovered(event) {
       status: 'recovered',
     });
   } catch (err) {
-    console.error(`[events] FAILED to mark cart recovered — checkoutId: ${checkoutId || 'unknown'}, error:`, err);
+    logError(`events:markCartRecovered-failed checkoutId=${checkoutId || 'unknown'}`, err);
     await logFailedEvent({
       handler: 'wixEcom_onAbandonedCheckoutRecovered',
       checkoutId: checkoutId || 'unknown',
@@ -195,7 +196,7 @@ export async function wixMembers_onMemberCreated(event) {
     const { triggerWelcomeSequence } = await import('backend/emailAutomation.web');
     await triggerWelcomeSequence(contactId, email, firstName);
   } catch (err) {
-    console.error('[events] Error triggering welcome sequence:', err);
+    logError('events:wixMembers_onMemberCreated-welcomeSequenceFailed', err);
   }
 
   // CF-9swp: Seed welcome points (endowed progress) for new members
@@ -203,7 +204,7 @@ export async function wixMembers_onMemberCreated(event) {
     const { seedWelcomePoints } = await import('backend/gamificationEventReceiver.web');
     await seedWelcomePoints(contactId);
   } catch (err) {
-    console.error('[events] Error seeding welcome points:', err);
+    logError('events:wixMembers_onMemberCreated-seedPointsFailed', err);
   }
 }
 
@@ -233,14 +234,14 @@ export async function wixEcom_onOrderCreated(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'confirmed');
   } catch (err) {
-    console.error('[events] Order status webhook (confirmed) failed:', err);
+    logError('events:wixEcom_onOrderApproved-webhookFailed', err);
   }
 
   try {
     const { triggerPostPurchaseSequence } = await import('backend/emailAutomation.web');
     await triggerPostPurchaseSequence(contactId, email, firstName, orderNumber, total, lineItems, { memberId });
   } catch (err) {
-    console.error('[events] Error triggering post-purchase sequence:', err);
+    logError('events:wixEcom_onOrderApproved-postPurchaseFailed', err);
   }
 
   if (memberId) {
@@ -259,7 +260,7 @@ export async function wixEcom_onOrderCreated(event) {
           const { checkAndTriggerTierMilestone } = await import('backend/emailAutomation.web');
           await checkAndTriggerTierMilestone(memberId, email, firstName, newTotal, oldTotal);
         } catch (err) {
-          console.error('[events] Error checking tier milestone:', err);
+          logError('events:wixEcom_onOrderApproved-tierMilestoneFailed', err);
         }
       }
 
@@ -272,7 +273,7 @@ export async function wixEcom_onOrderCreated(event) {
         await recordChallengeProgress({ memberId, challengeId: challenge.challengeId });
       }
     } catch (err) {
-      console.error('[events] Error recording gamification on order:', err);
+      logError('events:wixEcom_onOrderApproved-gamificationFailed', err);
     }
 
     // cf-bu2: complete any pending referral attribution for web checkouts
@@ -280,7 +281,7 @@ export async function wixEcom_onOrderCreated(event) {
       const { _processReferralOnOrderCreated } = await import('backend/referralService.web');
       await _processReferralOnOrderCreated(memberId, orderNumber);
     } catch (err) {
-      console.error('[events] Error processing referral on order:', err);
+      logError('events:wixEcom_onOrderApproved-referralFailed', err);
     }
   }
 
@@ -290,7 +291,7 @@ export async function wixEcom_onOrderCreated(event) {
       const { checkSwatchAttribution } = await import('backend/swatchAttribution.web');
       await checkSwatchAttribution(email, orderNumber, Number(total));
     } catch (err) {
-      console.error('[events] Error checking swatch attribution:', err);
+      logError('events:wixEcom_onOrderApproved-swatchAttributionFailed', err);
     }
   }
 
@@ -300,11 +301,11 @@ export async function wixEcom_onOrderCreated(event) {
     if (orderContainsSwatchKit(order.lineItems || [])) {
       const result = await recordSwatchKitPurchase(orderNumber, memberId, email, []);
       if (!result?.success && !result?.alreadyIssued) {
-        console.error('[events] Swatch kit credit issuance failed silently:', result?.error, { orderNumber });
+        logError(`events:wixEcom_onOrderApproved-swatchKitCreditFailedSilent orderNumber=${orderNumber} reason=${result?.error || 'unknown'}`, null);
       }
     }
   } catch (err) {
-    console.error('[events] Swatch kit credit issuance failed:', err);
+    logError('events:wixEcom_onOrderApproved-swatchKitCreditThrew', err);
   }
 }
 
@@ -327,7 +328,7 @@ export async function wixEcom_onOrderApproved(event) {
     const { receiveGamificationEvent } = await import('backend/gamificationEventReceiver.web');
     await receiveGamificationEvent('gamification_order_complete', { orderTotal }, memberId);
   } catch (err) {
-    console.error('[events] wixEcom_onOrderApproved: gamification earn failed', err);
+    logError('events:wixEcom_onOrderApproved-earnFailed', err);
   }
 }
 
@@ -349,7 +350,7 @@ export async function wixEcom_onOrderFulfilled(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'shipped');
   } catch (err) {
-    console.error('[events] Order status webhook (shipped) failed:', err);
+    logError('events:wixEcom_onOrderShipped-webhookFailed', err);
   }
 
   if (!memberId) return;
@@ -358,7 +359,7 @@ export async function wixEcom_onOrderFulfilled(event) {
     const { handleOrderFulfilled } = await import('backend/notificationOrchestrator.web');
     await handleOrderFulfilled({ memberId, orderNumber, trackingNumber });
   } catch (err) {
-    console.error('[events] Error handling order fulfilled SMS:', err);
+    logError('events:wixEcom_onOrderFulfilled-smsFailed', err);
   }
 }
 
@@ -377,7 +378,7 @@ export async function wixEcom_onFulfillmentCreated(event) {
     const { handleFulfillmentShippingNotification } = await import('backend/emailAutomation.web');
     handleFulfillmentShippingNotification(event);
   } catch (err) {
-    console.error('[events] Error handling fulfillment created:', err);
+    logError('events:wixEcom_onFulfillmentCreated-failed', err);
   }
 }
 
@@ -398,7 +399,7 @@ export async function wixEcom_onFulfillmentUpdated(event) {
     const { handleFulfillmentShippingNotification } = await import('backend/emailAutomation.web');
     handleFulfillmentShippingNotification(event);
   } catch (err) {
-    console.error('[events] Error handling fulfillment updated:', err);
+    logError('events:wixEcom_onFulfillmentUpdated-failed', err);
   }
 }
 
@@ -415,7 +416,7 @@ export async function wixEcom_onOrderDelivered(event) {
     const { handleOrderDelivered } = await import('backend/emailAutomation.web');
     handleOrderDelivered(event);
   } catch (err) {
-    console.error('[events] Error handling order delivered:', err);
+    logError('events:wixEcom_onOrderDelivered-failed', err);
   }
 }
 
@@ -433,7 +434,7 @@ export async function wixEcom_onOrderCanceled(event) {
     const { handleOrderStatusChange } = await import('backend/orderStatusWebhook.web');
     await handleOrderStatusChange(order, 'cancelled');
   } catch (err) {
-    console.error('[events] Order status webhook (cancelled) failed:', err);
+    logError('events:wixEcom_onOrderCanceled-webhookFailed', err);
   }
 
   if (!email) return;
@@ -442,7 +443,7 @@ export async function wixEcom_onOrderCanceled(event) {
     const { cancelSequenceForOrder } = await import('backend/emailAutomation.web');
     await cancelSequenceForOrder(email, orderNumber);
   } catch (err) {
-    console.error('[events] Error cancelling care sequence:', err);
+    logError('events:wixEcom_onOrderCanceled-careSequenceFailed', err);
   }
 }
 
@@ -457,7 +458,7 @@ export async function wixStores_onProductCreated(event) {
   const productId = product._id || '';
 
   if (!productId) {
-    console.warn('[events] wixStores_onProductCreated received event without product ID');
+    logError('events:wixStores_onProductCreated-missingId', null);
     return;
   }
 
@@ -474,7 +475,7 @@ export async function wixStores_onProductCreated(event) {
       imageUrl: product.mainMedia || product.media?.mainMedia?.image?.url || '',
     });
   } catch (err) {
-    console.error('[events] Content orchestration failed for new product:', err);
+    logError('events:wixStores_onProductCreated-orchestrationFailed', err);
     await logFailedEvent({
       handler: 'wixStores_onProductCreated',
       productId,
@@ -495,7 +496,7 @@ export async function wixStores_onProductUpdated(event) {
   const productId = product._id || '';
 
   if (!productId) {
-    console.warn('[events] wixStores_onProductUpdated received event without product ID');
+    logError('events:wixStores_onProductUpdated-missingId', null);
     return;
   }
 
@@ -521,7 +522,7 @@ export async function wixStores_onProductUpdated(event) {
       newPrice,
     });
   } catch (err) {
-    console.error('[events] Content orchestration failed for price drop:', err);
+    logError('events:wixStores_onProductUpdated-priceDropOrchestrationFailed', err);
     await logFailedEvent({
       handler: 'wixStores_onProductUpdated',
       productId,
@@ -565,7 +566,7 @@ export async function wixStores_onInventoryVariantUpdated(event) {
 
     // Check for soft failure (returned { success: false } without throwing)
     if (result && !result.success) {
-      console.error(`[events] Restock notifications returned failure — productId: ${productId}, error: ${result.error || 'unknown'}`);
+      logError(`events:dispatchRestockNotifications-failure productId=${productId} reason=${result.error || 'unknown'}`, null);
       await logFailedEvent({
         handler: 'wixStores_onInventoryVariantUpdated',
         productId: productId || 'unknown',
@@ -588,10 +589,10 @@ export async function wixStores_onInventoryVariantUpdated(event) {
         });
       }
     } catch (orchErr) {
-      console.error('[events] Content orchestration failed for restock:', orchErr);
+      logError('events:dispatchRestockNotifications-orchestrationFailed', orchErr);
     }
   } catch (err) {
-    console.error(`[events] FAILED restock notifications — productId: ${productId || 'unknown'}, error:`, err);
+    logError(`events:dispatchRestockNotifications productId=${productId || 'unknown'}`, err);
     await logFailedEvent({
       handler: 'wixStores_onInventoryVariantUpdated',
       productId: productId || 'unknown',
@@ -627,7 +628,7 @@ export async function wixMembers_onMemberUpdated(event) {
 
   const parsed = _parseBirthdayMonthDay(birthday);
   if (!parsed) {
-    console.warn('[events] wixMembers_onMemberUpdated: unparseable birthday for member', memberId, ':', birthday);
+    logError(`events:wixMembers_onMemberUpdated-unparseableBirthday memberId=${memberId}`, null);
     return;
   }
 
@@ -636,7 +637,7 @@ export async function wixMembers_onMemberUpdated(event) {
     // so we must spread the existing record to avoid destroying other fields.
     const existing = await wixData.get('Members/PrivateMembersData', memberId);
     if (!existing) {
-      console.warn('[events] wixMembers_onMemberUpdated: no PrivateMembersData record for member', memberId);
+      logError(`events:wixMembers_onMemberUpdated-noPrivateMembersData memberId=${memberId}`, null);
       return;
     }
     await wixData.update('Members/PrivateMembersData', {
@@ -645,7 +646,7 @@ export async function wixMembers_onMemberUpdated(event) {
       birthday_day: parsed.day,
     });
   } catch (err) {
-    console.error(`[events] Failed to sync birthday fields for member ${memberId}:`, err?.message ?? err);
+    logError(`events:wixMembers_onMemberUpdated-syncFailed memberId=${memberId}`, err);
     await logFailedEvent({
       handler: 'wixMembers_onMemberUpdated',
       error: err.message,

--- a/src/backend/inventoryService.web.js
+++ b/src/backend/inventoryService.web.js
@@ -39,6 +39,7 @@ import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const DEFAULT_LOW_STOCK_THRESHOLD = 5;
 const LOW_STOCK_URGENCY_THRESHOLD = 5;
@@ -92,7 +93,7 @@ export const getStockStatus = webMethod(
 
       return { status, variants, preOrder: anyPreOrder };
     } catch (err) {
-      console.error('Error getting stock status:', err);
+      logError('inventoryService:getStockStatus-failed', err);
       return { status: 'in_stock', variants: [], preOrder: false };
     }
   }
@@ -143,7 +144,7 @@ export const signUpBackInStock = webMethod(
       logAuditEvent('BackInStockSignups', 'submit', cleanEmail, { productId: cleanProductId });
       return { success: true };
     } catch (err) {
-      console.error('Error signing up for back-in-stock:', err);
+      logError('inventoryService:signUpBackInStock-failed', err);
       return { success: false, error: 'Failed to sign up' };
     }
   }
@@ -191,7 +192,7 @@ export const getInventoryUrgency = webMethod(
 
       return { level: 'none', count: totalQty, message: '' };
     } catch (err) {
-      console.error('[inventoryService] Error getting inventory urgency:', err);
+      logError('inventoryService:getInventoryUrgency-failed', err);
       return { level: 'none', count: 0, message: '' };
     }
   }

--- a/src/backend/inventorySync.web.js
+++ b/src/backend/inventorySync.web.js
@@ -24,6 +24,7 @@ import { Permissions, webMethod } from 'wix-web-module';
 import { products } from 'wix-stores-backend';
 import wixData from 'wix-data';
 import { sanitize } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 const THRESHOLDS_COLLECTION = 'InventoryThresholds';
 const ALERTS_COLLECTION = 'LowStockAlerts';
@@ -218,7 +219,7 @@ export async function syncInventoryFromStore() {
               if (result.alertCreated) alertsCreated++;
             } catch (err) {
               errors++;
-              console.error(`[inventorySync] Failed to sync product ${product._id}:`, err?.message ?? err);
+              logError(`inventorySync:syncInventoryFromStore-productFailed id=${product._id}`, err);
             }
           }),
         );
@@ -237,10 +238,9 @@ export async function syncInventoryFromStore() {
       }
     }
 
-    console.log(`[inventorySync] Sync complete: ${synced} products, ${alertsCreated} alerts, ${errors} errors`);
     return { success: true, synced, alertsCreated, errors };
   } catch (err) {
-    console.error('[inventorySync] Sync failed:', err?.message ?? err);
+    logError('inventorySync:syncInventoryFromStore-failed', err);
     return { success: false, synced, alertsCreated, errors };
   }
 }

--- a/src/backend/lifecycleCron.web.js
+++ b/src/backend/lifecycleCron.web.js
@@ -31,6 +31,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { sendBatchReminders } from 'backend/challengeReminderService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 const ORDERS_COLLECTION = 'Stores/Orders';
 const PAGE_SIZE = 100;
@@ -113,7 +114,7 @@ export const scanLifecycleMilestones = webMethod(
         results,
       };
     } catch (err) {
-      console.error('[lifecycleCron] scanLifecycleMilestones failed:', err?.message);
+      logError('lifecycleCron:scanLifecycleMilestones-failed', err);
       return { success: false, ordersScanned: 0, milestonesFound: 0, results: [] };
     }
   }
@@ -197,14 +198,14 @@ export const runDailyChallengeReminders = webMethod(
             await sendPushToMember(record.memberId, PUSH_EVENTS.CHALLENGE_REMINDER, {});
           }
         } catch (pushErr) {
-          console.error(`[lifecycleCron] challenge reminder push failed for ${record.memberId}:`, pushErr?.message);
+          logError(`lifecycleCron:runDailyChallengeReminders-reminderFailed memberId=${record.memberId}`, pushErr);
         }
       };
 
       const { sent, failed } = await sendBatchReminders('daily', sendFn);
       return { success: true, sent, failed };
     } catch (err) {
-      console.error('[lifecycleCron] runDailyChallengeReminders failed:', err?.message);
+      logError('lifecycleCron:runDailyChallengeReminders-failed', err);
       return { success: false, sent: 0, failed: 0 };
     }
   }

--- a/src/backend/lifecycleEmailSender.web.js
+++ b/src/backend/lifecycleEmailSender.web.js
@@ -22,6 +22,7 @@
 
 import wixData from 'wix-data';
 import { scanLifecycleMilestones } from 'backend/lifecycleCron.web';
+import { logError } from 'backend/utils/errorHandler';
 
 export const SENT_LIFECYCLE_MAILS_COLLECTION = 'SentLifecycleMails';
 export const LIFECYCLE_EMAIL_QUEUE_TYPE = 'lifecycle';
@@ -123,7 +124,7 @@ export async function sendLifecycleEmails() {
 
     return { success: true, totalScanned: ordersScanned, queued, skipped };
   } catch (err) {
-    console.error('[lifecycleEmailSender] sendLifecycleEmails failed:', err);
+    logError('lifecycleEmailSender:sendLifecycleEmails-failed', err);
     return { success: false, totalScanned: 0, queued: 0, skipped: 0, error: 'Failed to send lifecycle emails.' };
   }
 }

--- a/src/backend/liveChat.web.js
+++ b/src/backend/liveChat.web.js
@@ -28,6 +28,7 @@ import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { safeParse } from 'backend/utils/safeParse';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── Default office hours (EST) ──────────────────────────────────────
 
@@ -171,7 +172,7 @@ export const getOfficeHoursStatus = webMethod(
         nextOpen: getNextOpenTime(officeHours, now),
       };
     } catch (err) {
-      console.error('getOfficeHoursStatus error:', err);
+      logError('liveChat:getOfficeHoursStatus-failed', err);
       return {
         isOnline: false,
         message: 'Leave a message and we\'ll get back to you soon!',
@@ -218,7 +219,7 @@ export const getCannedResponses = webMethod(
         responses: DEFAULT_CANNED_RESPONSES,
       };
     } catch (err) {
-      console.error('getCannedResponses error:', err);
+      logError('liveChat:getCannedResponses-failed', err);
       return { success: true, responses: DEFAULT_CANNED_RESPONSES };
     }
   }
@@ -271,7 +272,7 @@ export const matchCannedResponse = webMethod(
 
       return { matched: false };
     } catch (err) {
-      console.error('matchCannedResponse error:', err);
+      logError('liveChat:matchCannedResponse-failed', err);
       return { matched: false };
     }
   }
@@ -339,7 +340,7 @@ export const createSupportTicket = webMethod(
         message: 'Your message has been received! We\'ll get back to you soon.',
       };
     } catch (err) {
-      console.error('createSupportTicket error:', err);
+      logError('liveChat:createSupportTicket-failed', err);
       return { success: false, error: 'Unable to submit message. Please try again.' };
     }
   }
@@ -419,7 +420,7 @@ export const getChatContext = webMethod(
 
       return { success: true, context };
     } catch (err) {
-      console.error('getChatContext error:', err);
+      logError('liveChat:getChatContext-failed', err);
       return { success: true, context: { page: '', userName: '', userEmail: '', isLoggedIn: false, recentOrders: [] } };
     }
   }

--- a/src/backend/liveChatService.web.js
+++ b/src/backend/liveChatService.web.js
@@ -12,6 +12,7 @@ import wixData from 'wix-data';
 import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { checkRateLimit } from 'backend/utils/rateLimit';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 // ─── Office Hours Config ─────────────────────────────────────────
 
@@ -83,7 +84,7 @@ export const isOnline = webMethod(
 
       return { online, nextOpen, message };
     } catch (err) {
-      console.error('Error checking online status:', err);
+      logError('liveChatService:isOnline-failed', err);
       return { online: false, nextOpen: null, message: 'Chat is currently unavailable.' };
     }
   }
@@ -167,7 +168,7 @@ export const sendMessage = webMethod(
       logAuditEvent('ChatMessages', 'insert', record.sessionId);
       return { success: true, messageId: inserted._id };
     } catch (err) {
-      console.error('Error sending chat message:', err);
+      logError('liveChatService:sendMessage-failed', err);
       return { success: false, error: 'Failed to send message' };
     }
   }
@@ -207,7 +208,7 @@ export const getChatHistory = webMethod(
         read: item.read,
       }));
     } catch (err) {
-      console.error('Error fetching chat history:', err);
+      logError('liveChatService:getChatHistory-failed', err);
       return [];
     }
   }
@@ -258,7 +259,7 @@ export const createSupportTicket = webMethod(
       logAuditEvent('SupportTickets', 'submit', email.trim());
       return { success: true, ticketId: inserted._id };
     } catch (err) {
-      console.error('Error creating support ticket:', err);
+      logError('liveChatService:createSupportTicket-failed', err);
       return { success: false, error: 'Failed to create ticket' };
     }
   }

--- a/src/backend/liveInventory.web.js
+++ b/src/backend/liveInventory.web.js
@@ -7,6 +7,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { getStockStatus, signUpBackInStock } from 'backend/inventoryService.web';
 import { validateEmail } from 'backend/utils/sanitize';
+import { logError } from 'backend/utils/errorHandler';
 
 // ── getProductInventory ───────────────────────────────────────────────
 
@@ -38,7 +39,7 @@ export const getProductInventory = webMethod(
 
       return { success: true, status, quantity };
     } catch (e) {
-      console.error('[liveInventory] getProductInventory failed:', e);
+      logError('liveInventory:getProductInventory-failed', e);
       return { success: false, error: 'Failed to fetch inventory' };
     }
   }
@@ -62,7 +63,7 @@ export const registerStockNotification = webMethod(
 
       return await signUpBackInStock({ productId, email });
     } catch (e) {
-      console.error('[liveInventory] registerStockNotification failed:', e);
+      logError('liveInventory:registerStockNotification-failed', e);
       return { success: false, error: 'Failed to register notification' };
     }
   }

--- a/src/backend/localSeoService.web.js
+++ b/src/backend/localSeoService.web.js
@@ -21,6 +21,7 @@ import {
 } from 'backend/utils/localSeoData';
 import { generateLocalBusinessSchema, SCHEMA_OPENING_HOURS, STORE_HOURS_DISPLAY } from 'backend/localSeo.web';
 import { buildBreadcrumbSchema, buildBreadcrumbList, buildFaqSchema } from 'public/localSeoHelpers';
+import { logError } from 'backend/utils/errorHandler';
 
 const CMS_COLLECTION = 'LocalSeoCities';
 
@@ -118,7 +119,7 @@ export const getLocalPage = webMethod(
       try {
         featuredProducts = await _fetchProductsByCity(cityData, 4);
       } catch (e) {
-        console.warn('[localSeoService] Failed to fetch featured products for page:', cleanSlug, e.message, e);
+        logError('localSeoService:getLocalPage-featuredProductsFailed', e);
       }
 
       return {
@@ -167,7 +168,7 @@ export const getLocalPage = webMethod(
         },
       };
     } catch (err) {
-      console.error('[localSeoService] Error loading local page:', slug, err.name, err.message, err);
+      logError('localSeoService:getLocalPage-failed', err);
       return { success: false, error: 'Failed to load local page.', page: null };
     }
   }
@@ -282,7 +283,7 @@ export const getFeaturedProductsForCity = webMethod(
       const products = await _fetchProductsByCity(cityData, limit);
       return { success: true, products };
     } catch (err) {
-      console.error('[localSeoService] Error loading featured products:', slug, err.name, err.message, err);
+      logError('localSeoService:getFeaturedProductsForCity-failed', err);
       return { success: false, error: 'Failed to load featured products.', products: [] };
     }
   }
@@ -331,7 +332,7 @@ export const getRelatedCityLinks = webMethod(
 
       return { success: true, links };
     } catch (err) {
-      console.error('[localSeoService] Error loading related city links:', slug, err.name, err.message, err);
+      logError('localSeoService:getRelatedCityLinks-failed', err);
       return { success: false, error: 'Failed to load related city links.', links: [] };
     }
   }
@@ -359,7 +360,7 @@ export const getAllLocalSlugs = webMethod(
       const allSlugs = [...new Set([...staticSlugs, ...cmsSlugs])];
       return { success: true, slugs: allSlugs };
     } catch (err) {
-      console.error('[localSeoService] Error getting local slugs:', err.name, err.message, err);
+      logError('localSeoService:getAllLocalSlugs-failed', err);
       return { success: false, slugs: [] };
     }
   }

--- a/src/backend/loyaltyMarketing.web.js
+++ b/src/backend/loyaltyMarketing.web.js
@@ -101,7 +101,7 @@ export const getEnrollmentPrompt = webMethod(
         },
       };
     } catch (err) {
-      console.error('[loyaltyMarketing] getEnrollmentPrompt error:', err);
+      logError('loyaltyMarketing:getEnrollmentPrompt-failed', err);
       return { success: false, shouldPrompt: false, benefits: null };
     }
   }
@@ -426,7 +426,7 @@ export const enrollMember = webMethod(
 
       return { success: true, welcomePoints: totalWelcome, account };
     } catch (err) {
-      console.error('[loyaltyMarketing] enrollMember error:', err);
+      logError('loyaltyMarketing:enrollMember-failed', err);
       return { success: false, welcomePoints: 0, account: null, error: 'Enrollment failed' };
     }
   }

--- a/src/backend/marketingSequences.web.js
+++ b/src/backend/marketingSequences.web.js
@@ -27,12 +27,9 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { enqueueEmail } from 'backend/emailQueueService.web';
+import { logError } from 'backend/utils/errorHandler';
 
 export const EMAIL_SEQUENCES_COLLECTION = 'EmailSequences';
-
-function logError(msg, err) {
-  console.error(`[marketingSequences] ${msg}`, err?.message ?? err ?? '');
-}
 
 // ── Internal: load active steps for a sequence type ──────────────────────────
 
@@ -97,7 +94,7 @@ export const triggerWelcomeSequence = webMethod(Permissions.Admin, async (params
     });
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerWelcomeSequence failed', err);
+    logError('marketingSequences:triggerWelcomeSequence-failed', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -136,7 +133,7 @@ export const triggerCartAbandonSequence = webMethod(Permissions.Admin, async (pa
     );
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerCartAbandonSequence failed', err);
+    logError('marketingSequences:triggerCartAbandonSequence-failed', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -170,7 +167,7 @@ export const triggerReviewRequestSequence = webMethod(Permissions.Admin, async (
     });
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerReviewRequestSequence failed', err);
+    logError('marketingSequences:triggerReviewRequestSequence-failed', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -241,7 +238,7 @@ export const runReviewRequestEmails = webMethod(Permissions.Admin, async () => {
 
     return { success: true, ordersScanned: orders.length, triggered, skipped, failed };
   } catch (err) {
-    logError('runReviewRequestEmails failed', err);
+    logError('marketingSequences:runReviewRequestEmails-failed', err);
     return { success: false, ordersScanned: 0, triggered: 0, skipped: 0, failed: 0 };
   }
 });
@@ -273,7 +270,7 @@ export const triggerWinbackSequence = webMethod(Permissions.Admin, async (params
     });
     return { success: true, enqueued };
   } catch (err) {
-    logError('triggerWinbackSequence failed', err);
+    logError('marketingSequences:triggerWinbackSequence-failed', err);
     return { success: false, error: err?.message ?? 'unknown error' };
   }
 });
@@ -328,7 +325,7 @@ export const scanAndTriggerWinback = webMethod(Permissions.Admin, async () => {
 
     return { success: true, scanned, triggered };
   } catch (err) {
-    logError('scanAndTriggerWinback failed', err);
+    logError('marketingSequences:scanAndTriggerWinback-failed', err);
     return { success: false, scanned: 0, triggered: 0, error: err?.message ?? 'unknown error' };
   }
 });

--- a/src/backend/memberPointsLedgerService.web.js
+++ b/src/backend/memberPointsLedgerService.web.js
@@ -11,6 +11,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'MemberPointsLedger';
 const DEFAULT_LIMIT = 20;
@@ -81,7 +82,7 @@ export const getMyPointsHistory = webMethod(
         hasMore,
       };
     } catch (err) {
-      console.error('[memberPointsLedgerService] getMyPointsHistory error:', err);
+      logError('memberPointsLedgerService:getMyPointsHistory-failed', err);
       return { success: false, entries: [], error: 'Unable to fetch points history' };
     }
   }

--- a/src/backend/membershipService.web.js
+++ b/src/backend/membershipService.web.js
@@ -15,6 +15,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { orders, plans } from 'wix-pricing-plans.v2';
 import { currentMember } from 'wix-members-backend';
+import { logError } from 'backend/utils/errorHandler';
 
 /** Plan slug identifiers — must match Wix Dashboard plan slugs. */
 export const PLAN_SLUGS = {
@@ -58,7 +59,7 @@ async function getActiveOrder() {
       o.status === 'ACTIVE' && CF_PLUS_SLUG_SET.has(o.planSlug)
     ) || null;
   } catch (err) {
-    console.error('[membershipService] Error fetching orders:', err);
+    logError('membershipService:getActiveOrder-failed', err);
     return null;
   }
 }
@@ -80,7 +81,7 @@ export const getMembershipPlans = webMethod(
       const allPlans = result.plans || [];
       return allPlans.filter(p => CF_PLUS_SLUG_SET.has(p.slug) && p.active);
     } catch (err) {
-      console.error('[membershipService] Error listing plans:', err);
+      logError('membershipService:getMembershipPlans-failed', err);
       return [];
     }
   }

--- a/src/backend/newsletterService.web.js
+++ b/src/backend/newsletterService.web.js
@@ -24,6 +24,7 @@ import { sanitize, validateEmail } from 'backend/utils/sanitize';
 import { logAuditEvent } from 'backend/utils/auditLog';
 import { _resolveContactIdInternal } from 'backend/contacts/contactResolver.web';
 import { checkRateLimit } from 'backend/utils/rateLimit';
+import { logError } from 'backend/utils/errorHandler';
 
 const DISCOUNT_CODE = 'WELCOME10';
 const KLAVIYO_API_BASE = 'https://a.klaviyo.com/api';
@@ -155,7 +156,7 @@ async function _syncToESPInternal(email, source) {
 
     return { synced: true };
   } catch (err) {
-    console.error('ESP sync error:', err);
+    logError('newsletterService:syncToESP-failed', err);
     return { synced: false, reason: 'sync_failed' };
   }
 }
@@ -256,7 +257,7 @@ export const unsubscribeFromESP = webMethod(
 
       return { unsubscribed: true };
     } catch (err) {
-      console.error('ESP unsubscribe error:', err);
+      logError('newsletterService:unsubscribeFromESP-failed', err);
       return { unsubscribed: false, reason: 'unsubscribe_failed' };
     }
   }
@@ -352,13 +353,13 @@ export const subscribeToNewsletter = webMethod(
       // double-queue on repeat subscribes). Non-blocking — a welcome-trigger
       // failure does not fail the subscribe call.
       _triggerWelcomeFlowInternal(cleaned, source).catch((err) => {
-        console.warn('[newsletterService] welcome auto-trigger failed (non-blocking):', err?.message ?? err);
+        logError('newsletterService:subscribeToNewsletter-welcomeTriggerFailed', err);
       });
 
       logAuditEvent('NewsletterSubscribers', 'subscribe', cleaned, { source });
       return { success: true, discountCode: DISCOUNT_CODE };
     } catch (err) {
-      console.error('Newsletter subscription error:', err);
+      logError('newsletterService:subscribeToNewsletter-failed', err);
       return { success: false, message: 'Subscription failed. Please try again.' };
     }
   }
@@ -388,7 +389,7 @@ async function _triggerWelcomeFlowInternal(email, source = '') {
     const { resolveContactId } = await import('backend/contacts/contactResolver.web');
     const contactId = await resolveContactId(email, '');
     if (!contactId) {
-      console.warn('[newsletterService] welcome auto-trigger skipped — resolveContactId returned empty', { email, source });
+      logError('newsletterService:_triggerWelcomeFlowInternal-noContactId', null);
       return;
     }
     const { triggerWelcomeSequence } = await import('backend/emailAutomation.web');

--- a/src/backend/notificationPreferences.web.js
+++ b/src/backend/notificationPreferences.web.js
@@ -15,7 +15,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import { currentMember } from 'wix-members-backend';
 import wixData from 'wix-data';
-import { logError } from 'backend/errorMonitoring.web.js';
+import { logError } from 'backend/utils/errorHandler';
 
 const COLLECTION = 'MemberNotificationPrefs';
 
@@ -67,7 +67,7 @@ export const getNotificationPreferences = webMethod(
         },
       };
     } catch (e) {
-      console.error('[notificationPreferences] getNotificationPreferences failed:', e?.message, e?.stack);
+      logError('notificationPreferences:getNotificationPreferences-failed', e);
       await logError({ context: 'notificationPreferences.getNotificationPreferences', message: e?.message, stack: e?.stack, severity: 'error' });
       return { success: false, error: 'Failed to load preferences' };
     }
@@ -115,7 +115,7 @@ export const saveNotificationPreferences = webMethod(
 
       return { success: true };
     } catch (e) {
-      console.error('[notificationPreferences] saveNotificationPreferences failed:', e?.message, e?.stack);
+      logError('notificationPreferences:saveNotificationPreferences-failed', e);
       await logError({ context: 'notificationPreferences.saveNotificationPreferences', message: e?.message, stack: e?.stack, severity: 'error' });
       return { success: false, error: 'Failed to save preferences' };
     }
@@ -165,7 +165,7 @@ export const unsubscribeAll = webMethod(
 
       return { success: true };
     } catch (e) {
-      console.error('[notificationPreferences] unsubscribeAll failed:', e?.message, e?.stack);
+      logError('notificationPreferences:unsubscribeAll-failed', e);
       await logError({ context: 'notificationPreferences.unsubscribeAll', message: e?.message, stack: e?.stack, severity: 'error' });
       return { success: false, error: 'Failed to unsubscribe' };
     }

--- a/src/backend/notificationService.web.js
+++ b/src/backend/notificationService.web.js
@@ -352,7 +352,7 @@ export const notifyOwner = webMethod(
     try {
       const ownerId = await getSecret('SITE_OWNER_CONTACT_ID');
       if (!ownerId) {
-        console.warn('[notificationService] notifyOwner: SITE_OWNER_CONTACT_ID secret not set — falling back to console');
+        logError('notificationService:notifyOwner-secretMissing', null);
       } else {
         await triggeredEmails.emailContact(resolveTemplateId('owner_alert'), ownerId, {
           variables: { subject: safeSubject, message: safeMessage },
@@ -361,11 +361,11 @@ export const notifyOwner = webMethod(
       }
     } catch (emailErr) {
       // Fall through to console fallback if email delivery fails
-      console.warn('[notificationService] notifyOwner email failed, falling back to console:', emailErr?.message);
+      logError('notificationService:notifyOwner-emailFailed', emailErr);
     }
 
     // Console fallback — ensures the alert surfaces in Wix logs even without email config
-    console.error(`[notificationService] OWNER ALERT — ${safeSubject}: ${safeMessage}`);
+    logError(`notificationService:notifyOwner-ownerAlert subject=${safeSubject}`, null);
     return { success: true, method: 'console' };
   }
 );

--- a/src/backend/photoGapReport.web.js
+++ b/src/backend/photoGapReport.web.js
@@ -12,6 +12,7 @@
 import { Permissions, webMethod } from 'wix-web-module';
 import wixData from 'wix-data';
 import { logAuditEvent } from 'backend/utils/auditLog';
+import { logError } from 'backend/utils/errorHandler';
 
 const DEFAULT_THRESHOLD = 3.0;
 const CATALOG_COLLECTION = 'Products';
@@ -59,7 +60,7 @@ export const generatePhotoGapReport = webMethod(
 
       return { success: true, report };
     } catch (err) {
-      console.error('[photoGapReport] Error generating report:', err);
+      logError('photoGapReport:generateReport-failed', err);
       return { success: false, error: 'Failed to generate photo gap report' };
     }
   }

--- a/src/backend/photoReviews.web.js
+++ b/src/backend/photoReviews.web.js
@@ -39,6 +39,7 @@ import wixData from 'wix-data';
 import { currentMember } from 'wix-members-backend';
 import { sanitize, validateId, isWixMediaUrl } from 'backend/utils/sanitize';
 import { receiveGamificationEvent } from 'backend/gamificationEventReceiver.web';
+import { logError } from 'backend/utils/errorHandler';
 
 async function requireMember() {
   const member = await currentMember.getMember();
@@ -114,11 +115,11 @@ export const submitPhotoReview = webMethod(
         'gamification_submit_review',
         { has_photo: true },
         memberId,
-      ).catch(err => console.warn('[photoReviews] gamification event failed:', err));
+      ).catch(err => logError('photoReviews:submitPhotoReview-gamificationFailed', err));
 
       return { success: true, id: inserted._id };
     } catch (err) {
-      console.error('[photoReviews] Error submitting photo review:', err);
+      logError('photoReviews:submitPhotoReview-failed', err);
       return { success: false, error: 'Failed to submit photo review.' };
     }
   }
@@ -170,7 +171,7 @@ export const moderatePhotoReview = webMethod(
       const allowed = PHOTO_STATUS_TRANSITIONS[currentStatus];
 
       if (!allowed || !allowed.includes(newStatus)) {
-        console.warn(`[photoReviews] Blocked transition: ${cleanId} ${currentStatus} → ${newStatus} by ${memberId}`);
+        logError(`photoReviews:moderatePhotoReview-blockedTransition id=${cleanId} ${currentStatus}→${newStatus}`, null);
         return {
           success: false,
           error: `Cannot ${cleanAction} a review with status '${currentStatus}'.`,
@@ -185,7 +186,7 @@ export const moderatePhotoReview = webMethod(
       await wixData.update('PhotoReviews', existing);
       return { success: true, previousStatus, newStatus };
     } catch (err) {
-      console.error('[photoReviews] Error moderating review:', err);
+      logError('photoReviews:moderatePhotoReview-failed', err);
       return { success: false, error: 'Failed to moderate review.' };
     }
   }
@@ -230,7 +231,7 @@ export const getPhotoGallery = webMethod(
 
       return { success: true, photos };
     } catch (err) {
-      console.error('[photoReviews] Error getting photo gallery:', err);
+      logError('photoReviews:getPhotoGallery-failed', err);
       return { success: false, error: 'Failed to load gallery.', photos: [] };
     }
   }

--- a/tests/cf-homn-batchM-logError.test.js
+++ b/tests/cf-homn-batchM-logError.test.js
@@ -1,0 +1,184 @@
+/**
+ * cf-homn (cf-44qt batch-M): src/backend 20-file console.* → logError migration.
+ *
+ * Static analysis: asserts 0 console.* calls remain in each file and that
+ * every canonical logError tag is present in the source.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/backend');
+const src = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+const ALL_FILES = [
+  'inventoryService.web.js',
+  'inventorySync.web.js',
+  'lifecycleCron.web.js',
+  'lifecycleEmailSender.web.js',
+  'liveChat.web.js',
+  'liveChatService.web.js',
+  'liveInventory.web.js',
+  'liveShowroom.web.js',
+  'localSeoService.web.js',
+  'loyaltyMarketing.web.js',
+  'marketingSequences.web.js',
+  'memberPointsLedgerService.web.js',
+  'membershipService.web.js',
+  'newsletterService.web.js',
+  'notificationPreferences.web.js',
+  'notificationService.web.js',
+  'orderTracking.web.js',
+  'photoGapReport.web.js',
+  'photoReviews.web.js',
+  'contacts/contactResolver.web.js',
+];
+
+// Files that already import logError — no import assertion needed for others
+const ALREADY_HAS_IMPORT = new Set([
+  'loyaltyMarketing.web.js',
+  'notificationService.web.js',
+]);
+
+// Files with 0 console.* before migration — no tags expected
+const ALREADY_CLEAN = new Set(['liveShowroom.web.js', 'orderTracking.web.js']);
+
+const FILE_TAGS = {
+  'inventoryService.web.js': [
+    'inventoryService:getStockStatus-failed',
+    'inventoryService:signUpBackInStock-failed',
+    'inventoryService:getInventoryUrgency-failed',
+  ],
+  'inventorySync.web.js': [
+    'inventorySync:syncInventoryFromStore-productFailed',
+    'inventorySync:syncInventoryFromStore-failed',
+  ],
+  'lifecycleCron.web.js': [
+    'lifecycleCron:scanLifecycleMilestones-failed',
+    'lifecycleCron:runDailyChallengeReminders-reminderFailed',
+    'lifecycleCron:runDailyChallengeReminders-failed',
+  ],
+  'lifecycleEmailSender.web.js': [
+    'lifecycleEmailSender:sendLifecycleEmails-failed',
+  ],
+  'liveChat.web.js': [
+    'liveChat:getOfficeHoursStatus-failed',
+    'liveChat:getCannedResponses-failed',
+    'liveChat:matchCannedResponse-failed',
+    'liveChat:createSupportTicket-failed',
+    'liveChat:getChatContext-failed',
+  ],
+  'liveChatService.web.js': [
+    'liveChatService:isOnline-failed',
+    'liveChatService:sendMessage-failed',
+    'liveChatService:getChatHistory-failed',
+    'liveChatService:createSupportTicket-failed',
+  ],
+  'liveInventory.web.js': [
+    'liveInventory:getProductInventory-failed',
+    'liveInventory:registerStockNotification-failed',
+  ],
+  'localSeoService.web.js': [
+    'localSeoService:getLocalPage-featuredProductsFailed',
+    'localSeoService:getLocalPage-failed',
+    'localSeoService:getFeaturedProductsForCity-failed',
+    'localSeoService:getRelatedCityLinks-failed',
+    'localSeoService:getAllLocalSlugs-failed',
+  ],
+  'loyaltyMarketing.web.js': [
+    'loyaltyMarketing:getEnrollmentPrompt-failed',
+    'loyaltyMarketing:enrollMember-failed',
+  ],
+  'marketingSequences.web.js': [
+    'marketingSequences:triggerWelcomeSequence-failed',
+    'marketingSequences:triggerCartAbandonSequence-failed',
+    'marketingSequences:triggerReviewRequestSequence-failed',
+    'marketingSequences:runReviewRequestEmails-failed',
+    'marketingSequences:triggerWinbackSequence-failed',
+    'marketingSequences:scanAndTriggerWinback-failed',
+  ],
+  'memberPointsLedgerService.web.js': [
+    'memberPointsLedgerService:getMyPointsHistory-failed',
+  ],
+  'membershipService.web.js': [
+    'membershipService:getActiveOrder-failed',
+    'membershipService:getMembershipPlans-failed',
+  ],
+  'newsletterService.web.js': [
+    'newsletterService:syncToESP-failed',
+    'newsletterService:unsubscribeFromESP-failed',
+    'newsletterService:subscribeToNewsletter-welcomeTriggerFailed',
+    'newsletterService:subscribeToNewsletter-failed',
+    'newsletterService:_triggerWelcomeFlowInternal-noContactId',
+  ],
+  'notificationPreferences.web.js': [
+    'notificationPreferences:getNotificationPreferences-failed',
+    'notificationPreferences:saveNotificationPreferences-failed',
+    'notificationPreferences:unsubscribeAll-failed',
+  ],
+  'notificationService.web.js': [
+    'notificationService:notifyOwner-secretMissing',
+    'notificationService:notifyOwner-emailFailed',
+    'notificationService:notifyOwner-ownerAlert',
+  ],
+  'photoGapReport.web.js': [
+    'photoGapReport:generateReport-failed',
+  ],
+  'photoReviews.web.js': [
+    'photoReviews:submitPhotoReview-gamificationFailed',
+    'photoReviews:submitPhotoReview-failed',
+    'photoReviews:moderatePhotoReview-blockedTransition',
+    'photoReviews:moderatePhotoReview-failed',
+    'photoReviews:getPhotoGallery-failed',
+  ],
+  'contacts/contactResolver.web.js': [
+    'contactResolver:_resolveContactIdInternal-appendOrCreateFailed',
+    'contactResolver:_resolveContactIdInternal-noContactId',
+  ],
+};
+
+function tagPattern(tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+  );
+}
+
+describe('cf-homn (cf-44qt batch-M): 20-file console.* → logError', () => {
+  describe('all 20 files: zero console.* calls', () => {
+    it.each(ALL_FILES)('%s has no console.* calls', (file) => {
+      const source = src(file);
+      const calls = source.match(/console\.(error|warn|log|debug|info)\s*\(/g) || [];
+      expect(calls).toEqual([]);
+    });
+  });
+
+  describe('all non-already-imported files: logError imported from errorHandler', () => {
+    it.each(ALL_FILES.filter(f => !ALREADY_HAS_IMPORT.has(f) && !ALREADY_CLEAN.has(f)))(
+      '%s imports logError from errorHandler',
+      (file) => {
+        const source = src(file);
+        expect(source).toMatch(
+          /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler/,
+        );
+      }
+    );
+  });
+
+  describe('per-file canonical logError tags', () => {
+    for (const [file, tags] of Object.entries(FILE_TAGS)) {
+      describe(file, () => {
+        it.each(tags)('uses tag %s', (tag) => {
+          const source = src(file);
+          expect(source).toMatch(tagPattern(tag));
+        });
+      });
+    }
+  });
+
+  it('summary: 55 logError tags across 18 migrated files', () => {
+    const total = Object.values(FILE_TAGS).reduce((sum, tags) => sum + tags.length, 0);
+    expect(total).toBe(55);
+  });
+});

--- a/tests/cf-pvlr-batchS-eventsLogError.test.js
+++ b/tests/cf-pvlr-batchS-eventsLogError.test.js
@@ -1,0 +1,98 @@
+/**
+ * cf-pvlr (cf-44qt batch-S): events.js console.* → logError migration.
+ *
+ * Single-file PR migrating all 33 console.* sites in src/backend/events.js
+ * (Wix platform event handlers) to canonical `logError(tag, err)` from
+ * `backend/utils/errorHandler` with the `events:<handler>(-<reason>)?`
+ * tag namespace.
+ *
+ * Coverage: revalidate webhook + DLQ writer + every onXxx Wix event
+ * handler (abandoned cart, order approved/shipped/fulfilled/delivered/
+ * cancelled, product created/updated, restock, member created/updated).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/events.js'),
+  'utf-8',
+);
+
+const EXPECTED_TAGS = [
+  // Revalidate webhook + DLQ
+  'events:revalidate-webhookStatus',
+  'events:revalidate-webhookFailed',
+  'events:writeFailedEvent-dlqFailed',
+  // Abandoned cart
+  'events:wixEcom_onAbandonedCart-failed',
+  'events:markCartRecovered-failed',
+  // Member created
+  'events:wixMembers_onMemberCreated-welcomeSequenceFailed',
+  'events:wixMembers_onMemberCreated-seedPointsFailed',
+  // Order approved (the biggest cluster)
+  'events:wixEcom_onOrderApproved-webhookFailed',
+  'events:wixEcom_onOrderApproved-postPurchaseFailed',
+  'events:wixEcom_onOrderApproved-tierMilestoneFailed',
+  'events:wixEcom_onOrderApproved-gamificationFailed',
+  'events:wixEcom_onOrderApproved-referralFailed',
+  'events:wixEcom_onOrderApproved-swatchAttributionFailed',
+  'events:wixEcom_onOrderApproved-swatchKitCreditFailedSilent',
+  'events:wixEcom_onOrderApproved-swatchKitCreditThrew',
+  'events:wixEcom_onOrderApproved-earnFailed',
+  // Order shipped / fulfilled
+  'events:wixEcom_onOrderShipped-webhookFailed',
+  'events:wixEcom_onOrderFulfilled-smsFailed',
+  // Fulfillment
+  'events:wixEcom_onFulfillmentCreated-failed',
+  'events:wixEcom_onFulfillmentUpdated-failed',
+  // Delivered
+  'events:wixEcom_onOrderDelivered-failed',
+  // Cancelled
+  'events:wixEcom_onOrderCanceled-webhookFailed',
+  'events:wixEcom_onOrderCanceled-careSequenceFailed',
+  // Stores: product created
+  'events:wixStores_onProductCreated-missingId',
+  'events:wixStores_onProductCreated-orchestrationFailed',
+  // Stores: product updated
+  'events:wixStores_onProductUpdated-missingId',
+  'events:wixStores_onProductUpdated-priceDropOrchestrationFailed',
+  // Restock dispatch
+  'events:dispatchRestockNotifications-failure',
+  'events:dispatchRestockNotifications-orchestrationFailed',
+  'events:dispatchRestockNotifications',
+  // Member updated (birthday sync)
+  'events:wixMembers_onMemberUpdated-unparseableBirthday',
+  'events:wixMembers_onMemberUpdated-noPrivateMembersData',
+  'events:wixMembers_onMemberUpdated-syncFailed',
+];
+
+function tagPattern(tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+  );
+}
+
+describe('cf-pvlr (cf-44qt batch-S): events.js console.* → logError', () => {
+  it('contains zero console.* calls of any kind', () => {
+    const calls = SRC.match(/console\.(error|warn|log|debug|info)\s*\(/g) || [];
+    expect(calls).toEqual([]);
+  });
+
+  it('imports logError from backend/utils/errorHandler', () => {
+    expect(SRC).toMatch(
+      /import\s+\{[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler/,
+    );
+  });
+
+  it.each(EXPECTED_TAGS)('uses canonical logError tag %s', (tag) => {
+    expect(SRC).toMatch(tagPattern(tag));
+  });
+
+  it('summary: 33 sites migrated', () => {
+    expect(EXPECTED_TAGS).toHaveLength(33);
+  });
+});

--- a/tests/contactResolver.cfxdji.test.js
+++ b/tests/contactResolver.cfxdji.test.js
@@ -19,6 +19,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
+import { logError } from '../src/backend/utils/errorHandler.js';
 import {
   __seedContacts,
   __reset as resetCrm,
@@ -33,6 +37,7 @@ import {
 beforeEach(() => {
   resetCrm();
   vi.restoreAllMocks();
+  vi.clearAllMocks();
 });
 
 describe('cf-xdji · resolveContactId — happy path', () => {
@@ -115,27 +120,22 @@ describe('cf-xdji · resolveContactId — validation', () => {
 describe('cf-xdji · resolveContactId — failure modes', () => {
   it('returns null when appendOrCreateContact throws', async () => {
     vi.spyOn(contacts, 'appendOrCreateContact').mockRejectedValue(new Error('CRM unavailable'));
-    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
-    // Logged with the email + 'failed' substring so support can correlate
-    // a queue-side "no contact ID for recipient" with the upstream cause.
-    const logged = consoleErr.mock.calls.flat().map(String).join('\n');
-    expect(logged).toContain('shopper@example.com');
-    expect(logged).toContain('appendOrCreateContact failed');
-    consoleErr.mockRestore();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('appendOrCreateContact'),
+      expect.any(Error),
+    );
   });
 
   it('returns null when appendOrCreateContact resolves with no contactId', async () => {
     vi.spyOn(contacts, 'appendOrCreateContact').mockResolvedValue({});
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = await resolveContactId('shopper@example.com');
     expect(result).toBeNull();
-    expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining('returned no contactId'),
-      expect.anything(),
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('noContactId'),
+      null,
     );
-    consoleWarn.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary
- Migrates all `console.error`/`console.warn`/`console.log` calls across 18 `src/backend` files to canonical `logError` from `backend/utils/errorHandler`
- 2 files (liveShowroom, orderTracking) were already clean — included in zero-console assertion
- Special cases: removes local logError shim in `marketingSequences.web.js`, corrects wrong import in `notificationPreferences.web.js`
- TDD: 92/92 tests pass (`tests/cf-homn-batchM-logError.test.js`)

## Files migrated (18)
inventoryService, inventorySync, lifecycleCron, lifecycleEmailSender, liveChat, liveChatService, liveInventory, localSeoService, loyaltyMarketing, marketingSequences, memberPointsLedgerService, membershipService, newsletterService, notificationPreferences, notificationService, photoGapReport, photoReviews, contacts/contactResolver

## Test plan
- [x] `npx vitest run tests/cf-homn-batchM-logError.test.js` → 92/92 pass
- [x] Zero `console.*` in all 20 files (including 2 pre-clean)
- [x] 55 canonical `<module>:<fn>-<reason>` tags verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)