### PR TITLE
fix(cf-xv1g): normalize reviewsService.web.js bracket-style logError tags to colon-namespace

### DIFF
--- a/src/backend/reviewsService.web.js
+++ b/src/backend/reviewsService.web.js
@@ -233,7 +233,7 @@ export const submitReview = webMethod(
 
       return { success: true, reviewId: saved._id };
     } catch (err) {
-      logError('[reviewsService] submitReview failed', err);
+      logError('reviewsService:submitReview-failed', err);
       return { success: false, error: 'Unable to submit review. Please try again.' };
     }
   }
@@ -260,7 +260,7 @@ export const markHelpful = webMethod(
       await wixData.update(COLLECTION, review);
       return { success: true, helpful: review.helpful };
     } catch (err) {
-      logError('[reviewsService] markHelpful failed', err);
+      logError('reviewsService:markHelpful-failed', err);
       return { success: false };
     }
   }
@@ -305,7 +305,7 @@ export const flagReview = webMethod(
 
       return { success: true };
     } catch (err) {
-      logError('[reviewsService] flagReview failed', err);
+      logError('reviewsService:flagReview-failed', err);
       return { success: false, error: 'Failed to flag review' };
     }
   }
@@ -334,7 +334,7 @@ export const getPendingReviews = webMethod(
         total: result.totalCount,
       };
     } catch (err) {
-      logError('[reviewsService] getPendingReviews failed', err);
+      logError('reviewsService:getPendingReviews-failed', err);
       return { success: false, reviews: [], total: 0 };
     }
   }
@@ -390,7 +390,7 @@ export const moderateReview = webMethod(
       logAuditEvent(COLLECTION, `moderate_${action}`, rid, { previousStatus, newStatus });
       return { success: true, previousStatus, newStatus };
     } catch (err) {
-      logError('[reviewsService] moderateReview failed', err);
+      logError('reviewsService:moderateReview-failed', err);
       return { success: false, error: 'Failed to moderate review.' };
     }
   }
@@ -448,7 +448,7 @@ export const getCategoryReviewSummaries = webMethod(
 
       return summaries;
     } catch (err) {
-      logError('[reviewsService] getCategoryReviewSummaries failed', err);
+      logError('reviewsService:getCategoryReviewSummaries-failed', err);
       return {};
     }
   }
@@ -476,7 +476,7 @@ async function checkVerifiedPurchase(memberId, productId) {
     }
     return false;
   } catch (err) {
-    logError('[reviewsService] verifiedPurchaseCheck failed', err);
+    logError('reviewsService:verifiedPurchaseCheck-failed', err);
     return false;
   }
 }
@@ -573,7 +573,7 @@ export const submitVideoReview = webMethod(
 
       return { success: true, reviewId: inserted._id };
     } catch (err) {
-      logError('[reviewsService] submitVideoReview failed', err);
+      logError('reviewsService:submitVideoReview-failed', err);
       return { success: false, error: 'Failed to submit video review.' };
     }
   }
@@ -615,7 +615,7 @@ export const getVideoReviews = webMethod(
 
       return { success: true, reviews, totalCount: result.totalCount };
     } catch (err) {
-      logError('[reviewsService] getVideoReviews failed', err);
+      logError('reviewsService:getVideoReviews-failed', err);
       return { success: false, error: 'Failed to load video reviews.', reviews: [] };
     }
   }
@@ -654,13 +654,13 @@ export const moderateVideoReview = webMethod(
         try {
           await receiveGamificationEvent('video_review_approved', { memberId: review.memberId });
         } catch (e) {
-          logError('[reviewsService] moderateVideoReview gamification-trigger failed', e);
+          logError('reviewsService:moderateVideoReview-gamificationTriggerFailed', e);
         }
       }
 
       return { success: true };
     } catch (err) {
-      logError('[reviewsService] moderateVideoReview failed', err);
+      logError('reviewsService:moderateVideoReview-failed', err);
       return { success: false, error: 'Failed to moderate video review.' };
     }
   }
@@ -744,7 +744,7 @@ export const getFeaturedReviews = webMethod(
 
       return { success: true, reviews };
     } catch (err) {
-      logError('[reviewsService] getFeaturedReviews failed', err);
+      logError('reviewsService:getFeaturedReviews-failed', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }

--- a/tests/reviewsServiceTagStyleNormalization.test.js
+++ b/tests/reviewsServiceTagStyleNormalization.test.js
@@ -1,0 +1,50 @@
+/**
+ * cf-xv1g (cf-44qt.tagstyle.fu1): pin normalized colon-namespace logError
+ * tags in src/backend/reviewsService.web.js.
+ *
+ * PR #1417 (cf-m7yg) noted 4 pre-existing bracket-style calls; full file
+ * had 12. All normalized to 'reviewsService:functionName-reason' format.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(
+  path.resolve(TEST_DIR, '../src/backend/reviewsService.web.js'),
+  'utf-8',
+);
+
+const NORMALIZED_TAGS = [
+  'reviewsService:submitReview-failed',
+  'reviewsService:markHelpful-failed',
+  'reviewsService:flagReview-failed',
+  'reviewsService:getPendingReviews-failed',
+  'reviewsService:moderateReview-failed',
+  'reviewsService:getCategoryReviewSummaries-failed',
+  'reviewsService:verifiedPurchaseCheck-failed',
+  'reviewsService:submitVideoReview-failed',
+  'reviewsService:getVideoReviews-failed',
+  'reviewsService:moderateVideoReview-gamificationTriggerFailed',
+  'reviewsService:moderateVideoReview-failed',
+  'reviewsService:getFeaturedReviews-failed',
+];
+
+describe('cf-xv1g: reviewsService.web.js bracket-style tag normalization', () => {
+  it('has no remaining bracket-style [reviewsService] logError tags', () => {
+    const bracketCalls = SRC.match(/logError\s*\(\s*['"`]\[reviewsService\]/g) || [];
+    expect(bracketCalls).toEqual([]);
+  });
+
+  describe('each normalized colon-namespace tag is present', () => {
+    for (const tag of NORMALIZED_TAGS) {
+      it(`tag "${tag}" appears in the source`, () => {
+        const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        expect(SRC).toMatch(
+          new RegExp(`logError\\s*\\(\\s*['"\`]${escaped}['"\`]`),
+        );
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Replaces 12 pre-existing `'[reviewsService] X failed'` logError tags with `'reviewsService:fn-reason'` colon-namespace format per the cf-44qt wave convention. No logic change — tag strings only.

Note: cf-m7yg noted 4 such calls; full file audit found 12. All normalized in one pass. Rebased on current main (976b51f0, post 17 merges).

Supersedes #1554 (conflicted against main).

## Test plan

- [x] `tests/reviewsServiceTagStyleNormalization.test.js` (new): asserts zero bracket-style tags + pins all 12 normalized tags — 13 tests
- [x] `tests/reviewsServiceLogErrorMigration.test.js` (existing): 9 tests unchanged/passing
- [x] 22/22 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)