### PR TITLE
fix(cf-thyn): cf-44qt batch-R — 3-file console.warn sweep (10 sites) → canonical logError

### DIFF
--- a/src/backend/cartRecovery.web.js
+++ b/src/backend/cartRecovery.web.js
@@ -222,7 +222,7 @@ async function getLoyaltyContext(contactId, cartTotal) {
       hasLoyalty: 'true',
     };
   } catch (err) {
-    console.warn('[cartRecovery] getLoyaltyContext failed — sending without loyalty data:', err.message);
+    logError('cartRecovery:getLoyaltyContext-failed', err);
     return empty;
   }
 }

--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -2697,7 +2697,7 @@ export async function post_contactSubmissions(request) {
       const bodyText = await request.body.text();
       body = JSON.parse(bodyText);
     } catch (parseErr) {
-      console.warn('[contactSubmissions] body parse failed:', parseErr?.message ?? parseErr);
+      logError('http-functions:contactSubmissions-bodyParseFailed', parseErr);
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
@@ -2798,7 +2798,7 @@ export async function post_mailingListSignups(request) {
       const bodyText = await request.body.text();
       body = JSON.parse(bodyText);
     } catch (parseErr) {
-      console.warn('[mailingListSignups] body parse failed:', parseErr?.message ?? parseErr);
+      logError('http-functions:mailingListSignups-bodyParseFailed', parseErr);
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
@@ -3042,7 +3042,7 @@ export async function post_notifyMe(request) {
       const bodyText = await request.body.text();
       body = JSON.parse(bodyText);
     } catch (parseErr) {
-      console.warn('[notifyMe] body parse failed:', parseErr?.message ?? parseErr);
+      logError('http-functions:notifyMe-bodyParseFailed', parseErr);
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
@@ -3152,7 +3152,7 @@ export async function get_deliveryZone(request) {
     // so ops can distinguish wrapper-validation 400s from service-validation
     // 400s without a stack.
     if (result && typeof result.error === 'string' && result.error.length > 0) {
-      console.warn('[deliveryZone] service emitted error envelope:', result.error);
+      logError('http-functions:deliveryZone-serviceError', new Error(result.error));
       return badRequest({
         body: JSON.stringify({ success: false, error: result.error }),
         headers: JSON_HEADERS,
@@ -3198,7 +3198,7 @@ export async function post_sampleRequests(request) {
       const bodyText = await request.body.text();
       body = JSON.parse(bodyText);
     } catch (parseErr) {
-      console.warn('[sampleRequests] body parse failed:', parseErr?.message ?? parseErr);
+      logError('http-functions:sampleRequests-bodyParseFailed', parseErr);
       return badRequest({ body: JSON.stringify({ success: false, error: 'Invalid JSON body' }), headers: JSON_HEADERS });
     }
 
@@ -3516,7 +3516,7 @@ export async function post_recordSpinGrant(request) {
       // (cfw forgot to forward the Bearer token). cf-yvs4: return 401 not
       // 200 so cfw's velo-client.ts surfaces the failure as a thrown
       // VeloRpcError rather than the silent lying-status it gets today.
-      console.warn('[recordSpinGrant] getMember failed — treating as unauthenticated:', err && err.message);
+      logError('http-functions:recordSpinGrant-unauthenticated', err);
       return response({
         status: 401,
         body: JSON.stringify({ success: false, error: 'Authentication required' }),
@@ -3619,7 +3619,7 @@ export async function post_submitSurvey(request) {
   try {
     member = await currentMember.getMember();
   } catch (err) {
-    console.warn('[submitSurvey] getMember failed — treating as unauthenticated:', err && err.message);
+    logError('http-functions:submitSurvey-unauthenticated', err);
     return response({
       status: 401,
       body: JSON.stringify({ success: false, error: 'Authentication required' }),

--- a/src/backend/swatchKitService.web.js
+++ b/src/backend/swatchKitService.web.js
@@ -99,7 +99,7 @@ export const recordSwatchKitPurchase = webMethod(
         return { success: true, creditId: existing.items[0].creditId, alreadyIssued: true };
       }
     } catch (err) {
-      console.warn('[swatchKitService] idempotency check failed, proceeding:', err?.message);
+      logError('swatchKitService:recordSwatchKitPurchase-idempotencyFailed', err);
     }
 
     // Issue $5 store credit via storeCreditService
@@ -164,7 +164,7 @@ export const getSwatchKitCreditStatus = webMethod(
       // through (stale session, misconfiguration). Surface it as a distinct
       // error instead of returning "no credit" — that's silent-failure
       // masquerade. See cf-2ag.
-      console.warn('[swatchKitService] getSwatchKitCreditStatus: no member on session (cf-2ag)');
+      logError('swatchKitService:getSwatchKitCreditStatus-noMember', null);
       return { hasPendingCredit: false, error: 'auth_required' };
     }
 

--- a/tests/cf-44qt-sibling-cartRecovery-logError.test.js
+++ b/tests/cf-44qt-sibling-cartRecovery-logError.test.js
@@ -49,8 +49,8 @@ describe('cf-44qt sibling — cartRecovery.web.js console.error → logError', (
     }
   });
 
-  it('logError invocation count matches the 6 migrated sites (no over-migration drift)', () => {
+  it('logError invocation count matches the 7 migrated sites (no over-migration drift)', () => {
     const matches = SRC.match(/logError\s*\(/g) || [];
-    expect(matches.length).toBe(6);
+    expect(matches.length).toBe(7);
   });
 });

--- a/tests/cf-thyn-batchR-LogErrorMigration.test.js
+++ b/tests/cf-thyn-batchR-LogErrorMigration.test.js
@@ -1,0 +1,97 @@
+/**
+ * cf-thyn (cf-44qt batch-R): 3-file console.warn sweep (10 sites).
+ *
+ * Files:
+ *   - cartRecovery.web.js (1 site: getLoyaltyContext)
+ *   - swatchKitService.web.js (2 sites: idempotency check + auth guard)
+ *   - http-functions.js (7 sites: body parse failures + getMember failures + deliveryZone)
+ *
+ * All files already import logError from backend/utils/errorHandler.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(TEST_DIR, '../src/backend');
+
+function read(rel) {
+  return fs.readFileSync(path.resolve(SRC, rel), 'utf-8');
+}
+
+function tagPattern(tag) {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(
+    `logError\\s*\\(\\s*['"\`]${escaped}(?:['"\`]|\\s|\\$\\{)`,
+  );
+}
+
+describe('cf-thyn (cf-44qt batch-R): 3-file console.warn sweep', () => {
+  describe('cartRecovery.web.js', () => {
+    const src = read('cartRecovery.web.js');
+
+    it('has no raw console.warn calls', () => {
+      const calls = src.match(/console\.\w+\s*\(/g) || [];
+      expect(calls).toHaveLength(0);
+    });
+
+    it('uses logError tag cartRecovery:getLoyaltyContext-failed', () => {
+      expect(src).toMatch(tagPattern('cartRecovery:getLoyaltyContext-failed'));
+    });
+  });
+
+  describe('swatchKitService.web.js', () => {
+    const src = read('swatchKitService.web.js');
+
+    it('has no raw console.warn calls', () => {
+      const calls = src.match(/console\.\w+\s*\(/g) || [];
+      expect(calls).toHaveLength(0);
+    });
+
+    it('uses logError tag swatchKitService:recordSwatchKitPurchase-idempotencyFailed', () => {
+      expect(src).toMatch(tagPattern('swatchKitService:recordSwatchKitPurchase-idempotencyFailed'));
+    });
+
+    it('uses logError tag swatchKitService:getSwatchKitCreditStatus-noMember', () => {
+      expect(src).toMatch(tagPattern('swatchKitService:getSwatchKitCreditStatus-noMember'));
+    });
+  });
+
+  describe('http-functions.js', () => {
+    const src = read('http-functions.js');
+
+    it('has no raw console.warn calls', () => {
+      const calls = src.match(/console\.\w+\s*\(/g) || [];
+      expect(calls).toHaveLength(0);
+    });
+
+    it('uses logError tag http-functions:contactSubmissions-bodyParseFailed', () => {
+      expect(src).toMatch(tagPattern('http-functions:contactSubmissions-bodyParseFailed'));
+    });
+
+    it('uses logError tag http-functions:mailingListSignups-bodyParseFailed', () => {
+      expect(src).toMatch(tagPattern('http-functions:mailingListSignups-bodyParseFailed'));
+    });
+
+    it('uses logError tag http-functions:notifyMe-bodyParseFailed', () => {
+      expect(src).toMatch(tagPattern('http-functions:notifyMe-bodyParseFailed'));
+    });
+
+    it('uses logError tag http-functions:deliveryZone-serviceError', () => {
+      expect(src).toMatch(tagPattern('http-functions:deliveryZone-serviceError'));
+    });
+
+    it('uses logError tag http-functions:sampleRequests-bodyParseFailed', () => {
+      expect(src).toMatch(tagPattern('http-functions:sampleRequests-bodyParseFailed'));
+    });
+
+    it('uses logError tag http-functions:recordSpinGrant-unauthenticated', () => {
+      expect(src).toMatch(tagPattern('http-functions:recordSpinGrant-unauthenticated'));
+    });
+
+    it('uses logError tag http-functions:submitSurvey-unauthenticated', () => {
+      expect(src).toMatch(tagPattern('http-functions:submitSurvey-unauthenticated'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

cf-44qt convoy batch-R: migrates the last 10 raw `console.warn` call sites in 3 backend files to canonical `logError(tag, err)`. All 3 files already imported logError — these were the final warn-only stragglers not covered by any prior batch.

**Files migrated (10 sites):**
- `cartRecovery.web.js` ×1: `getLoyaltyContext-failed`
- `swatchKitService.web.js` ×2: `recordSwatchKitPurchase-idempotencyFailed`, `getSwatchKitCreditStatus-noMember`
- `http-functions.js` ×7: `contactSubmissions/mailingListSignups/notifyMe/sampleRequests-bodyParseFailed`, `deliveryZone-serviceError`, `recordSpinGrant/submitSurvey-unauthenticated`

**Test coverage:**
- `tests/cf-thyn-batchR-LogErrorMigration.test.js` — new TDD pin: no-raw-console checks + per-tag assertions (13 tests)
- `tests/cf-44qt-sibling-cartRecovery-logError.test.js` — updated logError invocation count 6→7

## Test plan
- [ ] All 13 tests in `cf-thyn-batchR-LogErrorMigration.test.js` pass GREEN
- [ ] `cf-44qt-sibling-cartRecovery-logError.test.js` passes (count updated 6→7)
- [ ] `swatchKitService.test.js` + `swatchKitServiceSilentFailureCleanup.test.js` pass
- [ ] `cartRecovery.test.js` + `cartRecoveryLogError.test.js` pass
- [ ] `httpFunctions.test.js` passes
- [ ] Zero `console.warn` calls remain in all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)