### PR TITLE
test(cf-d24u): pin logError migration — batch9 5-module colon-namespace assertions

### DIFF
--- a/tests/cf-44qt-logError-batch9.test.js
+++ b/tests/cf-44qt-logError-batch9.test.js
@@ -1,22 +1,25 @@
 /**
- * TDD tests pinning logError migration for batch9:
- *   googleMerchantFeed.web.js  (2 sites)
- *   guideSeoService.web.js     (2 sites)
- *   inventorySync.web.js       (2 sites)
- *   inventoryService.web.js    (3 sites)
- *   facebookCatalog.web.js     (4 sites)
+ * @file cf-44qt-logError-batch9.test.js
+ * @description Pin logError migration for batch9: 5 backend modules.
+ * Tests trigger each error path and assert logError is called with a tag
+ * containing the module prefix (colon-namespace style).
  *
- * cf-44qt
+ * Modules:
+ *   - googleMerchantFeed.web.js   (2 sites: generateFeed, getFeedData)
+ *   - guideSeoService.web.js      (2 sites: getRelatedProducts, getGuidePageSeoData)
+ *   - inventorySync.web.js        (2 sites: syncProduct, syncFailed)
+ *   - inventoryService.web.js     (3 sites: getStockStatus, signUpBackInStock, getInventoryUrgency)
+ *   - facebookCatalog.web.js      (4+ sites: buildCatalogBatch, refreshFacebookCatalog-*)
+ *
+ * cf-d24u
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// ── vi.hoisted mocks ─────────────────────────────────────────────────
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
 
 const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }));
 const { mockQueryProducts } = vi.hoisted(() => ({ mockQueryProducts: vi.fn() }));
 const { mockNotifyOwner } = vi.hoisted(() => ({ mockNotifyOwner: vi.fn() }));
-
-// ── Static mocks ─────────────────────────────────────────────────────
 
 vi.mock('wix-web-module', () => ({
   Permissions: { Anyone: 'Anyone', Admin: 'Admin', SiteMember: 'SiteMember' },
@@ -28,6 +31,7 @@ vi.mock('backend/utils/errorHandler', () => ({ logError: mockLogError }));
 vi.mock('backend/utils/sanitize', () => ({
   sanitize: (v, max = 500) => (typeof v === 'string' ? v.trim().slice(0, max) : ''),
   validateEmail: (v) => (typeof v === 'string' && v.includes('@') ? v.trim() : ''),
+  validateId: (v) => (typeof v === 'string' && v.trim() ? v.trim() : null),
 }));
 
 vi.mock('backend/utils/mediaHelpers', () => ({
@@ -56,7 +60,7 @@ vi.mock('backend/notificationService.web', () => ({
 
 import { __seed, __setQueryError, __reset } from './__mocks__/wix-data.js';
 
-// ── Import SUT ───────────────────────────────────────────────────────
+// ── SUT imports ───────────────────────────────────────────────────────────────
 
 const { generateFeed, getFeedData } =
   await import('../src/backend/googleMerchantFeed.web.js');
@@ -69,41 +73,41 @@ const { getStockStatus, signUpBackInStock, getInventoryUrgency } =
 const { refreshFacebookCatalog } =
   await import('../src/backend/facebookCatalog.web.js');
 
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 // googleMerchantFeed
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 
 describe('googleMerchantFeed — logError migration', () => {
   beforeEach(() => { __reset(); mockLogError.mockClear(); });
 
-  it('generateFeed calls logError on query failure', async () => {
+  it('generateFeed: logError called with googleMerchantFeed: prefix on query failure', async () => {
     __setQueryError('Stores/Products', new Error('db fail'));
     await generateFeed();
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('googleMerchantFeed'),
+      expect.stringMatching(/^googleMerchantFeed:/),
       expect.any(Error),
     );
   });
 
-  it('getFeedData calls logError on query failure', async () => {
+  it('getFeedData: logError called with googleMerchantFeed: prefix on query failure', async () => {
     __setQueryError('Stores/Products', new Error('db fail'));
     const r = await getFeedData();
     expect(Array.isArray(r)).toBe(true);
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('googleMerchantFeed'),
+      expect.stringMatching(/^googleMerchantFeed:/),
       expect.any(Error),
     );
   });
 });
 
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 // guideSeoService
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 
 describe('guideSeoService — logError migration', () => {
   beforeEach(() => { __reset(); mockLogError.mockClear(); });
 
-  it('getRelatedProducts calls logError on query failure', async () => {
+  it('getRelatedProducts: logError called with guideSeoService tag on query failure', async () => {
     __setQueryError('Products', new Error('db fail'));
     const r = await getRelatedProducts('futon-frames', 6);
     expect(r.success).toBe(false);
@@ -112,16 +116,17 @@ describe('guideSeoService — logError migration', () => {
       expect.any(Error),
     );
   });
+
 });
 
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 // inventorySync
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 
 describe('inventorySync — logError migration', () => {
   beforeEach(() => { __reset(); mockLogError.mockClear(); });
 
-  it('triggerInventorySync calls logError when queryProducts throws', async () => {
+  it('triggerInventorySync: logError called with inventorySync: prefix when queryProducts throws', async () => {
     mockQueryProducts.mockReturnValue({
       limit: vi.fn().mockReturnThis(),
       find: vi.fn().mockRejectedValue(new Error('wix stores fail')),
@@ -129,51 +134,51 @@ describe('inventorySync — logError migration', () => {
     const r = await triggerInventorySync();
     expect(r.success).toBe(false);
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('inventorySync'),
+      expect.stringMatching(/^inventorySync:/),
       expect.any(Error),
     );
   });
 });
 
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 // inventoryService
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 
 describe('inventoryService — logError migration', () => {
   beforeEach(() => { __reset(); mockLogError.mockClear(); });
 
-  it('getStockStatus calls logError on query failure', async () => {
+  it('getStockStatus: logError called with inventoryService: prefix on query failure', async () => {
     __setQueryError('InventoryLevels', new Error('db fail'));
     await getStockStatus('prod-1');
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('inventoryService'),
+      expect.stringMatching(/^inventoryService:/),
       expect.any(Error),
     );
   });
 
-  it('signUpBackInStock calls logError on query failure', async () => {
+  it('signUpBackInStock: logError called with inventoryService: prefix on query failure', async () => {
     __setQueryError('BackInStockSignups', new Error('db fail'));
     const r = await signUpBackInStock({ productId: 'prod-1', email: 'test@example.com' });
     expect(r.success).toBe(false);
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('inventoryService'),
+      expect.stringMatching(/^inventoryService:/),
       expect.any(Error),
     );
   });
 
-  it('getInventoryUrgency calls logError on query failure', async () => {
+  it('getInventoryUrgency: logError called with inventoryService: prefix on query failure', async () => {
     __setQueryError('InventoryLevels', new Error('db fail'));
     await getInventoryUrgency('prod-1');
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('inventoryService'),
+      expect.stringMatching(/^inventoryService:/),
       expect.any(Error),
     );
   });
 });
 
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 // facebookCatalog
-// ════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════
 
 describe('facebookCatalog — logError migration', () => {
   beforeEach(() => {
@@ -182,12 +187,12 @@ describe('facebookCatalog — logError migration', () => {
     mockNotifyOwner.mockResolvedValue(undefined);
   });
 
-  it('refreshFacebookCatalog calls logError on query failure', async () => {
+  it('refreshFacebookCatalog: logError called with facebookCatalog: prefix on query failure', async () => {
     __setQueryError('Stores/Products', new Error('db fail'));
     const r = await refreshFacebookCatalog();
     expect(r.success).toBe(false);
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('facebookCatalog'),
+      expect.stringMatching(/^facebookCatalog:/),
       expect.toSatisfy(v => v === null || v instanceof Error),
     );
   });


### PR DESCRIPTION
## Summary
- Adds tests/cf-44qt-logError-batch9.test.js pinning logError call sites for the 5 batch9 modules
- 8 tests: googleMerchantFeed (2), guideSeoService (1), inventorySync (1), inventoryService (3), facebookCatalog (1)
- No source file changes (test-only per cf-d24u spec)

## Test plan
- [x] npm test tests/cf-44qt-logError-batch9.test.js -> 8/8 pass

Generated with Claude Code