### PR TITLE
fix(cf-ze3c): guideSeoService.web.js bracket→colon logError migration (2 sites)

### DIFF
--- a/src/backend/guideSeoService.web.js
+++ b/src/backend/guideSeoService.web.js
@@ -122,7 +122,7 @@ export const getRelatedProducts = webMethod(
         })),
       };
     } catch (err) {
-      logError('[guideSeoService] getRelatedProducts', err);
+      logError('guideSeoService:getRelatedProducts', err);
       return { success: false, products: [] };
     }
   }
@@ -203,7 +203,7 @@ export const getGuidePageSeoData = webMethod(
         relatedGuides: guidesResult.success ? guidesResult.guides : [],
       };
     } catch (err) {
-      logError('[guideSeoService] getGuidePageSeoData', err);
+      logError('guideSeoService:getGuidePageSeoData', err);
       return { success: false, howToSchema: null, relatedProducts: [], relatedGuides: [] };
     }
   }

--- a/tests/cf-44qt-logError-batch9.test.js
+++ b/tests/cf-44qt-logError-batch9.test.js
@@ -108,7 +108,7 @@ describe('guideSeoService — logError migration', () => {
     const r = await getRelatedProducts('futon-frames', 6);
     expect(r.success).toBe(false);
     expect(mockLogError).toHaveBeenCalledWith(
-      expect.stringContaining('guideSeoService'),
+      'guideSeoService:getRelatedProducts',
       expect.any(Error),
     );
   });


### PR DESCRIPTION
## Summary
- Migrates 2 bracket-format tags to canonical colon-namespace in guideSeoService.web.js
- Tightens cf-44qt-logError-batch9.test.js guideSeoService assertion to exact match
- Fixes pre-existing guideSeoServiceLogErrorMigration.test.js failure

## Test plan
- [x] npm test tests/cf-44qt-logError-batch9.test.js tests/guideSeoServiceLogErrorMigration.test.js -> 13/13 pass

Generated with Claude Code