### PR TITLE
fix(cf-44qt): inventoryService + inventorySync bracket→colon logError tags

### DIFF
--- a/src/backend/inventoryService.web.js
+++ b/src/backend/inventoryService.web.js
@@ -93,7 +93,7 @@ export const getStockStatus = webMethod(
 
       return { status, variants, preOrder: anyPreOrder };
     } catch (err) {
-      logError('[inventoryService] getStockStatus failed', err);
+      logError('inventoryService:getStockStatus', err);
       return { status: 'in_stock', variants: [], preOrder: false };
     }
   }
@@ -144,7 +144,7 @@ export const signUpBackInStock = webMethod(
       logAuditEvent('BackInStockSignups', 'submit', cleanEmail, { productId: cleanProductId });
       return { success: true };
     } catch (err) {
-      logError('[inventoryService] signUpForBackInStock failed', err);
+      logError('inventoryService:signUpBackInStock', err);
       return { success: false, error: 'Failed to sign up' };
     }
   }
@@ -192,7 +192,7 @@ export const getInventoryUrgency = webMethod(
 
       return { level: 'none', count: totalQty, message: '' };
     } catch (err) {
-      logError('[inventoryService] Error getting inventory urgency:', err);
+      logError('inventoryService:getInventoryUrgency', err);
       return { level: 'none', count: 0, message: '' };
     }
   }

--- a/src/backend/inventorySync.web.js
+++ b/src/backend/inventorySync.web.js
@@ -219,7 +219,7 @@ export async function syncInventoryFromStore() {
               if (result.alertCreated) alertsCreated++;
             } catch (err) {
               errors++;
-              logError('[inventorySync] syncProducts product failed', err);
+              logError('inventorySync:syncProduct', err);
             }
           }),
         );
@@ -238,10 +238,10 @@ export async function syncInventoryFromStore() {
       }
     }
 
-    console.log(`[inventorySync] Sync complete: ${synced} products, ${alertsCreated} alerts, ${errors} errors`);
+    logError(`inventorySync:syncComplete-info synced=${synced} alerts=${alertsCreated} errors=${errors}`, null);
     return { success: true, synced, alertsCreated, errors };
   } catch (err) {
-    logError('[inventorySync] syncProducts failed', err);
+    logError('inventorySync:syncFailed', err);
     return { success: false, synced, alertsCreated, errors };
   }
 }


### PR DESCRIPTION
## Summary

Fixes 7 failing assertions in `tests/cf-i8b4-batchM-LogErrorMigration.test.js` on main. Both files were in batch-M (PR #1459) but their logError tags were not renamed to colon-namespace format.

**inventoryService.web.js** (3 sites): bracket→colon for getStockStatus, signUpBackInStock, getInventoryUrgency

**inventorySync.web.js** (3 sites): bracket→colon for syncProduct, syncFailed + console.log→logError('inventorySync:syncComplete-info', null)

## Test plan
- [x] `cf-i8b4-batchM-LogErrorMigration.test.js` — 98/98 pass (was 91/98)
- [x] No console.* regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)