### PR TITLE
fix(cf-dr1t): Assembly Guides.js console.error → logError, silence test stderr

### DIFF
--- a/src/pages/Assembly Guides.js
+++ b/src/pages/Assembly Guides.js
@@ -16,6 +16,7 @@ import {
   getCategoryIcon,
 } from 'public/assemblyGuideHelpers.js';
 import { initPageSeo } from 'public/pageSeo.js';
+import { logError } from 'backend/utils/errorHandler';
 
 let allGuides = [];
 let currentCategory = null;
@@ -44,7 +45,7 @@ async function loadGuides() {
     showLoading(false);
     announce($w, `${allGuides.length} assembly guide${allGuides.length !== 1 ? 's' : ''} available`);
   } catch (err) {
-    console.error('Error loading assembly guides:', err);
+    logError('assemblyGuides:loadGuides', err);
     showLoading(false);
     showEmpty('Unable to load assembly guides. Please try again later.');
   }

--- a/src/pages/Assembly Guides.js
+++ b/src/pages/Assembly Guides.js
@@ -16,7 +16,6 @@ import {
   getCategoryIcon,
 } from 'public/assemblyGuideHelpers.js';
 import { initPageSeo } from 'public/pageSeo.js';
-import { logError } from 'backend/utils/errorHandler';
 
 let allGuides = [];
 let currentCategory = null;
@@ -45,7 +44,9 @@ async function loadGuides() {
     showLoading(false);
     announce($w, `${allGuides.length} assembly guide${allGuides.length !== 1 ? 's' : ''} available`);
   } catch (err) {
-    logError('assemblyGuides:loadGuides', err);
+    import('backend/errorMonitoring.web').then(({ logError }) => {
+      logError({ message: err.message, stack: err.stack, page: 'Assembly Guides', context: 'assemblyGuides:loadGuides' });
+    }).catch(() => console.error('assemblyGuides:loadGuides', err));
     showLoading(false);
     showEmpty('Unable to load assembly guides. Please try again later.');
   }

--- a/tests/assemblyGuidesPageHookup.test.js
+++ b/tests/assemblyGuidesPageHookup.test.js
@@ -68,7 +68,7 @@ vi.mock('backend/assemblyGuides.web', () => ({
   getCareTips: (...args) => getCareTips(...args),
 }));
 
-vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+vi.mock('backend/errorMonitoring.web', () => ({ logError: vi.fn() }));
 
 const trackEvent = vi.fn();
 vi.mock('public/engagementTracker', () => ({

--- a/tests/assemblyGuidesPageHookup.test.js
+++ b/tests/assemblyGuidesPageHookup.test.js
@@ -68,6 +68,8 @@ vi.mock('backend/assemblyGuides.web', () => ({
   getCareTips: (...args) => getCareTips(...args),
 }));
 
+vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }));
+
 const trackEvent = vi.fn();
 vi.mock('public/engagementTracker', () => ({
   trackEvent: (...args) => trackEvent(...args),


### PR DESCRIPTION
## Summary
- Migrates `console.error('Error loading assembly guides:', err)` → `logError('assemblyGuides:loadGuides', err)` in `src/pages/Assembly Guides.js`
- Adds `vi.mock('backend/utils/errorHandler', () => ({ logError: vi.fn() }))` to `tests/assemblyGuidesPageHookup.test.js`
- The "shows error message when listAssemblyGuides fails" test intentionally throws `Network error` — the unmocked `console.error` was producing noisy stderr in CI that looked like a real failure

## Root cause
Source file had one un-migrated `console.error` catch site. Test had no `errorHandler` mock, so the caught error logged to real stderr via the source's console.error.

## Test plan
- [x] `npm test -- tests/assemblyGuidesPageHookup.test.js` → 60/60 pass, zero stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)