### PR TITLE
fix(cf-n4wy batch-O): correct logError tag names in 4 backend files

### DIFF
--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -758,7 +758,7 @@ export const getActiveChallenges = webMethod(
       // through (stale session, misconfiguration). Surface it as a distinct
       // error instead of returning "no challenges" — that's silent-failure
       // masquerade. See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getActiveChallenges-unauthenticated', null);
+      logError('gamificationCore:getActiveChallenges-noMemberId', null);
       return { challenges: [], error: 'auth_required' };
     }
 
@@ -1089,7 +1089,7 @@ export const getStreakData = webMethod(
       // Velo SiteMember gate leak — distinguishable from "authed but no streak
       // yet" (which also returns zeros, but without the error field).
       // See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getStreakData-unauthenticated', null);
+      logError('gamificationCore:getStreakData-noMemberId', null);
       return { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
     }
     const record = await findMemberRecord(memberId);
@@ -1208,7 +1208,7 @@ export const getMemberTier = webMethod(
       // Velo SiteMember gate leak — return the baseline Trail Blazer shape
       // but signal the auth anomaly so widgets can gate tier benefits display.
       // See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getMemberTier-unauthenticated', null);
+      logError('gamificationCore:getMemberTier-noMemberId', null);
       return { ...computeTierInfo(0), error: 'auth_required' };
     }
     const record = await findMemberRecord(memberId);
@@ -1248,7 +1248,7 @@ export const getActivityFeed = webMethod(
       // Velo SiteMember gate leak. Array return preserved for consumer compat;
       // observability lives in the warn so Wix runtime logs surface the leak.
       // See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getActivityFeed-unauthenticated', null);
+      logError('gamificationCore:getActivityFeed-authRequired', null);
       return [];
     }
     if (caller._id !== memberId) {

--- a/src/backend/swatchKitService.web.js
+++ b/src/backend/swatchKitService.web.js
@@ -99,7 +99,7 @@ export const recordSwatchKitPurchase = webMethod(
         return { success: true, creditId: existing.items[0].creditId, alreadyIssued: true };
       }
     } catch (err) {
-      logError('swatchKitService:recordSwatchKitPurchase-idempotencyFailed', err);
+      logError('swatchKitService:issueSwatchKitCredit-idempotencyCheckFailed', err);
     }
 
     // Issue $5 store credit via storeCreditService
@@ -113,12 +113,12 @@ export const recordSwatchKitPurchase = webMethod(
         orderReference: cleanOrderId,
       });
       if (!creditResult?.success) {
-        logError('[swatchKitService] recordSwatchKitPurchase issueStoreCredit returned failure', new Error(JSON.stringify(creditResult || {})));
+        logError('swatchKitService:issueSwatchKitCredit-creditFailed', new Error(JSON.stringify(creditResult || {})));
         return { success: false, error: 'credit_issuance_failed' };
       }
       creditId = creditResult.creditId || '';
     } catch (err) {
-      logError('[swatchKitService] recordSwatchKitPurchase issueStoreCredit threw', err);
+      logError('swatchKitService:issueSwatchKitCredit-creditThrew', err);
       return { success: false, error: 'credit_issuance_failed' };
     }
 
@@ -140,7 +140,7 @@ export const recordSwatchKitPurchase = webMethod(
       });
     } catch (err) {
       // Non-fatal — credit is real even if CMS write fails
-      logError(`[swatchKitService] recordSwatchKitPurchase CMS-insert failed after credit issued — MANUAL RECONCILIATION orderId=${cleanOrderId} creditId=${creditId}`, err);
+      logError(`swatchKitService:issueSwatchKitCredit-cmsInsertFailedManualReconcile orderId=${cleanOrderId} creditId=${creditId}`, err);
     }
 
     return { success: true, creditId };
@@ -191,7 +191,7 @@ export const getSwatchKitCreditStatus = webMethod(
         amount: SWATCH_KIT_CREDIT_AMOUNT,
       };
     } catch (err) {
-      logError('[swatchKitService] getSwatchKitCreditStatus failed', err);
+      logError('swatchKitService:getSwatchKitCreditStatus', err);
       return { hasPendingCredit: false, error: 'lookup_failed' };
     }
   }
@@ -230,7 +230,7 @@ export const markCreditApplied = webMethod(
       });
       return { success: true };
     } catch (err) {
-      logError('[swatchKitService] markCreditApplied failed', err);
+      logError('swatchKitService:markCreditApplied', err);
       return { success: false, error: 'update_failed' };
     }
   }

--- a/src/backend/swatchRequest.web.js
+++ b/src/backend/swatchRequest.web.js
@@ -102,7 +102,7 @@ async function resolveSwatchNames(swatchIds) {
       wixData.query('FabricSwatches').eq('_id', id).limit(1).find()
         .then(r => {
           const name = r.items[0]?.name;
-          if (!name) logError(`swatchRequest:buildSwatchList-notFound id=${id}`, null);
+          if (!name) logError('swatchRequest:resolveSwatchNames-notFound', null);
           return name || id;
         })
     )
@@ -243,10 +243,10 @@ export const submitSwatchRequest = webMethod(
             productSlug: cleanSlug || null,
           });
         } catch (emailErr) {
-          logError('swatchRequest:submitSwatchRequest-nurtureEmailFailed', emailErr);
+          logError('swatchRequest:submitSwatchRequest-nurtureQueueFailed', emailErr);
         }
       } else {
-        logError(`swatchRequest:submitSwatchRequest-noContactId email=${contact.email}`, null);
+        logError('swatchRequest:submitSwatchRequest-skippedEmptyContactId', null);
       }
 
       // cf-obsb Path A: send the customer-facing swatch confirmation email
@@ -262,7 +262,7 @@ export const submitSwatchRequest = webMethod(
           swatchNames,
           productName: productNameForEmail,
         }).catch((emailErr) => {
-          logError('swatchRequest:submitSwatchRequest-confirmationFailed', emailErr);
+          logError('swatchRequest:submitSwatchRequest-confirmationSendFailed', emailErr);
         });
       }
 

--- a/src/backend/videoReviewService.web.js
+++ b/src/backend/videoReviewService.web.js
@@ -113,7 +113,7 @@ export const submitVideoReview = webMethod(
 
       return { success: true, reviewId: record._id };
     } catch (err) {
-      logError('[videoReviewService] submitVideoReview failed', err);
+      logError('videoReviewService:submitVideoReview', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -161,7 +161,7 @@ export const getVideoReviews = webMethod(
 
       return { success: true, reviews, totalCount: result.totalCount ?? reviews.length };
     } catch (err) {
-      logError('[videoReviewService] getVideoReviews failed', err);
+      logError('videoReviewService:getVideoReviews', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }
@@ -210,7 +210,7 @@ export const moderateVideoReview = webMethod(
 
       return { success: true };
     } catch (err) {
-      logError('[videoReviewService] moderateVideoReview failed', err);
+      logError('videoReviewService:moderateVideoReview', err);
       return { success: false, error: 'internal_error' };
     }
   }
@@ -251,7 +251,7 @@ export const getProductVideoReviews = webMethod(
 
       return { success: true, reviews };
     } catch (err) {
-      logError('[videoReviewService] getProductVideoReviews failed', err);
+      logError('videoReviewService:getProductVideoReviews', err);
       return { success: false, reviews: [], error: 'internal_error' };
     }
   }
@@ -280,7 +280,7 @@ export const getVideoReviewCount = webMethod(
 
       return { success: true, count };
     } catch (err) {
-      logError('[videoReviewService] getVideoReviewCount failed', err);
+      logError('videoReviewService:getVideoReviewCount', err);
       return { success: false, count: 0, error: 'internal_error' };
     }
   }


### PR DESCRIPTION
## Summary

- **videoReviewService**: 5 bracket→colon logError tag migrations
- **swatchRequest**: 4 tag corrections (resolveSwatchNames-notFound, -nurtureQueueFailed, -skippedEmptyContactId, -confirmationSendFailed)
- **gamificationCore**: 4 suffix corrections (-unauthenticated → -noMemberId / -authRequired)
- **swatchKitService**: 6 tag corrections — issueSwatchKitCredit function-name prefix, bracket→colon, template literal for CMS insert reconcile log

Fixes 11+ failing assertions in tests/cf-n4wy-batchO-LogErrorMigration.test.js on main. The cf-n4wy bead was closed but source files were not fully updated to match the source-pin test expectations.

## Test plan

- [x] npx vitest run tests/cf-n4wy-batchO-LogErrorMigration.test.js → 61/61 passed

Generated with Claude Code