### PR TITLE
fix(test-infra): whiteGlove futureDate timezone fix — local date to match source semantics

### DIFF
--- a/tests/whiteGloveDeliverySms.test.js
+++ b/tests/whiteGloveDeliverySms.test.js
@@ -47,7 +47,10 @@ function futureDate(offsetDays = 2) {
   const d = new Date();
   d.setDate(d.getDate() + offsetDays);
   while (d.getDay() === 0) d.setDate(d.getDate() + 1);
-  return d.toISOString().split('T')[0];
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 function todayStr() {

--- a/tests/whiteGloveScheduling.test.js
+++ b/tests/whiteGloveScheduling.test.js
@@ -34,9 +34,11 @@ beforeEach(() => {
 function futureDate(offsetDays = 2) {
   const d = new Date();
   d.setDate(d.getDate() + offsetDays);
-  // Advance to next Mon-Sat if on Sunday
   while (d.getDay() === 0) d.setDate(d.getDate() + 1);
-  return d.toISOString().split('T')[0];
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 function makeAppt(overrides = {}) {


### PR DESCRIPTION
## Summary

- `futureDate()` in `whiteGloveScheduling.test.js` and `whiteGloveDeliverySms.test.js` was skipping Sundays using `getDay()` (local time) but returning `toISOString().split('T')[0]` (UTC date).
- In US timezones (UTC-5 to UTC-8), late-evening local Saturday becomes UTC Sunday, causing `new Date(dateStr + 'T12:00:00').getDay()` in the source to return 0 (Sunday) → rejected with "Deliveries are available Monday through Saturday".
- Fixed by building the return string from local `getFullYear/getMonth/getDate` components.
- `dateInDays()` and `todayStr()` are unchanged (UTC, matching source's `toDateStr` helper used by cron reminder functions).

## Test plan
- [ ] `npx vitest run tests/whiteGloveScheduling.test.js` — 46 tests pass
- [ ] `npx vitest run tests/whiteGloveDeliverySms.test.js` — 30 tests pass
- [ ] Full suite: 14 fewer failures than before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)