### PR TITLE
fix(cf-2k7u batch-Q): conversionDashboard bracket→colon logError tags ×4

### DIFF
--- a/src/backend/conversionDashboard.web.js
+++ b/src/backend/conversionDashboard.web.js
@@ -101,7 +101,7 @@ export const getConversionFunnel = webMethod(
         },
       };
     } catch (err) {
-      logError('[conversionDashboard] getConversionFunnel', err);
+      logError('conversionDashboard:getConversionFunnel', err);
       return { success: false, funnel: null };
     }
   }
@@ -157,7 +157,7 @@ export const getDailyConversionTrend = webMethod(
 
       return { success: true, trend };
     } catch (err) {
-      logError('[conversionDashboard] getDailyConversionTrend', err);
+      logError('conversionDashboard:getDailyConversionTrend', err);
       return { success: false, trend: [] };
     }
   }
@@ -212,7 +212,7 @@ export const getCategoryConversion = webMethod(
 
       return { success: true, categories };
     } catch (err) {
-      logError('[conversionDashboard] getCategoryConversion', err);
+      logError('conversionDashboard:getCategoryConversion', err);
       return { success: false, categories: [] };
     }
   }
@@ -251,7 +251,7 @@ export const getDashboardSummary = webMethod(
         },
       };
     } catch (err) {
-      logError('[conversionDashboard] getDashboardSummary', err);
+      logError('conversionDashboard:getDashboardSummary', err);
       return { success: false, summary: null };
     }
   }


### PR DESCRIPTION
## Summary

Corrects 4 logError tags in `conversionDashboard.web.js` from bracket format to colon namespace format, fixing the remaining 4 failing assertions in `tests/cf-2k7u-batchQ-LogErrorMigration.test.js`.

Changes: `[conversionDashboard] fn` → `conversionDashboard:fn` for all 4 webMethod catch blocks.

## Test plan

- [x] `npx vitest run tests/cf-2k7u-batchQ-LogErrorMigration.test.js` → 80/80 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)