### PR TITLE
fix: align cf-tok3-photoReviews test to canonical colon tag format

### DIFF
--- a/src/backend/photoReviews.web.js
+++ b/src/backend/photoReviews.web.js
@@ -119,7 +119,7 @@ export const submitPhotoReview = webMethod(
 
       return { success: true, id: inserted._id };
     } catch (err) {
-      logError('photoReviews.submitPhotoReview', err);
+      logError('photoReviews:submitPhotoReview', err);
       return { success: false, error: 'Failed to submit photo review.' };
     }
   }
@@ -186,7 +186,7 @@ export const moderatePhotoReview = webMethod(
       await wixData.update('PhotoReviews', existing);
       return { success: true, previousStatus, newStatus };
     } catch (err) {
-      logError('photoReviews.moderatePhotoReview', err);
+      logError('photoReviews:moderatePhotoReview', err);
       return { success: false, error: 'Failed to moderate review.' };
     }
   }
@@ -231,7 +231,7 @@ export const getPhotoGallery = webMethod(
 
       return { success: true, photos };
     } catch (err) {
-      logError('photoReviews.getPhotoGallery', err);
+      logError('photoReviews:getPhotoGallery', err);
       return { success: false, error: 'Failed to load gallery.', photos: [] };
     }
   }

--- a/tests/cf-tok3-photoReviews-logError.test.js
+++ b/tests/cf-tok3-photoReviews-logError.test.js
@@ -27,10 +27,10 @@ describe('cf-tok3 photoReviews — console.error → logError migration', () => 
     );
   });
 
-  it('all 3 webMethods route through photoReviews.* context tags', async () => {
+  it('all 3 webMethods route through photoReviews:* context tags', async () => {
     const src = await readSrc();
-    expect(src).toMatch(/logError\(\s*['"]photoReviews\.submitPhotoReview['"]/);
-    expect(src).toMatch(/logError\(\s*['"]photoReviews\.moderatePhotoReview['"]/);
-    expect(src).toMatch(/logError\(\s*['"]photoReviews\.getPhotoGallery['"]/);
+    expect(src).toMatch(/logError\(\s*['"]photoReviews:submitPhotoReview['"]/);
+    expect(src).toMatch(/logError\(\s*['"]photoReviews:moderatePhotoReview['"]/);
+    expect(src).toMatch(/logError\(\s*['"]photoReviews:getPhotoGallery['"]/);
   });
 });


### PR DESCRIPTION
## Summary

`tests/cf-tok3-photoReviews-logError.test.js` expected dot-format tags (`photoReviews.submitPhotoReview`) that conflicted with `tests/photoReviewsLogErrorMigration.test.js`, which enforces colon format with a drift guard.

- Reverts `photoReviews.web.js` to canonical colon format (`photoReviews:*`)
- Updates `cf-tok3-photoReviews-logError.test.js` to expect colon format

Consistent with canonical `module:functionName` convention enforced across all cf-44qt convoy files.

## Test plan

- [x] `npx vitest run tests/photoReviewsLogErrorMigration.test.js tests/cf-tok3-photoReviews-logError.test.js` → 9/9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)