### PR TITLE
fix(cf-crdn): drop stale /failed/ assertions + migrate trendingSearches logError tag

### DIFF
--- a/src/backend/trendingSearches.web.js
+++ b/src/backend/trendingSearches.web.js
@@ -51,7 +51,7 @@ export const getTrendingSearches = webMethod(
 
       return { success: true, terms };
     } catch (e) {
-      logError('[trendingSearches] getTrendingSearches failed', e);
+      logError('trendingSearches:getTrendingSearches', e);
       return { success: false, terms: [...DEFAULT_TERMS], error: 'Failed to load trending searches' };
     }
   }

--- a/tests/productReviewsSilentFailureCleanup.test.js
+++ b/tests/productReviewsSilentFailureCleanup.test.js
@@ -44,7 +44,6 @@ describe('cf-44qt sibling — productReviews.web.js observability cleanup', () =
     const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
     expect(allTags).toMatch(/productReviews/);
     expect(allTags).toMatch(/getReviewSummary/);
-    expect(allTags).toMatch(/failed/);
   });
 
   it('getUnifiedReviews wires logError on Reviews query throw', async () => {

--- a/tests/promotionsSilentFailureCleanup.test.js
+++ b/tests/promotionsSilentFailureCleanup.test.js
@@ -39,7 +39,6 @@ describe('cf-44qt sibling — promotions.web.js observability cleanup', () => {
     const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
     expect(allTags).toMatch(/promotions/);
     expect(allTags).toMatch(/getActivePromotion/);
-    expect(allTags).toMatch(/failed/);
   });
 
   it('getFlashSales wires logError on Promotions query throw', async () => {

--- a/tests/wwexFreightSilentFailureCleanup.test.js
+++ b/tests/wwexFreightSilentFailureCleanup.test.js
@@ -53,7 +53,6 @@ describe('cf-44qt sibling — wwex-freight.web.js observability cleanup', () => 
     const allTags = logErrorSpy.mock.calls.map((c) => c[0]).join('|');
     expect(allTags).toMatch(/wwex-freight/);
     expect(allTags).toMatch(/getLTLRates/);
-    expect(allTags).toMatch(/failed/);
     expect(result.success).toBe(false);
     expect(result.fallback).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- Remove `expect(allTags).toMatch(/failed/)` from 3 SilentFailureCleanup test files where the source uses colon-notation tags that don't include the word "failed" (`promotions:getActivePromotion`, `productReviews:getReviewSummary`, `wwex-freight:getLTLRates`)
- Migrate `trendingSearches.web.js` logError tag from bracket notation `[trendingSearches] getTrendingSearches failed` to colon notation `trendingSearches:getTrendingSearches` so the `trendingSearchesLogErrorMigration` drift guard passes

## Test plan

- [x] 15/15 tests pass: `npx vitest run tests/promotionsSilentFailureCleanup tests/wwexFreightSilentFailureCleanup tests/productReviewsSilentFailureCleanup tests/priceDropCronSilentFailureCleanup tests/trendingSearchesLogErrorMigration`

Closes cf-crdn

🤖 Generated with [Claude Code](https://claude.com/claude-code)