### PR TITLE
fix(cf-7s1j): resolve remaining logError migration regressions

### DIFF
--- a/src/backend/customizationService.web.js
+++ b/src/backend/customizationService.web.js
@@ -63,7 +63,7 @@ export const getCustomizationOptions = webMethod(
         })),
       };
     } catch (err) {
-      logError('[customizationService] getCustomizationOptions', err);
+      logError('customizationService:getCustomizationOptions', err);
       return empty;
     }
   }
@@ -136,7 +136,7 @@ export const saveConfiguration = webMethod(
       const result = await wixData.insert('SavedCustomizations', record);
       return result;
     } catch (err) {
-      logError('[customizationService] saveCustomizationConfig', err);
+      logError('customizationService:saveCustomizationConfig', err);
       return { error: 'Failed to save configuration' };
     }
   }
@@ -177,7 +177,7 @@ export const getSavedConfigurations = webMethod(
         _createdDate: item._createdDate,
       }));
     } catch (err) {
-      logError('[customizationService] getSavedConfigurations', err);
+      logError('customizationService:getSavedConfigurations', err);
       return [];
     }
   }
@@ -203,7 +203,7 @@ export const getConfigurationById = webMethod(
 
       return result;
     } catch (err) {
-      logError('[customizationService] getConfiguration', err);
+      logError('customizationService:getConfiguration', err);
       return null;
     }
   }

--- a/src/backend/gamificationCore.web.js
+++ b/src/backend/gamificationCore.web.js
@@ -758,7 +758,7 @@ export const getActiveChallenges = webMethod(
       // through (stale session, misconfiguration). Surface it as a distinct
       // error instead of returning "no challenges" — that's silent-failure
       // masquerade. See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getActiveChallenges-noMemberId', null);
+      logError('gamificationCore:getActiveChallenges-unauthenticated', null);
       return { challenges: [], error: 'auth_required' };
     }
 
@@ -1089,7 +1089,7 @@ export const getStreakData = webMethod(
       // Velo SiteMember gate leak — distinguishable from "authed but no streak
       // yet" (which also returns zeros, but without the error field).
       // See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getStreakData-noMemberId', null);
+      logError('gamificationCore:getStreakData-unauthenticated', null);
       return { currentStreak: 0, longestStreak: 0, lastActivityDate: null, error: 'auth_required' };
     }
     const record = await findMemberRecord(memberId);
@@ -1208,7 +1208,7 @@ export const getMemberTier = webMethod(
       // Velo SiteMember gate leak — return the baseline Trail Blazer shape
       // but signal the auth anomaly so widgets can gate tier benefits display.
       // See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getMemberTier-noMemberId', null);
+      logError('gamificationCore:getMemberTier-unauthenticated', null);
       return { ...computeTierInfo(0), error: 'auth_required' };
     }
     const record = await findMemberRecord(memberId);
@@ -1248,7 +1248,7 @@ export const getActivityFeed = webMethod(
       // Velo SiteMember gate leak. Array return preserved for consumer compat;
       // observability lives in the warn so Wix runtime logs surface the leak.
       // See cf-1y7 (cf-2ag cascade).
-      logError('gamificationCore:getActivityFeed-authRequired', null);
+      logError('gamificationCore:getActivityFeed-unauthenticated', null);
       return [];
     }
     if (caller._id !== memberId) {

--- a/src/backend/styleQuiz.web.js
+++ b/src/backend/styleQuiz.web.js
@@ -156,7 +156,7 @@ export const getQuizRecommendations = webMethod(
       scored.sort((a, b) => b.score - a.score);
       return scored.slice(0, 5);
     } catch (err) {
-      logError('styleQuiz:getRecommendations', err);
+      logError('styleQuiz:getQuizRecommendations-failed', err);
       return [];
     }
   }
@@ -351,7 +351,7 @@ export const captureQuizLead = webMethod(
       logAuditEvent('NewsletterSubscribers', 'quiz_lead', cleaned);
       return { success: true };
     } catch (err) {
-      logError('styleQuiz:captureLeadForm', err);
+      logError('styleQuiz:captureQuizLead', err);
       return { success: false, message: 'Capture failed. Please try again.' };
     }
   }

--- a/tests/cf-2k7u-batchQ-LogErrorMigration.test.js
+++ b/tests/cf-2k7u-batchQ-LogErrorMigration.test.js
@@ -84,10 +84,10 @@ const FILES = {
   'gamificationCore.web.js': {
     requiresImport: true,
     tags: [
-      'gamificationCore:getActiveChallenges-noMemberId',
-      'gamificationCore:getStreakData-noMemberId',
-      'gamificationCore:getMemberTier-noMemberId',
-      'gamificationCore:getActivityFeed-authRequired',
+      'gamificationCore:getActiveChallenges-unauthenticated',
+      'gamificationCore:getStreakData-unauthenticated',
+      'gamificationCore:getMemberTier-unauthenticated',
+      'gamificationCore:getActivityFeed-unauthenticated',
       'gamificationCore:getActivityFeed-forbidden',
     ],
   },
@@ -130,8 +130,8 @@ const FILES = {
   'styleQuiz.web.js': {
     requiresImport: true,
     tags: [
-      'styleQuiz:getRecommendations',
-      'styleQuiz:captureLeadForm',
+      'styleQuiz:getQuizRecommendations-failed',
+      'styleQuiz:captureQuizLead',
     ],
   },
 };

--- a/tests/cf-44qt-sibling-customization-logError.test.js
+++ b/tests/cf-44qt-sibling-customization-logError.test.js
@@ -39,7 +39,7 @@ describe('cf-44qt sibling — customizationService.web.js console.error → logE
     ];
     for (const label of labels) {
       const re = new RegExp(
-        `logError\\(\\s*['"]\\[customizationService\\] ${label}['"]`,
+        `logError\\(\\s*['"]customizationService:${label}['"]`,
       );
       expect(SRC).toMatch(re);
     }

--- a/tests/cf-n4wy-batchO-LogErrorMigration.test.js
+++ b/tests/cf-n4wy-batchO-LogErrorMigration.test.js
@@ -88,10 +88,10 @@ const FILES = {
   'gamificationCore.web.js': {
     requiresImport: true,
     tags: [
-      'gamificationCore:getActiveChallenges-noMemberId',
-      'gamificationCore:getStreakData-noMemberId',
-      'gamificationCore:getMemberTier-noMemberId',
-      'gamificationCore:getActivityFeed-authRequired',
+      'gamificationCore:getActiveChallenges-unauthenticated',
+      'gamificationCore:getStreakData-unauthenticated',
+      'gamificationCore:getMemberTier-unauthenticated',
+      'gamificationCore:getActivityFeed-unauthenticated',
       'gamificationCore:getActivityFeed-forbidden',
     ],
   },

--- a/tests/cf-tok3-batch5-logError.test.js
+++ b/tests/cf-tok3-batch5-logError.test.js
@@ -1,0 +1,40 @@
+/**
+ * @file cf-tok3-batch5-logError.test.js
+ * @description cf-tok3 batch5 — re-ship of customizationService + photoReviews
+ * after PR #1428 was closed due to challengeService conflict with cf-44qt batch5.
+ * These 2 files are NOT in any cf-44qt batch — exclusively cf-tok3.
+ *
+ * Mayor PACE ALERT 08:59 — cf-tok3 wave.
+ */
+import { describe, it, expect } from 'vitest';
+
+const FILES = ['customizationService', 'photoReviews'];
+
+async function readSrc(name) {
+  const { readFile } = await import('node:fs/promises');
+  return readFile(
+    new URL(`../src/backend/${name}.web.js`, import.meta.url),
+    'utf8',
+  );
+}
+
+describe.each(FILES)('cf-tok3 %s — console.error → logError migration', (name) => {
+  it('source file contains zero raw console.error calls', async () => {
+    const src = await readSrc(name);
+    const stripped = src.replace(/\/\/.*$/gm, '');
+    expect(stripped).not.toMatch(/console\.error/);
+  });
+
+  it('source file imports logError from backend/utils/errorHandler', async () => {
+    const src = await readSrc(name);
+    expect(src).toMatch(
+      /import\s+\{\s*[^}]*\blogError\b[^}]*\}\s+from\s+['"]backend\/utils\/errorHandler['"]/,
+    );
+  });
+
+  it(`source file uses ${name}.* context tag prefix in at least one logError call`, async () => {
+    const src = await readSrc(name);
+    const moduleTagRegex = new RegExp(`logError[\\s\\S]*?['"]${name}[.:]`);
+    expect(src).toMatch(moduleTagRegex);
+  });
+});


### PR DESCRIPTION
## Summary

- Advances 10 backend source files from bracket/dot logError format to canonical colon format (`module:fn` pattern), removing local wrapper functions
- Aligns 17 test files to match the advanced tag names, resolving all 25 remaining failures in the cf-7s1j regression scope
- All 1206 test files pass (37820 tests pass, 12 skipped, 59 todo)

**Source changes:**
- `contentOrchestrator.web.js` — 7 bracket → colon tags
- `customizationService.web.js` — 4 bracket → colon tags
- `gamificationCore.web.js` — `-noMemberId`/`-authRequired` → `-unauthenticated` (4 tags)
- `marketingSequences.web.js` — remove `_logErrorCanonical` wrapper, use direct import
- `newsletterService.web.js` — canonical tag names
- `priceDropCron.web.js` — 4 bracket → colon tags
- `promotions.web.js` — 2 bracket → colon tags
- `rewardEngine.web.js` — remove `_logErrorCanonical` wrapper, use direct import
- `styleQuiz.web.js` — `getRecommendations` → `getQuizRecommendations-failed`; `captureLeadForm` → `captureQuizLead`
- `swatchService.web.js` — 4 bracket → colon with renames (`getAllSwatchFamilies`, `getSwatchCount`)

## Test plan

- [x] Full vitest suite: 1206 test files passed, 0 failures
- [x] Targeted runs on gamificationCoreWebMethods, priceDropCron, styleQuizSilentFailureCleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)