### PR TITLE
feat(cf-69fi.fu3): opt-in gh pr merge --auto for narrow ratchet PRs

### DIFF
--- a/scripts/cf-dead-routes/auto_ratchet.py
+++ b/scripts/cf-dead-routes/auto_ratchet.py
@@ -102,9 +102,14 @@ def decide_ratchet(baseline: Path, live: dict[str, int]) -> dict | None:
         "Ratcheting the floor DOWN (this PR) tightens the gate; never raises it.",
         "Cleanup wave drift gets caught on the next PR after this lands.",
         "",
-        "**Manual merge — never auto-merge.** 5-agent review still applies per",
-        "mayor's 2026-05-15 standing order, but the diff is mechanical + the",
-        "rationale is canonical (matches `_meta.ratchet_pattern` in baseline.json).",
+        "**Auto-merge enabled (cf-69fi.fu3):** this PR carries the `auto-merge-ratchet`",
+        "label and has `gh pr merge --auto --squash` set at creation. It will merge",
+        "automatically once all required CI checks pass.",
+        "",
+        "5-agent review still applies per mayor's 2026-05-15 standing order. The diff",
+        "is mechanical (only `baseline.json`, counts strictly down) but reviewers must",
+        "use **Request Changes** — not just a comment — to block the auto-merge if",
+        "something looks wrong.",
     ])
 
     return {

--- a/scripts/cf-dead-routes/test_auto_ratchet.py
+++ b/scripts/cf-dead-routes/test_auto_ratchet.py
@@ -182,14 +182,14 @@ def test_pr_body_omits_unchanged_axis(tmp_path):
 
 def test_pr_body_auto_merge_notice(tmp_path):
     """cf-69fi.fu3: PR body must tell reviewers that auto-merge is enabled and
-    that 'Request Changes' (not just a comment) is the correct veto mechanism."""
+    that 'Request Changes' (exact casing — markdown bold) is the correct veto."""
     ar = _import_ar()
     baseline = tmp_path / "b.json"
     _write_baseline(baseline, dead=5, ucd=0)
     decision = ar.decide_ratchet(baseline=baseline, live={"dead": 3, "unused_can_delete": 0})
     body = decision["pr_body"]
-    assert "auto-merge" in body.lower()
-    assert "request changes" in body.lower()
+    assert "auto-merge" in body
+    assert "Request Changes" in body
 
 
 def test_pr_body_no_longer_says_manual_merge(tmp_path):

--- a/scripts/cf-dead-routes/test_auto_ratchet.py
+++ b/scripts/cf-dead-routes/test_auto_ratchet.py
@@ -180,6 +180,30 @@ def test_pr_body_omits_unchanged_axis(tmp_path):
     assert "unused_can_delete:" not in body  # unchanged, don't mention
 
 
+def test_pr_body_auto_merge_notice(tmp_path):
+    """cf-69fi.fu3: PR body must tell reviewers that auto-merge is enabled and
+    that 'Request Changes' (not just a comment) is the correct veto mechanism."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=5, ucd=0)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 3, "unused_can_delete": 0})
+    body = decision["pr_body"]
+    assert "auto-merge" in body.lower()
+    assert "request changes" in body.lower()
+
+
+def test_pr_body_no_longer_says_manual_merge(tmp_path):
+    """cf-69fi.fu3: the old 'Manual merge — never auto-merge' line must be gone
+    now that auto-merge is opted in for narrow ratchet PRs."""
+    ar = _import_ar()
+    baseline = tmp_path / "b.json"
+    _write_baseline(baseline, dead=5, ucd=0)
+    decision = ar.decide_ratchet(baseline=baseline, live={"dead": 3, "unused_can_delete": 0})
+    body = decision["pr_body"]
+    assert "never auto-merge" not in body
+    assert "Manual merge" not in body
+
+
 # ── Write contract ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **`scripts/cf-dead-routes/auto_ratchet.py`** — PR body footer updated: replaces "Manual merge — never auto-merge" with an auto-merge notice telling reviewers to use **Request Changes** (not just a comment) to block the merge before CI finishes.
- **`scripts/cf-dead-routes/test_auto_ratchet.py`** — 2 new tests pin the new footer contract (14/14 pass): `test_pr_body_auto_merge_notice`, `test_pr_body_no_longer_says_manual_merge`. Assertions use exact casing (`"Request Changes"` and `"auto-merge"` — no `.lower()` fuzz).
- **`dead-code-baseline-ratchet.yml`** — see workflow diff below; excluded from commit (requires `workflow` OAuth scope).

Bead: cf-69fi.fu3 | Parent: cf-69fi (merged PR #1354) | Sibling: cf-69fi.fu2 (merged PR #1357)

**Narrow criteria that make auto-merge safe** (both guaranteed by bot design):
1. Only `baseline.json` changed — no other files
2. Counts strictly < previous baseline (the `decide_ratchet` guard refuses any axis that rose)

5-agent review still applies per mayor's 2026-05-15 mandate.

## ⚠️ Workflow change — manual step required (Stilgar / repo-admin)

This commit excludes `.github/workflows/dead-code-baseline-ratchet.yml` — apply this full diff manually after merge:

```diff
@@ -4,7 +4,9 @@ name: Dead-Code Baseline Ratchet
 # dead-code counts. If the live counts are STRICTLY below the checked-in
 # baseline on at least one axis (and no axis rose), open a PR ratcheting
 # baseline.json down with a generated explanation. Never raises baseline;
-# never auto-merges — 5-agent CR per mayor's mandate still applies.
+# auto-merges when CI passes if allow_auto_merge is enabled on the repo
+# (cf-69fi.fu3) — 5-agent CR per mayor's mandate still applies. Use
+# "Request Changes" (not just a comment) to block the auto-merge.
 #
 # Mirrors .github/workflows/coverage-ratchet.yml (the vitest analog).
 on:
@@ -114,9 +116,13 @@ jobs:
           git add scripts/cf-dead-routes/baseline.json
           git commit -m "chore(ci): ratchet dead-code baseline (dead=$NEW_DEAD, unused_can_delete=$NEW_UCD)"
           git push -u origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore(cf-69fi.fu2): ratchet dead-code baseline (dead=$NEW_DEAD, ucd=$NEW_UCD)" \
             --body-file /tmp/cf-dead-routes/pr-body.md \
-            --label "ci-ratchet,cf-69fi"
+            --label "ci-ratchet,cf-69fi,auto-merge-ratchet")
+          echo "PR created: $PR_URL"
+          gh pr merge --auto --squash "$PR_URL" \
+            && echo "Auto-merge enabled on $PR_URL" \
+            || echo "WARNING: auto-merge unavailable — merge $PR_URL manually (ensure allow_auto_merge is enabled in repo settings)"
```

## ⚠️ One-time repo setting (Stilgar / repo-admin)

`allow_auto_merge` is currently `false` on this repo. Enable it in **Settings → General → Allow auto-merge** so `gh pr merge --auto` succeeds. Until then the workflow prints a WARNING and ratchet PRs still work — just merged manually.

Also create the `auto-merge-ratchet` label (Settings → Labels) so the bot can tag ratchet PRs at creation.

## Test plan

- [ ] 14/14 `python3 -m pytest scripts/cf-dead-routes/test_auto_ratchet.py` pass (including exact-casing `"Request Changes"` assert)
- [ ] After workflow diff + repo settings applied: trigger `workflow_dispatch` on `dead-code-baseline-ratchet` with a manually ratcheted baseline → PR opens with `auto-merge-ratchet` label + auto-merge enabled
- [ ] Auto-merge fires after CI passes; PR merges without operator action
- [ ] Reviewer "Request Changes" blocks the auto-merge until resolved

## Crew review

<!-- 5 distinct agent sign-offs required before merge (5-agent mandate 2026-05-15) -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)