### PR TITLE
docs(cf-3qt.9): RETIRED banners on Wix Studio editor guides

### DIFF
--- a/EDITOR-HOOKUP-GUIDE.md
+++ b/EDITOR-HOOKUP-GUIDE.md
@@ -1,3 +1,6 @@
+> **RETIRED** — Wix Studio retired post cf-3qt Phase 8 cutover. Archive reference only.
+> Active codebase: [carolina-futons-web](https://github.com/DreadPirateRobertz/carolina-futons-web)
+
 # Editor Hookup Guide — Element ID Map & Manual Work Queue
 
 **Generated**: 2026-03-15 | **Last Updated**: 2026-05-05 (v4.6 — Post-cf-3qt session refresh: (a) confirmed PushTokens / SpinGrants / MobileChallengeCompletions / CrossRigSyncLog present on STAGING_SITE per Wix Data API verification 2026-05-05; (b) flagged cf-c6g5 — STAGING_SITE Triggered Emails dashboard is empty, 20 templates need batch-copy from prod, all email touchpoints currently 500; (c) added Diagnostic Endpoints section (`/_functions/contactSubmissionsDiagnostic`, /api/auth/diag pending quartz); (d) added Repo Drift lessons from cf-w1lg (cfutons monorepo ↔ carolina-futons-stage3-velo divergence — cfw → Velo HTTP calls 404 until publish); (e) Hookup-coverage snapshot from cf-ah0m + cf-o2kq parity audit: 255 features, 201✓ / 28~ / 25✗ / 1?; (f) Phase 8 cutover prep link. Previous: v4.5 — CMS collections 32→36: added Landings, PressMentions, PressKitAssets, ComparisonFeatures (cf-3qt Phase 4/5). v4.4 — CMS 28→32: PushTokens, SpinGrants, MobileChallengeCompletions, CrossRigSyncLog. v4.3 — Phase 8 COMPLETE. v4.2 — Night shift 5 merges.)

--- a/EDITOR_HOOKUP_GUIDE.html
+++ b/EDITOR_HOOKUP_GUIDE.html
@@ -361,6 +361,11 @@ body.focus-mode .page-section.focus-visible { display: block; }
 </head>
 <body>
 
+<div style="background:#c0392b;color:#fff;font-family:sans-serif;font-size:1.1rem;font-weight:700;padding:18px 24px;text-align:center;letter-spacing:0.03em;border-bottom:4px solid #922b21;">
+  ⚠ RETIRED — Wix Studio retired post cf-3qt Phase 8 cutover. Archive reference only.
+  See <a href="https://github.com/DreadPirateRobertz/carolina-futons-web" style="color:#f9e4e4;text-decoration:underline;">carolina-futons-web</a> for the active Next.js codebase.
+</div>
+
 <div class="header">
   <div class="header-top">
     <div>


### PR DESCRIPTION
## Summary

- Adds a prominent red RETIRED banner to `EDITOR_HOOKUP_GUIDE.html` (inline HTML banner at top of body)
- Adds a blockquote RETIRED banner to `EDITOR-HOOKUP-GUIDE.md` (above the H1)
- Content preserved — archive reference only, no deletions

Banner text: *"Wix Studio retired post cf-3qt Phase 8 cutover. Archive reference only."*

Pre-cutover prep per melania approval (cf-3qt.9). Safe to merge any time — no production risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)