### PR TITLE
fix(cf-y2wg): post_submitSurvey IDOR pre-check queries wrong collection

### DIFF
--- a/src/backend/http-functions.js
+++ b/src/backend/http-functions.js
@@ -46,7 +46,7 @@ import * as _pushNotificationServiceModule from 'backend/pushNotificationService
 // block (`import * as wishlistServiceModule from 'backend/wishlistService.web';`).
 // Don't re-import here.
 import * as _styleQuizModule from 'backend/styleQuiz.web';
-import { submitSurveyResponse } from 'backend/surveyService.web';
+import { submitSurveyResponse, SURVEY_COLLECTION } from 'backend/surveyService.web';
 import { grantSpin } from 'backend/spinRedemptionService.web';
 import { submitCommunityPhoto } from 'backend/communityPhoto.web';
 // cf-bkxh: namespace import for giftRegistry dispatcher.
@@ -3634,7 +3634,10 @@ export async function post_submitSurvey(request) {
     });
   }
   try {
-    const lookup = await wixData.query('Survey')
+    // cf-y2wg: single source of truth on collection name — was hard-
+    // coded 'Survey' and silently mismatched the webMethod's
+    // SurveyResponses, returning 404 for every legitimate caller.
+    const lookup = await wixData.query(SURVEY_COLLECTION)
       .eq('memberId', member._id)
       .eq('orderId', orderId)
       .limit(1)

--- a/src/backend/surveyService.web.js
+++ b/src/backend/surveyService.web.js
@@ -25,7 +25,12 @@ import { currentMember } from 'wix-members-backend';
 import { sanitize } from 'backend/utils/sanitize';
 import { logError } from 'backend/utils/errorHandler';
 
-const SURVEY_COLLECTION = 'SurveyResponses';
+// cf-y2wg: exported so the post_submitSurvey HTTP wrapper in
+// http-functions.js queries the SAME collection the webMethod writes
+// to. Pre-cf-y2wg the wrapper hard-coded 'Survey' and the webMethod
+// hard-coded 'SurveyResponses'; the IDOR pre-check looked at a
+// non-existent collection and silently 404'd every submission.
+export const SURVEY_COLLECTION = 'SurveyResponses';
 const MAX_COMMENT_LENGTH = 1000;
 const NPS_MIN = 0;
 const NPS_MAX = 10;

--- a/tests/cfvtx5Dispatchers.test.js
+++ b/tests/cfvtx5Dispatchers.test.js
@@ -52,6 +52,10 @@ vi.mock('backend/styleQuiz.web', () => ({
 }));
 vi.mock('backend/surveyService.web', () => ({
   submitSurveyResponse: vi.fn(),
+  // cf-y2wg: http-functions.js imports the collection-name constant
+  // from surveyService.web so the IDOR pre-check and the webMethod
+  // hit the SAME collection. Mock has to expose it too.
+  SURVEY_COLLECTION: 'SurveyResponses',
 }));
 vi.mock('backend/spinRedemptionService.web', () => ({
   grantSpin: vi.fn(),
@@ -75,7 +79,7 @@ import { getActiveChallenges, getLeaderboard as gamificationGetLeaderboard, reco
 import { getMyLoyaltyAccount, redeemReward } from 'backend/loyaltyService.web';
 import { getMyPushPreferences } from 'backend/pushNotificationService.web';
 import { captureQuizLead } from 'backend/styleQuiz.web';
-import { submitSurveyResponse } from 'backend/surveyService.web';
+import { submitSurveyResponse, SURVEY_COLLECTION } from 'backend/surveyService.web';
 import { grantSpin } from 'backend/spinRedemptionService.web';
 import { __setMember } from './__mocks__/wix-members-backend.js';
 import { __seed, __reset as __resetData } from './__mocks__/wix-data.js';
@@ -345,7 +349,9 @@ describe('cf-vtx5 · post_submitSurvey', () => {
   beforeEach(() => {
     // Default: authenticated member + a Survey row owned by them at order-1.
     __setMember({ _id: 'member-77', loginEmail: 'm@e.com' });
-    __seed('Survey', [{ _id: 'srv-1', memberId: 'member-77', orderId: 'order-1' }]);
+    // cf-y2wg: seed the SAME collection the webMethod writes to —
+    // not a separate 'Survey' that doesn't exist in prod.
+    __seed(SURVEY_COLLECTION, [{ _id: 'srv-1', memberId: 'member-77', orderId: 'order-1' }]);
   });
 
   it('shims cfw shape {score, comments, orderId} → webMethod {orderId, npsScore, comment}', async () => {
@@ -384,7 +390,7 @@ describe('cf-vtx5 · post_submitSurvey', () => {
     // Pre-check passes (caller has a member + matching orderId), so the
     // webMethod is invoked and surfaces its own auth_required envelope.
     __setMember({ _id: 'member-77', loginEmail: 'm@e.com' });
-    __seed('Survey', [{ _id: 'sv-1', memberId: 'member-77', orderId: 'order-1' }]);
+    __seed(SURVEY_COLLECTION, [{ _id: 'sv-1', memberId: 'member-77', orderId: 'order-1' }]);
     const res = await post_submitSurvey(flatReq({ score: 5, orderId: 'order-1' }));
     expect(res.status).toBe(401);
   });
@@ -397,6 +403,29 @@ describe('cf-vtx5 · post_submitSurvey', () => {
     expect(res.status).toBe(404);
     expect(JSON.parse(res.body)).toMatchObject({ success: false, error: expect.stringMatching(/no survey/i) });
     expect(vi.mocked(submitSurveyResponse)).not.toHaveBeenCalled();
+  });
+
+  // cf-y2wg: regression pin — wrapper MUST query the same collection
+  // the webMethod operates on. Pre-fix, http-functions.js hard-coded
+  // 'Survey' while surveyService.web.js wrote to 'SurveyResponses',
+  // so the IDOR pre-check 404'd every legitimate caller and no
+  // submission ever reached the webMethod in prod. Constant is
+  // imported from surveyService.web; if a future contributor changes
+  // either side independently this test fails.
+  it('cf-y2wg: IDOR pre-check queries the SAME collection the webMethod writes to', async () => {
+    expect(SURVEY_COLLECTION).toBe('SurveyResponses');
+    // Seed ONLY the wrong (legacy 'Survey') collection — the wrapper
+    // must NOT find the row there.
+    __resetData();
+    __setMember({ _id: 'member-77', loginEmail: 'm@e.com' });
+    __seed('Survey', [{ _id: 'old', memberId: 'member-77', orderId: 'order-1' }]);
+    const res1 = await post_submitSurvey(flatReq({ score: 8, orderId: 'order-1' }));
+    expect(res1.status).toBe(404);
+    // Re-seed under the canonical name — the wrapper finds it.
+    __seed(SURVEY_COLLECTION, [{ _id: 'new', memberId: 'member-77', orderId: 'order-1' }]);
+    vi.mocked(submitSurveyResponse).mockResolvedValue({ success: true });
+    const res2 = await post_submitSurvey(flatReq({ score: 8, orderId: 'order-1' }));
+    expect(res2.status).toBe(200);
   });
 
   it('cf-yvs4: returns 401 when no SiteMember context', async () => {


### PR DESCRIPTION
## Why
\`http-functions.js:3637\` was hard-coded \`wixData.query('Survey')\` while \`surveyService.web.js\` writes rows into \`SurveyResponses\` (constant on line 28, used 6 places — \`scheduleSurvey\` inserts, \`submitSurveyResponse\` updates, \`getSurveyForOrder\` reads, aggregations query).

Every authenticated NPS submission hit the IDOR pre-check, found nothing in the non-existent \`Survey\` collection, and returned 404 "No survey found for this order" before ever delegating to the webMethod.

Existing tests at \`cfvtx5Dispatchers.test.js:347/387\` passed because they seeded the same wrong name (\`__seed('Survey', …)\`) — pinning a mismatched contract instead of the real one. Classic test-pins-the-bug.

## Fix
- Export \`SURVEY_COLLECTION\` from \`surveyService.web.js\` so wrapper + webMethod share a single source of truth.
- Import it in \`http-functions.js\` and use it in the pre-check query.
- Update existing tests to seed via the imported constant (not hard-coded \`'Survey'\`).
- **New regression-pin test** \`cf-y2wg: IDOR pre-check queries the SAME collection the webMethod writes to\` — seeds the legacy \`Survey\` name, asserts the wrapper does NOT find it (404), then re-seeds under \`SURVEY_COLLECTION\` and asserts the happy path (200). Future drift fails this test instead of silently shipping a 404.

## Why this PR alone isn't enough
Companion to **cfw PR DreadPirateRobertz/carolina-futons-web#1071** (forwards the \`Authorization: Bearer\` header from the cfw server action). Both are required for end-to-end NPS submissions to succeed:
- Before #1071: every cfw fetch was anonymous → 401 here. This PR's 404 fix wouldn't even be reached.
- Before this PR: even an authenticated caller with the bearer forwarded would 404 at the collection-name mismatch.

## Test plan
- [x] \`vitest run tests/cfvtx5Dispatchers.test.js\` — 42/42 green (was 41 + 1 new regression pin).
- [x] \`vitest run tests/{surveyService,cfvtx5Dispatchers,cf-1mlj-survey-*}.test.js\` — 132/132 green across all survey-touching tests.
- [ ] After both PRs deploy: log in as a member with a real \`SurveyResponses\` row → hit \`/survey?orderId=<that-order>\` → submit → verify \`completedAt\` + \`npsScore\` populated in the row.

## Refs
- Source bead: \`cf-y2wg\` (cfutons rig)
- Mirror bead: \`cfw-t4gl\` (cfutons_web rig — both halves tracked there)
- Companion cfw PR: DreadPirateRobertz/carolina-futons-web#1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)